### PR TITLE
Do not modify policy LB VS rules on VS update

### DIFF
--- a/nsxt/provider.go
+++ b/nsxt/provider.go
@@ -533,6 +533,18 @@ func configurePolicyConnectorData(d *schema.ResourceData, clients *nsxtClients) 
 	return nil
 }
 
+type enablePartialPatchHeaderProcessor struct {
+}
+
+func newEnablePartialPatchHeaderProcessor() *enablePartialPatchHeaderProcessor {
+	return &enablePartialPatchHeaderProcessor{}
+}
+
+func (processor enablePartialPatchHeaderProcessor) Process(req *http.Request) error {
+	req.Header.Set("nsx-enable-partial-patch", "true")
+	return nil
+}
+
 type remoteBasicAuthHeaderProcessor struct {
 }
 

--- a/nsxt/resource_nsxt_policy_lb_virtual_server.go
+++ b/nsxt/resource_nsxt_policy_lb_virtual_server.go
@@ -514,6 +514,9 @@ func resourceNsxtPolicyLBVirtualServerRead(d *schema.ResourceData, m interface{}
 
 func resourceNsxtPolicyLBVirtualServerUpdate(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
+	// NOTE: Partial patch is required to respect rules that might have
+	// been added manually
+	connector.AddRequestProcessor(newEnablePartialPatchHeaderProcessor())
 	client := infra.NewDefaultLbVirtualServersClient(connector)
 	if client == nil {
 		return policyResourceNotSupportedError()


### PR DESCRIPTION
As opposed to FW objects, LB objects on NSX do not support partial
patch updates by default. This leads to LB virtual server deleting
existing rules on unrelated terraform config update. To fix this,
enable partial patch by adding corresponding header.