### PR TITLE
Expose vlan_ids attribute for overlay segments

### DIFF
--- a/nsxt/resource_nsxt_policy_segment.go
+++ b/nsxt/resource_nsxt_policy_segment.go
@@ -8,9 +8,6 @@ import (
 )
 
 func resourceNsxtPolicySegment() *schema.Resource {
-	segSchema := getPolicyCommonSegmentSchema()
-	delete(segSchema, "vlan_ids")
-
 	return &schema.Resource{
 		Create: resourceNsxtPolicySegmentCreate,
 		Read:   resourceNsxtPolicySegmentRead,
@@ -20,7 +17,7 @@ func resourceNsxtPolicySegment() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 
-		Schema: segSchema,
+		Schema: getPolicyCommonSegmentSchema(false),
 	}
 }
 

--- a/nsxt/resource_nsxt_policy_segment_test.go
+++ b/nsxt/resource_nsxt_policy_segment_test.go
@@ -146,6 +146,7 @@ func TestAccResourceNsxtPolicySegment_updateAdvConfig(t *testing.T) {
 					resource.TestCheckResourceAttr(testResourceName, "subnet.0.cidr", "12.12.2.1/24"),
 					resource.TestCheckResourceAttr(testResourceName, "domain_name", "tftest.org"),
 					resource.TestCheckResourceAttr(testResourceName, "overlay_id", "1011"),
+					resource.TestCheckResourceAttr(testResourceName, "vlan_ids.#", "2"),
 					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
 					resource.TestCheckResourceAttr(testResourceName, "advanced_config.0.connectivity", "OFF"),
 					resource.TestCheckResourceAttr(testResourceName, "advanced_config.0.local_egress", "true"),
@@ -161,6 +162,7 @@ func TestAccResourceNsxtPolicySegment_updateAdvConfig(t *testing.T) {
 					resource.TestCheckResourceAttr(testResourceName, "subnet.0.cidr", "12.12.2.1/24"),
 					resource.TestCheckResourceAttr(testResourceName, "domain_name", "tftest.org"),
 					resource.TestCheckResourceAttr(testResourceName, "overlay_id", "1011"),
+					resource.TestCheckResourceAttr(testResourceName, "vlan_ids.#", "1"),
 					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
 					resource.TestCheckResourceAttr(testResourceName, "advanced_config.0.connectivity", "ON"),
 					resource.TestCheckResourceAttr(testResourceName, "advanced_config.0.local_egress", "false"),
@@ -524,6 +526,7 @@ resource "nsxt_policy_segment" "test" {
   description  = "Acceptance Test"
   domain_name  = "tftest.org"
   overlay_id   = 1011
+  vlan_ids     = ["101", "102"]
 
   transport_zone_path = data.nsxt_policy_transport_zone.test.path
 
@@ -552,6 +555,7 @@ resource "nsxt_policy_segment" "test" {
   description  = "Acceptance Test"
   domain_name  = "tftest.org"
   overlay_id   = 1011
+  vlan_ids     = ["101-104"]
 
   transport_zone_path = data.nsxt_policy_transport_zone.test.path
 

--- a/nsxt/resource_nsxt_policy_vlan_segment.go
+++ b/nsxt/resource_nsxt_policy_vlan_segment.go
@@ -8,7 +8,7 @@ import (
 )
 
 func resourceNsxtPolicyVlanSegment() *schema.Resource {
-	segSchema := getPolicyCommonSegmentSchema()
+	segSchema := getPolicyCommonSegmentSchema(true)
 	delete(segSchema, "overlay_id")
 	delete(segSchema, "connectivity_path")
 

--- a/nsxt/segment_common.go
+++ b/nsxt/segment_common.go
@@ -238,7 +238,7 @@ func getPolicySegmentSecurityProfilesSchema() *schema.Resource {
 	}
 }
 
-func getPolicyCommonSegmentSchema() map[string]*schema.Schema {
+func getPolicyCommonSegmentSchema(vlanRequired bool) map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"nsx_id":       getNsxIDSchema(),
 		"path":         getPathSchema(),
@@ -297,7 +297,8 @@ func getPolicyCommonSegmentSchema() map[string]*schema.Schema {
 				Type:         schema.TypeString,
 				ValidateFunc: validateVLANIdOrRange,
 			},
-			Required: true,
+			Required: vlanRequired,
+			Optional: !vlanRequired,
 		},
 		"discovery_profile": {
 			Type:        schema.TypeList,

--- a/website/docs/r/policy_segment.html.markdown
+++ b/website/docs/r/policy_segment.html.markdown
@@ -59,6 +59,7 @@ The following arguments are supported:
 * `connectivity_path` - (Optional) Policy path to the connecting Tier-0 or Tier-1.
 * `domain_name`- (Optional) DNS domain names.
 * `overlay_id` - (Optional) Overlay connectivity ID for this Segment.
+* `vlan_ids` - (Optional) List of VLAN IDs or ranges. Specifying vlan ids can be useful for overlay segments, f.e. for EVPN.
 * `transport_zone_path` - (Required) Policy path to the Overlay transport zone. This property is required if more than one overlay transport zone is defined, and none is marked as default.
 * `dhcp_config_path` - (Optional) Policy path to DHCP server or relay configuration to use for subnets configured on this segment. This attribute is supported with NSX 3.0.0 onwards.
 * `subnet` - (Optional) Subnet configuration block.


### PR DESCRIPTION
This is to allow use case where VM tags packets and/or EVPN