### PR TITLE
Ability to set tags on specific port/logical_switch

### DIFF
--- a/nsxt/resource_nsxt_vm_tags.go
+++ b/nsxt/resource_nsxt_vm_tags.go
@@ -35,7 +35,6 @@ func resourceNsxtVMTags() *schema.Resource {
 				Type:        schema.TypeString,
 				Description: "(Optional) Logical switch id",
 				Optional:    true,
-				Computed:    true,
 			},
 			"tag":              getTagsSchema(),
 			"logical_port_tag": getTagsSchema(),

--- a/nsxt/resource_nsxt_vm_tags_test.go
+++ b/nsxt/resource_nsxt_vm_tags_test.go
@@ -5,9 +5,12 @@ package nsxt
 
 import (
 	"fmt"
+	"github.com/vmware/go-vmware-nsxt/common"
+	"github.com/vmware/go-vmware-nsxt/manager"
+	"testing"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
-	"testing"
 )
 
 var vmTagsResourceName = "test"
@@ -70,6 +73,68 @@ func TestAccResourceNsxtVMTags_import_basic(t *testing.T) {
 	})
 }
 
+func TestAccResourceNsxtVMTags_withSpecificLogicalPort(t *testing.T) {
+	vmID := getTestVMID()
+	logicalSwitchID := getTestLogicalSwitchID()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccEnvDefined(t, "NSXT_TEST_VM_ID")
+			testAccEnvDefined(t, "NSXT_TEST_LOGICAL_SWITCH_ID")
+			testAccEnvDefined(t, "NSXT_TEST_NON_TAGGED_LOGICAL_SWITCH_ID")
+		},
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNSXVMTagsCheckDestroy(state)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNSXVMTagsCreateTemplateSpecificLogicalSwitch(vmID, logicalSwitchID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNSXVMTagsCheckExists(),
+					testAccNSXVMPortTagsCheckNotExist(
+						[]common.Tag{
+							{
+								Scope: "a",
+								Tag:   "b",
+							},
+						},
+					),
+					resource.TestCheckResourceAttr(vmTagsFullResourceName, "tag.#", "1"),
+					resource.TestCheckResourceAttr(vmTagsFullResourceName, "logical_port_tag.#", "1"),
+					resource.TestCheckResourceAttr(vmTagsFullResourceName, "logical_port_tag.934310497.scope", "a"),
+					resource.TestCheckResourceAttr(vmTagsFullResourceName, "logical_port_tag.934310497.tag", "b"),
+				),
+			},
+			{
+				Config: testAccNSXVMTagsUpdateTemplateSpecificLogicalSwitch(vmID, logicalSwitchID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNSXVMTagsCheckExists(),
+					testAccNSXVMPortTagsCheckNotExist(
+						[]common.Tag{
+							{
+								Scope: "c",
+								Tag:   "d",
+							},
+							{
+								Scope: "e",
+								Tag:   "f",
+							},
+						},
+					),
+					resource.TestCheckResourceAttr(vmTagsFullResourceName, "tag.#", "2"),
+					resource.TestCheckResourceAttr(vmTagsFullResourceName, "logical_port_tag.#", "2"),
+					resource.TestCheckResourceAttr(vmTagsFullResourceName, "logical_port_tag.600822426.scope", "c"),
+					resource.TestCheckResourceAttr(vmTagsFullResourceName, "logical_port_tag.600822426.tag", "d"),
+					resource.TestCheckResourceAttr(vmTagsFullResourceName, "logical_port_tag.3616979359.scope", "e"),
+					resource.TestCheckResourceAttr(vmTagsFullResourceName, "logical_port_tag.3616979359.tag", "f"),
+				),
+			},
+		},
+	})
+}
+
 func testAccNSXVMTagsCheckExists() resource.TestCheckFunc {
 	return func(state *terraform.State) error {
 
@@ -88,6 +153,46 @@ func testAccNSXVMTagsCheckExists() resource.TestCheckFunc {
 		_, err := findVMByExternalID(nsxClient, resourceID)
 		if err != nil {
 			return fmt.Errorf("Failed to find VM %s", resourceID)
+		}
+
+		return nil
+	}
+}
+
+func testAccNSXVMPortTagsCheckNotExist(checkedTags []common.Tag) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+		nonTaggedLogicalSwitchID := getTestNonTaggedLogicalSwitchID()
+		nsxClient := testAccProvider.Meta().(nsxtClients).NsxtClient
+
+		rs, ok := state.RootModule().Resources[vmTagsFullResourceName]
+		if !ok {
+			return fmt.Errorf("NSX tags resource %s not found in resources", vmTagsFullResourceName)
+		}
+
+		resourceID := rs.Primary.ID
+		if resourceID == "" {
+			return fmt.Errorf("NSX vm tags resource ID not set in resources ")
+		}
+
+		ports, err := findPortsByExternalID(nsxClient, resourceID)
+		if err != nil {
+			return fmt.Errorf("Error during logical port retrieval: %v", err)
+		}
+
+		if len(ports) > 0 {
+			var nonTaggedPort manager.LogicalPort
+			for _, port := range ports {
+				if port.LogicalSwitchId == nonTaggedLogicalSwitchID {
+					nonTaggedPort = port
+					break
+				}
+			}
+
+			if checkIfTagInPort(nonTaggedPort, checkedTags) {
+				return fmt.Errorf("The port attached to %s shouldn't be tagged with %s", nonTaggedLogicalSwitchID, checkedTags)
+			}
+		} else {
+			return fmt.Errorf("VM %s is not attached to any networks", resourceID)
 		}
 
 		return nil
@@ -152,4 +257,61 @@ resource "nsxt_vm_tags" "%s" {
     tag   = "d"
   }
 }`, vmTagsResourceName, instanceID)
+}
+
+func testAccNSXVMTagsCreateTemplateSpecificLogicalSwitch(instanceID string, logicalSwitchID string) string {
+	return fmt.Sprintf(`
+resource "nsxt_vm_tags" "%s" {
+  instance_id = "%s"
+  logical_switch_id = "%s"
+
+  tag {
+    scope = "scope1"
+    tag   = "tag1"
+  }
+
+  logical_port_tag {
+    scope = "a"
+    tag   = "b"
+  }
+}`, vmTagsResourceName, instanceID, logicalSwitchID)
+}
+
+func testAccNSXVMTagsUpdateTemplateSpecificLogicalSwitch(instanceID string, logicalSwitchID string) string {
+	return fmt.Sprintf(`
+resource "nsxt_vm_tags" "%s" {
+  instance_id = "%s"
+  logical_switch_id = "%s"
+
+  tag {
+    scope = "scope1"
+    tag   = "tag1"
+  }
+
+  tag {
+    scope = "scope2"
+    tag   = "tag2"
+  }
+
+  logical_port_tag {
+    scope = "c"
+    tag   = "d"
+  }
+
+  logical_port_tag {
+    scope = "e"
+    tag   = "f"
+  }
+}`, vmTagsResourceName, instanceID, logicalSwitchID)
+}
+
+func checkIfTagInPort(nonTaggedPort manager.LogicalPort, checkedTags []common.Tag) bool {
+	for _, tag := range nonTaggedPort.Tags {
+		for _, checkedTag := range checkedTags {
+			if tag.Scope == checkedTag.Scope && tag.Tag == checkedTag.Tag {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/nsxt/resource_nsxt_vm_tags_test.go
+++ b/nsxt/resource_nsxt_vm_tags_test.go
@@ -81,8 +81,8 @@ func TestAccResourceNsxtVMTags_withSpecificLogicalPort(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccEnvDefined(t, "NSXT_TEST_VM_ID")
-			testAccEnvDefined(t, "NSXT_TEST_LOGICAL_SWITCH_ID")
-			testAccEnvDefined(t, "NSXT_TEST_NON_TAGGED_LOGICAL_SWITCH_ID")
+			testAccEnvDefined(t, "NSXT_TEST_VM_LOGICAL_SWITCH_ID")
+			testAccEnvDefined(t, "NSXT_TEST_VM_NON_TAGGED_LOGICAL_SWITCH_ID")
 		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {

--- a/nsxt/utils_test.go
+++ b/nsxt/utils_test.go
@@ -90,11 +90,11 @@ func getTestVMName() string {
 }
 
 func getTestLogicalSwitchID() string {
-	return os.Getenv("NSXT_TEST_LOGICAL_SWITCH_ID")
+	return os.Getenv("NSXT_TEST_VM_LOGICAL_SWITCH_ID")
 }
 
 func getTestNonTaggedLogicalSwitchID() string {
-	return os.Getenv("NSXT_TEST_NON_TAGGED_LOGICAL_SWITCH_ID")
+	return os.Getenv("NSXT_TEST_VM_NON_TAGGED_LOGICAL_SWITCH_ID")
 }
 
 func getTestCertificateName(isClient bool) string {

--- a/nsxt/utils_test.go
+++ b/nsxt/utils_test.go
@@ -89,6 +89,14 @@ func getTestVMName() string {
 	return os.Getenv("NSXT_TEST_VM_NAME")
 }
 
+func getTestLogicalSwitchID() string {
+	return os.Getenv("NSXT_TEST_LOGICAL_SWITCH_ID")
+}
+
+func getTestNonTaggedLogicalSwitchID() string {
+	return os.Getenv("NSXT_TEST_NON_TAGGED_LOGICAL_SWITCH_ID")
+}
+
 func getTestCertificateName(isClient bool) string {
 	if isClient {
 		return os.Getenv("NSXT_TEST_CLIENT_CERTIFICATE_NAME")


### PR DESCRIPTION
This PR adds the ability to set vm port tags on specific ports by specifying the specific logical_switch_id/network the vm is attached to. Our use case is when integrating NSX Container Plug-In (NCP) with Kubernetes VMs.

NCP requires us to attach an additional network interface to the VMs to be used as the "Dataplane" network switch, and tag the ports attached there with special `ncp/node_name` and `ncp/cluster` tags, as explained [here](https://docs.vmware.com/en/VMware-NSX-T-Data-Center/2.5/ncp-kubernetes/GUID-4987811C-1107-4D54-AE8A-827D45F10506.html).

To work it around, we previously wrote a python script to tag those dataplane ports, and eventually created this feature to the nsxt_vm_tags.

Requesting reviews and comments @annakhm 