### PR TITLE
Avoid using site_path parameter in realization ds

### DIFF
--- a/nsxt/data_source_nsxt_policy_realization_info.go
+++ b/nsxt/data_source_nsxt_policy_realization_info.go
@@ -98,7 +98,7 @@ func dataSourceNsxtPolicyRealizationInfoRead(d *schema.ResourceData, m interface
 				}
 			} else {
 				client := realized_state.NewDefaultRealizedEntitiesClient(connector)
-				realizationResult, realizationError = client.List(path, &policySite)
+				realizationResult, realizationError = client.List(path, nil)
 			}
 			state := "UNKNOWN"
 			if realizationError == nil {


### PR DESCRIPTION
This parameter is not supported before NSX 3.0.0