### PR TITLE
Assign UUID to ha vip resource upon import

### DIFF
--- a/nsxt/resource_nsxt_policy_tier0_gateway_ha_vip_config.go
+++ b/nsxt/resource_nsxt_policy_tier0_gateway_ha_vip_config.go
@@ -359,7 +359,7 @@ func resourceNsxtPolicyTier0GatewayHAVipConfigImport(d *schema.ResourceData, m i
 
 	d.Set("tier0_id", tier0ID)
 	d.Set("locale_service_id", localeServiceID)
-	d.SetId(localeServiceID)
+	d.SetId(newUUID())
 
 	return []*schema.ResourceData{d}, nil
 }


### PR DESCRIPTION
This is for sake of consistency with non-imported instances.