### PR TITLE
Improve error handling for policy resources

### DIFF
--- a/nsxt/provider.go
+++ b/nsxt/provider.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"strings"
 
@@ -408,7 +409,8 @@ func getAPIToken(vmcAuthHost string, vmcAccessToken string) (string, error) {
 	token := jwtToken{}
 	err = json.NewDecoder(res.Body).Decode(&token)
 	if err != nil {
-		return "", fmt.Errorf("Failed to decode access token from response: %v", err)
+		// Not fatal
+		log.Printf("[WARNING]: Failed to decode access token from response: %v", err)
 	}
 
 	return token.AccessToken, nil


### PR DESCRIPTION
As of today, provied cannot rely on vapi converter to return
conversion error in case target type does not match the actual
content. This change works around this issue and prints raw error
data whenever conversion is not succesful.
In addition, avoid erroring when VMC token decoder returns an error,
since for some error the token remains functional. Print a warning
instead.