### PR TITLE
Add nsxt_logical_switch data source

### DIFF
--- a/nsxt/data_source_nsxt_logical_switch.go
+++ b/nsxt/data_source_nsxt_logical_switch.go
@@ -1,0 +1,104 @@
+/* Copyright © 2018 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: MPL-2.0 */
+
+package nsxt
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/vmware/go-vmware-nsxt/manager"
+)
+
+func dataSourceNsxtLogicalSwitch() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceNsxtLogicalSwitchRead,
+
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Description: "Unique ID of this resource",
+				Optional:    true,
+				Computed:    true,
+			},
+			"display_name": {
+				Type:        schema.TypeString,
+				Description: "The display name of this resource",
+				Optional:    true,
+				Computed:    true,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Description: "Description of this resource",
+				Optional:    true,
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func dataSourceNsxtLogicalSwitchRead(d *schema.ResourceData, m interface{}) error {
+	// Read a logical tier1 router by name or id
+	nsxClient := m.(nsxtClients).NsxtClient
+	if nsxClient == nil {
+		return dataSourceNotSupportedError()
+	}
+
+	objID := d.Get("id").(string)
+	objName := d.Get("display_name").(string)
+	var obj manager.LogicalSwitch
+	if objID != "" {
+		// Get by id
+		objGet, resp, err := nsxClient.LogicalSwitchingApi.GetLogicalSwitch(nsxClient.Context, objID)
+
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			return fmt.Errorf("Logical tier1 router %s was not found", objID)
+		}
+		if err != nil {
+			return fmt.Errorf("Error while reading logical switch %s: %v", objID, err)
+		}
+		obj = objGet
+	} else if objName == "" {
+		return fmt.Errorf("Error obtaining logical switch ID or name during read")
+	} else {
+		// Get by full name/prefix
+		objList, _, err := nsxClient.LogicalSwitchingApi.ListLogicalSwitches(nsxClient.Context, nil)
+		if err != nil {
+			return fmt.Errorf("Error while reading logical switches: %v", err)
+		}
+
+		// go over the list to find the correct one (prefer a perfect match. If not - prefix match)
+		var perfectMatch []manager.LogicalSwitch
+		var prefixMatch []manager.LogicalSwitch
+		for _, objInList := range objList.Results {
+			if strings.HasPrefix(objInList.DisplayName, objName) {
+				prefixMatch = append(prefixMatch, objInList)
+			}
+			if objInList.DisplayName == objName {
+				perfectMatch = append(perfectMatch, objInList)
+			}
+		}
+		if len(perfectMatch) > 0 {
+			if len(perfectMatch) > 1 {
+				return fmt.Errorf("Found multiple logical switches with name '%s'", objName)
+			}
+			obj = perfectMatch[0]
+		} else if len(prefixMatch) > 0 {
+			if len(prefixMatch) > 1 {
+				return fmt.Errorf("Found multiple logical switches with name starting with '%s'", objName)
+			}
+			obj = prefixMatch[0]
+		} else {
+			return fmt.Errorf("Logical switch with name '%s' was not found", objName)
+		}
+	}
+
+	d.SetId(obj.Id)
+	d.Set("display_name", obj.DisplayName)
+	d.Set("description", obj.Description)
+	d.Set("transport_zone_id", obj.TransportZoneId)
+
+	return nil
+}

--- a/nsxt/data_source_nsxt_logical_switch.go
+++ b/nsxt/data_source_nsxt_logical_switch.go
@@ -35,6 +35,12 @@ func dataSourceNsxtLogicalSwitch() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 			},
+			"transport_zone_id": {
+				Type:        schema.TypeString,
+				Description: "ID of the transport zone configured for the logical switch",
+				Optional:    true,
+				Computed:    true,
+			},
 		},
 	}
 }

