### PR TITLE
Remove include_rule_count param in policy list

### DIFF
--- a/nsxt/data_source_nsxt_policy_gateway_policy.go
+++ b/nsxt/data_source_nsxt_policy_gateway_policy.go
@@ -47,7 +47,7 @@ func listGatewayPolicies(domain string, connector *client.RestConnector) ([]mode
 	total := 0
 
 	for {
-		policies, err := client.List(domain, cursor, nil, &boolFalse, nil, nil, &boolFalse, nil)
+		policies, err := client.List(domain, cursor, nil, nil, nil, nil, &boolFalse, nil)
 		if err != nil {
 			return results, err
 		}

--- a/nsxt/data_source_nsxt_policy_security_policy.go
+++ b/nsxt/data_source_nsxt_policy_security_policy.go
@@ -53,7 +53,7 @@ func listSecurityPolicies(domain string, connector *client.RestConnector) ([]mod
 	total := 0
 
 	for {
-		policies, err := client.List(domain, cursor, nil, &boolFalse, nil, nil, &boolFalse, nil)
+		policies, err := client.List(domain, cursor, nil, nil, nil, nil, &boolFalse, nil)
 		if err != nil {
 			return results, err
 		}


### PR DESCRIPTION
This parameter is not supported in earlier versions.