### PR TITLE
Add policy security policy data sources

### DIFF
--- a/nsxt/data_source_nsxt_policy_security_policy.go
+++ b/nsxt/data_source_nsxt_policy_security_policy.go
@@ -1,0 +1,169 @@
+/* Copyright © 2019 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: MPL-2.0 */
+
+package nsxt
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/bindings"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
+	gm_model "github.com/vmware/vsphere-automation-sdk-go/services/nsxt-gm/model"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/domains"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+)
+
+func dataSourceNsxtPolicySecurityPolicy() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceNsxtPolicySecurityPolicyRead,
+
+		Schema: map[string]*schema.Schema{
+			"id":           getDataSourceIDSchema(),
+			"display_name": getDataSourceDisplayNameSchema(),
+			"description":  getDataSourceDescriptionSchema(),
+			"path":         getPathSchema(),
+			"domain":       getDataSourceDomainNameSchema(),
+			"is_default": {
+				Type:        schema.TypeBool,
+				Description: "Is this a default policy",
+				Optional:    true,
+				Default:     false,
+			},
+			"category": {
+				Type:         schema.TypeString,
+				Description:  "Category",
+				ValidateFunc: validation.StringInSlice(securityPolicyCategoryValues, false),
+				Optional:     true,
+				Computed:     true,
+			},
+		},
+	}
+}
+
+// Local Manager Only
+func listSecurityPolicies(domain string, connector *client.RestConnector) ([]model.SecurityPolicy, error) {
+	client := domains.NewDefaultSecurityPoliciesClient(connector)
+
+	var results []model.SecurityPolicy
+	boolFalse := false
+	var cursor *string
+	total := 0
+
+	for {
+		policies, err := client.List(domain, cursor, nil, &boolFalse, nil, nil, &boolFalse, nil)
+		if err != nil {
+			return results, err
+		}
+		results = append(results, policies.Results...)
+		if total == 0 && policies.ResultCount != nil {
+			// first response
+			total = int(*policies.ResultCount)
+		}
+
+		cursor = policies.Cursor
+		if len(results) >= total {
+			return results, nil
+		}
+	}
+}
+
+func dataSourceNsxtPolicySecurityPolicyRead(d *schema.ResourceData, m interface{}) error {
+	connector := getPolicyConnector(m)
+
+	category := d.Get("category").(string)
+	domain := d.Get("domain").(string)
+	isDefault := d.Get("is_default").(bool)
+	if isPolicyGlobalManager(m) {
+		query := make(map[string]string)
+		query["parent_path"] = "*/" + domain
+		if category != "" {
+			query["category"] = category
+		}
+		query["is_default"] = fmt.Sprintf("%v", isDefault)
+		obj, err := policyDataSourceResourceReadWithValidation(d, connector, "SecurityPolicy", query, false)
+		if err != nil {
+			return err
+		}
+
+		converter := bindings.NewTypeConverter()
+		converter.SetMode(bindings.REST)
+		dataValue, errors := converter.ConvertToGolang(obj, gm_model.SecurityPolicyBindingType())
+		if len(errors) > 0 {
+			return errors[0]
+		}
+
+		policy := dataValue.(gm_model.SecurityPolicy)
+		d.Set("category", policy.Category)
+		return nil
+	}
+
+	objID := d.Get("id").(string)
+	objName := d.Get("display_name").(string)
+
+	var obj model.SecurityPolicy
+	if objID != "" {
+		// Get by id
+		client := domains.NewDefaultSecurityPoliciesClient(connector)
+		objGet, err := client.Get(domain, objID)
+		if isNotFoundError(err) {
+			return fmt.Errorf("Security Policy with ID %s was not found", objID)
+		}
+
+		if err != nil {
+			return fmt.Errorf("Error while reading Security Policy %s: %v", objID, err)
+		}
+		obj = objGet
+	} else if objName == "" && category == "" {
+		return fmt.Errorf("Security Policy id, display name or category must be specified")
+	} else {
+		objList, err := listSecurityPolicies(domain, connector)
+		if err != nil {
+			return fmt.Errorf("Error while reading Security Policies: %v", err)
+		}
+		// go over the list to find the correct one (prefer a perfect match. If not - prefix match)
+		var perfectMatch []model.SecurityPolicy
+		var prefixMatch []model.SecurityPolicy
+		for _, objInList := range objList {
+			if category != "" && category != *objInList.Category {
+				continue
+			}
+			if *objInList.IsDefault != isDefault {
+				continue
+			}
+			if objName != "" {
+				if strings.HasPrefix(*objInList.DisplayName, objName) {
+					prefixMatch = append(prefixMatch, objInList)
+				}
+				if *objInList.DisplayName == objName {
+					perfectMatch = append(perfectMatch, objInList)
+				}
+			} else {
+				prefixMatch = append(prefixMatch, objInList)
+			}
+		}
+		if len(perfectMatch) > 0 {
+			if len(perfectMatch) > 1 {
+				return fmt.Errorf("Found multiple Security Policies with name '%s'", objName)
+			}
+			obj = perfectMatch[0]
+		} else if len(prefixMatch) > 0 {
+			if len(prefixMatch) > 1 {
+				return fmt.Errorf("Found multiple Security Policies with name starting with '%s' and category '%s'", objName, category)
+			}
+			obj = prefixMatch[0]
+		} else {
+			return fmt.Errorf("Security Policy with name '%s' and category '%s' was not found", objName, category)
+		}
+	}
+
+	d.SetId(*obj.Id)
+	d.Set("display_name", obj.DisplayName)
+	d.Set("description", obj.Description)
+	d.Set("path", obj.Path)
+	d.Set("category", obj.Category)
+
+	return nil
+}