--- a/nsxt/data_source_nsxt_logical_switch_test.go
+++ b/nsxt/data_source_nsxt_logical_switch_test.go
@@ -1,0 +1,113 @@
+/* Copyright © 2018 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: MPL-2.0 */
+
+package nsxt
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/vmware/go-vmware-nsxt/manager"
+)
+
+func TestAccDataSourceNsxtLogicalSwitch_basic(t *testing.T) {
+	switchName := "terraform_test_switch"
+	testResourceName := "data.nsxt_logical_switch.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccDataSourceNsxtLogicalSwitchDeleteByName(switchName)
+		},
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {
+					if err := testAccDataSourceNsxtLogicalSwitchCreate(switchName); err != nil {
+						panic(err)
+					}
+				},
+				Config: testAccNSXLogicalSwitchReadTemplate(switchName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(testResourceName, "display_name", switchName),
+					resource.TestCheckResourceAttr(testResourceName, "description", switchName),
+				),
+			},
+			{
+				Config: testAccNSXNoLogicalSwitchTemplate(),
+			},
+		},
+	})
+}
+
+func testAccDataSourceNsxtLogicalSwitchCreate(switchName string) error {
+	nsxClient, err := testAccGetClient()
+	if err != nil {
+		return fmt.Errorf("Error during test client initialization: %v", err)
+	}
+
+	displayName := switchName
+	description := switchName
+	adminState := "UP"
+	replicationMode := "MTEP"
+	logicalSwitch := manager.LogicalSwitch{
+		AdminState:      adminState,
+		Description:     description,
+		DisplayName:     displayName,
+		TransportZoneId: getTransportZoneID(),
+		ReplicationMode: replicationMode,
+	}
+
+	logicalSwitch, resp, err := nsxClient.LogicalSwitchingApi.CreateLogicalSwitch(nsxClient.Context, logicalSwitch)
+	if err != nil {
+		return fmt.Errorf("Error during logical switch creation: %v", err)
+	}
+
+	if resp.StatusCode != http.StatusCreated {
+		return fmt.Errorf("Unexpected status returned during logical switch creation: %v", resp.StatusCode)
+	}
+	return nil
+}
+
+func testAccDataSourceNsxtLogicalSwitchDeleteByName(switchName string) error {
+	nsxClient, err := testAccGetClient()
+	if err != nil {
+		return fmt.Errorf("Error during test client initialization: %v", err)
+	}
+
+	// Find the object by name
+	objList, _, err := nsxClient.LogicalSwitchingApi.ListLogicalSwitches(nsxClient.Context, nil)
+	if err != nil {
+		return fmt.Errorf("Error while reading logical switches: %v", err)
+	}
+	// go over the list to find the correct one
+	for _, objInList := range objList.Results {
+		if objInList.DisplayName == switchName {
+			localVarOptionals := make(map[string]interface{})
+			responseCode, err := nsxClient.LogicalSwitchingApi.DeleteLogicalSwitch(nsxClient.Context, objInList.Id, localVarOptionals)
+			if err != nil {
+				return fmt.Errorf("Error during logical switch deletion: %v", err)
+			}
+
+			if responseCode.StatusCode != http.StatusOK {
+				return fmt.Errorf("Unexpected status returned during logical switch deletion: %v", responseCode.StatusCode)
+			}
+			return nil
+		}
+	}
+	return fmt.Errorf("Error while deleting logical switch '%s': service not found", switchName)
+}
+
+func testAccNSXLogicalSwitchReadTemplate(name string) string {
+	return fmt.Sprintf(`
+data "nsxt_logical_switch" "test" {
+  display_name = "%s"
+}`, name)
+}
+
+func testAccNSXNoLogicalSwitchTemplate() string {
+	return fmt.Sprintf(` `)
+}

--- a/nsxt/data_source_nsxt_logical_switch_test.go
+++ b/nsxt/data_source_nsxt_logical_switch_test.go
@@ -16,9 +16,10 @@ import (
 func TestAccDataSourceNsxtLogicalSwitch_basic(t *testing.T) {
 	switchName := "terraform_test_switch"
 	testResourceName := "data.nsxt_logical_switch.test"
+	transportZoneID := getTestTransportZoneID()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccEnvDefined(t, "NSXT_TEST_TRANSPORT_ZONE_ID") },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccDataSourceNsxtLogicalSwitchDeleteByName(switchName)
@@ -34,6 +35,7 @@ func TestAccDataSourceNsxtLogicalSwitch_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(testResourceName, "display_name", switchName),
 					resource.TestCheckResourceAttr(testResourceName, "description", switchName),
+					resource.TestCheckResourceAttr(testResourceName, "transport_zone_id", transportZoneID),
 				),
 			},
 			{
@@ -53,11 +55,13 @@ func testAccDataSourceNsxtLogicalSwitchCreate(switchName string) error {
 	description := switchName
 	adminState := "UP"
 	replicationMode := "MTEP"
+	transportZoneID := getTestTransportZoneID()
+
 	logicalSwitch := manager.LogicalSwitch{
 		AdminState:      adminState,
 		Description:     description,
 		DisplayName:     displayName,
-		TransportZoneId: getTransportZoneID(),
+		TransportZoneId: transportZoneID,
 		ReplicationMode: replicationMode,
 	}
 

--- a/nsxt/provider.go
+++ b/nsxt/provider.go
@@ -8,15 +8,16 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/vmware/go-vmware-nsxt"
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/core"
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/security"
-	"io/ioutil"
-	"net/http"
-	"strings"
 )
 
 var defaultRetryOnStatusCodes = []int{429, 503}
@@ -146,6 +147,7 @@ func Provider() terraform.ResourceProvider {
 			"nsxt_switching_profile":               dataSourceNsxtSwitchingProfile(),
 			"nsxt_logical_tier0_router":            dataSourceNsxtLogicalTier0Router(),
 			"nsxt_logical_tier1_router":            dataSourceNsxtLogicalTier1Router(),
+			"nsxt_logical_switch":                  dataSourceNsxtLogicalSwitch(),
 			"nsxt_mac_pool":                        dataSourceNsxtMacPool(),
 			"nsxt_ns_group":                        dataSourceNsxtNsGroup(),
 			"nsxt_ns_service":                      dataSourceNsxtNsService(),

--- a/nsxt/utils_test.go
+++ b/nsxt/utils_test.go
@@ -96,6 +96,10 @@ func getTestCertificateName(isClient bool) string {
 	return os.Getenv("NSXT_TEST_CERTIFICATE_NAME")
 }
 
+func getTestTransportZoneID() string {
+	return os.Getenv("NSXT_TEST_TRANSPORT_ZONE_ID")
+}
+
 func testAccEnvDefined(t *testing.T, envVar string) {
 	if len(os.Getenv(envVar)) == 0 {
 		t.Skipf("This test requires %s environment variable to be set", envVar)


### PR DESCRIPTION
This PR adds the nsxt_logical_switch data source. Our use case is to fetch logical switch ID by its name in terraform.

Requesting reviews and comments! @annakhm 