### PR TITLE
Condition MP tests on NSXT_TEST_MP env setting

### DIFF
--- a/nsxt/data_source_nsxt_edge_cluster_test.go
+++ b/nsxt/data_source_nsxt_edge_cluster_test.go
@@ -15,7 +15,7 @@ func TestAccDataSourceNsxtEdgeCluster_basic(t *testing.T) {
 	testResourceName := "data.nsxt_edge_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/nsxt/data_source_nsxt_firewall_section_test.go
+++ b/nsxt/data_source_nsxt_firewall_section_test.go
@@ -18,7 +18,7 @@ func TestAccDataSourceNsxtFirewallSection_basic(t *testing.T) {
 	testResourceName := "data.nsxt_firewall_section.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccDataSourceNsxtFirewallSectionDeleteByName(name)

--- a/nsxt/data_source_nsxt_ip_pool_test.go
+++ b/nsxt/data_source_nsxt_ip_pool_test.go
@@ -18,7 +18,7 @@ func TestAccDataSourceNsxtIPPool_basic(t *testing.T) {
 	testResourceName := "data.nsxt_ip_pool.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/nsxt/data_source_nsxt_logical_tier0_router_test.go
+++ b/nsxt/data_source_nsxt_logical_tier0_router_test.go
@@ -15,7 +15,7 @@ func TestAccDataSourceNsxtLogicalTier0Router_basic(t *testing.T) {
 	testResourceName := "data.nsxt_logical_tier0_router.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/nsxt/data_source_nsxt_logical_tier1_router_test.go
+++ b/nsxt/data_source_nsxt_logical_tier1_router_test.go
@@ -18,7 +18,7 @@ func TestAccDataSourceNsxtLogicalTier1Router_basic(t *testing.T) {
 	testResourceName := "data.nsxt_logical_tier1_router.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccDataSourceNsxtTier1RouterDeleteByName(routerName)

--- a/nsxt/data_source_nsxt_mac_pool_test.go
+++ b/nsxt/data_source_nsxt_mac_pool_test.go
@@ -15,7 +15,7 @@ func TestAccDataSourceNsxtMacPool_basic(t *testing.T) {
 	testResourceName := "data.nsxt_mac_pool.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/nsxt/data_source_nsxt_management_cluster_test.go
+++ b/nsxt/data_source_nsxt_management_cluster_test.go
@@ -13,7 +13,7 @@ func TestAccDataSourceNsxtManagementCluster_basic(t *testing.T) {
 	testResourceName := "data.nsxt_management_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/nsxt/data_source_nsxt_ns_group_test.go
+++ b/nsxt/data_source_nsxt_ns_group_test.go
@@ -18,7 +18,7 @@ func TestAccDataSourceNsxtNsGroup_basic(t *testing.T) {
 	testResourceName := "data.nsxt_ns_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccDataSourceNsxtNsGroupDeleteByName(groupName)

--- a/nsxt/data_source_nsxt_ns_service_test.go
+++ b/nsxt/data_source_nsxt_ns_service_test.go
@@ -18,7 +18,7 @@ func TestAccDataSourceNsxtNsService_basic(t *testing.T) {
 	testResourceName := "data.nsxt_ns_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccDataSourceNsxtNsServiceDeleteByName(serviceName)
@@ -48,7 +48,7 @@ func TestAccDataSourceNsxtNsService_systemOwned(t *testing.T) {
 	testResourceName := "data.nsxt_ns_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/nsxt/data_source_nsxt_switching_profile_test.go
+++ b/nsxt/data_source_nsxt_switching_profile_test.go
@@ -19,7 +19,7 @@ func TestAccDataSourceNsxtSwitchingProfile_basic(t *testing.T) {
 	testResourceName := "data.nsxt_switching_profile.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccDataSourceNsxtSwitchingProfileDeleteByName(profileName)

--- a/nsxt/data_source_nsxt_transport_zone_test.go
+++ b/nsxt/data_source_nsxt_transport_zone_test.go
@@ -15,7 +15,7 @@ func TestAccDataSourceNsxtTransportZone_basic(t *testing.T) {
 	testResourceName := "data.nsxt_transport_zone.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/nsxt/resource_nsxt_algorithm_type_ns_service_test.go
+++ b/nsxt/resource_nsxt_algorithm_type_ns_service_test.go
@@ -20,7 +20,7 @@ func TestAccResourceNsxtAlgorithmTypeNsService_basic(t *testing.T) {
 	updatedDestPort := "21"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXAlgServiceCheckDestroy(state, serviceName)
@@ -58,7 +58,7 @@ func TestAccResourceNsxtAlgorithmTypeNsService_importBasic(t *testing.T) {
 	serviceName := "test-nsx-alg-service"
 	testResourceName := "nsxt_algorithm_type_ns_service.test"
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXAlgServiceCheckDestroy(state, serviceName)

--- a/nsxt/resource_nsxt_dhcp_relay_profile_test.go
+++ b/nsxt/resource_nsxt_dhcp_relay_profile_test.go
@@ -18,7 +18,7 @@ func TestAccResourceNsxtDhcpRelayProfile_basic(t *testing.T) {
 	testResourceName := "nsxt_dhcp_relay_profile.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXDhcpRelayProfileCheckDestroy(state, prfName)
@@ -53,7 +53,7 @@ func TestAccResourceNsxtDhcpRelayProfile_importBasic(t *testing.T) {
 	testResourceName := "nsxt_dhcp_relay_profile.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXDhcpRelayProfileCheckDestroy(state, prfName)

--- a/nsxt/resource_nsxt_dhcp_relay_service_test.go
+++ b/nsxt/resource_nsxt_dhcp_relay_service_test.go
@@ -18,7 +18,7 @@ func TestAccResourceNsxtDhcpRelayService_basic(t *testing.T) {
 	testResourceName := "nsxt_dhcp_relay_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t); testAccOnlyLocalManager(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXDhcpRelayServiceCheckDestroy(state, prfName)
@@ -51,7 +51,7 @@ func TestAccResourceNsxtDhcpRelayService_importBasic(t *testing.T) {
 	testResourceName := "nsxt_dhcp_relay_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t); testAccOnlyLocalManager(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXDhcpRelayServiceCheckDestroy(state, prfName)

--- a/nsxt/resource_nsxt_dhcp_server_ip_pool_test.go
+++ b/nsxt/resource_nsxt_dhcp_server_ip_pool_test.go
@@ -27,7 +27,7 @@ func TestAccResourceNsxtDhcpServerIPPool_basic(t *testing.T) {
 	updatedLeaseTime := "1000000"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXDhcpServerIPPoolCheckDestroy(state, name)
@@ -94,7 +94,7 @@ func TestAccResourceNsxtDhcpServerIPPool_noOpts(t *testing.T) {
 	end2 := "1.1.1.160"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXDhcpServerIPPoolCheckDestroy(state, name)
@@ -140,7 +140,7 @@ func TestAccResourceNsxtDhcpServerIPPool_Import(t *testing.T) {
 	edgeClusterName := getEdgeClusterName()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXNATRuleCheckDestroy(state, name)

--- a/nsxt/resource_nsxt_dhcp_server_profile_test.go
+++ b/nsxt/resource_nsxt_dhcp_server_profile_test.go
@@ -19,7 +19,7 @@ func TestAccResourceNsxtDhcpServerProfile_basic(t *testing.T) {
 	edgeClusterName := getEdgeClusterName()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXDhcpServerProfileCheckDestroy(state, prfName)
@@ -55,7 +55,7 @@ func TestAccResourceNsxtDhcpServerProfile_importBasic(t *testing.T) {
 	edgeClusterName := getEdgeClusterName()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXDhcpServerProfileCheckDestroy(state, prfName)

--- a/nsxt/resource_nsxt_ether_type_ns_service_test.go
+++ b/nsxt/resource_nsxt_ether_type_ns_service_test.go
@@ -18,7 +18,7 @@ func TestAccResourceNsxtEtherTypeNsService_basic(t *testing.T) {
 	testResourceName := "nsxt_ether_type_ns_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXEtherServiceCheckDestroy(state, serviceName)
@@ -53,7 +53,7 @@ func TestAccResourceNsxtEtherTypeNsService_importBasic(t *testing.T) {
 	testResourceName := "nsxt_ether_type_ns_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXEtherServiceCheckDestroy(state, serviceName)

--- a/nsxt/resource_nsxt_firewall_section_test.go
+++ b/nsxt/resource_nsxt_firewall_section_test.go
@@ -21,7 +21,7 @@ func TestAccResourceNsxtFirewallSection_basic(t *testing.T) {
 	tos := ""
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXFirewallSectionCheckDestroy(state, sectionName)
@@ -76,7 +76,7 @@ target_id   = "${nsxt_ns_group.grp2.id}"
 }`
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXFirewallSectionCheckDestroy(state, sectionName)
@@ -123,7 +123,7 @@ func TestAccResourceNsxtFirewallSection_withRules(t *testing.T) {
 	ruleTos := ""
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXFirewallSectionCheckDestroy(state, sectionName)
@@ -173,7 +173,7 @@ func TestAccResourceNsxtFirewallSection_withRulesAndTags(t *testing.T) {
 	tos := ""
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXFirewallSectionCheckDestroy(state, sectionName)
@@ -237,7 +237,7 @@ applied_to {
 }`
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXFirewallSectionCheckDestroy(state, sectionName)
@@ -281,7 +281,7 @@ func TestAccResourceNsxtFirewallSection_ordered(t *testing.T) {
 	testResourceNames := [4]string{"nsxt_firewall_section.test1", "nsxt_firewall_section.test2", "nsxt_firewall_section.test3", "nsxt_firewall_section.test4"}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			for i := 0; i <= 3; i++ {
@@ -338,7 +338,12 @@ func TestAccResourceNsxtFirewallSection_edge(t *testing.T) {
 	testResourceName := "nsxt_firewall_section.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t); testAccNSXVersion(t, "2.4.0") },
+		PreCheck: func() {
+			testAccOnlyLocalManager(t)
+			testAccPreCheck(t)
+			testAccTestMP(t)
+			testAccNSXVersion(t, "2.4.0")
+		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXFirewallSectionCheckDestroy(state, sectionName)
@@ -383,7 +388,7 @@ func TestAccResourceNsxtFirewallSection_importBasic(t *testing.T) {
 	tos := string("")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXFirewallSectionCheckDestroy(state, sectionName)
@@ -409,7 +414,7 @@ func TestAccResourceNsxtFirewallSection_importWithRules(t *testing.T) {
 	tos := string("")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXFirewallSectionCheckDestroy(state, sectionName)
@@ -437,7 +442,7 @@ target_id = "${nsxt_ns_group.grp1.id}"
 }`
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXFirewallSectionCheckDestroy(state, sectionName)

--- a/nsxt/resource_nsxt_icmp_type_ns_service_test.go
+++ b/nsxt/resource_nsxt_icmp_type_ns_service_test.go
@@ -18,7 +18,7 @@ func TestAccResourceNsxtIcmpTypeNsService_basic(t *testing.T) {
 	testResourceName := "nsxt_icmp_type_ns_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXIcmpServiceCheckDestroy(state, serviceName)
@@ -57,7 +57,7 @@ func TestAccResourceNsxtIcmpTypeNsService_importBasic(t *testing.T) {
 	testResourceName := "nsxt_icmp_type_ns_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXIcmpServiceCheckDestroy(state, serviceName)

--- a/nsxt/resource_nsxt_igmp_type_ns_service_test.go
+++ b/nsxt/resource_nsxt_igmp_type_ns_service_test.go
@@ -18,7 +18,7 @@ func TestAccResourceNsxtIgmpTypeNsService_basic(t *testing.T) {
 	testResourceName := "nsxt_igmp_type_ns_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXIgmpServiceCheckDestroy(state, serviceName)
@@ -51,7 +51,7 @@ func TestAccResourceNsxtIgmpTypeNsService_importBasic(t *testing.T) {
 	testResourceName := "nsxt_igmp_type_ns_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXIgmpServiceCheckDestroy(state, serviceName)

--- a/nsxt/resource_nsxt_ip_block_subnet_test.go
+++ b/nsxt/resource_nsxt_ip_block_subnet_test.go
@@ -18,7 +18,12 @@ func TestAccResourceNsxtIpBlockSubnet_basic(t *testing.T) {
 	testResourceName := "nsxt_ip_block_subnet.test"
 	size := 16
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t); testAccNSXVersion(t, "2.4.0") },
+		PreCheck: func() {
+			testAccOnlyLocalManager(t)
+			testAccTestMP(t)
+			testAccPreCheck(t)
+			testAccNSXVersion(t, "2.4.0")
+		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXIpBlockSubnetCheckDestroy(state, name)
@@ -64,7 +69,12 @@ func TestAccResourceNsxtIpBlockSubnet_importBasic(t *testing.T) {
 	testResourceName := "nsxt_ip_block_subnet.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t); testAccNSXVersion(t, "2.4.0") },
+		PreCheck: func() {
+			testAccOnlyLocalManager(t)
+			testAccTestMP(t)
+			testAccPreCheck(t)
+			testAccNSXVersion(t, "2.4.0")
+		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXIpBlockSubnetCheckDestroy(state, name)

--- a/nsxt/resource_nsxt_ip_block_test.go
+++ b/nsxt/resource_nsxt_ip_block_test.go
@@ -19,7 +19,7 @@ func TestAccResourceNsxtIpBlock_basic(t *testing.T) {
 	cidr1 := "1.1.1.0/24"
 	cidr2 := "2.2.2.0/24"
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t); testAccOnlyLocalManager(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXIpBlockCheckDestroy(state, name)
@@ -65,7 +65,7 @@ func TestAccResourceNsxtIpBlock_importBasic(t *testing.T) {
 	testResourceName := "nsxt_ip_block.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t); testAccOnlyLocalManager(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXIpBlockCheckDestroy(state, name)

--- a/nsxt/resource_nsxt_ip_discovery_switching_profile_test.go
+++ b/nsxt/resource_nsxt_ip_discovery_switching_profile_test.go
@@ -18,7 +18,7 @@ func TestAccResourceNsxtIpDiscoverySwitchingProfile_basic(t *testing.T) {
 	testResourceName := "nsxt_ip_discovery_switching_profile.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXIpDiscoverySwitchingProfileCheckDestroy(state, name)
@@ -65,7 +65,7 @@ func TestAccResourceNsxtIpDiscoverySwitchingProfile_importBasic(t *testing.T) {
 	name := "test-nsx-application-profile"
 	testResourceName := "nsxt_ip_discovery_switching_profile.test"
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXIpDiscoverySwitchingProfileCheckDestroy(state, name)

--- a/nsxt/resource_nsxt_ip_pool_allocation_ip_address_test.go
+++ b/nsxt/resource_nsxt_ip_pool_allocation_ip_address_test.go
@@ -23,7 +23,12 @@ var testAccIPPoolName = "data.nsxt_ip_pool.acceptance_test"
 
 func TestAccResourceNsxtIPPoolAllocationIPAddress_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t); testAccEnvDefined(t, "NSXT_TEST_IP_POOL") },
+		PreCheck: func() {
+			testAccOnlyLocalManager(t)
+			testAccTestMP(t)
+			testAccPreCheck(t)
+			testAccEnvDefined(t, "NSXT_TEST_IP_POOL")
+		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXIPPoolAllocationIPAddressCheckDestroy(state)
@@ -44,7 +49,12 @@ func TestAccResourceNsxtIPPoolAllocationIPAddress_basic(t *testing.T) {
 func TestAccResourceNsxtIPPoolAllocationIPAddress_import(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t); testAccEnvDefined(t, "NSXT_TEST_IP_POOL"); testAccOnlyLocalManager(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccTestMP(t)
+			testAccEnvDefined(t, "NSXT_TEST_IP_POOL")
+			testAccOnlyLocalManager(t)
+		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXIPPoolAllocationIPAddressCheckDestroy(state)

--- a/nsxt/resource_nsxt_ip_pool_test.go
+++ b/nsxt/resource_nsxt_ip_pool_test.go
@@ -18,7 +18,7 @@ func TestAccResourceNsxtIpPool_basic(t *testing.T) {
 	testResourceName := "nsxt_ip_pool.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXIpPoolCheckDestroy(state, name)
@@ -58,7 +58,7 @@ func TestAccResourceNsxtIpPool_importBasic(t *testing.T) {
 	testResourceName := "nsxt_ip_pool.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXIpPoolCheckDestroy(state, name)

--- a/nsxt/resource_nsxt_ip_protocol_ns_service_test.go
+++ b/nsxt/resource_nsxt_ip_protocol_ns_service_test.go
@@ -18,7 +18,7 @@ func TestAccResourceNsxtIpProtocolNsService_basic(t *testing.T) {
 	testResourceName := "nsxt_ip_protocol_ns_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXIpProtocolServiceCheckDestroy(state, serviceName)
@@ -53,7 +53,7 @@ func TestAccResourceNsxtIpProtocolNsService_importBasic(t *testing.T) {
 	testResourceName := "nsxt_ip_protocol_ns_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXIpProtocolServiceCheckDestroy(state, serviceName)

--- a/nsxt/resource_nsxt_ip_set_test.go
+++ b/nsxt/resource_nsxt_ip_set_test.go
@@ -18,7 +18,7 @@ func TestAccResourceNsxtIpSet_basic(t *testing.T) {
 	testResourceName := "nsxt_ip_set.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXIpSetCheckDestroy(state, name)
@@ -53,7 +53,7 @@ func TestAccResourceNsxtIpSet_noName(t *testing.T) {
 	testResourceName := "nsxt_ip_set.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXIpSetCheckDestroy(state, name)
@@ -88,7 +88,7 @@ func TestAccResourceNsxtIpSet_importBasic(t *testing.T) {
 	testResourceName := "nsxt_ip_set.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXIpSetCheckDestroy(state, name)

--- a/nsxt/resource_nsxt_l4_port_set_ns_service_test.go
+++ b/nsxt/resource_nsxt_l4_port_set_ns_service_test.go
@@ -18,7 +18,7 @@ func TestAccResourceNsxtL4PortNsService_basic(t *testing.T) {
 	testResourceName := "nsxt_l4_port_set_ns_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXL4ServiceCheckDestroy(state, serviceName)
@@ -53,7 +53,7 @@ func TestAccResourceNsxtL4PortNsService_importBasic(t *testing.T) {
 	testResourceName := "nsxt_l4_port_set_ns_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXL4ServiceCheckDestroy(state, serviceName)

--- a/nsxt/resource_nsxt_lb_client_ssl_profile_test.go
+++ b/nsxt/resource_nsxt_lb_client_ssl_profile_test.go
@@ -18,7 +18,12 @@ func TestAccResourceNsxtLbClientSSLProfile_basic(t *testing.T) {
 	testResourceName := "nsxt_lb_client_ssl_profile.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
+		PreCheck: func() {
+			testAccOnlyLocalManager(t)
+			testAccTestMP(t)
+			testAccPreCheck(t)
+			testAccNSXVersion(t, "2.3.0")
+		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbClientSSLProfileCheckDestroy(state, name)
@@ -62,7 +67,12 @@ func TestAccResourceNsxtLbClientSSLProfile_importBasic(t *testing.T) {
 	name := "test"
 	testResourceName := "nsxt_lb_client_ssl_profile.test"
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
+		PreCheck: func() {
+			testAccOnlyLocalManager(t)
+			testAccTestMP(t)
+			testAccPreCheck(t)
+			testAccNSXVersion(t, "2.3.0")
+		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbClientSSLProfileCheckDestroy(state, name)

--- a/nsxt/resource_nsxt_lb_cookie_persistence_profile_test.go
+++ b/nsxt/resource_nsxt_lb_cookie_persistence_profile_test.go
@@ -22,7 +22,12 @@ func TestAccResourceNsxtLbCookiePersistenceProfile_basic(t *testing.T) {
 	updatedCookieName := "new_cookie"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
+		PreCheck: func() {
+			testAccOnlyLocalManager(t)
+			testAccTestMP(t)
+			testAccPreCheck(t)
+			testAccNSXVersion(t, "2.3.0")
+		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbCookiePersistenceProfileCheckDestroy(state, name)
@@ -72,7 +77,12 @@ func TestAccResourceNsxtLbCookiePersistenceProfile_insertMode(t *testing.T) {
 	updatedCookiePath := "/subfolder1"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
+		PreCheck: func() {
+			testAccOnlyLocalManager(t)
+			testAccTestMP(t)
+			testAccPreCheck(t)
+			testAccNSXVersion(t, "2.3.0")
+		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbCookiePersistenceProfileCheckDestroy(state, name)
@@ -126,7 +136,12 @@ func TestAccResourceNsxtLbCookiePersistenceProfile_importBasic(t *testing.T) {
 	name := "test-nsx-persistence-profile"
 	testResourceName := "nsxt_lb_cookie_persistence_profile.test"
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
+		PreCheck: func() {
+			testAccOnlyLocalManager(t)
+			testAccTestMP(t)
+			testAccPreCheck(t)
+			testAccNSXVersion(t, "2.3.0")
+		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbCookiePersistenceProfileCheckDestroy(state, name)

--- a/nsxt/resource_nsxt_lb_fast_tcp_application_profile_test.go
+++ b/nsxt/resource_nsxt_lb_fast_tcp_application_profile_test.go
@@ -24,7 +24,12 @@ func TestAccResourceNsxtLbFastTCPApplicationProfile_basic(t *testing.T) {
 	updatedMirroring := "false"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
+		PreCheck: func() {
+			testAccOnlyLocalManager(t)
+			testAccTestMP(t)
+			testAccPreCheck(t)
+			testAccNSXVersion(t, "2.3.0")
+		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbFastTCPApplicationProfileCheckDestroy(state, name)
@@ -61,7 +66,12 @@ func TestAccResourceNsxtLbFastTCPApplicationProfile_importBasic(t *testing.T) {
 	name := "test-nsx-application-profile"
 	testResourceName := "nsxt_lb_fast_tcp_application_profile.test"
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
+		PreCheck: func() {
+			testAccOnlyLocalManager(t)
+			testAccTestMP(t)
+			testAccPreCheck(t)
+			testAccNSXVersion(t, "2.3.0")
+		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbFastTCPApplicationProfileCheckDestroy(state, name)

--- a/nsxt/resource_nsxt_lb_fast_udp_application_profile_test.go
+++ b/nsxt/resource_nsxt_lb_fast_udp_application_profile_test.go
@@ -22,7 +22,12 @@ func TestAccResourceNsxtLbFastUDPApplicationProfile_basic(t *testing.T) {
 	updatedMirroring := "false"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
+		PreCheck: func() {
+			testAccOnlyLocalManager(t)
+			testAccTestMP(t)
+			testAccPreCheck(t)
+			testAccNSXVersion(t, "2.3.0")
+		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbFastUDPApplicationProfileCheckDestroy(state, name)
@@ -57,7 +62,12 @@ func TestAccResourceNsxtLbFastUDPApplicationProfile_importBasic(t *testing.T) {
 	name := "test-nsx-application-profile"
 	testResourceName := "nsxt_lb_fast_udp_application_profile.test"
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
+		PreCheck: func() {
+			testAccOnlyLocalManager(t)
+			testAccTestMP(t)
+			testAccPreCheck(t)
+			testAccNSXVersion(t, "2.3.0")
+		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbFastUDPApplicationProfileCheckDestroy(state, name)

--- a/nsxt/resource_nsxt_lb_http_application_profile_test.go
+++ b/nsxt/resource_nsxt_lb_http_application_profile_test.go
@@ -35,7 +35,12 @@ func TestAccResourceNsxtLbHTTPApplicationProfile_basic(t *testing.T) {
 	upNtlm := "false"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
+		PreCheck: func() {
+			testAccOnlyLocalManager(t)
+			testAccTestMP(t)
+			testAccPreCheck(t)
+			testAccNSXVersion(t, "2.3.0")
+		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbHTTPApplicationProfileCheckDestroy(state, name)
@@ -75,7 +80,12 @@ func TestAccResourceNsxtLbHTTPApplicationProfile_importBasic(t *testing.T) {
 	name := "test"
 	testResourceName := "nsxt_lb_http_application_profile.test"
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
+		PreCheck: func() {
+			testAccOnlyLocalManager(t)
+			testAccTestMP(t)
+			testAccPreCheck(t)
+			testAccNSXVersion(t, "2.3.0")
+		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbHTTPApplicationProfileCheckDestroy(state, name)

--- a/nsxt/resource_nsxt_lb_http_forwarding_rule_test.go
+++ b/nsxt/resource_nsxt_lb_http_forwarding_rule_test.go
@@ -21,7 +21,12 @@ func TestAccResourceNsxtLbHttpForwardingRule_basic(t *testing.T) {
 	updatedMatchType := "ENDS_WITH"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
+		PreCheck: func() {
+			testAccOnlyLocalManager(t)
+			testAccTestMP(t)
+			testAccPreCheck(t)
+			testAccNSXVersion(t, "2.3.0")
+		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbHTTPForwardingRuleCheckDestroy(state, name)
@@ -147,7 +152,12 @@ func TestAccResourceNsxtLbHttpForwardingRule_importBasic(t *testing.T) {
 	name := "test"
 	resourceName := "nsxt_lb_http_forwarding_rule.test"
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
+		PreCheck: func() {
+			testAccOnlyLocalManager(t)
+			testAccTestMP(t)
+			testAccPreCheck(t)
+			testAccNSXVersion(t, "2.3.0")
+		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbHTTPForwardingRuleCheckDestroy(state, name)

--- a/nsxt/resource_nsxt_lb_http_request_rewrite_rule_test.go
+++ b/nsxt/resource_nsxt_lb_http_request_rewrite_rule_test.go
@@ -21,7 +21,7 @@ func TestAccResourceNsxtLbHttpRequestRewriteRule_basic(t *testing.T) {
 	updatedMatchType := "ENDS_WITH"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbHTTPRequestRewriteRuleCheckDestroy(state, name)
@@ -175,7 +175,7 @@ func TestAccResourceNsxtLbHttpRequestRewriteRule_importBasic(t *testing.T) {
 	name := "test"
 	resourceName := "nsxt_lb_http_request_rewrite_rule.test"
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbHTTPRequestRewriteRuleCheckDestroy(state, name)

--- a/nsxt/resource_nsxt_lb_http_response_rewrite_rule_test.go
+++ b/nsxt/resource_nsxt_lb_http_response_rewrite_rule_test.go
@@ -21,7 +21,7 @@ func TestAccResourceNsxtLbHttpResponseRewriteRule_basic(t *testing.T) {
 	updatedMatchType := "REGEX"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbHTTPResponseRewriteRuleCheckDestroy(state, name)
@@ -141,7 +141,7 @@ func TestAccResourceNsxtLbHttpResponseRewriteRule_importBasic(t *testing.T) {
 	name := "test"
 	resourceName := "nsxt_lb_http_response_rewrite_rule.test"
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbHTTPResponseRewriteRuleCheckDestroy(state, name)

--- a/nsxt/resource_nsxt_lb_http_virtual_server_test.go
+++ b/nsxt/resource_nsxt_lb_http_virtual_server_test.go
@@ -25,7 +25,12 @@ func TestAccResourceNsxtLbHttpVirtualServer_basic(t *testing.T) {
 	updatedEnabled := "false"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
+		PreCheck: func() {
+			testAccOnlyLocalManager(t)
+			testAccTestMP(t)
+			testAccPreCheck(t)
+			testAccNSXVersion(t, "2.3.0")
+		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbHTTPVirtualServerCheckDestroy(state, name)
@@ -82,7 +87,12 @@ func TestAccResourceNsxtLbHttpVirtualServer_withRules(t *testing.T) {
 	updatedRule2 := "rule1"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
+		PreCheck: func() {
+			testAccOnlyLocalManager(t)
+			testAccTestMP(t)
+			testAccPreCheck(t)
+			testAccNSXVersion(t, "2.3.0")
+		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbHTTPVirtualServerCheckDestroy(state, name)
@@ -117,7 +127,12 @@ func TestAccResourceNsxtLbHttpVirtualServer_withSSL(t *testing.T) {
 	updatedDepth := "4"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
+		PreCheck: func() {
+			testAccOnlyLocalManager(t)
+			testAccTestMP(t)
+			testAccPreCheck(t)
+			testAccNSXVersion(t, "2.3.0")
+		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			testAccNSXDeleteCerts(t, testLbVirtualServerCertID, testLbVirtualServerClientCertID, testLbVirtualServerCaCertID)
@@ -188,7 +203,12 @@ func TestAccResourceNsxtLbHttpVirtualServer_importBasic(t *testing.T) {
 	name := "test"
 	resourceName := "nsxt_lb_http_virtual_server.test"
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
+		PreCheck: func() {
+			testAccOnlyLocalManager(t)
+			testAccTestMP(t)
+			testAccPreCheck(t)
+			testAccNSXVersion(t, "2.3.0")
+		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbHTTPVirtualServerCheckDestroy(state, name)

--- a/nsxt/resource_nsxt_lb_icmp_monitor_test.go
+++ b/nsxt/resource_nsxt_lb_icmp_monitor_test.go
@@ -25,7 +25,12 @@ func TestAccResourceNsxtLbIcmpMonitor_basic(t *testing.T) {
 	updatedCount := "5"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
+		PreCheck: func() {
+			testAccOnlyLocalManager(t)
+			testAccTestMP(t)
+			testAccPreCheck(t)
+			testAccNSXVersion(t, "2.3.0")
+		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbIcmpMonitorCheckDestroy(state, name)
@@ -69,7 +74,12 @@ func TestAccResourceNsxtLbIcmpMonitor_importBasic(t *testing.T) {
 	name := "test-nsx-monitor"
 	testResourceName := "nsxt_lb_icmp_monitor.test"
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
+		PreCheck: func() {
+			testAccOnlyLocalManager(t)
+			testAccTestMP(t)
+			testAccPreCheck(t)
+			testAccNSXVersion(t, "2.3.0")
+		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbIcmpMonitorCheckDestroy(state, name)

--- a/nsxt/resource_nsxt_lb_l4_monitor_test.go
+++ b/nsxt/resource_nsxt_lb_l4_monitor_test.go
@@ -42,7 +42,12 @@ func testAccResourceNsxtLbL4MonitorBasic(t *testing.T, protocol string) {
 	receive := "Server hello"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
+		PreCheck: func() {
+			testAccOnlyLocalManager(t)
+			testAccTestMP(t)
+			testAccPreCheck(t)
+			testAccNSXVersion(t, "2.3.0")
+		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbL4MonitorCheckDestroy(protocol, state, name)
@@ -88,7 +93,12 @@ func testAccResourceNsxtLbL4MonitorImport(t *testing.T, protocol string) {
 	name := "test-nsx-monitor"
 	testResourceName := fmt.Sprintf("nsxt_lb_%s_monitor.test", protocol)
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
+		PreCheck: func() {
+			testAccOnlyLocalManager(t)
+			testAccTestMP(t)
+			testAccPreCheck(t)
+			testAccNSXVersion(t, "2.3.0")
+		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbL4MonitorCheckDestroy(protocol, state, name)

--- a/nsxt/resource_nsxt_lb_l4_virtual_server_test.go
+++ b/nsxt/resource_nsxt_lb_l4_virtual_server_test.go
@@ -29,7 +29,7 @@ func testAccResourceNsxtLbL4VirtualServer(t *testing.T, protocol string) {
 	updatedMemberPort := "10098"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbL4VirtualServerCheckDestroy(state, protocol, name)
@@ -97,7 +97,7 @@ func testAccResourceNsxtLbL4VirtualServerImport(t *testing.T, protocol string) {
 	name := "test"
 	resourceName := fmt.Sprintf("nsxt_lb_%s_virtual_server.test", protocol)
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbL4VirtualServerCheckDestroy(state, protocol, name)

--- a/nsxt/resource_nsxt_lb_l7_monitor_test.go
+++ b/nsxt/resource_nsxt_lb_l7_monitor_test.go
@@ -41,7 +41,12 @@ func testAccResourceNsxtLbL7MonitorBasic(t *testing.T, protocol string) {
 	body2 := "YYYYYYYYYYYYYYYYYYY"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
+		PreCheck: func() {
+			testAccOnlyLocalManager(t)
+			testAccTestMP(t)
+			testAccPreCheck(t)
+			testAccNSXVersion(t, "2.3.0")
+		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbL7MonitorCheckDestroy(state, name)
@@ -86,7 +91,12 @@ func TestAccResourceNsxtLbHTTPSMonitor_withAuth(t *testing.T) {
 	testResourceName := "nsxt_lb_https_monitor.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
+		PreCheck: func() {
+			testAccOnlyLocalManager(t)
+			testAccTestMP(t)
+			testAccPreCheck(t)
+			testAccNSXVersion(t, "2.3.0")
+		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			testAccNSXDeleteCerts(t, testLbMonitorCertID, testLbMonitorClientCertID, testLbMonitorCaCertID)
@@ -120,7 +130,12 @@ func testAccResourceNsxtLbL7MonitorImport(t *testing.T, protocol string) {
 	name := "test-nsx-monitor"
 	testResourceName := fmt.Sprintf("nsxt_lb_%s_monitor.test", protocol)
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
+		PreCheck: func() {
+			testAccOnlyLocalManager(t)
+			testAccTestMP(t)
+			testAccPreCheck(t)
+			testAccNSXVersion(t, "2.3.0")
+		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbL7MonitorCheckDestroy(state, name)

--- a/nsxt/resource_nsxt_lb_passive_monitor_test.go
+++ b/nsxt/resource_nsxt_lb_passive_monitor_test.go
@@ -21,7 +21,12 @@ func TestAccResourceNsxtLbPassiveMonitor_basic(t *testing.T) {
 	updatedTimeout := "7"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
+		PreCheck: func() {
+			testAccOnlyLocalManager(t)
+			testAccTestMP(t)
+			testAccPreCheck(t)
+			testAccNSXVersion(t, "2.3.0")
+		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbPassiveMonitorCheckDestroy(state, name)
@@ -57,7 +62,12 @@ func TestAccResourceNsxtLbPassiveMonitor_importBasic(t *testing.T) {
 	name := "test-nsx-monitor"
 	testResourceName := "nsxt_lb_passive_monitor.test"
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
+		PreCheck: func() {
+			testAccOnlyLocalManager(t)
+			testAccTestMP(t)
+			testAccPreCheck(t)
+			testAccNSXVersion(t, "2.3.0")
+		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbPassiveMonitorCheckDestroy(state, name)

--- a/nsxt/resource_nsxt_lb_pool_test.go
+++ b/nsxt/resource_nsxt_lb_pool_test.go
@@ -24,7 +24,12 @@ func TestAccResourceNsxtLbPool_basic(t *testing.T) {
 	updatedSnatTranslationType := "SNAT_AUTO_MAP"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
+		PreCheck: func() {
+			testAccOnlyLocalManager(t)
+			testAccTestMP(t)
+			testAccPreCheck(t)
+			testAccNSXVersion(t, "2.3.0")
+		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbPoolCheckDestroy(state, name)
@@ -66,7 +71,12 @@ func TestAccResourceNsxtLbPool_withMonitors(t *testing.T) {
 	testResourceName := "nsxt_lb_pool.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
+		PreCheck: func() {
+			testAccOnlyLocalManager(t)
+			testAccTestMP(t)
+			testAccPreCheck(t)
+			testAccNSXVersion(t, "2.3.0")
+		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbPoolCheckDestroy(state, name)
@@ -114,7 +124,12 @@ func TestAccResourceNsxtLbPool_withIpSnat(t *testing.T) {
 	updatedIPAddress := "1.1.1.2-1.1.1.20"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
+		PreCheck: func() {
+			testAccOnlyLocalManager(t)
+			testAccTestMP(t)
+			testAccPreCheck(t)
+			testAccNSXVersion(t, "2.3.0")
+		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbPoolCheckDestroy(state, name)
@@ -165,7 +180,12 @@ func TestAccResourceNsxtLbPool_withMember(t *testing.T) {
 	memberIP := "1.1.1.1"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
+		PreCheck: func() {
+			testAccOnlyLocalManager(t)
+			testAccTestMP(t)
+			testAccPreCheck(t)
+			testAccNSXVersion(t, "2.3.0")
+		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbPoolCheckDestroy(state, name)
@@ -215,7 +235,12 @@ func TestAccResourceNsxtLbPool_withMemberGroup(t *testing.T) {
 	updatedPort := "60"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
+		PreCheck: func() {
+			testAccOnlyLocalManager(t)
+			testAccTestMP(t)
+			testAccPreCheck(t)
+			testAccNSXVersion(t, "2.3.0")
+		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbPoolCheckDestroy(state, name)
@@ -265,7 +290,12 @@ func TestAccResourceNsxtLbPool_importBasic(t *testing.T) {
 	name := "test-nsx-lb-pool"
 	testResourceName := "nsxt_lb_pool.test"
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
+		PreCheck: func() {
+			testAccOnlyLocalManager(t)
+			testAccTestMP(t)
+			testAccPreCheck(t)
+			testAccNSXVersion(t, "2.3.0")
+		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbPoolCheckDestroy(state, name)

--- a/nsxt/resource_nsxt_lb_server_ssl_profile_test.go
+++ b/nsxt/resource_nsxt_lb_server_ssl_profile_test.go
@@ -18,7 +18,12 @@ func TestAccResourceNsxtLbServerSSLProfile_basic(t *testing.T) {
 	testResourceName := "nsxt_lb_server_ssl_profile.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
+		PreCheck: func() {
+			testAccOnlyLocalManager(t)
+			testAccTestMP(t)
+			testAccPreCheck(t)
+			testAccNSXVersion(t, "2.3.0")
+		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbServerSSLProfileCheckDestroy(state, name)
@@ -58,7 +63,12 @@ func TestAccResourceNsxtLbServerSSLProfile_importBasic(t *testing.T) {
 	name := "test"
 	testResourceName := "nsxt_lb_server_ssl_profile.test"
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
+		PreCheck: func() {
+			testAccOnlyLocalManager(t)
+			testAccTestMP(t)
+			testAccPreCheck(t)
+			testAccNSXVersion(t, "2.3.0")
+		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbServerSSLProfileCheckDestroy(state, name)

--- a/nsxt/resource_nsxt_lb_service_test.go
+++ b/nsxt/resource_nsxt_lb_service_test.go
@@ -17,7 +17,7 @@ func TestAccResourceNsxtLbService_basic(t *testing.T) {
 	testResourceName := "nsxt_lb_service.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbServiceCheckDestroy(state, name)
@@ -60,7 +60,7 @@ func TestAccResourceNsxtLbService_withServers(t *testing.T) {
 	updatedLogLevel := "INFO"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbServiceCheckDestroy(state, name)
@@ -99,7 +99,7 @@ func TestAccResourceNsxtLbService_importBasic(t *testing.T) {
 	testResourceName := "nsxt_lb_service.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbServiceCheckDestroy(state, name)

--- a/nsxt/resource_nsxt_lb_source_ip_persistence_profile_test.go
+++ b/nsxt/resource_nsxt_lb_source_ip_persistence_profile_test.go
@@ -20,7 +20,7 @@ func TestAccResourceNsxtLbSourceIpPersistenceProfile_basic(t *testing.T) {
 	updatedTimeout := "200"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbSourceIPPersistenceProfileCheckDestroy(state, name)
@@ -60,7 +60,7 @@ func TestAccResourceNsxtLbSourceIpPersistenceProfile_importBasic(t *testing.T) {
 	name := "test-nsx-persistence-profile"
 	testResourceName := "nsxt_lb_source_ip_persistence_profile.test"
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbSourceIPPersistenceProfileCheckDestroy(state, name)

--- a/nsxt/resource_nsxt_logical_dhcp_port_test.go
+++ b/nsxt/resource_nsxt_logical_dhcp_port_test.go
@@ -19,7 +19,7 @@ func TestAccResourceNsxtLogicalDhcpPort_basic(t *testing.T) {
 	edgeClusterName := getEdgeClusterName()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLogicalPortCheckDestroy(state, portName)
@@ -60,7 +60,7 @@ func TestAccResourceNsxtLogicalDhcpPort_importBasic(t *testing.T) {
 	edgeClusterName := getEdgeClusterName()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLogicalPortCheckDestroy(state, portName)

--- a/nsxt/resource_nsxt_logical_dhcp_server_test.go
+++ b/nsxt/resource_nsxt_logical_dhcp_server_test.go
@@ -26,7 +26,7 @@ func TestAccResourceNsxtLogicalDhcpServer_basic(t *testing.T) {
 	ip5 := "1.1.1.23"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLogicalDhcpServerCheckDestroy(state, prfName)
@@ -86,7 +86,7 @@ func TestAccResourceNsxtLogicalDhcpServer_noOpts(t *testing.T) {
 	ip4 := "1.1.1.22"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLogicalDhcpServerCheckDestroy(state, prfName)
@@ -132,7 +132,7 @@ func TestAccResourceNsxtLogicalDhcpServer_importBasic(t *testing.T) {
 	edgeClusterName := getEdgeClusterName()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLogicalDhcpServerCheckDestroy(state, prfName)

--- a/nsxt/resource_nsxt_logical_port_test.go
+++ b/nsxt/resource_nsxt_logical_port_test.go
@@ -19,7 +19,7 @@ func TestAccResourceNsxtLogicalPort_basic(t *testing.T) {
 	transportZoneName := getOverlayTransportZoneName()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLogicalPortCheckDestroy(state, portName)
@@ -58,7 +58,7 @@ func TestAccResourceNsxtLogicalPort_withProfiles(t *testing.T) {
 	profileType := "QosSwitchingProfile"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			// Verify that the LP was deleted
@@ -109,7 +109,7 @@ func TestAccResourceNsxtLogicalPort_withNSGroup(t *testing.T) {
 	transportZoneName := getOverlayTransportZoneName()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLogicalPortCheckDestroy(state, portName)
@@ -138,7 +138,7 @@ func TestAccResourceNsxtLogicalPort_importBasic(t *testing.T) {
 	transportZoneName := getOverlayTransportZoneName()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLogicalPortCheckDestroy(state, portName)

--- a/nsxt/resource_nsxt_logical_router_centralized_service_port_test.go
+++ b/nsxt/resource_nsxt_logical_router_centralized_service_port_test.go
@@ -21,7 +21,12 @@ func TestAccResourceNsxtLogicalRouterCentralizedServicePort_basic(t *testing.T) 
 	routerObj := "nsxt_logical_tier1_router.rtr1.id"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
+		PreCheck: func() {
+			testAccOnlyLocalManager(t)
+			testAccTestMP(t)
+			testAccPreCheck(t)
+			testAccNSXVersion(t, "2.3.0")
+		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLogicalRouterCentralizedServicePortCheckDestroy(state, portName)
@@ -66,7 +71,12 @@ func TestAccResourceNsxtLogicalRouterCentralizedServicePort_onTier0(t *testing.T
 	routerObj := "data.nsxt_logical_tier0_router.tier0rtr.id"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
+		PreCheck: func() {
+			testAccOnlyLocalManager(t)
+			testAccTestMP(t)
+			testAccPreCheck(t)
+			testAccNSXVersion(t, "2.3.0")
+		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLogicalRouterCentralizedServicePortCheckDestroy(state, portName)
@@ -110,7 +120,12 @@ func TestAccResourceNsxtLogicalRouterCentralizedServicePort_importBasic(t *testi
 	routerObj := "nsxt_logical_tier1_router.rtr1.id"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
+		PreCheck: func() {
+			testAccOnlyLocalManager(t)
+			testAccTestMP(t)
+			testAccPreCheck(t)
+			testAccNSXVersion(t, "2.3.0")
+		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLogicalRouterCentralizedServicePortCheckDestroy(state, portName)
@@ -135,7 +150,12 @@ func TestAccResourceNsxtLogicalRouterCentralizedServicePort_onTier1(t *testing.T
 	edgeClusterName := getEdgeClusterName()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t); testAccNSXVersion(t, "2.3.0") },
+		PreCheck: func() {
+			testAccOnlyLocalManager(t)
+			testAccTestMP(t)
+			testAccPreCheck(t)
+			testAccNSXVersion(t, "2.3.0")
+		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLogicalRouterCentralizedServicePortCheckDestroy(state, portName)

--- a/nsxt/resource_nsxt_logical_router_downlink_port_test.go
+++ b/nsxt/resource_nsxt_logical_router_downlink_port_test.go
@@ -20,7 +20,7 @@ func TestAccResourceNsxtLogicalRouterDownlinkPort_basic(t *testing.T) {
 	edgeClusterName := getEdgeClusterName()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLogicalRouterDownlinkPortCheckDestroy(state, portName)
@@ -74,7 +74,7 @@ func TestAccResourceNsxtLogicalRouterDownlinkPort_withRelay(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLogicalRouterDownlinkPortCheckDestroy(state, portName)
@@ -119,7 +119,7 @@ func TestAccResourceNsxtLogicalRouterDownlinkPort_importBasic(t *testing.T) {
 	edgeClusterName := getEdgeClusterName()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLogicalRouterDownlinkPortCheckDestroy(state, portName)

--- a/nsxt/resource_nsxt_logical_router_link_port_on_tier0_test.go
+++ b/nsxt/resource_nsxt_logical_router_link_port_on_tier0_test.go
@@ -19,7 +19,7 @@ func TestAccResourceNsxtLogicalRouterLinkPortOnTier0_basic(t *testing.T) {
 	testResourceName := "nsxt_logical_router_link_port_on_tier0.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLogicalRouterLinkPortOnTier0CheckDestroy(state, name)
@@ -53,7 +53,7 @@ func TestAccResourceNsxtLogicalRouterLinkPortOnTier0_importBasic(t *testing.T) {
 	testResourceName := "nsxt_logical_router_link_port_on_tier0.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLogicalRouterLinkPortOnTier0CheckDestroy(state, name)

--- a/nsxt/resource_nsxt_logical_router_link_port_on_tier1_test.go
+++ b/nsxt/resource_nsxt_logical_router_link_port_on_tier1_test.go
@@ -20,7 +20,7 @@ func TestAccResourceNsxtLogicalRouterLinkPortOnTier1_basic(t *testing.T) {
 	testResourceName := "nsxt_logical_router_link_port_on_tier1.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLogicalRouterLinkPortOnTier1CheckDestroy(state, name)
@@ -59,7 +59,7 @@ func TestAccResourceNsxtLogicalRouterLinkPortOnTier1_importBasic(t *testing.T) {
 	testResourceName := "nsxt_logical_router_link_port_on_tier1.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLogicalRouterLinkPortOnTier1CheckDestroy(state, name)

--- a/nsxt/resource_nsxt_logical_switch_test.go
+++ b/nsxt/resource_nsxt_logical_switch_test.go
@@ -23,7 +23,7 @@ func TestAccResourceNsxtLogicalSwitch_basic(t *testing.T) {
 	transportZoneName := getOverlayTransportZoneName()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLogicalSwitchCheckDestroy(state, switchName, "nsxt_logical_switch")
@@ -76,7 +76,7 @@ func TestAccResourceNsxtLogicalSwitch_vlan(t *testing.T) {
 	replicationMode := ""
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLogicalSwitchCheckDestroy(state, switchName, "nsxt_logical_switch")
@@ -117,7 +117,7 @@ func TestAccResourceNsxtLogicalSwitch_withProfiles(t *testing.T) {
 	profileType := "SwitchSecuritySwitchingProfile"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			// Verify that the LS was deleted
@@ -172,7 +172,7 @@ func TestAccResourceNsxtLogicalSwitch_withMacPool(t *testing.T) {
 	replicationMode := "MTEP"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLogicalSwitchCheckDestroy(state, switchName, "nsxt_logical_switch")
@@ -207,7 +207,7 @@ func TestAccResourceNsxtLogicalSwitch_importBasic(t *testing.T) {
 	transportZoneName := getOverlayTransportZoneName()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLogicalSwitchCheckDestroy(state, switchName, "nsxt_logical_switch")

--- a/nsxt/resource_nsxt_logical_tier0_router_test.go
+++ b/nsxt/resource_nsxt_logical_tier0_router_test.go
@@ -20,7 +20,7 @@ func TestAccResourceNsxtLogicalTier0Router_basic(t *testing.T) {
 	edgeClusterName := getEdgeClusterName()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLogicalTier0RouterCheckDestroy(state, name)
@@ -58,7 +58,7 @@ func TestAccResourceNsxtLogicalTier0Router_active(t *testing.T) {
 	edgeClusterName := getEdgeClusterName()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLogicalTier0RouterCheckDestroy(state, name)
@@ -95,7 +95,7 @@ func TestAccResourceNsxtLogicalTier0Router_importBasic(t *testing.T) {
 	edgeClusterName := getEdgeClusterName()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLogicalTier0RouterCheckDestroy(state, name)

--- a/nsxt/resource_nsxt_logical_tier1_router_test.go
+++ b/nsxt/resource_nsxt_logical_tier1_router_test.go
@@ -20,7 +20,7 @@ func TestAccResourceNsxtLogicalTier1Router_basic(t *testing.T) {
 	edgeClusterName := getEdgeClusterName()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLogicalTier1RouterCheckDestroy(state, name)
@@ -69,7 +69,7 @@ func TestAccResourceNsxtLogicalTier1Router_importBasic(t *testing.T) {
 	edgeClusterName := getEdgeClusterName()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLogicalTier1RouterCheckDestroy(state, name)

--- a/nsxt/resource_nsxt_mac_management_switching_profile_test.go
+++ b/nsxt/resource_nsxt_mac_management_switching_profile_test.go
@@ -20,7 +20,7 @@ func TestAccResourceNsxtMacManagementSwitchingProfile_basic(t *testing.T) {
 	updatedLimit := "101"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t); testAccOnlyLocalManager(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXMacManagementSwitchingProfileCheckDestroy(state, name)
@@ -70,7 +70,7 @@ func TestAccResourceNsxtMacManagementSwitchingProfile_importBasic(t *testing.T) 
 	name := "test-nsx-application-profile"
 	testResourceName := "nsxt_mac_management_switching_profile.test"
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t); testAccOnlyLocalManager(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXMacManagementSwitchingProfileCheckDestroy(state, name)

--- a/nsxt/resource_nsxt_nat_rule_test.go
+++ b/nsxt/resource_nsxt_nat_rule_test.go
@@ -20,7 +20,7 @@ func TestAccResourceNsxtNatRule_snat(t *testing.T) {
 	edgeClusterName := getEdgeClusterName()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXNATRuleCheckDestroy(state, ruleName)
@@ -71,7 +71,7 @@ func TestAccResourceNsxtNatRule_snatImport(t *testing.T) {
 	edgeClusterName := getEdgeClusterName()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXNATRuleCheckDestroy(state, ruleName)
@@ -96,7 +96,7 @@ func TestAccResourceNsxtNatRule_dnat(t *testing.T) {
 	edgeClusterName := getEdgeClusterName()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXNATRuleCheckDestroy(state, ruleName)
@@ -143,7 +143,7 @@ func TestAccResourceNsxtNatRule_dnatImport(t *testing.T) {
 	edgeClusterName := getEdgeClusterName()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXNATRuleCheckDestroy(state, ruleName)
@@ -167,7 +167,12 @@ func TestAccResourceNsxtNatRule_noNnat(t *testing.T) {
 	edgeClusterName := getEdgeClusterName()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t); testAccNSXVersionLessThan(t, "3.0.0") },
+		PreCheck: func() {
+			testAccOnlyLocalManager(t)
+			testAccTestMP(t)
+			testAccPreCheck(t)
+			testAccNSXVersionLessThan(t, "3.0.0")
+		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXNATRuleCheckDestroy(state, ruleName)

--- a/nsxt/resource_nsxt_ns_group_test.go
+++ b/nsxt/resource_nsxt_ns_group_test.go
@@ -18,7 +18,7 @@ func TestAccResourceNsxtNSGroup_basic(t *testing.T) {
 	testResourceName := "nsxt_ns_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXNSGroupCheckDestroy(state, grpName)
@@ -54,7 +54,7 @@ func TestAccResourceNsxtNSGroup_nested(t *testing.T) {
 	testResourceName := "nsxt_ns_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXNSGroupCheckDestroy(state, grpName)
@@ -89,7 +89,7 @@ func TestAccResourceNsxtNSGroup_withCriteria(t *testing.T) {
 	transportZoneName := getOverlayTransportZoneName()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXNSGroupCheckDestroy(state, grpName)
@@ -124,7 +124,7 @@ func TestAccResourceNsxtNSGroup_importBasic(t *testing.T) {
 	testResourceName := "nsxt_ns_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXNSGroupCheckDestroy(state, grpName)
@@ -147,7 +147,7 @@ func TestAccResourceNsxtNSGroup_importWithCriteria(t *testing.T) {
 	testResourceName := "nsxt_ns_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXNSGroupCheckDestroy(state, grpName)

--- a/nsxt/resource_nsxt_ns_service_group_test.go
+++ b/nsxt/resource_nsxt_ns_service_group_test.go
@@ -18,7 +18,7 @@ func TestAccResourceNsxtNsServiceGroup_basic(t *testing.T) {
 	testResourceName := "nsxt_ns_service_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t); testAccOnlyLocalManager(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXServiceGroupCheckDestroy(state, serviceName)
@@ -53,7 +53,7 @@ func TestAccResourceNsxtNsServiceGroup_importBasic(t *testing.T) {
 	testResourceName := "nsxt_ns_service_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t); testAccOnlyLocalManager(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXServiceGroupCheckDestroy(state, serviceName)

--- a/nsxt/resource_nsxt_qos_switching_profile_test.go
+++ b/nsxt/resource_nsxt_qos_switching_profile_test.go
@@ -22,7 +22,7 @@ func TestAccResourceNsxtQosSwitchingProfile_basic(t *testing.T) {
 	updatedPeak := "400"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t); testAccOnlyLocalManager(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXQosSwitchingProfileCheckDestroy(state, name)
@@ -85,7 +85,7 @@ func TestAccResourceNsxtQosSwitchingProfile_importBasic(t *testing.T) {
 	name := "test-nsx-application-profile"
 	testResourceName := "nsxt_qos_switching_profile.test"
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t); testAccOnlyLocalManager(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXQosSwitchingProfileCheckDestroy(state, name)

--- a/nsxt/resource_nsxt_spoofguard_switching_profile_test.go
+++ b/nsxt/resource_nsxt_spoofguard_switching_profile_test.go
@@ -18,7 +18,7 @@ func TestAccResourceNsxtSpoofGuardSwitchingProfile_basic(t *testing.T) {
 	testResourceName := "nsxt_spoofguard_switching_profile.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t); testAccOnlyLocalManager(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXSpoofguardSwitchingProfileCheckDestroy(state, name)
@@ -59,7 +59,7 @@ func TestAccResourceNsxtSpoofGuardSwitchingProfile_importBasic(t *testing.T) {
 	name := "test-nsx-application-profile"
 	testResourceName := "nsxt_spoofguard_switching_profile.test"
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t); testAccOnlyLocalManager(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXSpoofguardSwitchingProfileCheckDestroy(state, name)

--- a/nsxt/resource_nsxt_static_route_test.go
+++ b/nsxt/resource_nsxt_static_route_test.go
@@ -29,7 +29,7 @@ func testAccResourceNsxtStaticRoute(t *testing.T, tier string) {
 	transportZoneName := getOverlayTransportZoneName()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXStaticRouteCheckDestroy(state, name)
@@ -80,7 +80,7 @@ func testAccResourceNsxtStaticRouteImport(t *testing.T, tier string) {
 	transportZoneName := getOverlayTransportZoneName()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXStaticRouteCheckDestroy(state, name)

--- a/nsxt/resource_nsxt_switch_security_switching_profile_test.go
+++ b/nsxt/resource_nsxt_switch_security_switching_profile_test.go
@@ -20,7 +20,7 @@ func TestAccResourceNsxtSwitchSecuritySwitchingProfile_basic(t *testing.T) {
 	updatedLimit := "400"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t); testAccOnlyLocalManager(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccTestMP(t); testAccOnlyLocalManager(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXSwitchSecuritySwitchingProfileCheckDestroy(state, name)
@@ -81,7 +81,7 @@ func TestAccResourceNsxtSwitchSecuritySwitchingProfile_importBasic(t *testing.T)
 	name := "test-nsx-application-profile"
 	testResourceName := "nsxt_switch_security_switching_profile.test"
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t); testAccOnlyLocalManager(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccTestMP(t); testAccOnlyLocalManager(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXSwitchSecuritySwitchingProfileCheckDestroy(state, name)

--- a/nsxt/resource_nsxt_vlan_logical_switch_test.go
+++ b/nsxt/resource_nsxt_vlan_logical_switch_test.go
@@ -23,7 +23,7 @@ func TestAccResourceNsxtVlanLogicalSwitch_basic(t *testing.T) {
 	updatedvlan := "2"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccTestMP(t); testAccOnlyLocalManager(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLogicalSwitchCheckDestroy(state, switchName, "nsxt_vlan_logical_switch")
@@ -64,7 +64,7 @@ func TestAccResourceNsxtVlanLogicalSwitch_withProfiles(t *testing.T) {
 	profileType := "SwitchSecuritySwitchingProfile"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccTestMP(t); testAccOnlyLocalManager(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			// Verify that the LS was deleted
@@ -118,7 +118,7 @@ func TestAccResourceNsxtVlanLogicalSwitch_withMacPool(t *testing.T) {
 	novlan := "0"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccTestMP(t); testAccOnlyLocalManager(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLogicalSwitchCheckDestroy(state, switchName, "nsxt_vlan_logical_switch")
@@ -151,7 +151,7 @@ func TestAccResourceNsxtVlanLogicalSwitch_importBasic(t *testing.T) {
 	transportZoneName := getVlanTransportZoneName()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccTestMP(t); testAccOnlyLocalManager(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLogicalSwitchCheckDestroy(state, switchName, "nsxt_vlan_logical_switch")

--- a/nsxt/resource_nsxt_vm_tags_test.go
+++ b/nsxt/resource_nsxt_vm_tags_test.go
@@ -18,7 +18,12 @@ func TestAccResourceNsxtVMTags_basic(t *testing.T) {
 	vmID := getTestVMID()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t); testAccEnvDefined(t, "NSXT_TEST_VM_ID"); testAccOnlyLocalManager(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccTestMP(t)
+			testAccEnvDefined(t, "NSXT_TEST_VM_ID")
+			testAccOnlyLocalManager(t)
+		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXVMTagsCheckDestroy(state)
@@ -52,7 +57,12 @@ func TestAccResourceNsxtVMTags_import_basic(t *testing.T) {
 	vmID := getTestVMID()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t); testAccEnvDefined(t, "NSXT_TEST_VM_ID"); testAccOnlyLocalManager(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccTestMP(t)
+			testAccEnvDefined(t, "NSXT_TEST_VM_ID")
+			testAccOnlyLocalManager(t)
+		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXVMTagsCheckDestroy(state)

--- a/nsxt/utils_test.go
+++ b/nsxt/utils_test.go
@@ -145,6 +145,12 @@ func testAccNSXGlobalManagerSitePrecheck(t *testing.T) {
 	}
 }
 
+func testAccTestMP(t *testing.T) {
+	if os.Getenv("NSXT_TEST_MP") != "true" && os.Getenv("NSXT_TEST_MP") != "1" {
+		t.Skipf("To run MP test suite, please enable NSXT_TEST_MP in your environment.")
+	}
+}
+
 // Create and delete CA and client cert for various tests
 func testAccNSXCreateCert(t *testing.T, name string, certPem string, certPK string, certType string) string {
 	nsxClient, err := testAccGetClient()


### PR DESCRIPTION
Since legacy MP resources and data sources are rarely modified and
underlying APIs are mostly frozen, we can save time by avoiding
MP tests in most acc test runs. Full test suite will be available
with setting NSXT_TEST_MP to true.