### PR TITLE
Introduce provider_info data source

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -2,6 +2,7 @@ TEST?=$$(go list ./... |grep -v 'vendor')
 GOFMT_FILES?=$$(find . -name '*.go' |grep -v vendor)
 WEBSITE_REPO=github.com/hashicorp/terraform-website
 PKG_NAME=nsxt
+GIT_COMMIT=$$(git rev-list -1 HEAD)
 
 default: build
 
@@ -11,7 +12,7 @@ tools:
 	GO111MODULE=on go install -mod=mod github.com/katbyte/terrafmt
 
 build: fmtcheck
-	go install
+	go install -ldflags "-X github.com/vmware/terraform-provider-nsxt/nsxt.GitCommit=$(GIT_COMMIT)"
 
 test: fmtcheck
 	go test -i $(TEST) || exit 1

--- a/nsxt/data_source_nsxt_provider_info.go
+++ b/nsxt/data_source_nsxt_provider_info.go
@@ -1,0 +1,38 @@
+/* Copyright © 2020 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: MPL-2.0 */
+
+package nsxt
+
+import (
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+var GitCommit string
+
+func dataSourceNsxtProviderInfo() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceNsxtProviderInfoRead,
+
+		Schema: map[string]*schema.Schema{
+			"commit": {
+				Type:        schema.TypeString,
+				Description: "Latest commit hash",
+				Computed:    true,
+			},
+			"date": {
+				Type:        schema.TypeString,
+				Description: "Date compiled",
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func dataSourceNsxtProviderInfoRead(d *schema.ResourceData, m interface{}) error {
+	d.SetId("nsxt")
+	d.Set("commit", GitCommit)
+	d.Set("date", time.Now().Format(time.Stamp))
+	return nil
+}

--- a/nsxt/provider.go
+++ b/nsxt/provider.go
@@ -170,6 +170,7 @@ func Provider() *schema.Provider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
+			"nsxt_provider_info":                   dataSourceNsxtProviderInfo(),
 			"nsxt_transport_zone":                  dataSourceNsxtTransportZone(),
 			"nsxt_switching_profile":               dataSourceNsxtSwitchingProfile(),
 			"nsxt_logical_tier0_router":            dataSourceNsxtLogicalTier0Router(),


### PR DESCRIPTION
This data source exposes commit and build date for the provider, in
order to ease testing effort. This data source is for internal use
and thus not documented.