--- a/nsxt/data_source_nsxt_policy_security_policy_test.go
+++ b/nsxt/data_source_nsxt_policy_security_policy_test.go
@@ -1,0 +1,108 @@
+/* Copyright © 2019 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: MPL-2.0 */
+
+package nsxt
+
+import (
+	"fmt"
+
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccDataSourceNsxtPolicySecurityPolicy_basic(t *testing.T) {
+	name := "terraform_ds_test"
+	category := "Application"
+	testResourceName := "data.nsxt_policy_security_policy.test"
+	withCategory := fmt.Sprintf(`category = "%s"`, category)
+	withDomain := `domain = "default"`
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicySecurityPolicyTemplate(name, category, ""),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(testResourceName, "display_name", name),
+					resource.TestCheckResourceAttr(testResourceName, "description", name),
+					resource.TestCheckResourceAttr(testResourceName, "category", category),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+				),
+			},
+			{
+				Config: testAccNsxtPolicySecurityPolicyTemplate(name, category, withCategory),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(testResourceName, "display_name", name),
+					resource.TestCheckResourceAttr(testResourceName, "description", name),
+					resource.TestCheckResourceAttr(testResourceName, "category", category),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+				),
+			},
+			{
+				Config: testAccNsxtPolicySecurityPolicyTemplate(name, category, withDomain),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(testResourceName, "display_name", name),
+					resource.TestCheckResourceAttr(testResourceName, "description", name),
+					resource.TestCheckResourceAttr(testResourceName, "category", category),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+				),
+			},
+			{
+				Config: testAccNsxtEmptyTemplate(),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceNsxtPolicySecurityPolicy_default(t *testing.T) {
+	testResourceName := "data.nsxt_policy_security_policy.test"
+	category1 := "Ethernet"
+	category2 := "Application"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyDefaultSecurityPolicyTemplate(category1),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(testResourceName, "display_name"),
+					resource.TestCheckResourceAttr(testResourceName, "category", category1),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+				),
+			},
+			{
+				Config: testAccNsxtPolicyDefaultSecurityPolicyTemplate(category2),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(testResourceName, "display_name"),
+					resource.TestCheckResourceAttr(testResourceName, "category", category2),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+				),
+			},
+		},
+	})
+}
+
+func testAccNsxtPolicySecurityPolicyTemplate(name string, category string, extra string) string {
+	return fmt.Sprintf(`
+resource "nsxt_policy_security_policy" "test" {
+  display_name = "%s"
+  description  = "%s"
+  category     = "%s"
+}
+
+data "nsxt_policy_security_policy" "test" {
+  display_name = nsxt_policy_security_policy.test.display_name
+  %s
+}`, name, name, category, extra)
+}
+
+func testAccNsxtPolicyDefaultSecurityPolicyTemplate(category string) string {
+	return fmt.Sprintf(`
+data "nsxt_policy_security_policy" "test" {
+  is_default = true
+  category   = "%s"
+}`, category)
+}

--- a/nsxt/provider.go
+++ b/nsxt/provider.go
@@ -197,6 +197,7 @@ func Provider() terraform.ResourceProvider {
 			"nsxt_policy_context_profile":          dataSourceNsxtPolicyContextProfile(),
 			"nsxt_policy_site":                     dataSourceNsxtPolicySite(),
 			"nsxt_policy_gateway_policy":           dataSourceNsxtPolicyGatewayPolicy(),
+			"nsxt_policy_security_policy":          dataSourceNsxtPolicySecurityPolicy(),
 			"nsxt_policy_group":                    dataSourceNsxtPolicyGroup(),
 		},
 

--- a/website/docs/d/policy_gateway_policy.html.markdown
+++ b/website/docs/d/policy_gateway_policy.html.markdown
@@ -8,7 +8,7 @@ description: A policy Gateway Policy data source.
 # nsxt_policy_gateway_policy
 
 This data source provides information about policy Gateway Policues configured on NSX.
-This data source can be useful for fetching policy path to use in `nsxt_policy_fixed_gateway_policy` resource.
+This data source can be useful for fetching policy path to use in `nsxt_policy_predefined_gateway_policy` resource.
 
 This data source is applicable to NSX Policy Manager, NSX Global Manager and VMC.
 
@@ -22,7 +22,7 @@ data "nsxt_policy_gateway_policy" "predefined" {
 
 ## Argument Reference
 
-* `id` - (Optional) The ID of Tier-0 gateway to retrieve.
+* `id` - (Optional) The ID of the gateway policy to retrieve.
 * `domain` - (Optional) The domain of the policy, defaults to `default`. Needs to be specified in VMC environment.
 * `category` - (Optional) Category of the policy to retrieve. May be useful to retrieve default policy.
 * `display_name` - (Optional) The Display Name prefix of the policy to retrieve.

--- a/website/docs/d/policy_security_policy.html.markdown
+++ b/website/docs/d/policy_security_policy.html.markdown
@@ -1,0 +1,37 @@
+---
+subcategory: "Policy - Firewall"
+layout: "nsxt"
+page_title: "NSXT: policy_security_policy"
+description: A policy Security Policy data source.
+---
+
+# nsxt_policy_security_policy
+
+This data source provides information about policy Security Policues configured on NSX.
+This data source can be useful for fetching policy path to use in `nsxt_policy_predefined_security_policy` resource.
+
+This data source is applicable to NSX Policy Manager, NSX Global Manager and VMC.
+
+## Example Usage
+
+```hcl
+data "nsxt_policy_security_policy" "predefined" {
+  is_default = true
+  category   = "Application"
+}
+```
+
+## Argument Reference
+
+* `id` - (Optional) The ID of Security Policy to retrieve.
+* `is_default` - (Optional) Whether this is a default policy. Default is `false`.
+* `domain` - (Optional) The domain of the policy, defaults to `default`. Needs to be specified in VMC environment.
+* `category` - (Optional) Category of the policy to retrieve.
+* `display_name` - (Optional) The Display Name of the policy to retrieve.
+
+## Attributes Reference
+
+In addition to arguments listed above, the following attributes are exported:
+
+* `description` - The description of the resource.
+* `path` - The NSX path of the policy resource.


### PR DESCRIPTION
This is mainly for convenience of retrieving default policy to use
in predefined security policy resource.
In addition, some fixes in docs for gateway policy data source.