### PR TITLE
Switch to randomized test names with fixed prefix

### DIFF
--- a/nsxt/data_source_nsxt_firewall_section_test.go
+++ b/nsxt/data_source_nsxt_firewall_section_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestAccDataSourceNsxtFirewallSection_basic(t *testing.T) {
-	name := "terraform_ds_test_firewall_section"
+	name := getAccTestDataSourceName()
 	testResourceName := "data.nsxt_firewall_section.test"
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/nsxt/data_source_nsxt_logical_tier1_router_test.go
+++ b/nsxt/data_source_nsxt_logical_tier1_router_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestAccDataSourceNsxtLogicalTier1Router_basic(t *testing.T) {
-	routerName := "terraform_ds_test_tier1"
+	routerName := getAccTestDataSourceName()
 	testResourceName := "data.nsxt_logical_tier1_router.test"
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/nsxt/data_source_nsxt_ns_group_test.go
+++ b/nsxt/data_source_nsxt_ns_group_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestAccDataSourceNsxtNsGroup_basic(t *testing.T) {
-	groupName := "terraform_ds_test_ns_group"
+	groupName := getAccTestDataSourceName()
 	testResourceName := "data.nsxt_ns_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/nsxt/data_source_nsxt_ns_service_test.go
+++ b/nsxt/data_source_nsxt_ns_service_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestAccDataSourceNsxtNsService_basic(t *testing.T) {
-	serviceName := "terraform_ds_test_ns_service"
+	serviceName := getAccTestDataSourceName()
 	testResourceName := "data.nsxt_ns_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/nsxt/data_source_nsxt_policy_gateway_policy_test.go
+++ b/nsxt/data_source_nsxt_policy_gateway_policy_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestAccDataSourceNsxtPolicyGatewayPolicy_basic(t *testing.T) {
-	name := "terraform_ds_test"
+	name := getAccTestDataSourceName()
 	category := "LocalGatewayRules"
 	testResourceName := "data.nsxt_policy_gateway_policy.test"
 	withCategory := fmt.Sprintf(`category = "%s"`, category)

--- a/nsxt/data_source_nsxt_policy_gateway_qos_profile_test.go
+++ b/nsxt/data_source_nsxt_policy_gateway_qos_profile_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestAccDataSourceNsxtPolicyGatewayQosProfile_basic(t *testing.T) {
-	name := "terraform_ds_test"
+	name := getAccTestDataSourceName()
 	testResourceName := "data.nsxt_policy_gateway_qos_profile.test"
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/nsxt/data_source_nsxt_policy_group_test.go
+++ b/nsxt/data_source_nsxt_policy_group_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestAccDataSourceNsxtPolicyGroup_basic(t *testing.T) {
-	name := "terraform_ds_test"
+	name := getAccTestDataSourceName()
 	domain := "default"
 	testResourceName := "data.nsxt_policy_group.test"
 
@@ -46,7 +46,7 @@ func TestAccDataSourceNsxtPolicyGroup_basic(t *testing.T) {
 }
 
 func TestAccDataSourceNsxtPolicyGroup_withSite(t *testing.T) {
-	name := "terraform_gm_ds_test"
+	name := getAccTestDataSourceName()
 	domain := getTestSiteName()
 	testResourceName := "data.nsxt_policy_group.test"
 

--- a/nsxt/data_source_nsxt_policy_ip_block_test.go
+++ b/nsxt/data_source_nsxt_policy_ip_block_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestAccDataSourceNsxtPolicyIpBlock_basic(t *testing.T) {
-	name := "terraform_ds_test"
+	name := getAccTestDataSourceName()
 	testResourceName := "data.nsxt_policy_ip_block.test"
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/nsxt/data_source_nsxt_policy_ip_pool_test.go
+++ b/nsxt/data_source_nsxt_policy_ip_pool_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestAccDataSourceNsxtPolicyIpPool_basic(t *testing.T) {
-	name := "terraform_ds_test"
+	name := getAccTestDataSourceName()
 	testResourceName := "data.nsxt_policy_ip_pool.test"
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/nsxt/data_source_nsxt_policy_ipv6_dad_profile_test.go
+++ b/nsxt/data_source_nsxt_policy_ipv6_dad_profile_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestAccDataSourceNsxtPolicyIpv6DadProfile_basic(t *testing.T) {
-	name := "terraform_ds_test"
+	name := getAccTestDataSourceName()
 	testResourceName := "data.nsxt_policy_ipv6_dad_profile.test"
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/nsxt/data_source_nsxt_policy_ipv6_ndra_profile_test.go
+++ b/nsxt/data_source_nsxt_policy_ipv6_ndra_profile_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestAccDataSourceNsxtPolicyIpv6NdraProfile_basic(t *testing.T) {
-	name := "terraform_ds_test"
+	name := getAccTestDataSourceName()
 	testResourceName := "data.nsxt_policy_ipv6_ndra_profile.test"
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/nsxt/data_source_nsxt_policy_lb_app_profile_test.go
+++ b/nsxt/data_source_nsxt_policy_lb_app_profile_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestAccDataSourceNsxtPolicyLBAppProfile_basic(t *testing.T) {
-	name := "terraform_ds_test"
+	name := getAccTestDataSourceName()
 	testResourceName := "data.nsxt_policy_lb_app_profile.test"
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/nsxt/data_source_nsxt_policy_lb_client_ssl_profile_test.go
+++ b/nsxt/data_source_nsxt_policy_lb_client_ssl_profile_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestAccDataSourceNsxtPolicyLBClientSslProfile_basic(t *testing.T) {
-	name := "terraform_ds_test"
+	name := getAccTestDataSourceName()
 	testResourceName := "data.nsxt_policy_lb_client_ssl_profile.test"
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/nsxt/data_source_nsxt_policy_lb_monitor_test.go
+++ b/nsxt/data_source_nsxt_policy_lb_monitor_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestAccDataSourceNsxtPolicyLBMonitor_basic(t *testing.T) {
-	name := "terraform_ds_test"
+	name := getAccTestDataSourceName()
 	testResourceName := "data.nsxt_policy_lb_monitor.test"
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/nsxt/data_source_nsxt_policy_lb_server_ssl_profile_test.go
+++ b/nsxt/data_source_nsxt_policy_lb_server_ssl_profile_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestAccDataSourceNsxtPolicyLBServerSslProfile_basic(t *testing.T) {
-	name := "terraform_ds_test"
+	name := getAccTestDataSourceName()
 	testResourceName := "data.nsxt_policy_lb_server_ssl_profile.test"
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/nsxt/data_source_nsxt_policy_qos_profile_test.go
+++ b/nsxt/data_source_nsxt_policy_qos_profile_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestAccDataSourceNsxtPolicyQosProfile_basic(t *testing.T) {
-	name := "terraform_ds_test"
+	name := getAccTestDataSourceName()
 	testResourceName := "data.nsxt_policy_qos_profile.test"
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/nsxt/data_source_nsxt_policy_realization_info_test.go
+++ b/nsxt/data_source_nsxt_policy_realization_info_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestAccDataSourceNsxtPolicyRealizationInfo_tier1DataSource(t *testing.T) {
 	resourceDataType := "nsxt_policy_tier1_gateway"
-	resourceName := "terraform_test_tier1_1"
+	resourceName := getAccTestDataSourceName()
 	entityType := ""
 	testResourceName := "data.nsxt_policy_realization_info.realization_info"
 
@@ -44,7 +44,7 @@ func TestAccDataSourceNsxtPolicyRealizationInfo_tier1DataSource(t *testing.T) {
 
 func TestAccDataSourceNsxtPolicyRealizationInfo_tier1DataSourceEntity(t *testing.T) {
 	resourceDataType := "nsxt_policy_tier1_gateway"
-	resourceName := "terraform_test_tier1_2"
+	resourceName := getAccTestDataSourceName()
 	entityType := "RealizedLogicalRouter"
 	testResourceName := "data.nsxt_policy_realization_info.realization_info"
 
@@ -75,7 +75,7 @@ func TestAccDataSourceNsxtPolicyRealizationInfo_tier1DataSourceEntity(t *testing
 
 func TestAccDataSourceNsxtPolicyRealizationInfo_tier1Resource(t *testing.T) {
 	resourceType := "nsxt_policy_tier1_gateway"
-	resourceName := "terraform_test_tier1_3"
+	resourceName := getAccTestDataSourceName()
 	entityType := "RealizedLogicalRouter"
 	testResourceName := "data.nsxt_policy_realization_info.realization_info"
 

--- a/nsxt/data_source_nsxt_policy_security_policy_test.go
+++ b/nsxt/data_source_nsxt_policy_security_policy_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestAccDataSourceNsxtPolicySecurityPolicy_basic(t *testing.T) {
-	name := "terraform_ds_test"
+	name := getAccTestDataSourceName()
 	category := "Application"
 	testResourceName := "data.nsxt_policy_security_policy.test"
 	withCategory := fmt.Sprintf(`category = "%s"`, category)

--- a/nsxt/data_source_nsxt_policy_tier0_gateway_test.go
+++ b/nsxt/data_source_nsxt_policy_tier0_gateway_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestAccDataSourceNsxtPolicyTier0Gateway_basic(t *testing.T) {
-	name := "terraform_test"
+	name := getAccTestDataSourceName()
 	testResourceName := "data.nsxt_policy_tier0_gateway.test"
 
 	resource.Test(t, resource.TestCase{

--- a/nsxt/data_source_nsxt_policy_tier1_gateway_test.go
+++ b/nsxt/data_source_nsxt_policy_tier1_gateway_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestAccDataSourceNsxtPolicyTier1Gateway_basic(t *testing.T) {
-	routerName := "terraform_ds_test_tier1"
+	routerName := getAccTestDataSourceName()
 	testResourceName := "data.nsxt_policy_tier1_gateway.test"
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/nsxt/data_source_nsxt_policy_vni_pool_test.go
+++ b/nsxt/data_source_nsxt_policy_vni_pool_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestAccDataSourceNsxtPolicyVniPoolConfig_basic(t *testing.T) {
-	name := "terraform_ds_test"
+	name := getAccTestDataSourceName()
 	testResourceName := "data.nsxt_policy_vni_pool.test"
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/nsxt/data_source_nsxt_switching_profile_test.go
+++ b/nsxt/data_source_nsxt_switching_profile_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestAccDataSourceNsxtSwitchingProfile_basic(t *testing.T) {
-	profileName := "terraform_ds_test_profile"
+	profileName := getAccTestDataSourceName()
 	profileType := "QosSwitchingProfile"
 	testResourceName := "data.nsxt_switching_profile.test"
 

--- a/nsxt/resource_nsxt_algorithm_type_ns_service_test.go
+++ b/nsxt/resource_nsxt_algorithm_type_ns_service_test.go
@@ -13,8 +13,8 @@ import (
 )
 
 func TestAccResourceNsxtAlgorithmTypeNsService_basic(t *testing.T) {
-	serviceName := "test-nsx-alg-service"
-	updateServiceName := fmt.Sprintf("%s-update", serviceName)
+	serviceName := getAccTestResourceName()
+	updateServiceName := getAccTestResourceName()
 	testResourceName := "nsxt_algorithm_type_ns_service.test"
 	destPort := "21"
 	updatedDestPort := "21"
@@ -23,7 +23,7 @@ func TestAccResourceNsxtAlgorithmTypeNsService_basic(t *testing.T) {
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNSXAlgServiceCheckDestroy(state, serviceName)
+			return testAccNSXAlgServiceCheckDestroy(state, updateServiceName)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -55,7 +55,7 @@ func TestAccResourceNsxtAlgorithmTypeNsService_basic(t *testing.T) {
 }
 
 func TestAccResourceNsxtAlgorithmTypeNsService_importBasic(t *testing.T) {
-	serviceName := "test-nsx-alg-service"
+	serviceName := getAccTestResourceName()
 	testResourceName := "nsxt_algorithm_type_ns_service.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },

--- a/nsxt/resource_nsxt_dhcp_relay_profile_test.go
+++ b/nsxt/resource_nsxt_dhcp_relay_profile_test.go
@@ -13,15 +13,15 @@ import (
 )
 
 func TestAccResourceNsxtDhcpRelayProfile_basic(t *testing.T) {
-	prfName := "test-nsx-dhcp-relay-profile"
-	updatePrfName := fmt.Sprintf("%s-update", prfName)
+	prfName := getAccTestResourceName()
+	updatePrfName := getAccTestResourceName()
 	testResourceName := "nsxt_dhcp_relay_profile.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNSXDhcpRelayProfileCheckDestroy(state, prfName)
+			return testAccNSXDhcpRelayProfileCheckDestroy(state, updatePrfName)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -49,7 +49,7 @@ func TestAccResourceNsxtDhcpRelayProfile_basic(t *testing.T) {
 }
 
 func TestAccResourceNsxtDhcpRelayProfile_importBasic(t *testing.T) {
-	prfName := "test-nsx-dhcp-relay-profile"
+	prfName := getAccTestResourceName()
 	testResourceName := "nsxt_dhcp_relay_profile.test"
 
 	resource.Test(t, resource.TestCase{

--- a/nsxt/resource_nsxt_dhcp_relay_service_test.go
+++ b/nsxt/resource_nsxt_dhcp_relay_service_test.go
@@ -13,8 +13,8 @@ import (
 )
 
 func TestAccResourceNsxtDhcpRelayService_basic(t *testing.T) {
-	prfName := "test-nsx-dhcp-relay-service"
-	updatePrfName := fmt.Sprintf("%s-update", prfName)
+	prfName := getAccTestResourceName()
+	updatePrfName := getAccTestResourceName()
 	testResourceName := "nsxt_dhcp_relay_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -47,7 +47,7 @@ func TestAccResourceNsxtDhcpRelayService_basic(t *testing.T) {
 }
 
 func TestAccResourceNsxtDhcpRelayService_importBasic(t *testing.T) {
-	prfName := "test-nsx-dhcp-relay-service"
+	prfName := getAccTestResourceName()
 	testResourceName := "nsxt_dhcp_relay_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/nsxt/resource_nsxt_dhcp_server_ip_pool_test.go
+++ b/nsxt/resource_nsxt_dhcp_server_ip_pool_test.go
@@ -13,12 +13,12 @@ import (
 	"github.com/vmware/go-vmware-nsxt/manager"
 )
 
-var testNsxtDhcpServerIPPoolName = "test"
+var testNsxtDhcpServerIPPoolName = getAccTestResourceName()
 var testNsxtDhcpServerIPPoolResourceName = "nsxt_dhcp_server_ip_pool.test"
 
 func TestAccResourceNsxtDhcpServerIPPool_basic(t *testing.T) {
 	name := testNsxtDhcpServerIPPoolName
-	updatedName := "test-update"
+	updatedName := getAccTestResourceName()
 	testResourceName := testNsxtDhcpServerIPPoolResourceName
 	edgeClusterName := getEdgeClusterName()
 	gateway := "1.1.1.1"
@@ -30,7 +30,7 @@ func TestAccResourceNsxtDhcpServerIPPool_basic(t *testing.T) {
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNSXDhcpServerIPPoolCheckDestroy(state, name)
+			return testAccNSXDhcpServerIPPoolCheckDestroy(state, updatedName)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -85,7 +85,7 @@ func TestAccResourceNsxtDhcpServerIPPool_basic(t *testing.T) {
 
 func TestAccResourceNsxtDhcpServerIPPool_noOpts(t *testing.T) {
 	name := testNsxtDhcpServerIPPoolName
-	updatedName := "test-update"
+	updatedName := getAccTestResourceName()
 	testResourceName := testNsxtDhcpServerIPPoolResourceName
 	edgeClusterName := getEdgeClusterName()
 	start1 := "1.1.1.100"
@@ -97,7 +97,7 @@ func TestAccResourceNsxtDhcpServerIPPool_noOpts(t *testing.T) {
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNSXDhcpServerIPPoolCheckDestroy(state, name)
+			return testAccNSXDhcpServerIPPoolCheckDestroy(state, updatedName)
 		},
 		Steps: []resource.TestStep{
 			{

--- a/nsxt/resource_nsxt_dhcp_server_profile_test.go
+++ b/nsxt/resource_nsxt_dhcp_server_profile_test.go
@@ -13,8 +13,8 @@ import (
 )
 
 func TestAccResourceNsxtDhcpServerProfile_basic(t *testing.T) {
-	prfName := "test-nsx-dhcp-server-profile"
-	updatePrfName := fmt.Sprintf("%s-update", prfName)
+	prfName := getAccTestResourceName()
+	updatePrfName := getAccTestResourceName()
 	testResourceName := "nsxt_dhcp_server_profile.test"
 	edgeClusterName := getEdgeClusterName()
 
@@ -22,7 +22,7 @@ func TestAccResourceNsxtDhcpServerProfile_basic(t *testing.T) {
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNSXDhcpServerProfileCheckDestroy(state, prfName)
+			return testAccNSXDhcpServerProfileCheckDestroy(state, updatePrfName)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -50,7 +50,7 @@ func TestAccResourceNsxtDhcpServerProfile_basic(t *testing.T) {
 }
 
 func TestAccResourceNsxtDhcpServerProfile_importBasic(t *testing.T) {
-	prfName := "test-nsx-dhcp-server-profile"
+	prfName := getAccTestResourceName()
 	testResourceName := "nsxt_dhcp_server_profile.test"
 	edgeClusterName := getEdgeClusterName()
 

--- a/nsxt/resource_nsxt_ether_type_ns_service_test.go
+++ b/nsxt/resource_nsxt_ether_type_ns_service_test.go
@@ -13,15 +13,15 @@ import (
 )
 
 func TestAccResourceNsxtEtherTypeNsService_basic(t *testing.T) {
-	serviceName := "test-nsx-ether-service"
-	updateServiceName := fmt.Sprintf("%s-update", serviceName)
+	serviceName := getAccTestResourceName()
+	updateServiceName := getAccTestResourceName()
 	testResourceName := "nsxt_ether_type_ns_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNSXEtherServiceCheckDestroy(state, serviceName)
+			return testAccNSXEtherServiceCheckDestroy(state, updateServiceName)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -49,7 +49,7 @@ func TestAccResourceNsxtEtherTypeNsService_basic(t *testing.T) {
 }
 
 func TestAccResourceNsxtEtherTypeNsService_importBasic(t *testing.T) {
-	serviceName := "test-nsx-ether-service"
+	serviceName := getAccTestResourceName()
 	testResourceName := "nsxt_ether_type_ns_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/nsxt/resource_nsxt_firewall_section_test.go
+++ b/nsxt/resource_nsxt_firewall_section_test.go
@@ -291,7 +291,7 @@ func TestAccResourceNsxtFirewallSection_ordered(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNSXFirewallSectionCreateOrderedTemplate(),
+				Config: testAccNSXFirewallSectionCreateOrderedTemplate(sectionNames),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNSXFirewallSectionExists(sectionNames[0], testResourceNames[0]),
 					resource.TestCheckResourceAttr(testResourceNames[0], "display_name", sectionNames[0]),
@@ -305,7 +305,7 @@ func TestAccResourceNsxtFirewallSection_ordered(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNSXFirewallSectionUpdateOrderedTemplate(),
+				Config: testAccNSXFirewallSectionUpdateOrderedTemplate(sectionNames),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNSXFirewallSectionExists(sectionNames[0], testResourceNames[0]),
 					resource.TestCheckResourceAttr(testResourceNames[0], "display_name", sectionNames[0]),
@@ -645,16 +645,16 @@ resource "nsxt_firewall_section" "test" {
 }`, updatedName, tags, tos)
 }
 
-func testAccNSXFirewallSectionCreateOrderedTemplate() string {
-	return `
+func testAccNSXFirewallSectionCreateOrderedTemplate(names [4]string) string {
+	return fmt.Sprintf(`
 resource "nsxt_firewall_section" "test1" {
-  display_name = "s1"
+  display_name = "%s"
   section_type = "LAYER3"
   stateful     = true
 }
 
 resource "nsxt_firewall_section" "test2" {
-  display_name  = "s2"
+  display_name  = "%s"
   section_type  = "LAYER3"
   insert_before = "${nsxt_firewall_section.test1.id}"
   stateful      = true
@@ -669,44 +669,44 @@ resource "nsxt_firewall_section" "test2" {
 }
 
 resource "nsxt_firewall_section" "test3" {
-  display_name  = "s3"
+  display_name  = "%s"
   section_type  = "LAYER3"
   insert_before = "${nsxt_firewall_section.test2.id}"
   stateful      = true
 }
 
-`
+`, names[0], names[1], names[2])
 }
 
-func testAccNSXFirewallSectionUpdateOrderedTemplate() string {
-	return `
+func testAccNSXFirewallSectionUpdateOrderedTemplate(names [4]string) string {
+	return fmt.Sprintf(`
 resource "nsxt_firewall_section" "test1" {
-  display_name  = "s1"
+  display_name  = "%s"
   section_type  = "LAYER3"
   insert_before = "${nsxt_firewall_section.test4.id}"
   stateful      = true
 }
 
 resource "nsxt_firewall_section" "test2" {
-  display_name  = "s2"
+  display_name  = "%s"
   section_type  = "LAYER3"
   insert_before = "${nsxt_firewall_section.test1.id}"
   stateful      = true
 }
 
 resource "nsxt_firewall_section" "test3" {
-  display_name = "s3"
+  display_name = "%s"
   section_type = "LAYER3"
   stateful     = true
 }
 
 resource "nsxt_firewall_section" "test4" {
-  display_name = "s4"
+  display_name = "%s"
   section_type = "LAYER3"
   stateful     = true
 }
 
-`
+`, names[0], names[1], names[2], names[3])
 }
 
 func testAccNSXEdgeFirewallSectionCreateTemplate(edgeCluster string, transportZone string, name string, ruleName string) string {

--- a/nsxt/resource_nsxt_firewall_section_test.go
+++ b/nsxt/resource_nsxt_firewall_section_test.go
@@ -13,8 +13,8 @@ import (
 )
 
 func TestAccResourceNsxtFirewallSection_basic(t *testing.T) {
-	sectionName := "test-nsx-firewall-section-basic"
-	updatesectionName := fmt.Sprintf("%s-update", sectionName)
+	sectionName := getAccTestResourceName()
+	updateSectionName := getAccTestResourceName()
 	testResourceName := "nsxt_firewall_section.test"
 	tags := singleTag
 	updatedTags := doubleTags
@@ -24,7 +24,7 @@ func TestAccResourceNsxtFirewallSection_basic(t *testing.T) {
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNSXFirewallSectionCheckDestroy(state, sectionName)
+			return testAccNSXFirewallSectionCheckDestroy(state, updateSectionName)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -41,10 +41,10 @@ func TestAccResourceNsxtFirewallSection_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNSXFirewallSectionUpdateEmptyTemplate(updatesectionName, updatedTags, tos),
+				Config: testAccNSXFirewallSectionUpdateEmptyTemplate(updateSectionName, updatedTags, tos),
 				Check: resource.ComposeTestCheckFunc(
-					testAccNSXFirewallSectionExists(updatesectionName, testResourceName),
-					resource.TestCheckResourceAttr(testResourceName, "display_name", updatesectionName),
+					testAccNSXFirewallSectionExists(updateSectionName, testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", updateSectionName),
 					resource.TestCheckResourceAttr(testResourceName, "description", "Acceptance Test Update"),
 					resource.TestCheckResourceAttr(testResourceName, "tag.#", "2"),
 					resource.TestCheckResourceAttr(testResourceName, "section_type", "LAYER3"),
@@ -58,8 +58,7 @@ func TestAccResourceNsxtFirewallSection_basic(t *testing.T) {
 }
 
 func TestAccResourceNsxtFirewallSection_withTos(t *testing.T) {
-	sectionName := "test-nsx-firewall-section-tos"
-	updatesectionName := fmt.Sprintf("%s-update", sectionName)
+	sectionName := getAccTestResourceName()
 	testResourceName := "nsxt_firewall_section.test"
 	tags := singleTag
 	tos := `applied_to {
@@ -96,10 +95,10 @@ target_id   = "${nsxt_ns_group.grp2.id}"
 				),
 			},
 			{
-				Config: testAccNSXFirewallSectionUpdateEmptyTemplate(updatesectionName, tags, updatedTos),
+				Config: testAccNSXFirewallSectionUpdateEmptyTemplate(sectionName, tags, updatedTos),
 				Check: resource.ComposeTestCheckFunc(
-					testAccNSXFirewallSectionExists(updatesectionName, testResourceName),
-					resource.TestCheckResourceAttr(testResourceName, "display_name", updatesectionName),
+					testAccNSXFirewallSectionExists(sectionName, testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", sectionName),
 					resource.TestCheckResourceAttr(testResourceName, "description", "Acceptance Test Update"),
 					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
 					resource.TestCheckResourceAttr(testResourceName, "section_type", "LAYER3"),
@@ -113,8 +112,7 @@ target_id   = "${nsxt_ns_group.grp2.id}"
 }
 
 func TestAccResourceNsxtFirewallSection_withRules(t *testing.T) {
-	sectionName := "test-nsx-firewall-section-rules"
-	updatesectionName := fmt.Sprintf("%s-update", sectionName)
+	sectionName := getAccTestResourceName()
 	testResourceName := "nsxt_firewall_section.test"
 	ruleName := "rule1.0"
 	updatedRuleName := "rule1.1"
@@ -145,10 +143,10 @@ func TestAccResourceNsxtFirewallSection_withRules(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNSXFirewallSectionUpdateTemplate(updatesectionName, updatedRuleName, tags, tos),
+				Config: testAccNSXFirewallSectionUpdateTemplate(sectionName, updatedRuleName, tags, tos),
 				Check: resource.ComposeTestCheckFunc(
-					testAccNSXFirewallSectionExists(updatesectionName, testResourceName),
-					resource.TestCheckResourceAttr(testResourceName, "display_name", updatesectionName),
+					testAccNSXFirewallSectionExists(sectionName, testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", sectionName),
 					resource.TestCheckResourceAttr(testResourceName, "description", "Acceptance Test Update"),
 					resource.TestCheckResourceAttr(testResourceName, "section_type", "LAYER3"),
 					resource.TestCheckResourceAttr(testResourceName, "stateful", "true"),
@@ -163,8 +161,7 @@ func TestAccResourceNsxtFirewallSection_withRules(t *testing.T) {
 }
 
 func TestAccResourceNsxtFirewallSection_withRulesAndTags(t *testing.T) {
-	sectionName := "test-nsx-firewall-section-tags"
-	updatesectionName := fmt.Sprintf("%s-update", sectionName)
+	sectionName := getAccTestResourceName()
 	testResourceName := "nsxt_firewall_section.test"
 	ruleName := "rule1.0"
 	updatedRuleName := "rule1.1"
@@ -195,10 +192,10 @@ func TestAccResourceNsxtFirewallSection_withRulesAndTags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNSXFirewallSectionUpdateTemplate(updatesectionName, updatedRuleName, updatedTags, tos),
+				Config: testAccNSXFirewallSectionUpdateTemplate(sectionName, updatedRuleName, updatedTags, tos),
 				Check: resource.ComposeTestCheckFunc(
-					testAccNSXFirewallSectionExists(updatesectionName, testResourceName),
-					resource.TestCheckResourceAttr(testResourceName, "display_name", updatesectionName),
+					testAccNSXFirewallSectionExists(sectionName, testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", sectionName),
 					resource.TestCheckResourceAttr(testResourceName, "description", "Acceptance Test Update"),
 					resource.TestCheckResourceAttr(testResourceName, "section_type", "LAYER3"),
 					resource.TestCheckResourceAttr(testResourceName, "stateful", "true"),
@@ -213,8 +210,7 @@ func TestAccResourceNsxtFirewallSection_withRulesAndTags(t *testing.T) {
 }
 
 func TestAccResourceNsxtFirewallSection_withRulesAndTos(t *testing.T) {
-	sectionName := "test-nsx-firewall-section-rules_and_tos"
-	updatesectionName := fmt.Sprintf("%s-update", sectionName)
+	sectionName := getAccTestResourceName()
 	testResourceName := "nsxt_firewall_section.test"
 	ruleName := "rule1.0"
 	updatedRuleName := "rule1.1"
@@ -259,10 +255,10 @@ applied_to {
 				),
 			},
 			{
-				Config: testAccNSXFirewallSectionUpdateTemplate(updatesectionName, updatedRuleName, tags, updatedTos),
+				Config: testAccNSXFirewallSectionUpdateTemplate(sectionName, updatedRuleName, tags, updatedTos),
 				Check: resource.ComposeTestCheckFunc(
-					testAccNSXFirewallSectionExists(updatesectionName, testResourceName),
-					resource.TestCheckResourceAttr(testResourceName, "display_name", updatesectionName),
+					testAccNSXFirewallSectionExists(sectionName, testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", sectionName),
 					resource.TestCheckResourceAttr(testResourceName, "description", "Acceptance Test Update"),
 					resource.TestCheckResourceAttr(testResourceName, "section_type", "LAYER3"),
 					resource.TestCheckResourceAttr(testResourceName, "stateful", "true"),
@@ -277,7 +273,7 @@ applied_to {
 }
 
 func TestAccResourceNsxtFirewallSection_ordered(t *testing.T) {
-	sectionNames := [4]string{"s1", "s2", "s3", "s4"}
+	sectionNames := [4]string{getAccTestResourceName(), getAccTestResourceName(), getAccTestResourceName(), getAccTestResourceName()}
 	testResourceNames := [4]string{"nsxt_firewall_section.test1", "nsxt_firewall_section.test2", "nsxt_firewall_section.test3", "nsxt_firewall_section.test4"}
 
 	resource.Test(t, resource.TestCase{
@@ -330,10 +326,9 @@ func TestAccResourceNsxtFirewallSection_ordered(t *testing.T) {
 }
 
 func TestAccResourceNsxtFirewallSection_edge(t *testing.T) {
-	sectionName := "test-nsx-firewall-section-basic"
+	sectionName := getAccTestResourceName()
 	edgeClusterName := getEdgeClusterName()
 	transportZoneName := getOverlayTransportZoneName()
-	updatesectionName := fmt.Sprintf("%s-update", sectionName)
 	ruleName := "test"
 	testResourceName := "nsxt_firewall_section.test"
 
@@ -364,10 +359,10 @@ func TestAccResourceNsxtFirewallSection_edge(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNSXEdgeFirewallSectionCreateTemplate(edgeClusterName, transportZoneName, updatesectionName, ruleName),
+				Config: testAccNSXEdgeFirewallSectionCreateTemplate(edgeClusterName, transportZoneName, sectionName, ruleName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccNSXFirewallSectionExists(updatesectionName, testResourceName),
-					resource.TestCheckResourceAttr(testResourceName, "display_name", updatesectionName),
+					testAccNSXFirewallSectionExists(sectionName, testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", sectionName),
 					resource.TestCheckResourceAttr(testResourceName, "description", "Acceptance Test"),
 					resource.TestCheckResourceAttr(testResourceName, "section_type", "LAYER3"),
 					resource.TestCheckResourceAttr(testResourceName, "stateful", "false"),
@@ -382,7 +377,7 @@ func TestAccResourceNsxtFirewallSection_edge(t *testing.T) {
 }
 
 func TestAccResourceNsxtFirewallSection_importBasic(t *testing.T) {
-	sectionName := "test-nsx-firewall-section-basic"
+	sectionName := getAccTestResourceName()
 	testResourceName := "nsxt_firewall_section.test"
 	tags := singleTag
 	tos := string("")
@@ -407,7 +402,7 @@ func TestAccResourceNsxtFirewallSection_importBasic(t *testing.T) {
 }
 
 func TestAccResourceNsxtFirewallSection_importWithRules(t *testing.T) {
-	sectionName := "test-nsx-firewall-section-rules"
+	sectionName := getAccTestResourceName()
 	testResourceName := "nsxt_firewall_section.test"
 	ruleName := "rule1.0"
 	tags := singleTag
@@ -433,7 +428,7 @@ func TestAccResourceNsxtFirewallSection_importWithRules(t *testing.T) {
 }
 
 func TestAccResourceNsxtFirewallSection_importWithTos(t *testing.T) {
-	sectionName := "test-nsx-firewall-section-tos"
+	sectionName := getAccTestResourceName()
 	testResourceName := "nsxt_firewall_section.test"
 	tags := singleTag
 	tos := `applied_to {

--- a/nsxt/resource_nsxt_icmp_type_ns_service_test.go
+++ b/nsxt/resource_nsxt_icmp_type_ns_service_test.go
@@ -13,15 +13,15 @@ import (
 )
 
 func TestAccResourceNsxtIcmpTypeNsService_basic(t *testing.T) {
-	serviceName := "test-nsx-icmp-service"
-	updateServiceName := fmt.Sprintf("%s-update", serviceName)
+	serviceName := getAccTestResourceName()
+	updateServiceName := getAccTestResourceName()
 	testResourceName := "nsxt_icmp_type_ns_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNSXIcmpServiceCheckDestroy(state, serviceName)
+			return testAccNSXIcmpServiceCheckDestroy(state, updateServiceName)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -53,7 +53,7 @@ func TestAccResourceNsxtIcmpTypeNsService_basic(t *testing.T) {
 }
 
 func TestAccResourceNsxtIcmpTypeNsService_importBasic(t *testing.T) {
-	serviceName := "test-nsx-icmp-service"
+	serviceName := getAccTestResourceName()
 	testResourceName := "nsxt_icmp_type_ns_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/nsxt/resource_nsxt_igmp_type_ns_service_test.go
+++ b/nsxt/resource_nsxt_igmp_type_ns_service_test.go
@@ -13,15 +13,15 @@ import (
 )
 
 func TestAccResourceNsxtIgmpTypeNsService_basic(t *testing.T) {
-	serviceName := "test-nsx-igmp-service"
-	updateServiceName := fmt.Sprintf("%s-update", serviceName)
+	serviceName := getAccTestResourceName()
+	updateServiceName := getAccTestResourceName()
 	testResourceName := "nsxt_igmp_type_ns_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNSXIgmpServiceCheckDestroy(state, serviceName)
+			return testAccNSXIgmpServiceCheckDestroy(state, updateServiceName)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -47,7 +47,7 @@ func TestAccResourceNsxtIgmpTypeNsService_basic(t *testing.T) {
 }
 
 func TestAccResourceNsxtIgmpTypeNsService_importBasic(t *testing.T) {
-	serviceName := "test-nsx-igmp-service"
+	serviceName := getAccTestResourceName()
 	testResourceName := "nsxt_igmp_type_ns_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/nsxt/resource_nsxt_ip_block_subnet_test.go
+++ b/nsxt/resource_nsxt_ip_block_subnet_test.go
@@ -13,8 +13,8 @@ import (
 )
 
 func TestAccResourceNsxtIpBlockSubnet_basic(t *testing.T) {
-	name := "test-nsx-ip-block-subnet"
-	updateName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
+	updateName := getAccTestResourceName()
 	testResourceName := "nsxt_ip_block_subnet.test"
 	size := 16
 	resource.Test(t, resource.TestCase{
@@ -26,7 +26,7 @@ func TestAccResourceNsxtIpBlockSubnet_basic(t *testing.T) {
 		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNSXIpBlockSubnetCheckDestroy(state, name)
+			return testAccNSXIpBlockSubnetCheckDestroy(state, updateName)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -65,7 +65,7 @@ func TestAccResourceNsxtIpBlockSubnet_basic(t *testing.T) {
 }
 
 func TestAccResourceNsxtIpBlockSubnet_importBasic(t *testing.T) {
-	name := "test-nsx-ip-block-subnet"
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_ip_block_subnet.test"
 
 	resource.Test(t, resource.TestCase{

--- a/nsxt/resource_nsxt_ip_block_test.go
+++ b/nsxt/resource_nsxt_ip_block_test.go
@@ -13,8 +13,8 @@ import (
 )
 
 func TestAccResourceNsxtIpBlock_basic(t *testing.T) {
-	name := "test-nsx-ip-block"
-	updateName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
+	updateName := getAccTestResourceName()
 	testResourceName := "nsxt_ip_block.test"
 	cidr1 := "1.1.1.0/24"
 	cidr2 := "2.2.2.0/24"
@@ -22,7 +22,7 @@ func TestAccResourceNsxtIpBlock_basic(t *testing.T) {
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNSXIpBlockCheckDestroy(state, name)
+			return testAccNSXIpBlockCheckDestroy(state, updateName)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -61,7 +61,7 @@ func TestAccResourceNsxtIpBlock_basic(t *testing.T) {
 }
 
 func TestAccResourceNsxtIpBlock_importBasic(t *testing.T) {
-	name := "test-nsx-ip-block"
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_ip_block.test"
 
 	resource.Test(t, resource.TestCase{

--- a/nsxt/resource_nsxt_ip_discovery_switching_profile_test.go
+++ b/nsxt/resource_nsxt_ip_discovery_switching_profile_test.go
@@ -13,15 +13,15 @@ import (
 )
 
 func TestAccResourceNsxtIpDiscoverySwitchingProfile_basic(t *testing.T) {
-	name := "test-nsx-switching-profile"
-	updatedName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
+	updatedName := getAccTestResourceName()
 	testResourceName := "nsxt_ip_discovery_switching_profile.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNSXIpDiscoverySwitchingProfileCheckDestroy(state, name)
+			return testAccNSXIpDiscoverySwitchingProfileCheckDestroy(state, updatedName)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -62,7 +62,7 @@ func TestAccResourceNsxtIpDiscoverySwitchingProfile_basic(t *testing.T) {
 }
 
 func TestAccResourceNsxtIpDiscoverySwitchingProfile_importBasic(t *testing.T) {
-	name := "test-nsx-application-profile"
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_ip_discovery_switching_profile.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },

--- a/nsxt/resource_nsxt_ip_pool_test.go
+++ b/nsxt/resource_nsxt_ip_pool_test.go
@@ -13,15 +13,15 @@ import (
 )
 
 func TestAccResourceNsxtIpPool_basic(t *testing.T) {
-	name := "test-nsx-ip-pool"
-	updateName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
+	updateName := getAccTestResourceName()
 	testResourceName := "nsxt_ip_pool.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNSXIpPoolCheckDestroy(state, name)
+			return testAccNSXIpPoolCheckDestroy(state, updateName)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -54,7 +54,7 @@ func TestAccResourceNsxtIpPool_basic(t *testing.T) {
 }
 
 func TestAccResourceNsxtIpPool_importBasic(t *testing.T) {
-	name := "test-nsx-ip-pool"
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_ip_pool.test"
 
 	resource.Test(t, resource.TestCase{

--- a/nsxt/resource_nsxt_ip_protocol_ns_service_test.go
+++ b/nsxt/resource_nsxt_ip_protocol_ns_service_test.go
@@ -13,15 +13,15 @@ import (
 )
 
 func TestAccResourceNsxtIpProtocolNsService_basic(t *testing.T) {
-	serviceName := "test-nsx-ip-protocol-service"
-	updateServiceName := fmt.Sprintf("%s-update", serviceName)
+	serviceName := getAccTestResourceName()
+	updateServiceName := getAccTestResourceName()
 	testResourceName := "nsxt_ip_protocol_ns_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNSXIpProtocolServiceCheckDestroy(state, serviceName)
+			return testAccNSXIpProtocolServiceCheckDestroy(state, updateServiceName)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -49,7 +49,7 @@ func TestAccResourceNsxtIpProtocolNsService_basic(t *testing.T) {
 }
 
 func TestAccResourceNsxtIpProtocolNsService_importBasic(t *testing.T) {
-	serviceName := "test-nsx-ip-protocol-service"
+	serviceName := getAccTestResourceName()
 	testResourceName := "nsxt_ip_protocol_ns_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/nsxt/resource_nsxt_ip_set_test.go
+++ b/nsxt/resource_nsxt_ip_set_test.go
@@ -13,15 +13,15 @@ import (
 )
 
 func TestAccResourceNsxtIpSet_basic(t *testing.T) {
-	name := "test-nsx-ip-set"
-	updateName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
+	updateName := getAccTestResourceName()
 	testResourceName := "nsxt_ip_set.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNSXIpSetCheckDestroy(state, name)
+			return testAccNSXIpSetCheckDestroy(state, updateName)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -84,7 +84,7 @@ func TestAccResourceNsxtIpSet_noName(t *testing.T) {
 }
 
 func TestAccResourceNsxtIpSet_importBasic(t *testing.T) {
-	name := "test-nsx-ip-set"
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_ip_set.test"
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/nsxt/resource_nsxt_l4_port_set_ns_service_test.go
+++ b/nsxt/resource_nsxt_l4_port_set_ns_service_test.go
@@ -13,15 +13,15 @@ import (
 )
 
 func TestAccResourceNsxtL4PortNsService_basic(t *testing.T) {
-	serviceName := "test-nsx-l4-service"
-	updateServiceName := fmt.Sprintf("%s-update", serviceName)
+	serviceName := getAccTestResourceName()
+	updateServiceName := getAccTestResourceName()
 	testResourceName := "nsxt_l4_port_set_ns_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNSXL4ServiceCheckDestroy(state, serviceName)
+			return testAccNSXL4ServiceCheckDestroy(state, updateServiceName)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -49,7 +49,7 @@ func TestAccResourceNsxtL4PortNsService_basic(t *testing.T) {
 }
 
 func TestAccResourceNsxtL4PortNsService_importBasic(t *testing.T) {
-	serviceName := "test-nsx-l4-service"
+	serviceName := getAccTestResourceName()
 	testResourceName := "nsxt_l4_port_set_ns_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/nsxt/resource_nsxt_lb_client_ssl_profile_test.go
+++ b/nsxt/resource_nsxt_lb_client_ssl_profile_test.go
@@ -13,8 +13,8 @@ import (
 )
 
 func TestAccResourceNsxtLbClientSSLProfile_basic(t *testing.T) {
-	name := "test"
-	updatedName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
+	updatedName := getAccTestResourceName()
 	testResourceName := "nsxt_lb_client_ssl_profile.test"
 
 	resource.Test(t, resource.TestCase{
@@ -26,7 +26,7 @@ func TestAccResourceNsxtLbClientSSLProfile_basic(t *testing.T) {
 		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNSXLbClientSSLProfileCheckDestroy(state, name)
+			return testAccNSXLbClientSSLProfileCheckDestroy(state, updatedName)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -64,7 +64,7 @@ func TestAccResourceNsxtLbClientSSLProfile_basic(t *testing.T) {
 }
 
 func TestAccResourceNsxtLbClientSSLProfile_importBasic(t *testing.T) {
-	name := "test"
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_lb_client_ssl_profile.test"
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {

--- a/nsxt/resource_nsxt_lb_client_ssl_profile_test.go
+++ b/nsxt/resource_nsxt_lb_client_ssl_profile_test.go
@@ -17,7 +17,7 @@ func TestAccResourceNsxtLbClientSSLProfile_basic(t *testing.T) {
 	updatedName := getAccTestResourceName()
 	testResourceName := "nsxt_lb_client_ssl_profile.test"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccOnlyLocalManager(t)
 			testAccTestMP(t)
@@ -66,7 +66,7 @@ func TestAccResourceNsxtLbClientSSLProfile_basic(t *testing.T) {
 func TestAccResourceNsxtLbClientSSLProfile_importBasic(t *testing.T) {
 	name := getAccTestResourceName()
 	testResourceName := "nsxt_lb_client_ssl_profile.test"
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccOnlyLocalManager(t)
 			testAccTestMP(t)

--- a/nsxt/resource_nsxt_lb_cookie_persistence_profile_test.go
+++ b/nsxt/resource_nsxt_lb_cookie_persistence_profile_test.go
@@ -21,7 +21,7 @@ func TestAccResourceNsxtLbCookiePersistenceProfile_basic(t *testing.T) {
 	cookieName := "my_cookie"
 	updatedCookieName := "new_cookie"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccOnlyLocalManager(t)
 			testAccTestMP(t)
@@ -75,7 +75,7 @@ func TestAccResourceNsxtLbCookiePersistenceProfile_insertMode(t *testing.T) {
 	cookiePath := "/subfolder1"
 	updatedCookiePath := "/subfolder1"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccOnlyLocalManager(t)
 			testAccTestMP(t)
@@ -134,7 +134,7 @@ func TestAccResourceNsxtLbCookiePersistenceProfile_insertMode(t *testing.T) {
 func TestAccResourceNsxtLbCookiePersistenceProfile_importBasic(t *testing.T) {
 	name := getAccTestResourceName()
 	testResourceName := "nsxt_lb_cookie_persistence_profile.test"
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccOnlyLocalManager(t)
 			testAccTestMP(t)

--- a/nsxt/resource_nsxt_lb_cookie_persistence_profile_test.go
+++ b/nsxt/resource_nsxt_lb_cookie_persistence_profile_test.go
@@ -13,8 +13,8 @@ import (
 )
 
 func TestAccResourceNsxtLbCookiePersistenceProfile_basic(t *testing.T) {
-	name := "test-nsx-persistence-profile"
-	updatedName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
+	updatedName := getAccTestResourceName()
 	testResourceName := "nsxt_lb_cookie_persistence_profile.test"
 	mode := "PREFIX"
 	updatedMode := "REWRITE"
@@ -30,7 +30,7 @@ func TestAccResourceNsxtLbCookiePersistenceProfile_basic(t *testing.T) {
 		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNSXLbCookiePersistenceProfileCheckDestroy(state, name)
+			return testAccNSXLbCookiePersistenceProfileCheckDestroy(state, updatedName)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -66,8 +66,7 @@ func TestAccResourceNsxtLbCookiePersistenceProfile_basic(t *testing.T) {
 }
 
 func TestAccResourceNsxtLbCookiePersistenceProfile_insertMode(t *testing.T) {
-	name := "test-nsx-persistence-profile"
-	updatedName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_lb_cookie_persistence_profile.test"
 	cookieName := "my_cookie"
 	updatedCookieName := "new_cookie"
@@ -109,10 +108,10 @@ func TestAccResourceNsxtLbCookiePersistenceProfile_insertMode(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNSXLbCookiePersistenceProfileInsertTemplate(updatedName, updatedCookieName, updatedCookieDomain, updatedCookiePath),
+				Config: testAccNSXLbCookiePersistenceProfileInsertTemplate(name, updatedCookieName, updatedCookieDomain, updatedCookiePath),
 				Check: resource.ComposeTestCheckFunc(
-					testAccNSXLbCookiePersistenceProfileExists(updatedName, testResourceName),
-					resource.TestCheckResourceAttr(testResourceName, "display_name", updatedName),
+					testAccNSXLbCookiePersistenceProfileExists(name, testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", name),
 					resource.TestCheckResourceAttr(testResourceName, "description", "test description"),
 					resource.TestCheckResourceAttr(testResourceName, "cookie_mode", "INSERT"),
 					resource.TestCheckResourceAttr(testResourceName, "cookie_name", updatedCookieName),
@@ -133,7 +132,7 @@ func TestAccResourceNsxtLbCookiePersistenceProfile_insertMode(t *testing.T) {
 }
 
 func TestAccResourceNsxtLbCookiePersistenceProfile_importBasic(t *testing.T) {
-	name := "test-nsx-persistence-profile"
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_lb_cookie_persistence_profile.test"
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {

--- a/nsxt/resource_nsxt_lb_fast_tcp_application_profile_test.go
+++ b/nsxt/resource_nsxt_lb_fast_tcp_application_profile_test.go
@@ -13,8 +13,8 @@ import (
 )
 
 func TestAccResourceNsxtLbFastTCPApplicationProfile_basic(t *testing.T) {
-	name := "test-nsx-application-profile"
-	updatedName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
+	updatedName := getAccTestResourceName()
 	testResourceName := "nsxt_lb_fast_tcp_application_profile.test"
 	closeTimeout := "10"
 	updatedCloseTimeout := "20"
@@ -32,7 +32,7 @@ func TestAccResourceNsxtLbFastTCPApplicationProfile_basic(t *testing.T) {
 		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNSXLbFastTCPApplicationProfileCheckDestroy(state, name)
+			return testAccNSXLbFastTCPApplicationProfileCheckDestroy(state, updatedName)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -63,7 +63,7 @@ func TestAccResourceNsxtLbFastTCPApplicationProfile_basic(t *testing.T) {
 }
 
 func TestAccResourceNsxtLbFastTCPApplicationProfile_importBasic(t *testing.T) {
-	name := "test-nsx-application-profile"
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_lb_fast_tcp_application_profile.test"
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {

--- a/nsxt/resource_nsxt_lb_fast_tcp_application_profile_test.go
+++ b/nsxt/resource_nsxt_lb_fast_tcp_application_profile_test.go
@@ -23,7 +23,7 @@ func TestAccResourceNsxtLbFastTCPApplicationProfile_basic(t *testing.T) {
 	mirroring := "true"
 	updatedMirroring := "false"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccOnlyLocalManager(t)
 			testAccTestMP(t)
@@ -65,7 +65,7 @@ func TestAccResourceNsxtLbFastTCPApplicationProfile_basic(t *testing.T) {
 func TestAccResourceNsxtLbFastTCPApplicationProfile_importBasic(t *testing.T) {
 	name := getAccTestResourceName()
 	testResourceName := "nsxt_lb_fast_tcp_application_profile.test"
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccOnlyLocalManager(t)
 			testAccTestMP(t)

--- a/nsxt/resource_nsxt_lb_fast_udp_application_profile_test.go
+++ b/nsxt/resource_nsxt_lb_fast_udp_application_profile_test.go
@@ -13,8 +13,8 @@ import (
 )
 
 func TestAccResourceNsxtLbFastUDPApplicationProfile_basic(t *testing.T) {
-	name := "test-nsx-application-profile"
-	updatedName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
+	updatedName := getAccTestResourceName()
 	testResourceName := "nsxt_lb_fast_udp_application_profile.test"
 	idleTimeout := "100"
 	updatedIdleTimeout := "200"
@@ -30,7 +30,7 @@ func TestAccResourceNsxtLbFastUDPApplicationProfile_basic(t *testing.T) {
 		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNSXLbFastUDPApplicationProfileCheckDestroy(state, name)
+			return testAccNSXLbFastUDPApplicationProfileCheckDestroy(state, updatedName)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -59,7 +59,7 @@ func TestAccResourceNsxtLbFastUDPApplicationProfile_basic(t *testing.T) {
 }
 
 func TestAccResourceNsxtLbFastUDPApplicationProfile_importBasic(t *testing.T) {
-	name := "test-nsx-application-profile"
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_lb_fast_udp_application_profile.test"
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {

--- a/nsxt/resource_nsxt_lb_fast_udp_application_profile_test.go
+++ b/nsxt/resource_nsxt_lb_fast_udp_application_profile_test.go
@@ -21,7 +21,7 @@ func TestAccResourceNsxtLbFastUDPApplicationProfile_basic(t *testing.T) {
 	mirroring := "true"
 	updatedMirroring := "false"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccOnlyLocalManager(t)
 			testAccTestMP(t)
@@ -61,7 +61,7 @@ func TestAccResourceNsxtLbFastUDPApplicationProfile_basic(t *testing.T) {
 func TestAccResourceNsxtLbFastUDPApplicationProfile_importBasic(t *testing.T) {
 	name := getAccTestResourceName()
 	testResourceName := "nsxt_lb_fast_udp_application_profile.test"
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccOnlyLocalManager(t)
 			testAccTestMP(t)

--- a/nsxt/resource_nsxt_lb_http_application_profile_test.go
+++ b/nsxt/resource_nsxt_lb_http_application_profile_test.go
@@ -13,8 +13,8 @@ import (
 )
 
 func TestAccResourceNsxtLbHTTPApplicationProfile_basic(t *testing.T) {
-	name := "test"
-	updatedName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
+	updatedName := getAccTestResourceName()
 	testResourceName := "nsxt_lb_http_application_profile.test"
 	httpRedirect := "http://www.aaa.com"
 	httpsRedirect := "false"
@@ -43,7 +43,7 @@ func TestAccResourceNsxtLbHTTPApplicationProfile_basic(t *testing.T) {
 		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNSXLbHTTPApplicationProfileCheckDestroy(state, name)
+			return testAccNSXLbHTTPApplicationProfileCheckDestroy(state, updatedName)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -77,7 +77,7 @@ func TestAccResourceNsxtLbHTTPApplicationProfile_basic(t *testing.T) {
 }
 
 func TestAccResourceNsxtLbHTTPApplicationProfile_importBasic(t *testing.T) {
-	name := "test"
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_lb_http_application_profile.test"
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {

--- a/nsxt/resource_nsxt_lb_http_forwarding_rule_test.go
+++ b/nsxt/resource_nsxt_lb_http_forwarding_rule_test.go
@@ -33,10 +33,10 @@ func TestAccResourceNsxtLbHttpForwardingRule_basic(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNSXLbHTTPForwardingRuleCreateTemplate(matchStrategy, matchType, "true", "false"),
+				Config: testAccNSXLbHTTPForwardingRuleCreateTemplate(name, matchStrategy, matchType, "true", "false"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNSXLbHTTPForwardingRuleExists(name, fullName),
-					resource.TestCheckResourceAttr(fullName, "display_name", "test"),
+					resource.TestCheckResourceAttr(fullName, "display_name", name),
 					resource.TestCheckResourceAttr(fullName, "description", "test description"),
 					resource.TestCheckResourceAttr(fullName, "match_strategy", matchStrategy),
 					testLbRuleConditionCount(fullName, "body", 2),
@@ -89,10 +89,10 @@ func TestAccResourceNsxtLbHttpForwardingRule_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNSXLbHTTPForwardingRuleCreateTemplate(updatedMatchStrategy, updatedMatchType, "false", "true"),
+				Config: testAccNSXLbHTTPForwardingRuleCreateTemplate(name, updatedMatchStrategy, updatedMatchType, "false", "true"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNSXLbHTTPForwardingRuleExists(name, fullName),
-					resource.TestCheckResourceAttr(fullName, "display_name", "test"),
+					resource.TestCheckResourceAttr(fullName, "display_name", name),
 					resource.TestCheckResourceAttr(fullName, "description", "test description"),
 					resource.TestCheckResourceAttr(fullName, "match_strategy", updatedMatchStrategy),
 					testLbRuleConditionCount(fullName, "body", 2),
@@ -228,17 +228,17 @@ func testAccNSXLbHTTPForwardingRuleCheckDestroy(state *terraform.State, displayN
 	return nil
 }
 
-func testAccNSXLbHTTPForwardingRuleCreateTemplate(matchStrategy string, matchType string, caseSensitive string, inverse string) string {
+func testAccNSXLbHTTPForwardingRuleCreateTemplate(name string, matchStrategy string, matchType string, caseSensitive string, inverse string) string {
 	return fmt.Sprintf(`
 resource "nsxt_lb_pool" "pool" {
   description = "test description"
 }
 
 resource "nsxt_lb_http_forwarding_rule" "test" {
-  display_name   = "test"
+  display_name   = "%s"
   description    = "test description"
   match_strategy = "%s"
-`, matchStrategy) +
+`, name, matchStrategy) +
 		testAccNSXLbRuleValueConditionTemplate("body", "value", "EQUALS", "false", "false", 1) +
 		testAccNSXLbRuleValueConditionTemplate("body", "value", matchType, caseSensitive, inverse, 2) +
 		testAccNSXLbRuleNameValueConditionTemplate("header", "EQUALS", "false", "false", 1) +

--- a/nsxt/resource_nsxt_lb_http_forwarding_rule_test.go
+++ b/nsxt/resource_nsxt_lb_http_forwarding_rule_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestAccResourceNsxtLbHttpForwardingRule_basic(t *testing.T) {
-	name := "test"
+	name := getAccTestResourceName()
 	fullName := "nsxt_lb_http_forwarding_rule.test"
 	matchStrategy := "ALL"
 	updatedMatchStrategy := "ANY"
@@ -149,7 +149,7 @@ func TestAccResourceNsxtLbHttpForwardingRule_basic(t *testing.T) {
 }
 
 func TestAccResourceNsxtLbHttpForwardingRule_importBasic(t *testing.T) {
-	name := "test"
+	name := getAccTestResourceName()
 	resourceName := "nsxt_lb_http_forwarding_rule.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {

--- a/nsxt/resource_nsxt_lb_http_request_rewrite_rule_test.go
+++ b/nsxt/resource_nsxt_lb_http_request_rewrite_rule_test.go
@@ -28,10 +28,10 @@ func TestAccResourceNsxtLbHttpRequestRewriteRule_basic(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNSXLbHTTPRequestRewriteRuleCreateTemplate(matchStrategy, matchType, "true", "false"),
+				Config: testAccNSXLbHTTPRequestRewriteRuleCreateTemplate(name, matchStrategy, matchType, "true", "false"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNSXLbHTTPRequestRewriteRuleExists(name, fullName),
-					resource.TestCheckResourceAttr(fullName, "display_name", "test"),
+					resource.TestCheckResourceAttr(fullName, "display_name", name),
 					resource.TestCheckResourceAttr(fullName, "description", "test description"),
 					resource.TestCheckResourceAttr(fullName, "match_strategy", matchStrategy),
 					testLbRuleConditionCount(fullName, "body", 2),
@@ -91,10 +91,10 @@ func TestAccResourceNsxtLbHttpRequestRewriteRule_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNSXLbHTTPRequestRewriteRuleCreateTemplate(updatedMatchStrategy, updatedMatchType, "false", "true"),
+				Config: testAccNSXLbHTTPRequestRewriteRuleCreateTemplate(name, updatedMatchStrategy, updatedMatchType, "false", "true"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNSXLbHTTPRequestRewriteRuleExists(name, fullName),
-					resource.TestCheckResourceAttr(fullName, "display_name", "test"),
+					resource.TestCheckResourceAttr(fullName, "display_name", name),
 					resource.TestCheckResourceAttr(fullName, "description", "test description"),
 					resource.TestCheckResourceAttr(fullName, "match_strategy", updatedMatchStrategy),
 					testLbRuleConditionCount(fullName, "body", 2),
@@ -288,13 +288,13 @@ func testAccNSXLbRuleSimpleMatchConditionTemplate(conditionType string, value st
     `, conditionType, conditionType, value, matchType, inverse)
 }
 
-func testAccNSXLbHTTPRequestRewriteRuleCreateTemplate(matchStrategy string, matchType string, caseSensitive string, inverse string) string {
+func testAccNSXLbHTTPRequestRewriteRuleCreateTemplate(name string, matchStrategy string, matchType string, caseSensitive string, inverse string) string {
 	return fmt.Sprintf(`
 resource "nsxt_lb_http_request_rewrite_rule" "test" {
-  display_name   = "test"
+  display_name   = "%s"
   description    = "test description"
   match_strategy = "%s"
-`, matchStrategy) +
+`, name, matchStrategy) +
 		testAccNSXLbRuleValueConditionTemplate("body", "value", "EQUALS", "false", "false", 1) +
 		testAccNSXLbRuleValueConditionTemplate("body", "value", matchType, caseSensitive, inverse, 2) +
 		testAccNSXLbRuleNameValueConditionTemplate("header", "EQUALS", "false", "false", 1) +

--- a/nsxt/resource_nsxt_lb_http_request_rewrite_rule_test.go
+++ b/nsxt/resource_nsxt_lb_http_request_rewrite_rule_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestAccResourceNsxtLbHttpRequestRewriteRule_basic(t *testing.T) {
-	name := "test"
+	name := getAccTestResourceName()
 	fullName := "nsxt_lb_http_request_rewrite_rule.test"
 	matchStrategy := "ALL"
 	updatedMatchStrategy := "ANY"
@@ -172,7 +172,7 @@ func testLbRuleConditionAttr(resourceName string, conditionType string, setHash 
 }
 
 func TestAccResourceNsxtLbHttpRequestRewriteRule_importBasic(t *testing.T) {
-	name := "test"
+	name := getAccTestResourceName()
 	resourceName := "nsxt_lb_http_request_rewrite_rule.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },

--- a/nsxt/resource_nsxt_lb_http_response_rewrite_rule_test.go
+++ b/nsxt/resource_nsxt_lb_http_response_rewrite_rule_test.go
@@ -28,10 +28,10 @@ func TestAccResourceNsxtLbHttpResponseRewriteRule_basic(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNSXLbHTTPResponseRewriteRuleCreateTemplate(matchStrategy, matchType, "true", "false"),
+				Config: testAccNSXLbHTTPResponseRewriteRuleCreateTemplate(name, matchStrategy, matchType, "true", "false"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNSXLbHTTPResponseRewriteRuleExists(name, fullName),
-					resource.TestCheckResourceAttr(fullName, "display_name", "test"),
+					resource.TestCheckResourceAttr(fullName, "display_name", name),
 					resource.TestCheckResourceAttr(fullName, "description", "test description"),
 					resource.TestCheckResourceAttr(fullName, "match_strategy", matchStrategy),
 					testLbRuleConditionCount(fullName, "request_header", 1),
@@ -80,10 +80,10 @@ func TestAccResourceNsxtLbHttpResponseRewriteRule_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNSXLbHTTPResponseRewriteRuleCreateTemplate(updatedMatchStrategy, updatedMatchType, "false", "true"),
+				Config: testAccNSXLbHTTPResponseRewriteRuleCreateTemplate(name, updatedMatchStrategy, updatedMatchType, "false", "true"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNSXLbHTTPResponseRewriteRuleExists(name, fullName),
-					resource.TestCheckResourceAttr(fullName, "display_name", "test"),
+					resource.TestCheckResourceAttr(fullName, "display_name", name),
 					resource.TestCheckResourceAttr(fullName, "description", "test description"),
 					resource.TestCheckResourceAttr(fullName, "match_strategy", updatedMatchStrategy),
 					testLbRuleConditionCount(fullName, "request_header", 1),
@@ -212,13 +212,13 @@ func testAccNSXLbHTTPResponseRewriteRuleCheckDestroy(state *terraform.State, dis
 	return nil
 }
 
-func testAccNSXLbHTTPResponseRewriteRuleCreateTemplate(matchStrategy string, matchType string, caseSensitive string, inverse string) string {
+func testAccNSXLbHTTPResponseRewriteRuleCreateTemplate(name string, matchStrategy string, matchType string, caseSensitive string, inverse string) string {
 	return fmt.Sprintf(`
 resource "nsxt_lb_http_response_rewrite_rule" "test" {
-  display_name   = "test"
+  display_name   = "%s"
   description    = "test description"
   match_strategy = "%s"
-`, matchStrategy) +
+`, name, matchStrategy) +
 		testAccNSXLbRuleNameValueConditionTemplate("request_header", "EQUALS", "true", "true", 1) +
 		testAccNSXLbRuleNameValueConditionTemplate("response_header", matchType, caseSensitive, inverse, 2) +
 		testAccNSXLbRuleNameValueConditionTemplate("cookie", matchType, caseSensitive, inverse, 1) +

--- a/nsxt/resource_nsxt_lb_http_response_rewrite_rule_test.go
+++ b/nsxt/resource_nsxt_lb_http_response_rewrite_rule_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestAccResourceNsxtLbHttpResponseRewriteRule_basic(t *testing.T) {
-	name := "test"
+	name := getAccTestResourceName()
 	fullName := "nsxt_lb_http_response_rewrite_rule.test"
 	matchStrategy := "ANY"
 	updatedMatchStrategy := "ALL"
@@ -138,7 +138,7 @@ func TestAccResourceNsxtLbHttpResponseRewriteRule_basic(t *testing.T) {
 }
 
 func TestAccResourceNsxtLbHttpResponseRewriteRule_importBasic(t *testing.T) {
-	name := "test"
+	name := getAccTestResourceName()
 	resourceName := "nsxt_lb_http_response_rewrite_rule.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },

--- a/nsxt/resource_nsxt_lb_http_virtual_server_test.go
+++ b/nsxt/resource_nsxt_lb_http_virtual_server_test.go
@@ -17,7 +17,7 @@ var testLbVirtualServerClientCertID string
 var testLbVirtualServerCaCertID string
 
 func TestAccResourceNsxtLbHttpVirtualServer_basic(t *testing.T) {
-	name := "test"
+	name := getAccTestResourceName()
 	fullName := "nsxt_lb_http_virtual_server.test"
 	port := "888"
 	updatedPort := "999"
@@ -79,7 +79,7 @@ func TestAccResourceNsxtLbHttpVirtualServer_basic(t *testing.T) {
 }
 
 func TestAccResourceNsxtLbHttpVirtualServer_withRules(t *testing.T) {
-	name := "test"
+	name := getAccTestResourceName()
 	fullName := "nsxt_lb_http_virtual_server.test"
 	rule1 := "rule1"
 	rule2 := "rule3"
@@ -121,7 +121,7 @@ func TestAccResourceNsxtLbHttpVirtualServer_withRules(t *testing.T) {
 }
 
 func TestAccResourceNsxtLbHttpVirtualServer_withSSL(t *testing.T) {
-	name := "test"
+	name := getAccTestResourceName()
 	fullName := "nsxt_lb_http_virtual_server.test"
 	depth := "2"
 	updatedDepth := "4"
@@ -199,7 +199,7 @@ func TestAccResourceNsxtLbHttpVirtualServer_withSSL(t *testing.T) {
 }
 
 func TestAccResourceNsxtLbHttpVirtualServer_importBasic(t *testing.T) {
-	name := "test"
+	name := getAccTestResourceName()
 	resourceName := "nsxt_lb_http_virtual_server.test"
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {

--- a/nsxt/resource_nsxt_lb_http_virtual_server_test.go
+++ b/nsxt/resource_nsxt_lb_http_virtual_server_test.go
@@ -16,6 +16,10 @@ var testLbVirtualServerCertID string
 var testLbVirtualServerClientCertID string
 var testLbVirtualServerCaCertID string
 
+var testLbVirtualServerHelper1Name = getAccTestResourceName()
+var testLbVirtualServerHelper2Name = getAccTestResourceName()
+var testLbVirtualServerHelper3Name = getAccTestResourceName()
+
 func TestAccResourceNsxtLbHttpVirtualServer_basic(t *testing.T) {
 	name := getAccTestResourceName()
 	fullName := "nsxt_lb_http_virtual_server.test"
@@ -37,10 +41,10 @@ func TestAccResourceNsxtLbHttpVirtualServer_basic(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNSXLbHTTPVirtualServerCreateTemplate(port, enabled),
+				Config: testAccNSXLbHTTPVirtualServerCreateTemplate(name, port, enabled),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNSXLbHTTPVirtualServerExists(name, fullName),
-					resource.TestCheckResourceAttr(fullName, "display_name", "test"),
+					resource.TestCheckResourceAttr(fullName, "display_name", name),
 					resource.TestCheckResourceAttr(fullName, "description", "test description"),
 					resource.TestCheckResourceAttr(fullName, "access_log_enabled", "true"),
 					resource.TestCheckResourceAttrSet(fullName, "application_profile_id"),
@@ -56,10 +60,10 @@ func TestAccResourceNsxtLbHttpVirtualServer_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNSXLbHTTPVirtualServerCreateTemplate(updatedPort, updatedEnabled),
+				Config: testAccNSXLbHTTPVirtualServerCreateTemplate(name, updatedPort, updatedEnabled),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNSXLbHTTPVirtualServerExists(name, fullName),
-					resource.TestCheckResourceAttr(fullName, "display_name", "test"),
+					resource.TestCheckResourceAttr(fullName, "display_name", name),
 					resource.TestCheckResourceAttr(fullName, "description", "test description"),
 					resource.TestCheckResourceAttr(fullName, "access_log_enabled", "true"),
 					resource.TestCheckResourceAttrSet(fullName, "application_profile_id"),
@@ -99,7 +103,7 @@ func TestAccResourceNsxtLbHttpVirtualServer_withRules(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNSXLbHTTPVirtualServerCreateTemplateWithRules(rule1, rule2),
+				Config: testAccNSXLbHTTPVirtualServerCreateTemplateWithRules(name, rule1, rule2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNSXLbHTTPVirtualServerExists(name, fullName),
 					resource.TestCheckResourceAttr(fullName, "ip_address", "1.1.1.1"),
@@ -108,7 +112,7 @@ func TestAccResourceNsxtLbHttpVirtualServer_withRules(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNSXLbHTTPVirtualServerCreateTemplateWithRules(updatedRule1, updatedRule2),
+				Config: testAccNSXLbHTTPVirtualServerCreateTemplateWithRules(name, updatedRule1, updatedRule2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNSXLbHTTPVirtualServerExists(name, fullName),
 					resource.TestCheckResourceAttr(fullName, "ip_address", "1.1.1.1"),
@@ -143,10 +147,10 @@ func TestAccResourceNsxtLbHttpVirtualServer_withSSL(t *testing.T) {
 				PreConfig: func() {
 					testLbVirtualServerCertID, testLbVirtualServerClientCertID, testLbVirtualServerCaCertID = testAccNSXCreateCerts(t)
 				},
-				Config: testAccNSXLbHTTPVirtualServerCreateTemplateWithSSL(depth),
+				Config: testAccNSXLbHTTPVirtualServerCreateTemplateWithSSL(name, depth),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNSXLbHTTPVirtualServerExists(name, fullName),
-					resource.TestCheckResourceAttr(fullName, "display_name", "test"),
+					resource.TestCheckResourceAttr(fullName, "display_name", name),
 					resource.TestCheckResourceAttr(fullName, "description", "test description"),
 					resource.TestCheckResourceAttr(fullName, "access_log_enabled", "false"),
 					resource.TestCheckResourceAttrSet(fullName, "application_profile_id"),
@@ -169,10 +173,10 @@ func TestAccResourceNsxtLbHttpVirtualServer_withSSL(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNSXLbHTTPVirtualServerCreateTemplateWithSSL(updatedDepth),
+				Config: testAccNSXLbHTTPVirtualServerCreateTemplateWithSSL(name, updatedDepth),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNSXLbHTTPVirtualServerExists(name, fullName),
-					resource.TestCheckResourceAttr(fullName, "display_name", "test"),
+					resource.TestCheckResourceAttr(fullName, "display_name", name),
 					resource.TestCheckResourceAttr(fullName, "description", "test description"),
 					resource.TestCheckResourceAttr(fullName, "access_log_enabled", "false"),
 					resource.TestCheckResourceAttrSet(fullName, "application_profile_id"),
@@ -278,29 +282,29 @@ func testAccNSXLbHTTPVirtualServerCheckDestroy(state *terraform.State, displayNa
 	return nil
 }
 
-func testAccNSXLbHTTPVirtualServerCreateTemplate(port string, enabled string) string {
+func testAccNSXLbHTTPVirtualServerCreateTemplate(name string, port string, enabled string) string {
 	return fmt.Sprintf(`
 resource "nsxt_lb_http_application_profile" "test" {
-  display_name = "lb virtual server test"
+  display_name = "%s"
 }
 
 resource "nsxt_lb_cookie_persistence_profile" "test" {
-  display_name = "lb virtual server test"
+  display_name = "%s"
   cookie_name  = "test"
 }
 
 resource "nsxt_lb_pool" "test" {
-  display_name = "lb virtual server test"
+  display_name = "%s"
   algorithm    = "ROUND_ROBIN"
 }
 
 resource "nsxt_lb_pool" "sorry" {
-  display_name = "lb virtual server test sorry pool"
+  display_name = "%s"
   algorithm    = "ROUND_ROBIN"
 }
 
 resource "nsxt_lb_http_virtual_server" "test" {
-  display_name               = "test"
+  display_name               = "%s"
   description                = "test description"
   access_log_enabled         = true
   application_profile_id     = "${nsxt_lb_http_application_profile.test.id}"
@@ -319,18 +323,18 @@ resource "nsxt_lb_http_virtual_server" "test" {
     tag   = "tag1"
   }
 }
-`, enabled, port)
+`, name, name, testLbVirtualServerHelper1Name, testLbVirtualServerHelper2Name, name, enabled, port)
 }
 
 // TODO: add other types of rules
-func testAccNSXLbHTTPVirtualServerCreateTemplateWithRules(rule1 string, rule2 string) string {
+func testAccNSXLbHTTPVirtualServerCreateTemplateWithRules(name string, rule1 string, rule2 string) string {
 	return fmt.Sprintf(`
 resource "nsxt_lb_http_application_profile" "test" {
-  display_name = "lb virtual server test"
+  display_name = "%s"
 }
 
 resource "nsxt_lb_http_request_rewrite_rule" "rule1" {
-  display_name = "lb virtual server test rule1"
+  display_name = "%s"
   method_condition {
     method = "HEAD"
   }
@@ -342,7 +346,7 @@ resource "nsxt_lb_http_request_rewrite_rule" "rule1" {
 }
 
 resource "nsxt_lb_http_request_rewrite_rule" "rule2" {
-  display_name = "lb virtual server test rule2"
+  display_name = "%s"
   uri_condition {
     uri        = "/hello"
     match_type = "STARTS_WITH"
@@ -355,7 +359,7 @@ resource "nsxt_lb_http_request_rewrite_rule" "rule2" {
 }
 
 resource "nsxt_lb_http_request_rewrite_rule" "rule3" {
-  display_name = "lb virtual server test rule3"
+  display_name = "%s"
   uri_condition {
     uri = "html"
     match_type = "ENDS_WITH"
@@ -368,19 +372,19 @@ resource "nsxt_lb_http_request_rewrite_rule" "rule3" {
 }
 
 resource "nsxt_lb_http_virtual_server" "test" {
-  display_name           = "test"
+  display_name           = "%s"
   application_profile_id = "${nsxt_lb_http_application_profile.test.id}"
   ip_address             = "1.1.1.1"
   port                   = "443"
   rule_ids               = ["${nsxt_lb_http_request_rewrite_rule.%s.id}", "${nsxt_lb_http_request_rewrite_rule.%s.id}"]
 }
-`, rule1, rule2)
+`, testLbVirtualServerHelper1Name, testLbVirtualServerHelper1Name, testLbVirtualServerHelper2Name, testLbVirtualServerHelper3Name, name, rule1, rule2)
 }
 
-func testAccNSXLbHTTPVirtualServerCreateTemplateWithSSL(depth string) string {
+func testAccNSXLbHTTPVirtualServerCreateTemplateWithSSL(name string, depth string) string {
 	return fmt.Sprintf(`
 resource "nsxt_lb_http_application_profile" "test" {
-  display_name = "lb virtual server test"
+  display_name = "%s"
 }
 
 data "nsxt_certificate" "ca" {
@@ -396,15 +400,15 @@ data "nsxt_certificate" "mine" {
 }
 
 resource "nsxt_lb_client_ssl_profile" "test" {
-  display_name = "lb virtual server test"
+  display_name = "%s"
 }
 
 resource "nsxt_lb_server_ssl_profile" "test" {
-  display_name = "lb virtual server test"
+  display_name = "%s"
 }
 
 resource "nsxt_lb_http_virtual_server" "test" {
-  display_name           = "test"
+  display_name           = "%s"
   description            = "test description"
   application_profile_id = "${nsxt_lb_http_application_profile.test.id}"
   ip_address             = "1.1.1.1"
@@ -427,14 +431,14 @@ resource "nsxt_lb_http_virtual_server" "test" {
   }
 
 }
-`, depth, depth)
+`, name, name, name, name, depth, depth)
 }
 
 func testAccNSXLbHTTPVirtualServerCreateTemplateTrivial() string {
-	return `
+	return fmt.Sprintf(`
 
 resource "nsxt_lb_http_application_profile" "test" {
-  display_name = "lb virtual server test"
+  display_name = "%s"
 }
 
 resource "nsxt_lb_http_virtual_server" "test" {
@@ -443,5 +447,5 @@ resource "nsxt_lb_http_virtual_server" "test" {
   ip_address             = "2.2.2.2"
   port                   = "443"
 }
-`
+`, testLbVirtualServerHelper1Name)
 }

--- a/nsxt/resource_nsxt_lb_icmp_monitor_test.go
+++ b/nsxt/resource_nsxt_lb_icmp_monitor_test.go
@@ -24,7 +24,7 @@ func TestAccResourceNsxtLbIcmpMonitor_basic(t *testing.T) {
 	dataLength := "100"
 	updatedCount := "5"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccOnlyLocalManager(t)
 			testAccTestMP(t)
@@ -73,7 +73,7 @@ func TestAccResourceNsxtLbIcmpMonitor_basic(t *testing.T) {
 func TestAccResourceNsxtLbIcmpMonitor_importBasic(t *testing.T) {
 	name := getAccTestResourceName()
 	testResourceName := "nsxt_lb_icmp_monitor.test"
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccOnlyLocalManager(t)
 			testAccTestMP(t)

--- a/nsxt/resource_nsxt_lb_icmp_monitor_test.go
+++ b/nsxt/resource_nsxt_lb_icmp_monitor_test.go
@@ -13,8 +13,8 @@ import (
 )
 
 func TestAccResourceNsxtLbIcmpMonitor_basic(t *testing.T) {
-	name := "test-nsx-monitor"
-	updatedName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
+	updatedName := getAccTestResourceName()
 	testResourceName := "nsxt_lb_icmp_monitor.test"
 	port := "7887"
 	updatedPort := "8778"
@@ -33,7 +33,7 @@ func TestAccResourceNsxtLbIcmpMonitor_basic(t *testing.T) {
 		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNSXLbIcmpMonitorCheckDestroy(state, name)
+			return testAccNSXLbIcmpMonitorCheckDestroy(state, updatedName)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -71,7 +71,7 @@ func TestAccResourceNsxtLbIcmpMonitor_basic(t *testing.T) {
 }
 
 func TestAccResourceNsxtLbIcmpMonitor_importBasic(t *testing.T) {
-	name := "test-nsx-monitor"
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_lb_icmp_monitor.test"
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {

--- a/nsxt/resource_nsxt_lb_l4_monitor_test.go
+++ b/nsxt/resource_nsxt_lb_l4_monitor_test.go
@@ -29,8 +29,8 @@ func TestAccResourceNsxtLbUdpMonitor_importBasic(t *testing.T) {
 }
 
 func testAccResourceNsxtLbL4MonitorBasic(t *testing.T, protocol string) {
-	name := "test-nsx-monitor"
-	updatedName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
+	updatedName := getAccTestResourceName()
 	testResourceName := fmt.Sprintf("nsxt_lb_%s_monitor.test", protocol)
 	port := "7887"
 	updatedPort := "8778"
@@ -50,7 +50,7 @@ func testAccResourceNsxtLbL4MonitorBasic(t *testing.T, protocol string) {
 		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNSXLbL4MonitorCheckDestroy(protocol, state, name)
+			return testAccNSXLbL4MonitorCheckDestroy(protocol, state, updatedName)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -90,7 +90,7 @@ func testAccResourceNsxtLbL4MonitorBasic(t *testing.T, protocol string) {
 }
 
 func testAccResourceNsxtLbL4MonitorImport(t *testing.T, protocol string) {
-	name := "test-nsx-monitor"
+	name := getAccTestResourceName()
 	testResourceName := fmt.Sprintf("nsxt_lb_%s_monitor.test", protocol)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {

--- a/nsxt/resource_nsxt_lb_l4_monitor_test.go
+++ b/nsxt/resource_nsxt_lb_l4_monitor_test.go
@@ -41,7 +41,7 @@ func testAccResourceNsxtLbL4MonitorBasic(t *testing.T, protocol string) {
 	send := "Client hello"
 	receive := "Server hello"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccOnlyLocalManager(t)
 			testAccTestMP(t)

--- a/nsxt/resource_nsxt_lb_l4_virtual_server_test.go
+++ b/nsxt/resource_nsxt_lb_l4_virtual_server_test.go
@@ -21,7 +21,7 @@ func TestAccResourceNsxtLbUDPVirtualServer_basic(t *testing.T) {
 }
 
 func testAccResourceNsxtLbL4VirtualServer(t *testing.T, protocol string) {
-	name := "test"
+	name := getAccTestResourceName()
 	fullName := fmt.Sprintf("nsxt_lb_%s_virtual_server.test", protocol)
 	port := "888-890"
 	updatedPort := "999"
@@ -39,7 +39,7 @@ func testAccResourceNsxtLbL4VirtualServer(t *testing.T, protocol string) {
 				Config: testAccNSXLbL4VirtualServerCreateTemplate(protocol, port, memberPort),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNSXLbL4VirtualServerExists(name, fullName),
-					resource.TestCheckResourceAttr(fullName, "display_name", "test"),
+					resource.TestCheckResourceAttr(fullName, "display_name", name),
 					resource.TestCheckResourceAttr(fullName, "description", "test description"),
 					resource.TestCheckResourceAttr(fullName, "access_log_enabled", "false"),
 					resource.TestCheckResourceAttrSet(fullName, "application_profile_id"),
@@ -62,7 +62,7 @@ func testAccResourceNsxtLbL4VirtualServer(t *testing.T, protocol string) {
 				Config: testAccNSXLbL4VirtualServerCreateTemplate(protocol, updatedPort, updatedMemberPort),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNSXLbL4VirtualServerExists(name, fullName),
-					resource.TestCheckResourceAttr(fullName, "display_name", "test"),
+					resource.TestCheckResourceAttr(fullName, "display_name", name),
 					resource.TestCheckResourceAttr(fullName, "description", "test description"),
 					resource.TestCheckResourceAttr(fullName, "access_log_enabled", "false"),
 					resource.TestCheckResourceAttrSet(fullName, "application_profile_id"),
@@ -94,7 +94,7 @@ func TestAccResourceNsxtLbUDPVirtualServer_importBasic(t *testing.T) {
 }
 
 func testAccResourceNsxtLbL4VirtualServerImport(t *testing.T, protocol string) {
-	name := "test"
+	name := getAccTestResourceName()
 	resourceName := fmt.Sprintf("nsxt_lb_%s_virtual_server.test", protocol)
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },

--- a/nsxt/resource_nsxt_lb_l4_virtual_server_test.go
+++ b/nsxt/resource_nsxt_lb_l4_virtual_server_test.go
@@ -12,6 +12,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
+var accTestLbVirtualServerHelper1Name = getAccTestResourceName()
+var accTestLbVirtualServerHelper2Name = getAccTestResourceName()
+
 func TestAccResourceNsxtLbTCPVirtualServer_basic(t *testing.T) {
 	testAccResourceNsxtLbL4VirtualServer(t, "tcp")
 }
@@ -36,7 +39,7 @@ func testAccResourceNsxtLbL4VirtualServer(t *testing.T, protocol string) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNSXLbL4VirtualServerCreateTemplate(protocol, port, memberPort),
+				Config: testAccNSXLbL4VirtualServerCreateTemplate(name, protocol, port, memberPort),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNSXLbL4VirtualServerExists(name, fullName),
 					resource.TestCheckResourceAttr(fullName, "display_name", name),
@@ -59,7 +62,7 @@ func testAccResourceNsxtLbL4VirtualServer(t *testing.T, protocol string) {
 				),
 			},
 			{
-				Config: testAccNSXLbL4VirtualServerCreateTemplate(protocol, updatedPort, updatedMemberPort),
+				Config: testAccNSXLbL4VirtualServerCreateTemplate(name, protocol, updatedPort, updatedMemberPort),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNSXLbL4VirtualServerExists(name, fullName),
 					resource.TestCheckResourceAttr(fullName, "display_name", name),
@@ -168,28 +171,28 @@ func testAccNSXLbL4VirtualServerCheckDestroy(state *terraform.State, protocol st
 	return nil
 }
 
-func testAccNSXLbL4VirtualServerCreateTemplate(protocol string, port string, memberPort string) string {
+func testAccNSXLbL4VirtualServerCreateTemplate(name string, protocol string, port string, memberPort string) string {
 	return fmt.Sprintf(`
 resource "nsxt_lb_fast_%s_application_profile" "test" {
-  display_name = "lb virtual server test"
+  display_name = "%s"
 }
 
 resource "nsxt_lb_source_ip_persistence_profile" "test" {
-  display_name = "lb virtual server test"
+  display_name = "%s"
 }
 
 resource "nsxt_lb_pool" "test" {
-  display_name = "lb virtual server test"
+  display_name = "%s"
   algorithm    = "ROUND_ROBIN"
 }
 
 resource "nsxt_lb_pool" "sorry" {
-  display_name = "lb virtual server test sorry pool"
+  display_name = "%s"
   algorithm    = "ROUND_ROBIN"
 }
 
 resource "nsxt_lb_%s_virtual_server" "test" {
-  display_name               = "test"
+  display_name               = "%s"
   description                = "test description"
   access_log_enabled         = false
   application_profile_id     = "${nsxt_lb_fast_%s_application_profile.test.id}"
@@ -208,7 +211,7 @@ resource "nsxt_lb_%s_virtual_server" "test" {
     tag   = "tag1"
   }
 }
-`, protocol, protocol, protocol, port, memberPort)
+`, protocol, name, name, accTestLbVirtualServerHelper1Name, accTestLbVirtualServerHelper2Name, protocol, name, protocol, port, memberPort)
 }
 
 func testAccNSXLbL4VirtualServerCreateTemplateTrivial(protocol string) string {

--- a/nsxt/resource_nsxt_lb_l7_monitor_test.go
+++ b/nsxt/resource_nsxt_lb_l7_monitor_test.go
@@ -40,7 +40,7 @@ func testAccResourceNsxtLbL7MonitorBasic(t *testing.T, protocol string) {
 	body1 := "XXXXXXXXXXXXXXXXXXX"
 	body2 := "YYYYYYYYYYYYYYYYYYY"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccOnlyLocalManager(t)
 			testAccTestMP(t)
@@ -90,7 +90,7 @@ func TestAccResourceNsxtLbHTTPSMonitor_withAuth(t *testing.T) {
 	name := getAccTestResourceName()
 	testResourceName := "nsxt_lb_https_monitor.test"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccOnlyLocalManager(t)
 			testAccTestMP(t)

--- a/nsxt/resource_nsxt_lb_l7_monitor_test.go
+++ b/nsxt/resource_nsxt_lb_l7_monitor_test.go
@@ -33,7 +33,7 @@ func TestAccResourceNsxtLbHTTPSMonitor_importBasic(t *testing.T) {
 }
 
 func testAccResourceNsxtLbL7MonitorBasic(t *testing.T, protocol string) {
-	name := "test-nsx-monitor"
+	name := getAccTestResourceName()
 	testResourceName := fmt.Sprintf("nsxt_lb_%s_monitor.test", protocol)
 	requestMethod := "HEAD"
 	updatedRequestMethod := "POST"
@@ -87,7 +87,7 @@ func testAccResourceNsxtLbL7MonitorBasic(t *testing.T, protocol string) {
 }
 
 func TestAccResourceNsxtLbHTTPSMonitor_withAuth(t *testing.T) {
-	name := "test-nsx-monitor"
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_lb_https_monitor.test"
 
 	resource.Test(t, resource.TestCase{
@@ -126,7 +126,7 @@ func TestAccResourceNsxtLbHTTPSMonitor_withAuth(t *testing.T) {
 }
 
 func testAccResourceNsxtLbL7MonitorImport(t *testing.T, protocol string) {
-	name := "test-nsx-monitor"
+	name := getAccTestResourceName()
 	testResourceName := fmt.Sprintf("nsxt_lb_%s_monitor.test", protocol)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {

--- a/nsxt/resource_nsxt_lb_passive_monitor_test.go
+++ b/nsxt/resource_nsxt_lb_passive_monitor_test.go
@@ -20,7 +20,7 @@ func TestAccResourceNsxtLbPassiveMonitor_basic(t *testing.T) {
 	timeout := "20"
 	updatedTimeout := "7"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccOnlyLocalManager(t)
 			testAccTestMP(t)
@@ -61,7 +61,7 @@ func TestAccResourceNsxtLbPassiveMonitor_basic(t *testing.T) {
 func TestAccResourceNsxtLbPassiveMonitor_importBasic(t *testing.T) {
 	name := getAccTestResourceName()
 	testResourceName := "nsxt_lb_passive_monitor.test"
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccOnlyLocalManager(t)
 			testAccTestMP(t)

--- a/nsxt/resource_nsxt_lb_passive_monitor_test.go
+++ b/nsxt/resource_nsxt_lb_passive_monitor_test.go
@@ -13,8 +13,8 @@ import (
 )
 
 func TestAccResourceNsxtLbPassiveMonitor_basic(t *testing.T) {
-	name := "test-nsx-monitor"
-	updatedName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
+	updatedName := getAccTestResourceName()
 	testResourceName := "nsxt_lb_passive_monitor.test"
 	maxFails := "9"
 	timeout := "20"
@@ -29,7 +29,7 @@ func TestAccResourceNsxtLbPassiveMonitor_basic(t *testing.T) {
 		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNSXLbPassiveMonitorCheckDestroy(state, name)
+			return testAccNSXLbPassiveMonitorCheckDestroy(state, updatedName)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -59,7 +59,7 @@ func TestAccResourceNsxtLbPassiveMonitor_basic(t *testing.T) {
 }
 
 func TestAccResourceNsxtLbPassiveMonitor_importBasic(t *testing.T) {
-	name := "test-nsx-monitor"
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_lb_passive_monitor.test"
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {

--- a/nsxt/resource_nsxt_lb_pool_test.go
+++ b/nsxt/resource_nsxt_lb_pool_test.go
@@ -23,7 +23,7 @@ func TestAccResourceNsxtLbPool_basic(t *testing.T) {
 	snatTranslationType := "TRANSPARENT"
 	updatedSnatTranslationType := "SNAT_AUTO_MAP"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccOnlyLocalManager(t)
 			testAccTestMP(t)
@@ -69,7 +69,7 @@ func TestAccResourceNsxtLbPool_withMonitors(t *testing.T) {
 	name := getAccTestResourceName()
 	testResourceName := "nsxt_lb_pool.test"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccOnlyLocalManager(t)
 			testAccTestMP(t)
@@ -121,7 +121,7 @@ func TestAccResourceNsxtLbPool_withIpSnat(t *testing.T) {
 	ipAddress := "1.1.1.1"
 	updatedIPAddress := "1.1.1.2-1.1.1.20"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccOnlyLocalManager(t)
 			testAccTestMP(t)
@@ -176,7 +176,7 @@ func TestAccResourceNsxtLbPool_withMember(t *testing.T) {
 	updatedSnatTranslationType := "SNAT_AUTO_MAP"
 	memberIP := "1.1.1.1"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccOnlyLocalManager(t)
 			testAccTestMP(t)
@@ -230,7 +230,7 @@ func TestAccResourceNsxtLbPool_withMemberGroup(t *testing.T) {
 	port := "50"
 	updatedPort := "60"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccOnlyLocalManager(t)
 			testAccTestMP(t)
@@ -285,7 +285,7 @@ func TestAccResourceNsxtLbPool_withMemberGroup(t *testing.T) {
 func TestAccResourceNsxtLbPool_importBasic(t *testing.T) {
 	name := getAccTestResourceName()
 	testResourceName := "nsxt_lb_pool.test"
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccOnlyLocalManager(t)
 			testAccTestMP(t)

--- a/nsxt/resource_nsxt_lb_pool_test.go
+++ b/nsxt/resource_nsxt_lb_pool_test.go
@@ -13,8 +13,8 @@ import (
 )
 
 func TestAccResourceNsxtLbPool_basic(t *testing.T) {
-	name := "test-nsx-lb-pool"
-	updatedName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
+	updatedName := getAccTestResourceName()
 	testResourceName := "nsxt_lb_pool.test"
 	algorithm := "LEAST_CONNECTION"
 	updatedAlgorithm := "WEIGHTED_ROUND_ROBIN"
@@ -32,7 +32,7 @@ func TestAccResourceNsxtLbPool_basic(t *testing.T) {
 		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNSXLbPoolCheckDestroy(state, name)
+			return testAccNSXLbPoolCheckDestroy(state, updatedName)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -66,8 +66,7 @@ func TestAccResourceNsxtLbPool_basic(t *testing.T) {
 }
 
 func TestAccResourceNsxtLbPool_withMonitors(t *testing.T) {
-	name := "test-nsx-lb-pool"
-	updatedName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_lb_pool.test"
 
 	resource.Test(t, resource.TestCase{
@@ -96,10 +95,10 @@ func TestAccResourceNsxtLbPool_withMonitors(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNSXLbPoolUpdateWithMonitorsTemplate(updatedName),
+				Config: testAccNSXLbPoolUpdateWithMonitorsTemplate(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccNSXLbPoolExists(updatedName, testResourceName),
-					resource.TestCheckResourceAttr(testResourceName, "display_name", updatedName),
+					testAccNSXLbPoolExists(name, testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", name),
 					resource.TestCheckResourceAttr(testResourceName, "description", "Updated Acceptance Test"),
 					resource.TestCheckResourceAttr(testResourceName, "tag.#", "0"),
 					resource.TestCheckResourceAttr(testResourceName, "member.#", "0"),
@@ -112,8 +111,7 @@ func TestAccResourceNsxtLbPool_withMonitors(t *testing.T) {
 }
 
 func TestAccResourceNsxtLbPool_withIpSnat(t *testing.T) {
-	name := "test-nsx-lb-pool"
-	updatedName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_lb_pool.test"
 	algorithm := "LEAST_CONNECTION"
 	updatedAlgorithm := "WEIGHTED_ROUND_ROBIN"
@@ -150,10 +148,10 @@ func TestAccResourceNsxtLbPool_withIpSnat(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNSXLbPoolUpdateWithSnatTemplate(updatedName, updatedAlgorithm, updatedMinActiveMembers, snatTranslationType, updatedIPAddress),
+				Config: testAccNSXLbPoolUpdateWithSnatTemplate(name, updatedAlgorithm, updatedMinActiveMembers, snatTranslationType, updatedIPAddress),
 				Check: resource.ComposeTestCheckFunc(
-					testAccNSXLbPoolExists(updatedName, testResourceName),
-					resource.TestCheckResourceAttr(testResourceName, "display_name", updatedName),
+					testAccNSXLbPoolExists(name, testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", name),
 					resource.TestCheckResourceAttr(testResourceName, "description", "Updated Acceptance Test"),
 					resource.TestCheckResourceAttr(testResourceName, "algorithm", updatedAlgorithm),
 					resource.TestCheckResourceAttr(testResourceName, "min_active_members", updatedMinActiveMembers),
@@ -168,8 +166,7 @@ func TestAccResourceNsxtLbPool_withIpSnat(t *testing.T) {
 }
 
 func TestAccResourceNsxtLbPool_withMember(t *testing.T) {
-	name := "test-nsx-lb-pool"
-	updatedName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_lb_pool.test"
 	algorithm := "LEAST_CONNECTION"
 	updatedAlgorithm := "WEIGHTED_ROUND_ROBIN"
@@ -207,17 +204,17 @@ func TestAccResourceNsxtLbPool_withMember(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNSXLbPoolUpdateWithMemberTemplate(updatedName, updatedAlgorithm, updatedMinActiveMembers, updatedSnatTranslationType, memberIP),
+				Config: testAccNSXLbPoolUpdateWithMemberTemplate(name, updatedAlgorithm, updatedMinActiveMembers, updatedSnatTranslationType, memberIP),
 				Check: resource.ComposeTestCheckFunc(
-					testAccNSXLbPoolExists(updatedName, testResourceName),
-					resource.TestCheckResourceAttr(testResourceName, "display_name", updatedName),
+					testAccNSXLbPoolExists(name, testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", name),
 					resource.TestCheckResourceAttr(testResourceName, "description", "Updated Acceptance Test"),
 					resource.TestCheckResourceAttr(testResourceName, "algorithm", updatedAlgorithm),
 					resource.TestCheckResourceAttr(testResourceName, "min_active_members", updatedMinActiveMembers),
 					resource.TestCheckResourceAttr(testResourceName, "snat_translation.0.type", updatedSnatTranslationType),
 					resource.TestCheckResourceAttr(testResourceName, "tag.#", "2"),
 					resource.TestCheckResourceAttr(testResourceName, "member.#", "2"),
-					resource.TestCheckResourceAttr(testResourceName, "member.0.display_name", updatedName+"-member"),
+					resource.TestCheckResourceAttr(testResourceName, "member.0.display_name", name+"-member"),
 					resource.TestCheckResourceAttr(testResourceName, "member.0.ip_address", memberIP),
 				),
 			},
@@ -226,8 +223,7 @@ func TestAccResourceNsxtLbPool_withMember(t *testing.T) {
 }
 
 func TestAccResourceNsxtLbPool_withMemberGroup(t *testing.T) {
-	name := "test-nsx-lb-pool"
-	updatedName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_lb_pool.test"
 	algorithm := "LEAST_CONNECTION"
 	size := "3"
@@ -265,10 +261,10 @@ func TestAccResourceNsxtLbPool_withMemberGroup(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNSXLbPoolUpdateWithMemberGroupTemplate(updatedName, algorithm, updatedPort),
+				Config: testAccNSXLbPoolUpdateWithMemberGroupTemplate(name, algorithm, updatedPort),
 				Check: resource.ComposeTestCheckFunc(
-					testAccNSXLbPoolExists(updatedName, testResourceName),
-					resource.TestCheckResourceAttr(testResourceName, "display_name", updatedName),
+					testAccNSXLbPoolExists(name, testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", name),
 					resource.TestCheckResourceAttr(testResourceName, "description", "Updated Acceptance Test"),
 					resource.TestCheckResourceAttr(testResourceName, "algorithm", algorithm),
 					resource.TestCheckResourceAttr(testResourceName, "member.#", "0"),
@@ -287,7 +283,7 @@ func TestAccResourceNsxtLbPool_withMemberGroup(t *testing.T) {
 }
 
 func TestAccResourceNsxtLbPool_importBasic(t *testing.T) {
-	name := "test-nsx-lb-pool"
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_lb_pool.test"
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {

--- a/nsxt/resource_nsxt_lb_server_ssl_profile_test.go
+++ b/nsxt/resource_nsxt_lb_server_ssl_profile_test.go
@@ -13,8 +13,8 @@ import (
 )
 
 func TestAccResourceNsxtLbServerSSLProfile_basic(t *testing.T) {
-	name := "test"
-	updatedName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
+	updatedName := getAccTestResourceName()
 	testResourceName := "nsxt_lb_server_ssl_profile.test"
 
 	resource.Test(t, resource.TestCase{
@@ -26,7 +26,7 @@ func TestAccResourceNsxtLbServerSSLProfile_basic(t *testing.T) {
 		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNSXLbServerSSLProfileCheckDestroy(state, name)
+			return testAccNSXLbServerSSLProfileCheckDestroy(state, updatedName)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -60,7 +60,7 @@ func TestAccResourceNsxtLbServerSSLProfile_basic(t *testing.T) {
 }
 
 func TestAccResourceNsxtLbServerSSLProfile_importBasic(t *testing.T) {
-	name := "test"
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_lb_server_ssl_profile.test"
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {

--- a/nsxt/resource_nsxt_lb_service_test.go
+++ b/nsxt/resource_nsxt_lb_service_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestAccResourceNsxtLbService_basic(t *testing.T) {
-	name := "test"
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_lb_service.test"
 
 	resource.Test(t, resource.TestCase{
@@ -54,7 +54,7 @@ func TestAccResourceNsxtLbService_basic(t *testing.T) {
 }
 
 func TestAccResourceNsxtLbService_withServers(t *testing.T) {
-	name := "test"
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_lb_service.test"
 	logLevel := "EMERGENCY"
 	updatedLogLevel := "INFO"
@@ -95,7 +95,7 @@ func TestAccResourceNsxtLbService_withServers(t *testing.T) {
 }
 
 func TestAccResourceNsxtLbService_importBasic(t *testing.T) {
-	name := "test"
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_lb_service.test"
 
 	resource.Test(t, resource.TestCase{

--- a/nsxt/resource_nsxt_lb_service_test.go
+++ b/nsxt/resource_nsxt_lb_service_test.go
@@ -24,7 +24,7 @@ func TestAccResourceNsxtLbService_basic(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNSXLbServiceCreateTemplate(),
+				Config: testAccNSXLbServiceCreateTemplate(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNSXLbServiceExists(name, testResourceName),
 					resource.TestCheckResourceAttr(testResourceName, "display_name", name),
@@ -37,7 +37,7 @@ func TestAccResourceNsxtLbService_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNSXLbServiceUpdateTemplate(),
+				Config: testAccNSXLbServiceUpdateTemplate(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNSXLbServiceExists(name, testResourceName),
 					resource.TestCheckResourceAttr(testResourceName, "display_name", name),
@@ -67,7 +67,7 @@ func TestAccResourceNsxtLbService_withServers(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNSXLbServiceCreateTemplateWithServers(logLevel),
+				Config: testAccNSXLbServiceCreateTemplateWithServers(name, logLevel),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNSXLbServiceExists(name, testResourceName),
 					resource.TestCheckResourceAttr(testResourceName, "display_name", name),
@@ -79,7 +79,7 @@ func TestAccResourceNsxtLbService_withServers(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNSXLbServiceCreateTemplateWithServers(updatedLogLevel),
+				Config: testAccNSXLbServiceCreateTemplateWithServers(name, updatedLogLevel),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNSXLbServiceExists(name, testResourceName),
 					resource.TestCheckResourceAttr(testResourceName, "display_name", name),
@@ -106,7 +106,7 @@ func TestAccResourceNsxtLbService_importBasic(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNSXLbServiceCreateTemplate(),
+				Config: testAccNSXLbServiceCreateTemplate(name),
 			},
 			{
 				ResourceName:      testResourceName,
@@ -200,10 +200,10 @@ resource "nsxt_logical_router_link_port_on_tier1" "test" {
 }`, edgeClusterName, tier0Name)
 }
 
-func testAccNSXLbServiceCreateTemplate() string {
-	return testAccNSXLbCreateTopology() + `
+func testAccNSXLbServiceCreateTemplate(name string) string {
+	return testAccNSXLbCreateTopology() + fmt.Sprintf(`
 resource "nsxt_lb_service" "test" {
-  display_name      = "test"
+  display_name      = "%s"
   enabled           = true
   description       = "Acceptance Test"
   logical_router_id = "${nsxt_logical_tier1_router.test.id}"
@@ -216,13 +216,13 @@ resource "nsxt_lb_service" "test" {
   }
 
   depends_on = ["nsxt_logical_router_link_port_on_tier1.test"]
-}`
+}`, name)
 }
 
-func testAccNSXLbServiceUpdateTemplate() string {
-	return testAccNSXLbCreateTopology() + `
+func testAccNSXLbServiceUpdateTemplate(name string) string {
+	return testAccNSXLbCreateTopology() + fmt.Sprintf(`
 resource "nsxt_lb_service" "test" {
-  display_name      = "test"
+  display_name      = "%s"
   enabled           = false
   description       = "Acceptance Test Update"
   logical_router_id = "${nsxt_logical_tier1_router.test.id}"
@@ -240,10 +240,10 @@ resource "nsxt_lb_service" "test" {
   }
 
   depends_on = ["nsxt_logical_router_link_port_on_tier1.test"]
-}`
+}`, name)
 }
 
-func testAccNSXLbServiceCreateTemplateWithServers(logLevel string) string {
+func testAccNSXLbServiceCreateTemplateWithServers(name string, logLevel string) string {
 	return testAccNSXLbCreateTopology() + fmt.Sprintf(`
 
 resource "nsxt_lb_fast_tcp_application_profile" "test" {
@@ -267,11 +267,11 @@ resource "nsxt_lb_udp_virtual_server" "test"{
 }
 
 resource "nsxt_lb_service" "test" {
-  display_name       = "test"
+  display_name       = "%s"
   logical_router_id  = "${nsxt_logical_tier1_router.test.id}"
   error_log_level    = "%s"
   virtual_server_ids = ["${nsxt_lb_tcp_virtual_server.test.id}", "${nsxt_lb_udp_virtual_server.test.id}"]
 
   depends_on = ["nsxt_logical_router_link_port_on_tier1.test"]
-}`, logLevel)
+}`, name, logLevel)
 }

--- a/nsxt/resource_nsxt_lb_source_ip_persistence_profile_test.go
+++ b/nsxt/resource_nsxt_lb_source_ip_persistence_profile_test.go
@@ -13,8 +13,8 @@ import (
 )
 
 func TestAccResourceNsxtLbSourceIpPersistenceProfile_basic(t *testing.T) {
-	name := "test-nsx-persistence-profile"
-	updatedName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
+	updatedName := getAccTestResourceName()
 	testResourceName := "nsxt_lb_source_ip_persistence_profile.test"
 	timeout := "100"
 	updatedTimeout := "200"
@@ -23,7 +23,7 @@ func TestAccResourceNsxtLbSourceIpPersistenceProfile_basic(t *testing.T) {
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNSXLbSourceIPPersistenceProfileCheckDestroy(state, name)
+			return testAccNSXLbSourceIPPersistenceProfileCheckDestroy(state, updatedName)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -57,7 +57,7 @@ func TestAccResourceNsxtLbSourceIpPersistenceProfile_basic(t *testing.T) {
 }
 
 func TestAccResourceNsxtLbSourceIpPersistenceProfile_importBasic(t *testing.T) {
-	name := "test-nsx-persistence-profile"
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_lb_source_ip_persistence_profile.test"
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },

--- a/nsxt/resource_nsxt_logical_dhcp_port_test.go
+++ b/nsxt/resource_nsxt_logical_dhcp_port_test.go
@@ -12,8 +12,8 @@ import (
 )
 
 func TestAccResourceNsxtLogicalDhcpPort_basic(t *testing.T) {
-	portName := "test-nsx-logical-dhcp-port"
-	updatePortName := fmt.Sprintf("%s-update", portName)
+	portName := getAccTestResourceName()
+	updatePortName := getAccTestResourceName()
 	testResourceName := "nsxt_logical_dhcp_port.test"
 	transportZoneName := getOverlayTransportZoneName()
 	edgeClusterName := getEdgeClusterName()
@@ -22,7 +22,7 @@ func TestAccResourceNsxtLogicalDhcpPort_basic(t *testing.T) {
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNSXLogicalPortCheckDestroy(state, portName)
+			return testAccNSXLogicalPortCheckDestroy(state, updatePortName)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -54,7 +54,7 @@ func TestAccResourceNsxtLogicalDhcpPort_basic(t *testing.T) {
 }
 
 func TestAccResourceNsxtLogicalDhcpPort_importBasic(t *testing.T) {
-	portName := "test-nsx-logical-dhcp-port"
+	portName := getAccTestResourceName()
 	testResourceName := "nsxt_logical_dhcp_port.test"
 	transportZoneName := getOverlayTransportZoneName()
 	edgeClusterName := getEdgeClusterName()

--- a/nsxt/resource_nsxt_logical_dhcp_server_test.go
+++ b/nsxt/resource_nsxt_logical_dhcp_server_test.go
@@ -13,8 +13,8 @@ import (
 )
 
 func TestAccResourceNsxtLogicalDhcpServer_basic(t *testing.T) {
-	prfName := "test-nsx-logical-dhcp-server"
-	updatePrfName := fmt.Sprintf("%s-update", prfName)
+	prfName := getAccTestResourceName()
+	updatePrfName := getAccTestResourceName()
 	testResourceName := "nsxt_logical_dhcp_server.test"
 	edgeClusterName := getEdgeClusterName()
 	ip1 := "1.1.1.10/24"
@@ -29,7 +29,7 @@ func TestAccResourceNsxtLogicalDhcpServer_basic(t *testing.T) {
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNSXLogicalDhcpServerCheckDestroy(state, prfName)
+			return testAccNSXLogicalDhcpServerCheckDestroy(state, updatePrfName)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -74,8 +74,7 @@ func TestAccResourceNsxtLogicalDhcpServer_basic(t *testing.T) {
 }
 
 func TestAccResourceNsxtLogicalDhcpServer_noOpts(t *testing.T) {
-	prfName := "test-nsx-logical-dhcp-server"
-	updatePrfName := fmt.Sprintf("%s-update", prfName)
+	prfName := getAccTestResourceName()
 	testResourceName := "nsxt_logical_dhcp_server.test"
 	edgeClusterName := getEdgeClusterName()
 	ip1 := "1.1.1.10/24"
@@ -108,10 +107,10 @@ func TestAccResourceNsxtLogicalDhcpServer_noOpts(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNSXLogicalDhcpServerUpdateNoOptsTemplate(edgeClusterName, updatePrfName, ip1upd, ip2upd, ip3, ip4),
+				Config: testAccNSXLogicalDhcpServerUpdateNoOptsTemplate(edgeClusterName, prfName, ip1upd, ip2upd, ip3, ip4),
 				Check: resource.ComposeTestCheckFunc(
-					testAccNSXLogicalDhcpServerExists(updatePrfName, testResourceName),
-					resource.TestCheckResourceAttr(testResourceName, "display_name", updatePrfName),
+					testAccNSXLogicalDhcpServerExists(prfName, testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", prfName),
 					resource.TestCheckResourceAttr(testResourceName, "description", "Acceptance Test Update"),
 					resource.TestCheckResourceAttrSet(testResourceName, "dhcp_profile_id"),
 					resource.TestCheckResourceAttr(testResourceName, "dhcp_server_ip", ip1upd),
@@ -127,7 +126,7 @@ func TestAccResourceNsxtLogicalDhcpServer_noOpts(t *testing.T) {
 }
 
 func TestAccResourceNsxtLogicalDhcpServer_importBasic(t *testing.T) {
-	prfName := "test-nsx-logical-dhcp-server"
+	prfName := getAccTestResourceName()
 	testResourceName := "nsxt_logical_dhcp_server.test"
 	edgeClusterName := getEdgeClusterName()
 

--- a/nsxt/resource_nsxt_logical_port_test.go
+++ b/nsxt/resource_nsxt_logical_port_test.go
@@ -13,8 +13,8 @@ import (
 )
 
 func TestAccResourceNsxtLogicalPort_basic(t *testing.T) {
-	portName := "test-nsx-logical-port"
-	updatePortName := fmt.Sprintf("%s-update", portName)
+	portName := getAccTestResourceName()
+	updatePortName := getAccTestResourceName()
 	testResourceName := "nsxt_logical_port.test"
 	transportZoneName := getOverlayTransportZoneName()
 
@@ -22,7 +22,7 @@ func TestAccResourceNsxtLogicalPort_basic(t *testing.T) {
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNSXLogicalPortCheckDestroy(state, portName)
+			return testAccNSXLogicalPortCheckDestroy(state, updatePortName)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -50,8 +50,8 @@ func TestAccResourceNsxtLogicalPort_basic(t *testing.T) {
 }
 
 func TestAccResourceNsxtLogicalPort_withProfiles(t *testing.T) {
-	portName := "test-nsx-logical-port-with-profiles"
-	updatePortName := fmt.Sprintf("%s-update", portName)
+	portName := getAccTestResourceName()
+	updatePortName := getAccTestResourceName()
 	testResourceName := "nsxt_logical_port.test"
 	transportZoneName := getOverlayTransportZoneName()
 	customProfileName := "terraform_test_LP_profile"
@@ -62,7 +62,7 @@ func TestAccResourceNsxtLogicalPort_withProfiles(t *testing.T) {
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			// Verify that the LP was deleted
-			err := testAccNSXLogicalPortCheckDestroy(state, portName)
+			err := testAccNSXLogicalPortCheckDestroy(state, updatePortName)
 			if err != nil {
 				return err
 			}
@@ -101,7 +101,7 @@ func TestAccResourceNsxtLogicalPort_withProfiles(t *testing.T) {
 func TestAccResourceNsxtLogicalPort_withNSGroup(t *testing.T) {
 	// Verify port can be deleted if its an effective member
 	// of existing NS Group
-	portName := "test-nsx-logical-port"
+	portName := getAccTestResourceName()
 	testResourceName := "nsxt_logical_port.test"
 	transportZoneName := getOverlayTransportZoneName()
 
@@ -130,7 +130,7 @@ func TestAccResourceNsxtLogicalPort_withNSGroup(t *testing.T) {
 }
 
 func TestAccResourceNsxtLogicalPort_importBasic(t *testing.T) {
-	portName := "test-nsx-logical-port"
+	portName := getAccTestResourceName()
 	testResourceName := "nsxt_logical_port.test"
 	transportZoneName := getOverlayTransportZoneName()
 

--- a/nsxt/resource_nsxt_logical_router_centralized_service_port_test.go
+++ b/nsxt/resource_nsxt_logical_router_centralized_service_port_test.go
@@ -13,8 +13,8 @@ import (
 )
 
 func TestAccResourceNsxtLogicalRouterCentralizedServicePort_basic(t *testing.T) {
-	portName := "test-nsx-logical-router-centralized-service-port"
-	updatePortName := fmt.Sprintf("%s-update", portName)
+	portName := getAccTestResourceName()
+	updatePortName := getAccTestResourceName()
 	testResourceName := "nsxt_logical_router_centralized_service_port.test"
 	transportZoneName := getOverlayTransportZoneName()
 	edgeClusterName := getEdgeClusterName()
@@ -29,7 +29,7 @@ func TestAccResourceNsxtLogicalRouterCentralizedServicePort_basic(t *testing.T) 
 		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNSXLogicalRouterCentralizedServicePortCheckDestroy(state, portName)
+			return testAccNSXLogicalRouterCentralizedServicePortCheckDestroy(state, updatePortName)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -63,8 +63,8 @@ func TestAccResourceNsxtLogicalRouterCentralizedServicePort_basic(t *testing.T) 
 }
 
 func TestAccResourceNsxtLogicalRouterCentralizedServicePort_onTier0(t *testing.T) {
-	portName := "test-nsx-logical-router-centralized-service-port"
-	updatePortName := fmt.Sprintf("%s-update", portName)
+	portName := getAccTestResourceName()
+	updatePortName := getAccTestResourceName()
 	testResourceName := "nsxt_logical_router_centralized_service_port.test"
 	transportZoneName := getOverlayTransportZoneName()
 	edgeClusterName := getEdgeClusterName()
@@ -79,7 +79,7 @@ func TestAccResourceNsxtLogicalRouterCentralizedServicePort_onTier0(t *testing.T
 		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNSXLogicalRouterCentralizedServicePortCheckDestroy(state, portName)
+			return testAccNSXLogicalRouterCentralizedServicePortCheckDestroy(state, updatePortName)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -113,7 +113,7 @@ func TestAccResourceNsxtLogicalRouterCentralizedServicePort_onTier0(t *testing.T
 }
 
 func TestAccResourceNsxtLogicalRouterCentralizedServicePort_importBasic(t *testing.T) {
-	portName := "test-nsx-logical-router-centralized-service-port"
+	portName := getAccTestResourceName()
 	testResourceName := "nsxt_logical_router_centralized_service_port.test"
 	transportZoneName := getOverlayTransportZoneName()
 	edgeClusterName := getEdgeClusterName()

--- a/nsxt/resource_nsxt_logical_router_downlink_port_test.go
+++ b/nsxt/resource_nsxt_logical_router_downlink_port_test.go
@@ -13,8 +13,8 @@ import (
 )
 
 func TestAccResourceNsxtLogicalRouterDownlinkPort_basic(t *testing.T) {
-	portName := "test-nsx-logical-router-downlink-port"
-	updatePortName := fmt.Sprintf("%s-update", portName)
+	portName := getAccTestResourceName()
+	updatePortName := getAccTestResourceName()
 	testResourceName := "nsxt_logical_router_downlink_port.test"
 	transportZoneName := getOverlayTransportZoneName()
 	edgeClusterName := getEdgeClusterName()
@@ -23,7 +23,7 @@ func TestAccResourceNsxtLogicalRouterDownlinkPort_basic(t *testing.T) {
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNSXLogicalRouterDownlinkPortCheckDestroy(state, portName)
+			return testAccNSXLogicalRouterDownlinkPortCheckDestroy(state, updatePortName)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -59,8 +59,8 @@ func TestAccResourceNsxtLogicalRouterDownlinkPort_basic(t *testing.T) {
 }
 
 func TestAccResourceNsxtLogicalRouterDownlinkPort_withRelay(t *testing.T) {
-	portName := "test-nsx-logical-router-downlink-port"
-	updatePortName := fmt.Sprintf("%s-update", portName)
+	portName := getAccTestResourceName()
+	updatePortName := getAccTestResourceName()
 	testResourceName := "nsxt_logical_router_downlink_port.test"
 	transportZoneName := getOverlayTransportZoneName()
 	edgeClusterName := getEdgeClusterName()
@@ -77,7 +77,7 @@ func TestAccResourceNsxtLogicalRouterDownlinkPort_withRelay(t *testing.T) {
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNSXLogicalRouterDownlinkPortCheckDestroy(state, portName)
+			return testAccNSXLogicalRouterDownlinkPortCheckDestroy(state, updatePortName)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -113,7 +113,7 @@ func TestAccResourceNsxtLogicalRouterDownlinkPort_withRelay(t *testing.T) {
 }
 
 func TestAccResourceNsxtLogicalRouterDownlinkPort_importBasic(t *testing.T) {
-	portName := "test-nsx-logical-router-downlink-port"
+	portName := getAccTestResourceName()
 	testResourceName := "nsxt_logical_router_downlink_port.test"
 	transportZoneName := getOverlayTransportZoneName()
 	edgeClusterName := getEdgeClusterName()

--- a/nsxt/resource_nsxt_logical_router_link_port_on_tier0_test.go
+++ b/nsxt/resource_nsxt_logical_router_link_port_on_tier0_test.go
@@ -13,16 +13,16 @@ import (
 )
 
 func TestAccResourceNsxtLogicalRouterLinkPortOnTier0_basic(t *testing.T) {
-	name := "test-nsx-port-on-tier0"
+	name := getAccTestResourceName()
+	updateName := getAccTestResourceName()
 	tier0RouterName := getTier0RouterName()
-	updateName := fmt.Sprintf("%s-update", name)
 	testResourceName := "nsxt_logical_router_link_port_on_tier0.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNSXLogicalRouterLinkPortOnTier0CheckDestroy(state, name)
+			return testAccNSXLogicalRouterLinkPortOnTier0CheckDestroy(state, updateName)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -48,7 +48,7 @@ func TestAccResourceNsxtLogicalRouterLinkPortOnTier0_basic(t *testing.T) {
 }
 
 func TestAccResourceNsxtLogicalRouterLinkPortOnTier0_importBasic(t *testing.T) {
-	name := "test-nsx-port-on-tier0"
+	name := getAccTestResourceName()
 	tier0RouterName := getTier0RouterName()
 	testResourceName := "nsxt_logical_router_link_port_on_tier0.test"
 

--- a/nsxt/resource_nsxt_logical_router_link_port_on_tier1_test.go
+++ b/nsxt/resource_nsxt_logical_router_link_port_on_tier1_test.go
@@ -13,17 +13,17 @@ import (
 )
 
 func TestAccResourceNsxtLogicalRouterLinkPortOnTier1_basic(t *testing.T) {
-	name := "test-nsx-port-on-tier1"
+	name := getAccTestResourceName()
+	updateName := getAccTestResourceName()
 	tier0RouterName := getTier0RouterName()
 	edgeClusterName := getEdgeClusterName()
-	updateName := fmt.Sprintf("%s-update", name)
 	testResourceName := "nsxt_logical_router_link_port_on_tier1.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNSXLogicalRouterLinkPortOnTier1CheckDestroy(state, name)
+			return testAccNSXLogicalRouterLinkPortOnTier1CheckDestroy(state, updateName)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -53,7 +53,7 @@ func TestAccResourceNsxtLogicalRouterLinkPortOnTier1_basic(t *testing.T) {
 }
 
 func TestAccResourceNsxtLogicalRouterLinkPortOnTier1_importBasic(t *testing.T) {
-	name := "test-nsx-port-on-tier1"
+	name := getAccTestResourceName()
 	tier0RouterName := getTier0RouterName()
 	edgeClusterName := getEdgeClusterName()
 	testResourceName := "nsxt_logical_router_link_port_on_tier1.test"

--- a/nsxt/resource_nsxt_logical_switch_test.go
+++ b/nsxt/resource_nsxt_logical_switch_test.go
@@ -14,8 +14,8 @@ import (
 )
 
 func TestAccResourceNsxtLogicalSwitch_basic(t *testing.T) {
-	switchName := "test-nsx-logical-switch-overlay"
-	updateSwitchName := fmt.Sprintf("%s-update", switchName)
+	switchName := getAccTestResourceName()
+	updateSwitchName := getAccTestResourceName()
 	resourceName := "testoverlay"
 	testResourceName := fmt.Sprintf("nsxt_logical_switch.%s", resourceName)
 	novlan := "0"
@@ -26,7 +26,7 @@ func TestAccResourceNsxtLogicalSwitch_basic(t *testing.T) {
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNSXLogicalSwitchCheckDestroy(state, switchName, "nsxt_logical_switch")
+			return testAccNSXLogicalSwitchCheckDestroy(state, updateSwitchName, "nsxt_logical_switch")
 		},
 		Steps: []resource.TestStep{
 			{
@@ -63,10 +63,9 @@ func TestAccResourceNsxtLogicalSwitch_basic(t *testing.T) {
 	})
 }
 
-// This use case is deprecated and should be removed with next major release
 func TestAccResourceNsxtLogicalSwitch_vlan(t *testing.T) {
-	switchName := "test-nsx-logical-switch-vlan"
-	updateSwitchName := fmt.Sprintf("%s-update", switchName)
+	switchName := getAccTestResourceName()
+	updateSwitchName := getAccTestResourceName()
 	transportZoneName := getVlanTransportZoneName()
 	resourceName := "testvlan"
 	testResourceName := fmt.Sprintf("nsxt_logical_switch.%s", resourceName)
@@ -79,7 +78,7 @@ func TestAccResourceNsxtLogicalSwitch_vlan(t *testing.T) {
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNSXLogicalSwitchCheckDestroy(state, switchName, "nsxt_logical_switch")
+			return testAccNSXLogicalSwitchCheckDestroy(state, updateSwitchName, "nsxt_logical_switch")
 		},
 		Steps: []resource.TestStep{
 			{
@@ -108,8 +107,7 @@ func TestAccResourceNsxtLogicalSwitch_vlan(t *testing.T) {
 }
 
 func TestAccResourceNsxtLogicalSwitch_withProfiles(t *testing.T) {
-	switchName := "test-nsx-logical-switch-with-profiles"
-	updateSwitchName := fmt.Sprintf("%s-update", switchName)
+	switchName := getAccTestResourceName()
 	resourceName := "test_profiles"
 	testResourceName := fmt.Sprintf("nsxt_logical_switch.%s", resourceName)
 	transportZoneName := getOverlayTransportZoneName()
@@ -146,10 +144,10 @@ func TestAccResourceNsxtLogicalSwitch_withProfiles(t *testing.T) {
 			},
 			{
 				// Replace the custom switching profile with OOB one
-				Config: testAccNSXLogicalSwitchUpdateWithProfilesTemplate(resourceName, updateSwitchName, transportZoneName),
+				Config: testAccNSXLogicalSwitchUpdateWithProfilesTemplate(resourceName, switchName, transportZoneName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccNSXLogicalSwitchExists(updateSwitchName, testResourceName),
-					resource.TestCheckResourceAttr(testResourceName, "display_name", updateSwitchName),
+					testAccNSXLogicalSwitchExists(switchName, testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", switchName),
 					// Counting only custom profiles so count should be 0
 					resource.TestCheckResourceAttr(testResourceName, "switching_profile_id.#", "0"),
 				),
@@ -159,7 +157,7 @@ func TestAccResourceNsxtLogicalSwitch_withProfiles(t *testing.T) {
 }
 
 func TestAccResourceNsxtLogicalSwitch_withMacPool(t *testing.T) {
-	switchName := "test-nsx-logical-switch-with-mac"
+	switchName := getAccTestResourceName()
 	resourceName := "test_mac_pool"
 	testResourceName := fmt.Sprintf("nsxt_logical_switch.%s", resourceName)
 	transportZoneName := getOverlayTransportZoneName()
@@ -195,7 +193,7 @@ func TestAccResourceNsxtLogicalSwitch_withMacPool(t *testing.T) {
 }
 
 func TestAccResourceNsxtLogicalSwitch_importBasic(t *testing.T) {
-	switchName := "test-nsx-logical-switch-overlay"
+	switchName := getAccTestResourceName()
 	resourceName := "testoverlay"
 	testResourceName := fmt.Sprintf("nsxt_logical_switch.%s", resourceName)
 	novlan := "0"

--- a/nsxt/resource_nsxt_logical_tier0_router_test.go
+++ b/nsxt/resource_nsxt_logical_tier0_router_test.go
@@ -13,8 +13,8 @@ import (
 )
 
 func TestAccResourceNsxtLogicalTier0Router_basic(t *testing.T) {
-	name := "test-nsx-logical-tier0-router"
-	updateName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
+	updateName := getAccTestResourceName()
 	testResourceName := "nsxt_logical_tier0_router.test"
 	haMode := "ACTIVE_STANDBY"
 	edgeClusterName := getEdgeClusterName()
@@ -23,7 +23,7 @@ func TestAccResourceNsxtLogicalTier0Router_basic(t *testing.T) {
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNSXLogicalTier0RouterCheckDestroy(state, name)
+			return testAccNSXLogicalTier0RouterCheckDestroy(state, updateName)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -51,8 +51,7 @@ func TestAccResourceNsxtLogicalTier0Router_basic(t *testing.T) {
 }
 
 func TestAccResourceNsxtLogicalTier0Router_active(t *testing.T) {
-	name := "test-nsx-logical-tier0-router"
-	updateName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_logical_tier0_router.test"
 	haMode := "ACTIVE_ACTIVE"
 	edgeClusterName := getEdgeClusterName()
@@ -75,10 +74,10 @@ func TestAccResourceNsxtLogicalTier0Router_active(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNSXLogicalTier0RouterUpdateTemplate(updateName, haMode, edgeClusterName),
+				Config: testAccNSXLogicalTier0RouterUpdateTemplate(name, haMode, edgeClusterName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccNSXLogicalTier0RouterExists(updateName, testResourceName),
-					resource.TestCheckResourceAttr(testResourceName, "display_name", updateName),
+					testAccNSXLogicalTier0RouterExists(name, testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", name),
 					resource.TestCheckResourceAttr(testResourceName, "description", "Acceptance Test Update"),
 					resource.TestCheckResourceAttr(testResourceName, "high_availability_mode", haMode),
 					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
@@ -89,7 +88,7 @@ func TestAccResourceNsxtLogicalTier0Router_active(t *testing.T) {
 }
 
 func TestAccResourceNsxtLogicalTier0Router_importBasic(t *testing.T) {
-	name := "test-nsx-logical-tier0-router"
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_logical_tier0_router.test"
 	haMode := "ACTIVE_STANDBY"
 	edgeClusterName := getEdgeClusterName()

--- a/nsxt/resource_nsxt_logical_tier1_router_test.go
+++ b/nsxt/resource_nsxt_logical_tier1_router_test.go
@@ -13,8 +13,8 @@ import (
 )
 
 func TestAccResourceNsxtLogicalTier1Router_basic(t *testing.T) {
-	name := "test-nsx-logical-tier1-router"
-	updateName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
+	updateName := getAccTestResourceName()
 	testResourceName := "nsxt_logical_tier1_router.test"
 	failoverMode := "PREEMPTIVE"
 	edgeClusterName := getEdgeClusterName()
@@ -23,7 +23,7 @@ func TestAccResourceNsxtLogicalTier1Router_basic(t *testing.T) {
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNSXLogicalTier1RouterCheckDestroy(state, name)
+			return testAccNSXLogicalTier1RouterCheckDestroy(state, updateName)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -63,7 +63,7 @@ func TestAccResourceNsxtLogicalTier1Router_basic(t *testing.T) {
 }
 
 func TestAccResourceNsxtLogicalTier1Router_importBasic(t *testing.T) {
-	name := "test-nsx-logical-tier1-router"
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_logical_tier1_router.test"
 	failoverMode := "PREEMPTIVE"
 	edgeClusterName := getEdgeClusterName()

--- a/nsxt/resource_nsxt_mac_management_switching_profile_test.go
+++ b/nsxt/resource_nsxt_mac_management_switching_profile_test.go
@@ -13,8 +13,8 @@ import (
 )
 
 func TestAccResourceNsxtMacManagementSwitchingProfile_basic(t *testing.T) {
-	name := "test-nsx-switching-profile"
-	updatedName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
+	updatedName := getAccTestResourceName()
 	testResourceName := "nsxt_mac_management_switching_profile.test"
 	limit := "100"
 	updatedLimit := "101"
@@ -23,7 +23,7 @@ func TestAccResourceNsxtMacManagementSwitchingProfile_basic(t *testing.T) {
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNSXMacManagementSwitchingProfileCheckDestroy(state, name)
+			return testAccNSXMacManagementSwitchingProfileCheckDestroy(state, updatedName)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -67,7 +67,7 @@ func TestAccResourceNsxtMacManagementSwitchingProfile_basic(t *testing.T) {
 }
 
 func TestAccResourceNsxtMacManagementSwitchingProfile_importBasic(t *testing.T) {
-	name := "test-nsx-application-profile"
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_mac_management_switching_profile.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },

--- a/nsxt/resource_nsxt_nat_rule_test.go
+++ b/nsxt/resource_nsxt_nat_rule_test.go
@@ -15,15 +15,15 @@ import (
 var testAccResourceNatRuleName = "nsxt_nat_rule.test"
 
 func TestAccResourceNsxtNatRule_snat(t *testing.T) {
-	ruleName := "test-nsx-snat-rule"
-	updateRuleName := fmt.Sprintf("%s-update", ruleName)
+	ruleName := getAccTestResourceName()
+	updateRuleName := getAccTestResourceName()
 	edgeClusterName := getEdgeClusterName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNSXNATRuleCheckDestroy(state, ruleName)
+			return testAccNSXNATRuleCheckDestroy(state, updateRuleName)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -67,7 +67,7 @@ func TestAccResourceNsxtNatRule_snat(t *testing.T) {
 }
 
 func TestAccResourceNsxtNatRule_snatImport(t *testing.T) {
-	ruleName := "test-nsx-snat-rule"
+	ruleName := getAccTestResourceName()
 	edgeClusterName := getEdgeClusterName()
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -91,8 +91,7 @@ func TestAccResourceNsxtNatRule_snatImport(t *testing.T) {
 }
 
 func TestAccResourceNsxtNatRule_dnat(t *testing.T) {
-	ruleName := "test-nsx-dnat-rule"
-	updateRuleName := fmt.Sprintf("%s-update", ruleName)
+	ruleName := getAccTestResourceName()
 	edgeClusterName := getEdgeClusterName()
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -119,10 +118,10 @@ func TestAccResourceNsxtNatRule_dnat(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNSXDNATRuleUpdateTemplate(updateRuleName, edgeClusterName),
+				Config: testAccNSXDNATRuleUpdateTemplate(ruleName, edgeClusterName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccNSXNATRuleCheckExists(updateRuleName, testAccResourceNatRuleName),
-					resource.TestCheckResourceAttr(testAccResourceNatRuleName, "display_name", updateRuleName),
+					testAccNSXNATRuleCheckExists(ruleName, testAccResourceNatRuleName),
+					resource.TestCheckResourceAttr(testAccResourceNatRuleName, "display_name", ruleName),
 					resource.TestCheckResourceAttr(testAccResourceNatRuleName, "description", "Acceptance Test Update"),
 					resource.TestCheckResourceAttrSet(testAccResourceNatRuleName, "logical_router_id"),
 					resource.TestCheckResourceAttr(testAccResourceNatRuleName, "tag.#", "2"),
@@ -139,7 +138,7 @@ func TestAccResourceNsxtNatRule_dnat(t *testing.T) {
 }
 
 func TestAccResourceNsxtNatRule_dnatImport(t *testing.T) {
-	ruleName := "test-nsx-dnat-rule"
+	ruleName := getAccTestResourceName()
 	edgeClusterName := getEdgeClusterName()
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -163,7 +162,7 @@ func TestAccResourceNsxtNatRule_dnatImport(t *testing.T) {
 }
 
 func TestAccResourceNsxtNatRule_noNnat(t *testing.T) {
-	ruleName := "test-nsx-nonat-rule"
+	ruleName := getAccTestResourceName()
 	edgeClusterName := getEdgeClusterName()
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/nsxt/resource_nsxt_ns_group_test.go
+++ b/nsxt/resource_nsxt_ns_group_test.go
@@ -12,16 +12,18 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
+var testAccNsxtNSGroupHelperName = getAccTestResourceName()
+
 func TestAccResourceNsxtNSGroup_basic(t *testing.T) {
-	grpName := "test-nsx-ns-group"
-	updateGrpName := fmt.Sprintf("%s-update", grpName)
+	grpName := getAccTestResourceName()
+	updateGrpName := getAccTestResourceName()
 	testResourceName := "nsxt_ns_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNSXNSGroupCheckDestroy(state, grpName)
+			return testAccNSXNSGroupCheckDestroy(state, updateGrpName)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -49,15 +51,15 @@ func TestAccResourceNsxtNSGroup_basic(t *testing.T) {
 }
 
 func TestAccResourceNsxtNSGroup_nested(t *testing.T) {
-	grpName := "test-nsx-ns-group"
-	updateGrpName := fmt.Sprintf("%s-update", grpName)
+	grpName := getAccTestResourceName()
+	updateGrpName := getAccTestResourceName()
 	testResourceName := "nsxt_ns_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNSXNSGroupCheckDestroy(state, grpName)
+			return testAccNSXNSGroupCheckDestroy(state, updateGrpName)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -83,8 +85,7 @@ func TestAccResourceNsxtNSGroup_nested(t *testing.T) {
 }
 
 func TestAccResourceNsxtNSGroup_withCriteria(t *testing.T) {
-	grpName := "test-nsx-ns-group"
-	updateGrpName := fmt.Sprintf("%s-update", grpName)
+	grpName := getAccTestResourceName()
 	testResourceName := "nsxt_ns_group.test"
 	transportZoneName := getOverlayTransportZoneName()
 
@@ -106,10 +107,10 @@ func TestAccResourceNsxtNSGroup_withCriteria(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNSXNSGroupCriteriaUpdateTemplate(updateGrpName, transportZoneName),
+				Config: testAccNSXNSGroupCriteriaUpdateTemplate(grpName, transportZoneName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccNSXNSGroupExists(updateGrpName, testResourceName),
-					resource.TestCheckResourceAttr(testResourceName, "display_name", updateGrpName),
+					testAccNSXNSGroupExists(grpName, testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", grpName),
 					resource.TestCheckResourceAttr(testResourceName, "description", "Acceptance Test Update"),
 					resource.TestCheckResourceAttr(testResourceName, "member.#", "1"),
 					resource.TestCheckResourceAttr(testResourceName, "membership_criteria.#", "1"),
@@ -120,7 +121,7 @@ func TestAccResourceNsxtNSGroup_withCriteria(t *testing.T) {
 }
 
 func TestAccResourceNsxtNSGroup_importBasic(t *testing.T) {
-	grpName := "test-nsx-ns-group"
+	grpName := getAccTestResourceName()
 	testResourceName := "nsxt_ns_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -143,7 +144,7 @@ func TestAccResourceNsxtNSGroup_importBasic(t *testing.T) {
 }
 
 func TestAccResourceNsxtNSGroup_importWithCriteria(t *testing.T) {
-	grpName := "test-nsx-ns-group"
+	grpName := getAccTestResourceName()
 	testResourceName := "nsxt_ns_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -322,7 +323,7 @@ data "nsxt_transport_zone" "tz1" {
 }
 
 resource "nsxt_logical_switch" "test" {
-  display_name      = "test-nsx-switch-for-group"
+  display_name      = "%s"
   admin_state       = "DOWN"
   replication_mode  = "MTEP"
   transport_zone_id = "${data.nsxt_transport_zone.tz1.id}"
@@ -341,5 +342,5 @@ resource "nsxt_ns_group" "test" {
     target_type = "LogicalSwitch"
     value = "${nsxt_logical_switch.test.id}"
   }
-}`, tzName, name)
+}`, tzName, testAccNsxtNSGroupHelperName, name)
 }

--- a/nsxt/resource_nsxt_ns_service_group_test.go
+++ b/nsxt/resource_nsxt_ns_service_group_test.go
@@ -13,15 +13,15 @@ import (
 )
 
 func TestAccResourceNsxtNsServiceGroup_basic(t *testing.T) {
-	serviceName := "test-nsx-service-group-for-import"
-	updateServiceName := fmt.Sprintf("%s-update", serviceName)
+	serviceName := getAccTestResourceName()
+	updateServiceName := getAccTestResourceName()
 	testResourceName := "nsxt_ns_service_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNSXServiceGroupCheckDestroy(state, serviceName)
+			return testAccNSXServiceGroupCheckDestroy(state, updateServiceName)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -49,7 +49,7 @@ func TestAccResourceNsxtNsServiceGroup_basic(t *testing.T) {
 }
 
 func TestAccResourceNsxtNsServiceGroup_importBasic(t *testing.T) {
-	serviceName := "test-nsx-service-group"
+	serviceName := getAccTestResourceName()
 	testResourceName := "nsxt_ns_service_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/nsxt/resource_nsxt_policy_bgp_neighbor_test.go
+++ b/nsxt/resource_nsxt_policy_bgp_neighbor_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 var accTestPolicyBgpNeighborConfigCreateAttributes = map[string]string{
-	"display_name":          "terra-test",
+	"display_name":          getAccTestResourceName(),
 	"description":           "terraform created",
 	"allow_as_in":           "true",
 	"graceful_restart_mode": "HELPER_ONLY",
@@ -25,7 +25,7 @@ var accTestPolicyBgpNeighborConfigCreateAttributes = map[string]string{
 }
 
 var accTestPolicyBgpNeighborConfigUpdateAttributes = map[string]string{
-	"display_name":          "terra-test-updated",
+	"display_name":          getAccTestResourceName(),
 	"description":           "terraform created",
 	"allow_as_in":           "false",
 	"graceful_restart_mode": "GR_AND_HELPER",
@@ -300,7 +300,7 @@ func TestAccResourceNsxtPolicyBgpNeighbor_subConfigPrefixList(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyBgpNeighbor_importBasic(t *testing.T) {
-	name := "terra-test-import"
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_policy_bgp_neighbor.test"
 
 	resource.Test(t, resource.TestCase{

--- a/nsxt/resource_nsxt_policy_context_profile_test.go
+++ b/nsxt/resource_nsxt_policy_context_profile_test.go
@@ -14,8 +14,8 @@ import (
 )
 
 func TestAccResourceNsxtPolicyContextProfile_basic(t *testing.T) {
-	name := "terraform-test"
-	updatedName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
+	updatedName := getAccTestResourceName()
 	testResourceName := "nsxt_policy_context_profile.test"
 	attributes := testAccNsxtPolicyContextProfileAttributeDomainNameTemplate()
 	updatedAttributes := testAccNsxtPolicyContextProfileAttributeURLCategoryTemplate()
@@ -66,7 +66,7 @@ func TestAccResourceNsxtPolicyContextProfile_basic(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyContextProfile_importBasic(t *testing.T) {
-	name := "terra-test-import"
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_policy_context_profile.test"
 	attributes := testAccNsxtPolicyContextProfileAttributeDomainNameTemplate()
 
@@ -90,8 +90,8 @@ func TestAccResourceNsxtPolicyContextProfile_importBasic(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyContextProfile_multipleAttributes(t *testing.T) {
-	name := "terraform-test"
-	updatedName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
+	updatedName := getAccTestResourceName()
 	testResourceName := "nsxt_policy_context_profile.test"
 	attributes := testAccNsxtPolicyContextProfileAttributeDomainNameTemplate()
 	updatedAttributes := testAccNsxtPolicyContextProfileAttributeDomainNameTemplate() + testAccNsxtPolicyContextProfileAttributeAppIDTemplate()
@@ -147,8 +147,8 @@ func TestAccResourceNsxtPolicyContextProfile_multipleAttributes(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyContextProfile_subAttributes(t *testing.T) {
-	name := "terraform-test"
-	updatedName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
+	updatedName := getAccTestResourceName()
 	testResourceName := "nsxt_policy_context_profile.test"
 	attributes := testAccNsxtPolicyContextProfileAttributeAppIDSubAttributesTemplate()
 	updatedAttributes := testAccNsxtPolicyContextProfileAttributeAppIDSubAttributesUpdatedTemplate()

--- a/nsxt/resource_nsxt_policy_dhcp_relay_test.go
+++ b/nsxt/resource_nsxt_policy_dhcp_relay_test.go
@@ -13,13 +13,13 @@ import (
 )
 
 var accTestPolicyDhcpRelayConfigCreateAttributes = map[string]string{
-	"display_name":     "terra-test",
+	"display_name":     getAccTestResourceName(),
 	"description":      "terraform created",
 	"server_addresses": "[\"2.2.2.3\", \"7001::23\"]",
 }
 
 var accTestPolicyDhcpRelayConfigUpdateAttributes = map[string]string{
-	"display_name":     "terra-test-updated",
+	"display_name":     getAccTestResourceName(),
 	"description":      "terraform updated",
 	"server_addresses": "[\"4.1.1.23\"]",
 }
@@ -32,7 +32,7 @@ func TestAccResourceNsxtPolicyDhcpRelayConfig_basic(t *testing.T) {
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNsxtPolicyDhcpRelayConfigCheckDestroy(state, accTestPolicyDhcpRelayConfigCreateAttributes["display_name"])
+			return testAccNsxtPolicyDhcpRelayConfigCheckDestroy(state, accTestPolicyDhcpRelayConfigUpdateAttributes["display_name"])
 		},
 		Steps: []resource.TestStep{
 			{
@@ -79,7 +79,7 @@ func TestAccResourceNsxtPolicyDhcpRelayConfig_basic(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyDhcpRelayConfig_importBasic(t *testing.T) {
-	name := "terra-test-import"
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_policy_dhcp_relay.test"
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/nsxt/resource_nsxt_policy_dhcp_server_test.go
+++ b/nsxt/resource_nsxt_policy_dhcp_server_test.go
@@ -12,13 +12,13 @@ import (
 )
 
 var accTestPolicyDhcpServerCreateAttributes = map[string]string{
-	"display_name": "terra-test",
+	"display_name": getAccTestResourceName(),
 	"description":  "terraform created",
 	"lease_time":   "200",
 }
 
 var accTestPolicyDhcpServerUpdateAttributes = map[string]string{
-	"display_name": "terra-test-updated",
+	"display_name": getAccTestResourceName(),
 	"description":  "terraform updated",
 	"lease_time":   "500",
 }
@@ -30,7 +30,7 @@ func TestAccResourceNsxtPolicyDhcpServer_basic(t *testing.T) {
 		PreCheck:  func() { testAccPreCheck(t); testAccNSXVersion(t, "3.0.0") },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNsxtPolicyDhcpServerCheckDestroy(state, accTestPolicyDhcpServerCreateAttributes["display_name"])
+			return testAccNsxtPolicyDhcpServerCheckDestroy(state, accTestPolicyDhcpServerUpdateAttributes["display_name"])
 		},
 		Steps: []resource.TestStep{
 			{
@@ -85,7 +85,7 @@ func TestAccResourceNsxtPolicyDhcpServer_basic(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyDhcpServer_importBasic(t *testing.T) {
-	name := "terra-test-import"
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_policy_dhcp_server.test"
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/nsxt/resource_nsxt_policy_dhcp_v4_static_binding_test.go
+++ b/nsxt/resource_nsxt_policy_dhcp_v4_static_binding_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 var accTestPolicyDhcpV4StaticBindingCreateAttributes = map[string]string{
-	"display_name":    "terra-test",
+	"display_name":    getAccTestResourceName(),
 	"description":     "terraform created",
 	"gateway_address": "10.2.2.1",
 	"hostname":        "test-create",
@@ -23,7 +23,7 @@ var accTestPolicyDhcpV4StaticBindingCreateAttributes = map[string]string{
 }
 
 var accTestPolicyDhcpV4StaticBindingUpdateAttributes = map[string]string{
-	"display_name":    "terra-test-updated",
+	"display_name":    getAccTestResourceName(),
 	"description":     "terraform updated",
 	"gateway_address": "10.2.2.2",
 	"hostname":        "test-update",
@@ -37,7 +37,7 @@ var testAccPolicyDhcpV4StaticBindingResourceName = "nsxt_policy_dhcp_v4_static_b
 func TestAccResourceNsxtPolicyDhcpV4StaticBinding_basic(t *testing.T) {
 	testResourceName := testAccPolicyDhcpV4StaticBindingResourceName
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
@@ -96,9 +96,9 @@ func TestAccResourceNsxtPolicyDhcpV4StaticBinding_basic(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyDhcpV4StaticBinding_importBasic(t *testing.T) {
-	name := "terra-test-import"
+	name := getAccTestResourceName()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {

--- a/nsxt/resource_nsxt_policy_dhcp_v6_static_binding_test.go
+++ b/nsxt/resource_nsxt_policy_dhcp_v6_static_binding_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 var accTestPolicyDhcpV6StaticBindingCreateAttributes = map[string]string{
-	"display_name":    "terra-test",
+	"display_name":    getAccTestResourceName(),
 	"description":     "terraform created",
 	"ip_addresses":    "1001::2",
 	"lease_time":      "3600",
@@ -25,7 +25,7 @@ var accTestPolicyDhcpV6StaticBindingCreateAttributes = map[string]string{
 }
 
 var accTestPolicyDhcpV6StaticBindingUpdateAttributes = map[string]string{
-	"display_name":    "terra-test-updated",
+	"display_name":    getAccTestResourceName(),
 	"description":     "terraform updated",
 	"lease_time":      "500",
 	"preferred_time":  "380",
@@ -41,11 +41,11 @@ var testAccPolicyDhcpV6StaticBindingResourceName = "nsxt_policy_dhcp_v6_static_b
 func TestAccResourceNsxtPolicyDhcpV6StaticBinding_basic(t *testing.T) {
 	testResourceName := testAccPolicyDhcpV6StaticBindingResourceName
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNsxtPolicyDhcpV6StaticBindingCheckDestroy(state, accTestPolicyDhcpV6StaticBindingCreateAttributes["display_name"])
+			return testAccNsxtPolicyDhcpV6StaticBindingCheckDestroy(state, accTestPolicyDhcpV6StaticBindingUpdateAttributes["display_name"])
 		},
 		Steps: []resource.TestStep{
 			{
@@ -114,9 +114,9 @@ func TestAccResourceNsxtPolicyDhcpV6StaticBinding_basic(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyDhcpV6StaticBinding_importBasic(t *testing.T) {
-	name := "terra-test-import"
+	name := getAccTestResourceName()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {

--- a/nsxt/resource_nsxt_policy_fixed_segment_test.go
+++ b/nsxt/resource_nsxt_policy_fixed_segment_test.go
@@ -11,7 +11,7 @@ import (
 var testAccPolicyFixedSegmentResourceName = "nsxt_policy_fixed_segment.test"
 
 func TestAccResourceNsxtPolicyFixedSegment_basicImport(t *testing.T) {
-	name := "terraform-test"
+	name := getAccTestResourceName()
 	tzName := getOverlayTransportZoneName()
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -35,8 +35,8 @@ func TestAccResourceNsxtPolicyFixedSegment_basicImport(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyFixedSegment_basicUpdate(t *testing.T) {
-	name := "terraform-test"
-	updatedName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
+	updatedName := getAccTestResourceName()
 	testResourceName := testAccPolicyFixedSegmentResourceName
 	tzName := getOverlayTransportZoneName()
 
@@ -44,7 +44,7 @@ func TestAccResourceNsxtPolicyFixedSegment_basicUpdate(t *testing.T) {
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNsxtPolicyFixedSegmentCheckDestroy(state, name)
+			return testAccNsxtPolicyFixedSegmentCheckDestroy(state, updatedName)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -78,8 +78,7 @@ func TestAccResourceNsxtPolicyFixedSegment_basicUpdate(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyFixedSegment_connectivityPath(t *testing.T) {
-	name := "terraform-test"
-	updatedName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
 	testResourceName := testAccPolicyFixedSegmentResourceName
 	tzName := getOverlayTransportZoneName()
 
@@ -105,10 +104,10 @@ func TestAccResourceNsxtPolicyFixedSegment_connectivityPath(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNsxtPolicyFixedSegmentUpdateConnectivityTemplate(tzName, updatedName),
+				Config: testAccNsxtPolicyFixedSegmentUpdateConnectivityTemplate(tzName, name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNsxtPolicyFixedSegmentExists(testResourceName),
-					resource.TestCheckResourceAttr(testResourceName, "display_name", updatedName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", name),
 					resource.TestCheckResourceAttr(testResourceName, "description", "Acceptance Test2"),
 					resource.TestCheckResourceAttr(testResourceName, "subnet.#", "1"),
 					resource.TestCheckResourceAttr(testResourceName, "subnet.0.cidr", "22.22.22.1/24"),
@@ -126,8 +125,7 @@ func TestAccResourceNsxtPolicyFixedSegment_connectivityPath(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyFixedSegment_updateAdvConfig(t *testing.T) {
-	name := "terraform-test"
-	updatedName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
 	testResourceName := testAccPolicyFixedSegmentResourceName
 	tzName := getOverlayTransportZoneName()
 
@@ -155,10 +153,10 @@ func TestAccResourceNsxtPolicyFixedSegment_updateAdvConfig(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNsxtPolicyFixedSegmentBasicAdvConfigUpdateTemplate(tzName, updatedName),
+				Config: testAccNsxtPolicyFixedSegmentBasicAdvConfigUpdateTemplate(tzName, name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNsxtPolicyFixedSegmentExists(testResourceName),
-					resource.TestCheckResourceAttr(testResourceName, "display_name", updatedName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", name),
 					resource.TestCheckResourceAttr(testResourceName, "description", "Acceptance Test"),
 					resource.TestCheckResourceAttr(testResourceName, "subnet.#", "1"),
 					resource.TestCheckResourceAttr(testResourceName, "subnet.0.cidr", "12.12.2.1/24"),
@@ -175,8 +173,7 @@ func TestAccResourceNsxtPolicyFixedSegment_updateAdvConfig(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyFixedSegment_withDhcp(t *testing.T) {
-	name := "terraform-test"
-	updatedName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
 	testResourceName := testAccPolicyFixedSegmentResourceName
 	leaseTimes := []string{"3600", "36000"}
 	preferredTimes := []string{"3200", "32000"}
@@ -219,10 +216,10 @@ func TestAccResourceNsxtPolicyFixedSegment_withDhcp(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNsxtPolicyFixedSegmentWithDhcpTemplate(tzName, updatedName, dnsServersV4[1], dnsServersV6[1], leaseTimes[1], preferredTimes[1]),
+				Config: testAccNsxtPolicyFixedSegmentWithDhcpTemplate(tzName, name, dnsServersV4[1], dnsServersV6[1], leaseTimes[1], preferredTimes[1]),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNsxtPolicyFixedSegmentExists(testResourceName),
-					resource.TestCheckResourceAttr(testResourceName, "display_name", updatedName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", name),
 					resource.TestCheckResourceAttr(testResourceName, "subnet.#", "2"),
 					resource.TestCheckResourceAttr(testResourceName, "subnet.0.cidr", "12.12.2.1/24"),
 					resource.TestCheckResourceAttr(testResourceName, "subnet.0.dhcp_v6_config.#", "0"),

--- a/nsxt/resource_nsxt_policy_gateway_policy_test.go
+++ b/nsxt/resource_nsxt_policy_gateway_policy_test.go
@@ -12,8 +12,8 @@ import (
 )
 
 func TestAccResourceNsxtPolicyGatewayPolicy_basic(t *testing.T) {
-	name := "terraform-test"
-	updatedName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
+	updatedName := getAccTestResourceName()
 	testResourceName := "nsxt_policy_gateway_policy.test"
 	comments1 := "Acceptance test create"
 	comments2 := "Acceptance test update"
@@ -29,7 +29,7 @@ func TestAccResourceNsxtPolicyGatewayPolicy_basic(t *testing.T) {
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNsxtPolicyGatewayPolicyCheckDestroy(state, name, defaultDomain)
+			return testAccNsxtPolicyGatewayPolicyCheckDestroy(state, updatedName, defaultDomain)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -114,7 +114,7 @@ func TestAccResourceNsxtPolicyGatewayPolicy_basic(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyGatewayPolicy_withDependencies(t *testing.T) {
-	name := "terraform-test"
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_policy_gateway_policy.test"
 	defaultAction := "ALLOW"
 	defaultDirection := "IN_OUT"
@@ -193,7 +193,7 @@ func TestAccResourceNsxtPolicyGatewayPolicy_withDependencies(t *testing.T) {
 	})
 }
 func TestAccResourceNsxtPolicyGatewayPolicy_importBasic(t *testing.T) {
-	name := "terraform-test-import"
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_policy_gateway_policy.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -216,7 +216,7 @@ func TestAccResourceNsxtPolicyGatewayPolicy_importBasic(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyGatewayPolicy_importNoTcpStrict(t *testing.T) {
-	name := "terraform-test-import"
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_policy_gateway_policy.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -239,8 +239,8 @@ func TestAccResourceNsxtPolicyGatewayPolicy_importNoTcpStrict(t *testing.T) {
 }
 
 func TestAccResourceNsxtGlobalPolicyGatewayPolicy_withSite(t *testing.T) {
-	name := "terraform-test"
-	updatedName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
+	updatedName := getAccTestResourceName()
 	domainName := getTestSiteName()
 	testResourceName := "nsxt_policy_gateway_policy.test"
 	comments1 := "Acceptance test create"
@@ -261,7 +261,7 @@ func TestAccResourceNsxtGlobalPolicyGatewayPolicy_withSite(t *testing.T) {
 		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNsxtPolicyGatewayPolicyCheckDestroy(state, name, domainName)
+			return testAccNsxtPolicyGatewayPolicyCheckDestroy(state, updatedName, domainName)
 		},
 		Steps: []resource.TestStep{
 			{

--- a/nsxt/resource_nsxt_policy_gateway_prefix_list_test.go
+++ b/nsxt/resource_nsxt_policy_gateway_prefix_list_test.go
@@ -17,7 +17,7 @@ import (
 var testAccResourcePolicyGWPrefixListName = "nsxt_policy_gateway_prefix_list.test"
 
 func TestAccResourceNsxtPolicyGatewayPrefixList_basic(t *testing.T) {
-	name := "test-nsx-policy-gw-prefix-list-basic"
+	name := getAccTestResourceName()
 	action := model.PrefixEntry_ACTION_DENY
 	actionUpdated := model.PrefixEntry_ACTION_PERMIT
 	ge := "20"
@@ -76,7 +76,7 @@ func TestAccResourceNsxtPolicyGatewayPrefixList_basic(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyGatewayPrefixList_import(t *testing.T) {
-	name := "test-nsx-policy-gw-prefix-list-import"
+	name := getAccTestResourceName()
 	action := model.PrefixEntry_ACTION_DENY
 	ge := "0"
 	le := "0"

--- a/nsxt/resource_nsxt_policy_group_test.go
+++ b/nsxt/resource_nsxt_policy_group_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestAccResourceNsxtPolicyGroup_basicImport(t *testing.T) {
-	name := "test-nsx-policy-group-ipaddrs"
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_policy_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -34,7 +34,7 @@ func TestAccResourceNsxtPolicyGroup_basicImport(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyGroup_AddressCriteria(t *testing.T) {
-	name := "test-nsx-policy-group-ipaddrs"
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_policy_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -84,8 +84,8 @@ func TestAccResourceNsxtPolicyGroup_AddressCriteria(t *testing.T) {
 }
 
 func TestAccResourceNsxtGlobalPolicyGroup_singleIPAddressCriteria(t *testing.T) {
-	name := "test-nsx-global-policy-group-ipaddrs"
-	updatedName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
+	updatedName := getAccTestResourceName()
 	testResourceName := "nsxt_policy_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -96,7 +96,7 @@ func TestAccResourceNsxtGlobalPolicyGroup_singleIPAddressCriteria(t *testing.T) 
 		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNsxtPolicyGroupCheckDestroy(state, name, getTestSiteName())
+			return testAccNsxtPolicyGroupCheckDestroy(state, updatedName, getTestSiteName())
 		},
 		Steps: []resource.TestStep{
 			{
@@ -132,15 +132,15 @@ func TestAccResourceNsxtGlobalPolicyGroup_singleIPAddressCriteria(t *testing.T) 
 }
 
 func TestAccResourceNsxtPolicyGroup_multipleIPAddressCriteria(t *testing.T) {
-	name := "test-nsx-policy-group-ipaddrs"
-	updatedName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
+	updatedName := getAccTestResourceName()
 	testResourceName := "nsxt_policy_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNsxtPolicyGroupCheckDestroy(state, name, defaultDomain)
+			return testAccNsxtPolicyGroupCheckDestroy(state, updatedName, defaultDomain)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -176,7 +176,7 @@ func TestAccResourceNsxtPolicyGroup_multipleIPAddressCriteria(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyGroup_pathCriteria(t *testing.T) {
-	name := "test-nsx-policy-group-paths"
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_policy_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -227,15 +227,15 @@ func TestAccResourceNsxtPolicyGroup_pathCriteria(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyGroup_nestedCriteria(t *testing.T) {
-	name := "test-nsx-policy-group-nested"
-	updatedName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
+	updatedName := getAccTestResourceName()
 	testResourceName := "nsxt_policy_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNsxtPolicyGroupCheckDestroy(state, name, defaultDomain)
+			return testAccNsxtPolicyGroupCheckDestroy(state, updatedName, defaultDomain)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -273,15 +273,15 @@ func TestAccResourceNsxtPolicyGroup_nestedCriteria(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyGroup_multipleCriteria(t *testing.T) {
-	name := "test-nsx-policy-group-multiple"
-	updatedName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
+	updatedName := getAccTestResourceName()
 	testResourceName := "nsxt_policy_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNsxtPolicyGroupCheckDestroy(state, name, defaultDomain)
+			return testAccNsxtPolicyGroupCheckDestroy(state, updatedName, defaultDomain)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -321,7 +321,7 @@ func TestAccResourceNsxtPolicyGroup_multipleCriteria(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyGroup_multipleNestedCriteria(t *testing.T) {
-	name := "test-nsx-policy-group-multiple-nested"
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_policy_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -400,15 +400,15 @@ func TestAccResourceNsxtPolicyGroup_multipleNestedCriteria(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyGroup_identityGroup(t *testing.T) {
-	name := "test-nsx-policy-group-identity-group"
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_policy_group.test"
-	updatedName := fmt.Sprintf("%s-update", name)
+	updatedName := getAccTestResourceName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t); testAccOnlyLocalManager(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNsxtPolicyGroupCheckDestroy(state, name, defaultDomain)
+			return testAccNsxtPolicyGroupCheckDestroy(state, updatedName, defaultDomain)
 		},
 		Steps: []resource.TestStep{
 			{

--- a/nsxt/resource_nsxt_policy_ip_address_allocation_test.go
+++ b/nsxt/resource_nsxt_policy_ip_address_allocation_test.go
@@ -13,16 +13,19 @@ import (
 )
 
 var accTestPolicyIPAddressAllocationCreateAttributes = map[string]string{
-	"display_name":  "terra-test",
+	"display_name":  getAccTestResourceName(),
 	"description":   "terraform created",
 	"allocation_ip": "12.12.12.11",
 }
 
 var accTestPolicyIPAddressAllocationUpdateAttributes = map[string]string{
-	"display_name":  "terra-test-updated",
+	"display_name":  getAccTestResourceName(),
 	"description":   "terraform updated",
 	"allocation_ip": "12.12.12.12",
 }
+
+var accTestPolicyIPAddressAllocationPoolName = getAccTestResourceName()
+var accTestPolicyIPAddressAllocationSubnetName = getAccTestResourceName()
 
 func TestAccResourceNsxtPolicyIPAddressAllocation_basic(t *testing.T) {
 	testResourceName := "nsxt_policy_ip_address_allocation.test"
@@ -31,7 +34,7 @@ func TestAccResourceNsxtPolicyIPAddressAllocation_basic(t *testing.T) {
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNsxtPolicyIPAddressAllocationCheckDestroy(state, accTestPolicyIPAddressAllocationCreateAttributes["display_name"])
+			return testAccNsxtPolicyIPAddressAllocationCheckDestroy(state, accTestPolicyIPAddressAllocationUpdateAttributes["display_name"])
 		},
 		Steps: []resource.TestStep{
 			{
@@ -121,7 +124,7 @@ func TestAccResourceNsxtPolicyIPAddressAllocation_anyIPBasic(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyIPAddressAllocation_importBasic(t *testing.T) {
-	name := "terra-test-import"
+	name := accTestPolicyIPAddressAllocationUpdateAttributes["display_name"]
 	testResourceName := "nsxt_policy_ip_address_allocation.test"
 
 	resource.Test(t, resource.TestCase{
@@ -271,18 +274,18 @@ data "nsxt_policy_realization_info" "realization_info" {
 }
 
 func testAccNsxtPolicyIPAddressAllocationDependenciesTemplate() string {
-	return `
+	return fmt.Sprintf(`
 resource "nsxt_policy_ip_pool" "test" {
-  display_name = "tfpool4"
+  display_name = "%s"
 }
 
 resource "nsxt_policy_ip_pool_static_subnet" "test" {
-  display_name = "tfsnet1"
+  display_name = "%s"
   pool_path    = nsxt_policy_ip_pool.test.path
   cidr         = "12.12.12.0/24"
   allocation_range {
     start = "12.12.12.10"
     end   = "12.12.12.20"
   }
-}`
+}`, accTestPolicyIPAddressAllocationPoolName, accTestPolicyIPAddressAllocationSubnetName)
 }

--- a/nsxt/resource_nsxt_policy_ip_block_test.go
+++ b/nsxt/resource_nsxt_policy_ip_block_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestAccResourceNsxtPolicyIPBlock_minimal(t *testing.T) {
-	name := "test-nsx-policy-ip-block"
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_policy_ip_block.test"
 	cidr := "192.168.1.0/24"
 
@@ -41,7 +41,7 @@ func TestAccResourceNsxtPolicyIPBlock_minimal(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyIPBlock_basic(t *testing.T) {
-	name := "test-nsx-policy-ip-block"
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_policy_ip_block.test"
 	cidr := "192.168.1.0/24"
 	cidr2 := "191.166.1.0/24"
@@ -82,7 +82,7 @@ func TestAccResourceNsxtPolicyIPBlock_basic(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyIPBlock_importBasic(t *testing.T) {
-	name := "test-nsx-policy-ip-block-import"
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_policy_ip_block.test"
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/nsxt/resource_nsxt_policy_ip_pool_block_subnet_test.go
+++ b/nsxt/resource_nsxt_policy_ip_pool_block_subnet_test.go
@@ -14,7 +14,7 @@ import (
 
 // TODO: remove extra test step config once IP Blocks don't need a delay to delete
 func TestAccResourceNsxtPolicyIPPoolBlockSubnet_minimal(t *testing.T) {
-	poolName := "tfpool5"
+	poolName := getAccTestResourceName()
 	name := "blocksubnet1"
 	testResourceName := "nsxt_policy_ip_pool_block_subnet.test"
 
@@ -48,8 +48,8 @@ func TestAccResourceNsxtPolicyIPPoolBlockSubnet_minimal(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyIPPoolBlockSubnet_basic(t *testing.T) {
-	poolName := "tfpool1"
-	name := "subnet1"
+	poolName := getAccTestResourceName()
+	name := getAccTestResourceName()
 	updatedName := fmt.Sprintf("%s-updated", name)
 	testResourceName := "nsxt_policy_ip_pool_block_subnet.test"
 
@@ -100,8 +100,8 @@ func TestAccResourceNsxtPolicyIPPoolBlockSubnet_basic(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyIPPoolBlockSubnet_import_basic(t *testing.T) {
-	poolName := "tfpool7"
-	name := "subnet2"
+	poolName := getAccTestResourceName()
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_policy_ip_pool_block_subnet.test"
 
 	resource.Test(t, resource.TestCase{

--- a/nsxt/resource_nsxt_policy_ip_pool_static_subnet_test.go
+++ b/nsxt/resource_nsxt_policy_ip_pool_static_subnet_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestAccResourceNsxtPolicyIPPoolStaticSubnet_minimal(t *testing.T) {
-	name := "staticsubnet1"
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_policy_ip_pool_static_subnet.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -45,8 +45,8 @@ func TestAccResourceNsxtPolicyIPPoolStaticSubnet_minimal(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyIPPoolStaticSubnet_basic(t *testing.T) {
-	name := "tfpool1"
-	updatedName := fmt.Sprintf("%s-updated", name)
+	name := getAccTestResourceName()
+	updatedName := getAccTestResourceName()
 	testResourceName := "nsxt_policy_ip_pool_static_subnet.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -112,7 +112,7 @@ func TestAccResourceNsxtPolicyIPPoolStaticSubnet_basic(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyIPPoolStaticSubnet_import_basic(t *testing.T) {
-	name := "tfpool8"
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_policy_ip_pool_static_subnet.test"
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/nsxt/resource_nsxt_policy_ip_pool_test.go
+++ b/nsxt/resource_nsxt_policy_ip_pool_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestAccResourceNsxtPolicyIPPool_minimal(t *testing.T) {
-	name := "tfpool0"
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_policy_ip_pool.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -36,8 +36,8 @@ func TestAccResourceNsxtPolicyIPPool_minimal(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyIPPool_basic(t *testing.T) {
-	name := "tfpool1"
-	updatedName := fmt.Sprintf("%s-updated", name)
+	name := getAccTestResourceName()
+	updatedName := getAccTestResourceName()
 	testResourceName := "nsxt_policy_ip_pool.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -70,7 +70,7 @@ func TestAccResourceNsxtPolicyIPPool_basic(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyIPPool_import_basic(t *testing.T) {
-	name := "tfpool2"
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_policy_ip_pool.test"
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/nsxt/resource_nsxt_policy_lb_pool_test.go
+++ b/nsxt/resource_nsxt_policy_lb_pool_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 var accTestPolicyLBPoolCreateAttributes = map[string]string{
-	"display_name":            "terra-test",
+	"display_name":            getAccTestResourceName(),
 	"description":             "terraform created",
 	"algorithm":               "IP_HASH",
 	"min_active_members":      "2",
@@ -21,7 +21,7 @@ var accTestPolicyLBPoolCreateAttributes = map[string]string{
 }
 
 var accTestPolicyLBPoolUpdateAttributes = map[string]string{
-	"display_name":            "terra-test-updated",
+	"display_name":            getAccTestResourceName(),
 	"description":             "terraform updated",
 	"algorithm":               "WEIGHTED_ROUND_ROBIN",
 	"min_active_members":      "5",
@@ -35,7 +35,7 @@ func TestAccResourceNsxtPolicyLBPool_basic(t *testing.T) {
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNsxtPolicyLBPoolCheckDestroy(state, accTestPolicyLBPoolCreateAttributes["display_name"])
+			return testAccNsxtPolicyLBPoolCheckDestroy(state, accTestPolicyLBPoolUpdateAttributes["display_name"])
 		},
 		Steps: []resource.TestStep{
 			{
@@ -193,7 +193,7 @@ func TestAccResourceNsxtPolicyLBPool_snat(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyLBPool_importBasic(t *testing.T) {
-	name := "terra-test-import"
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_policy_lb_pool.test"
 
 	resource.Test(t, resource.TestCase{

--- a/nsxt/resource_nsxt_policy_lb_service_test.go
+++ b/nsxt/resource_nsxt_policy_lb_service_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 var accTestPolicyLBServiceCreateAttributes = map[string]string{
-	"display_name":      "terra-test",
+	"display_name":      getAccTestResourceName(),
 	"description":       "terraform created",
 	"connectivity_path": "nsxt_policy_tier1_gateway.test1.path",
 	"enabled":           "true",
@@ -22,13 +22,16 @@ var accTestPolicyLBServiceCreateAttributes = map[string]string{
 }
 
 var accTestPolicyLBServiceUpdateAttributes = map[string]string{
-	"display_name":      "terra-test-updated",
+	"display_name":      getAccTestResourceName(),
 	"description":       "terraform updated",
 	"connectivity_path": "nsxt_policy_tier1_gateway.test2.path",
 	"enabled":           "false",
 	"error_log_level":   "EMERGENCY",
 	"size":              "MEDIUM",
 }
+
+var accTestPolicyLBServiceGateway1Name = getAccTestResourceName()
+var accTestPolicyLBServiceGateway2Name = getAccTestResourceName()
 
 func TestAccResourceNsxtPolicyLBService_basic(t *testing.T) {
 	testResourceName := "nsxt_policy_lb_service.test"
@@ -91,7 +94,7 @@ func TestAccResourceNsxtPolicyLBService_basic(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyLBService_importBasic(t *testing.T) {
-	name := "terra-test-import"
+	name := accTestPolicyLBServiceUpdateAttributes["display_name"]
 	testResourceName := "nsxt_policy_lb_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -166,13 +169,13 @@ func testAccNsxtPolicyLBServiceTemplate(createFlow bool) string {
 	return testAccNsxtPolicyLBServiceDeps() + fmt.Sprintf(`
 
 resource "nsxt_policy_tier1_gateway" "test1" {
-  display_name      = "terraform-lb-test-1"
+  display_name      = "%s"
   edge_cluster_path = data.nsxt_policy_edge_cluster.test.path
   tier0_path        = nsxt_policy_tier0_gateway.test.path
 }
 
 resource "nsxt_policy_tier1_gateway" "test2" {
-  display_name      = "terraform-lb-test-2"
+  display_name      = "%s"
   edge_cluster_path = data.nsxt_policy_edge_cluster.test.path
   tier0_path        = nsxt_policy_tier0_gateway.test.path
 }
@@ -193,7 +196,7 @@ resource "nsxt_policy_lb_service" "test" {
 
 data "nsxt_policy_realization_info" "realization_info" {
   path = nsxt_policy_lb_service.test.path
-}`, attrMap["display_name"], attrMap["description"], attrMap["connectivity_path"], attrMap["enabled"], attrMap["error_log_level"], attrMap["size"])
+}`, accTestPolicyLBServiceGateway1Name, accTestPolicyLBServiceGateway2Name, attrMap["display_name"], attrMap["description"], attrMap["connectivity_path"], attrMap["enabled"], attrMap["error_log_level"], attrMap["size"])
 }
 
 // Terraform test does not respect T1-T0 dependency upon destroy,
@@ -201,12 +204,12 @@ data "nsxt_policy_realization_info" "realization_info" {
 func testAccNsxtPolicyLBServiceMinimalistic() string {
 	return testAccNsxtPolicyLBServiceDeps() + fmt.Sprintf(`
 resource "nsxt_policy_tier1_gateway" "test1" {
-  display_name      = "terraform-lb-test-1-update"
+  display_name      = "%s"
   edge_cluster_path = data.nsxt_policy_edge_cluster.test.path
 }
 
 resource "nsxt_policy_tier1_gateway" "test2" {
-  display_name      = "terraform-lb-test-2-update"
+  display_name      = "%s"
   edge_cluster_path = data.nsxt_policy_edge_cluster.test.path
 }
 resource "nsxt_policy_lb_service" "test" {
@@ -215,7 +218,7 @@ resource "nsxt_policy_lb_service" "test" {
 
 data "nsxt_policy_realization_info" "realization_info" {
   path = nsxt_policy_lb_service.test.path
-}`, accTestPolicyLBServiceUpdateAttributes["display_name"])
+}`, accTestPolicyLBServiceGateway1Name, accTestPolicyLBServiceGateway2Name, accTestPolicyLBServiceUpdateAttributes["display_name"])
 }
 
 func testAccNsxtPolicyLBServiceDeps() string {

--- a/nsxt/resource_nsxt_policy_lb_virtual_server_test.go
+++ b/nsxt/resource_nsxt_policy_lb_virtual_server_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 var accTestPolicyLBVirtualServerCreateAttributes = map[string]string{
-	"display_name":                "terra-test",
+	"display_name":                getAccTestResourceName(),
 	"description":                 "terraform created",
 	"access_log_enabled":          "true",
 	"default_pool_member_ports":   "777-778",
@@ -29,7 +29,7 @@ var accTestPolicyLBVirtualServerCreateAttributes = map[string]string{
 }
 
 var accTestPolicyLBVirtualServerUpdateAttributes = map[string]string{
-	"display_name":                "terra-test-updated",
+	"display_name":                getAccTestResourceName(),
 	"description":                 "terraform updated",
 	"access_log_enabled":          "false",
 	"default_pool_member_ports":   "555",
@@ -257,7 +257,7 @@ func TestAccResourceNsxtPolicyLBVirtualServer_withAccessList(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyLBVirtualServer_importBasic(t *testing.T) {
-	name := "terra-test-import"
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_policy_lb_virtual_server.test"
 
 	resource.Test(t, resource.TestCase{

--- a/nsxt/resource_nsxt_policy_nat_rule_test.go
+++ b/nsxt/resource_nsxt_policy_nat_rule_test.go
@@ -18,7 +18,7 @@ var testAccResourcePolicyNATRuleDestNet = "15.1.1.3"
 var testAccResourcePolicyNATRuleTransNet = "16.1.1.3"
 
 func TestAccResourceNsxtPolicyNATRule_minimalT0(t *testing.T) {
-	name := "test-nsx-policy-nat-rule-basic"
+	name := getAccTestResourceName()
 	action := model.PolicyNatRule_ACTION_REFLEXIVE
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -49,8 +49,8 @@ func TestAccResourceNsxtPolicyNATRule_minimalT0(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyNATRule_basicT1(t *testing.T) {
-	name := "test-nsx-policy-nat-rule-basic"
-	updateName := name + "updated"
+	name := getAccTestResourceName()
+	updateName := getAccTestResourceName()
 	snet := "22.1.1.2"
 	dnet := "33.1.1.2"
 	tnet := "44.1.1.2"
@@ -104,10 +104,10 @@ func TestAccResourceNsxtPolicyNATRule_basicT1(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNsxtPolicyNATRuleTier1UpdateMultipleSourceNetworksTemplate(updateName, action, testAccResourcePolicyNATRuleSourceNet, snet, dnet, tnet),
+				Config: testAccNsxtPolicyNATRuleTier1UpdateMultipleSourceNetworksTemplate(name, action, testAccResourcePolicyNATRuleSourceNet, snet, dnet, tnet),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNsxtPolicyNATRuleExists(testAccResourcePolicyNATRuleName),
-					resource.TestCheckResourceAttr(testAccResourcePolicyNATRuleName, "display_name", updateName),
+					resource.TestCheckResourceAttr(testAccResourcePolicyNATRuleName, "display_name", name),
 					resource.TestCheckResourceAttr(testAccResourcePolicyNATRuleName, "description", "Acceptance Test"),
 					resource.TestCheckResourceAttr(testAccResourcePolicyNATRuleName, "destination_networks.#", "1"),
 					resource.TestCheckResourceAttr(testAccResourcePolicyNATRuleName, "source_networks.#", "2"),
@@ -127,8 +127,8 @@ func TestAccResourceNsxtPolicyNATRule_basicT1(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyNATRule_basicT0(t *testing.T) {
-	name := "test-nsx-policy-nat-rule-basic"
-	updateName := name + "updated"
+	name := getAccTestResourceName()
+	updateName := getAccTestResourceName()
 	snet := "22.1.1.2"
 	tnet := "44.1.1.2"
 	action := model.PolicyNatRule_ACTION_REFLEXIVE
@@ -139,7 +139,7 @@ func TestAccResourceNsxtPolicyNATRule_basicT0(t *testing.T) {
 		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNsxtPolicyNATRuleCheckDestroy(state, name)
+			return testAccNsxtPolicyNATRuleCheckDestroy(state, updateName)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -185,7 +185,7 @@ func TestAccResourceNsxtPolicyNATRule_basicT0(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyNATRule_basicT1Import(t *testing.T) {
-	name := "test-nsx-policy-nat-rule-basic"
+	name := getAccTestResourceName()
 	action := model.PolicyNatRule_ACTION_DNAT
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/nsxt/resource_nsxt_policy_security_policy_test.go
+++ b/nsxt/resource_nsxt_policy_security_policy_test.go
@@ -12,8 +12,8 @@ import (
 )
 
 func TestAccResourceNsxtPolicySecurityPolicy_basic(t *testing.T) {
-	name := "terraform-test"
-	updatedName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
+	updatedName := getAccTestResourceName()
 	testResourceName := "nsxt_policy_security_policy.test"
 	comments1 := "Acceptance test create"
 	comments2 := "Acceptance test update"
@@ -29,7 +29,7 @@ func TestAccResourceNsxtPolicySecurityPolicy_basic(t *testing.T) {
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNsxtPolicySecurityPolicyCheckDestroy(state, name, defaultDomain)
+			return testAccNsxtPolicySecurityPolicyCheckDestroy(state, updatedName, defaultDomain)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -142,7 +142,7 @@ func TestAccResourceNsxtPolicySecurityPolicy_basic(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicySecurityPolicy_withDependencies(t *testing.T) {
-	name := "terraform-test"
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_policy_security_policy.test"
 	defaultAction := "ALLOW"
 	defaultDirection := "IN_OUT"
@@ -226,7 +226,7 @@ func TestAccResourceNsxtPolicySecurityPolicy_withDependencies(t *testing.T) {
 	})
 }
 func TestAccResourceNsxtPolicySecurityPolicy_importBasic(t *testing.T) {
-	name := "terraform-test-import"
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_policy_security_policy.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -248,9 +248,9 @@ func TestAccResourceNsxtPolicySecurityPolicy_importBasic(t *testing.T) {
 	})
 }
 func TestAccResourceNsxtGlobalPolicySecurityPolicy_withSite(t *testing.T) {
-	name := "terraform-test-site"
+	name := getAccTestResourceName()
+	updatedName := getAccTestResourceName()
 	testResourceName := "nsxt_policy_security_policy.test"
-	updatedName := fmt.Sprintf("%s-update", name)
 	comments1 := "Acceptance test create"
 	comments2 := "Acceptance test update"
 	direction1 := "IN"
@@ -269,7 +269,7 @@ func TestAccResourceNsxtGlobalPolicySecurityPolicy_withSite(t *testing.T) {
 		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNsxtPolicySecurityPolicyCheckDestroy(state, name, domain)
+			return testAccNsxtPolicySecurityPolicyCheckDestroy(state, updatedName, domain)
 		},
 		Steps: []resource.TestStep{
 			{

--- a/nsxt/resource_nsxt_policy_segment_test.go
+++ b/nsxt/resource_nsxt_policy_segment_test.go
@@ -8,6 +8,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
+var testPolicySegmentHelper1Name = getAccTestResourceName()
+var testPolicySegmentHelper2Name = getAccTestResourceName()
+
 func TestAccResourceNsxtPolicySegment_basicImport(t *testing.T) {
 	name := getAccTestResourceName()
 	testResourceName := "nsxt_policy_segment.test"
@@ -365,10 +368,10 @@ func testAccNsxtPolicySegmentCheckDestroy(state *terraform.State, displayName st
 }
 
 func testAccNsxtPolicySegmentDeps(tzName string) string {
-	return testAccNSXPolicyTransportZoneReadTemplate(tzName, false, true) + `
+	return testAccNSXPolicyTransportZoneReadTemplate(tzName, false, true) + fmt.Sprintf(`
 
 resource "nsxt_policy_tier1_gateway" "tier1ForSegments" {
-  display_name              = "t1gw"
+  display_name              = "%s"
   description               = "Acceptance Test"
   default_rule_logging      = "true"
   enable_firewall           = "false"
@@ -380,7 +383,7 @@ resource "nsxt_policy_tier1_gateway" "tier1ForSegments" {
 }
 
 resource "nsxt_policy_tier1_gateway" "anotherTier1ForSegments" {
-  display_name              = "t1gw-b"
+  display_name              = "%s"
   description               = "Another Tier1"
   default_rule_logging      = "true"
   enable_firewall           = "false"
@@ -389,7 +392,7 @@ resource "nsxt_policy_tier1_gateway" "anotherTier1ForSegments" {
   failover_mode             = "NON_PREEMPTIVE"
   pool_allocation           = "ROUTING"
   route_advertisement_types = ["TIER1_STATIC_ROUTES", "TIER1_CONNECTED"]
-}`
+}`, testPolicySegmentHelper1Name, testPolicySegmentHelper2Name)
 }
 
 func testAccNsxtPolicySegmentImportTemplate(tzName string, name string) string {

--- a/nsxt/resource_nsxt_policy_segment_test.go
+++ b/nsxt/resource_nsxt_policy_segment_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestAccResourceNsxtPolicySegment_basicImport(t *testing.T) {
-	name := "test-nsx-policy-segment"
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_policy_segment.test"
 	tzName := getOverlayTransportZoneName()
 
@@ -33,8 +33,8 @@ func TestAccResourceNsxtPolicySegment_basicImport(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicySegment_basicUpdate(t *testing.T) {
-	name := "test-nsx-policy-segment"
-	updatedName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
+	updatedName := getAccTestResourceName()
 	testResourceName := "nsxt_policy_segment.test"
 	tzName := getOverlayTransportZoneName()
 
@@ -42,7 +42,7 @@ func TestAccResourceNsxtPolicySegment_basicUpdate(t *testing.T) {
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNsxtPolicySegmentCheckDestroy(state, name)
+			return testAccNsxtPolicySegmentCheckDestroy(state, updatedName)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -76,8 +76,7 @@ func TestAccResourceNsxtPolicySegment_basicUpdate(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicySegment_connectivityPath(t *testing.T) {
-	name := "test-nsx-policy-segment"
-	updatedName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_policy_segment.test"
 	tzName := getOverlayTransportZoneName()
 
@@ -103,10 +102,10 @@ func TestAccResourceNsxtPolicySegment_connectivityPath(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNsxtPolicySegmentUpdateConnectivityTemplate(tzName, updatedName),
+				Config: testAccNsxtPolicySegmentUpdateConnectivityTemplate(tzName, name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNsxtPolicySegmentExists(testResourceName),
-					resource.TestCheckResourceAttr(testResourceName, "display_name", updatedName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", name),
 					resource.TestCheckResourceAttr(testResourceName, "description", "Acceptance Test2"),
 					resource.TestCheckResourceAttr(testResourceName, "subnet.#", "1"),
 					resource.TestCheckResourceAttr(testResourceName, "subnet.0.cidr", "22.22.22.1/24"),
@@ -124,8 +123,7 @@ func TestAccResourceNsxtPolicySegment_connectivityPath(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicySegment_updateAdvConfig(t *testing.T) {
-	name := "test-nsx-policy-segment"
-	updatedName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_policy_segment.test"
 	tzName := getOverlayTransportZoneName()
 
@@ -153,10 +151,10 @@ func TestAccResourceNsxtPolicySegment_updateAdvConfig(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNsxtPolicySegmentBasicAdvConfigUpdateTemplate(tzName, updatedName),
+				Config: testAccNsxtPolicySegmentBasicAdvConfigUpdateTemplate(tzName, name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNsxtPolicySegmentExists(testResourceName),
-					resource.TestCheckResourceAttr(testResourceName, "display_name", updatedName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", name),
 					resource.TestCheckResourceAttr(testResourceName, "description", "Acceptance Test"),
 					resource.TestCheckResourceAttr(testResourceName, "subnet.#", "1"),
 					resource.TestCheckResourceAttr(testResourceName, "subnet.0.cidr", "12.12.2.1/24"),
@@ -173,8 +171,7 @@ func TestAccResourceNsxtPolicySegment_updateAdvConfig(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicySegment_noTransportZone(t *testing.T) {
-	name := "test-nsx-policy-segment"
-	updatedName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_policy_segment.test"
 	cidr := "4003::1/64"
 	updatedCidr := "4004::1/64"
@@ -202,10 +199,10 @@ func TestAccResourceNsxtPolicySegment_noTransportZone(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNsxtPolicySegmentNoTransportZoneTemplate(updatedName, updatedCidr),
+				Config: testAccNsxtPolicySegmentNoTransportZoneTemplate(name, updatedCidr),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNsxtPolicySegmentExists(testResourceName),
-					resource.TestCheckResourceAttr(testResourceName, "display_name", updatedName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", name),
 					resource.TestCheckResourceAttr(testResourceName, "description", "Acceptance Test"),
 					resource.TestCheckResourceAttr(testResourceName, "subnet.#", "1"),
 					resource.TestCheckResourceAttr(testResourceName, "subnet.0.cidr", updatedCidr),
@@ -221,11 +218,10 @@ func TestAccResourceNsxtPolicySegment_noTransportZone(t *testing.T) {
 }
 
 // TODO: Rewrite this test based on profile resources when these are available.
-const testAccSegmentQosProfileName = "test-nsx-policy-segment-qos-profile"
+var testAccSegmentQosProfileName = getAccTestResourceName()
 
 func TestAccResourceNsxtPolicySegment_withProfiles(t *testing.T) {
-	name := "test-nsx-policy-segment"
-	updatedName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_policy_segment.test"
 	tzName := getOverlayTransportZoneName()
 
@@ -259,10 +255,10 @@ func TestAccResourceNsxtPolicySegment_withProfiles(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNsxtPolicySegmentWithProfilesUpdateTemplate(tzName, updatedName),
+				Config: testAccNsxtPolicySegmentWithProfilesUpdateTemplate(tzName, name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNsxtPolicySegmentExists(testResourceName),
-					resource.TestCheckResourceAttr(testResourceName, "display_name", updatedName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", name),
 					resource.TestCheckResourceAttr(testResourceName, "security_profile.#", "1"),
 					resource.TestCheckResourceAttrSet(testResourceName, "security_profile.0.spoofguard_profile_path"),
 					resource.TestCheckResourceAttrSet(testResourceName, "security_profile.0.security_profile_path"),
@@ -273,10 +269,10 @@ func TestAccResourceNsxtPolicySegment_withProfiles(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNsxtPolicySegmentWithProfilesRemoveAll(tzName, updatedName),
+				Config: testAccNsxtPolicySegmentWithProfilesRemoveAll(tzName, name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNsxtPolicySegmentExists(testResourceName),
-					resource.TestCheckResourceAttr(testResourceName, "display_name", updatedName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", name),
 					resource.TestCheckResourceAttr(testResourceName, "security_profile.#", "0"),
 					resource.TestCheckResourceAttr(testResourceName, "qos_profile.#", "0"),
 					resource.TestCheckResourceAttr(testResourceName, "discovery_profile.#", "0"),
@@ -287,8 +283,7 @@ func TestAccResourceNsxtPolicySegment_withProfiles(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicySegment_withDhcp(t *testing.T) {
-	name := "test-nsx-policy-segment"
-	updatedName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_policy_segment.test"
 	leaseTimes := []string{"3600", "36000"}
 	preferredTimes := []string{"3200", "32000"}
@@ -331,10 +326,10 @@ func TestAccResourceNsxtPolicySegment_withDhcp(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNsxtPolicySegmentWithDhcpTemplate(tzName, updatedName, dnsServersV4[1], dnsServersV6[1], leaseTimes[1], preferredTimes[1]),
+				Config: testAccNsxtPolicySegmentWithDhcpTemplate(tzName, name, dnsServersV4[1], dnsServersV6[1], leaseTimes[1], preferredTimes[1]),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNsxtPolicySegmentExists(testResourceName),
-					resource.TestCheckResourceAttr(testResourceName, "display_name", updatedName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", name),
 					resource.TestCheckResourceAttr(testResourceName, "subnet.#", "2"),
 					resource.TestCheckResourceAttr(testResourceName, "subnet.0.cidr", "12.12.2.1/24"),
 					resource.TestCheckResourceAttr(testResourceName, "subnet.0.dhcp_v6_config.#", "0"),

--- a/nsxt/resource_nsxt_policy_service_test.go
+++ b/nsxt/resource_nsxt_policy_service_test.go
@@ -14,8 +14,8 @@ import (
 )
 
 func TestAccResourceNsxtPolicyService_icmp(t *testing.T) {
-	name := "test-nsx-policy-icmp-type-service-basic"
-	updateName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
+	updateName := getAccTestResourceName()
 	testResourceName := "nsxt_policy_service.test"
 
 	resource.Test(t, resource.TestCase{
@@ -150,7 +150,7 @@ func TestAccResourceNsxtPolicyService_icmp(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyService_icmpNoEntryDisplayName(t *testing.T) {
-	name := "test-nsx-policy-icmp-type-service-no-display-name"
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_policy_service.test"
 
 	resource.Test(t, resource.TestCase{
@@ -187,8 +187,8 @@ func TestAccResourceNsxtPolicyService_icmpNoEntryDisplayName(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyService_l4PortSet(t *testing.T) {
-	name := "test-nsx-policy-l4-port-set-type-service-basic"
-	updateName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
+	updateName := getAccTestResourceName()
 	testResourceName := "nsxt_policy_service.test"
 
 	resource.Test(t, resource.TestCase{
@@ -296,7 +296,7 @@ func TestAccResourceNsxtPolicyService_l4PortSet(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyService_mixedServices(t *testing.T) {
-	name := "test-nsx-policy-mixed-service"
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_policy_service.test"
 
 	resource.Test(t, resource.TestCase{
@@ -345,15 +345,15 @@ func TestAccResourceNsxtPolicyService_mixedServices(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyService_igmp(t *testing.T) {
-	name := "test-nsx-policy-igmp-type-service"
-	updateName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
+	updateName := getAccTestResourceName()
 	testResourceName := "nsxt_policy_service.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNsxtPolicyServiceCheckDestroy(state, name)
+			return testAccNsxtPolicyServiceCheckDestroy(state, updateName)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -399,15 +399,15 @@ func TestAccResourceNsxtPolicyService_igmp(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyService_etherType(t *testing.T) {
-	name := "test-nsx-policy-ether-type-service"
-	updateName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
+	updateName := getAccTestResourceName()
 	testResourceName := "nsxt_policy_service.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNsxtPolicyServiceCheckDestroy(state, name)
+			return testAccNsxtPolicyServiceCheckDestroy(state, updateName)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -455,15 +455,15 @@ func TestAccResourceNsxtPolicyService_etherType(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyService_ipProtocolType(t *testing.T) {
-	name := "test-nsx-policy-ip-protocol-type-service"
-	updateName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
+	updateName := getAccTestResourceName()
 	testResourceName := "nsxt_policy_service.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNsxtPolicyServiceCheckDestroy(state, name)
+			return testAccNsxtPolicyServiceCheckDestroy(state, updateName)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -511,8 +511,8 @@ func TestAccResourceNsxtPolicyService_ipProtocolType(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyService_algType(t *testing.T) {
-	name := "test-nsx-policy-alg-service"
-	updateName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
+	updateName := getAccTestResourceName()
 	testResourceName := "nsxt_policy_service.test"
 	alg := "SUN_RPC_UDP"
 	destPort := "210"
@@ -524,7 +524,7 @@ func TestAccResourceNsxtPolicyService_algType(t *testing.T) {
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNsxtPolicyServiceCheckDestroy(state, name)
+			return testAccNsxtPolicyServiceCheckDestroy(state, updateName)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -576,7 +576,7 @@ func TestAccResourceNsxtPolicyService_algType(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyService_importBasic(t *testing.T) {
-	name := "test-nsx-policy-service-import"
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_policy_service.test"
 
 	resource.Test(t, resource.TestCase{

--- a/nsxt/resource_nsxt_policy_static_route_test.go
+++ b/nsxt/resource_nsxt_policy_static_route_test.go
@@ -12,10 +12,11 @@ import (
 )
 
 var testAccResourcePolicyStaticRouteName = "nsxt_policy_static_route.test"
+var testAccResourcePolicyStaticRouteGatewayName = getAccTestResourceName()
 
 func TestAccResourceNsxtPolicyStaticRoute_basicT0(t *testing.T) {
-	name := "test-nsx-policy-static-route-basic"
-	updateName := name + "updated"
+	name := getAccTestResourceName()
+	updateName := getAccTestResourceName()
 	network := "14.1.1.0/24"
 	updateNetwork := "15.1.1.0/24"
 
@@ -23,7 +24,7 @@ func TestAccResourceNsxtPolicyStaticRoute_basicT0(t *testing.T) {
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNsxtPolicyStaticRouteCheckDestroy(state, name)
+			return testAccNsxtPolicyStaticRouteCheckDestroy(state, updateName)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -70,8 +71,8 @@ func TestAccResourceNsxtPolicyStaticRoute_basicT0(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyStaticRoute_basicT1(t *testing.T) {
-	name := "test-nsx-policy-static-route-basic"
-	updateName := name + "updated"
+	name := getAccTestResourceName()
+	updateName := getAccTestResourceName()
 	network := "14.1.1.0/24"
 	updateNetwork := "15.1.1.0/24"
 
@@ -79,7 +80,7 @@ func TestAccResourceNsxtPolicyStaticRoute_basicT1(t *testing.T) {
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNsxtPolicyStaticRouteCheckDestroy(state, name)
+			return testAccNsxtPolicyStaticRouteCheckDestroy(state, updateName)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -126,7 +127,7 @@ func TestAccResourceNsxtPolicyStaticRoute_basicT1(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyStaticRoute_basicT0Import(t *testing.T) {
-	name := "test-nsx-policy-static-route-basic"
+	name := getAccTestResourceName()
 	network := "14.1.1.0/24"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -150,7 +151,7 @@ func TestAccResourceNsxtPolicyStaticRoute_basicT0Import(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyStaticRoute_basicT1Import(t *testing.T) {
-	name := "test-nsx-policy-static-route-basic"
+	name := getAccTestResourceName()
 	network := "14.1.1.0/24"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -301,7 +302,7 @@ resource "nsxt_policy_static_route" "test" {
 func testAccNsxtPolicyStaticRouteTier1CreateTemplate(name string, network string) string {
 	return fmt.Sprintf(`
 resource "nsxt_policy_tier1_gateway" "t1test" {
-  display_name              = "terraform-t1-gw"
+  display_name              = "%s"
   description               = "Acceptance Test"
 
 }
@@ -324,13 +325,13 @@ resource "nsxt_policy_static_route" "test" {
     tag   = "tag2"
   }
 }
-`, name, network)
+`, testAccResourcePolicyStaticRouteGatewayName, name, network)
 }
 
 func testAccNsxtPolicyStaticRouteMultipleHopsTier1CreateTemplate(name string, network string) string {
 	return fmt.Sprintf(`
 resource "nsxt_policy_tier1_gateway" "t1test" {
-  display_name              = "terraform-t1-gw"
+  display_name              = "%s"
   description               = "Acceptance Test"
 
 }
@@ -359,5 +360,5 @@ resource "nsxt_policy_static_route" "test" {
     tag   = "tag2"
   }
 }
-`, name, network)
+`, testAccResourcePolicyStaticRouteGatewayName, name, network)
 }

--- a/nsxt/resource_nsxt_policy_tier0_gateway_ha_vip_config_test.go
+++ b/nsxt/resource_nsxt_policy_tier0_gateway_ha_vip_config_test.go
@@ -19,8 +19,8 @@ func TestAccResourceNsxtPolicyTier0GatewayHaVipConfig_basic(t *testing.T) {
 	subnet2 := "1.1.12.2/24"
 	vipSubnet := "1.1.12.4/24"
 	updatedVipSubnet := "1.1.12.5/24"
-	tier0Name := "ha_tier0"
-	updatedTier0Name := "updated_ha_tier0"
+	tier0Name := getAccTestResourceName()
+	updatedTier0Name := getAccTestResourceName()
 	testResourceName := "nsxt_policy_tier0_gateway_ha_vip_config.test"
 
 	resource.Test(t, resource.TestCase{

--- a/nsxt/resource_nsxt_policy_tier0_gateway_interface_test.go
+++ b/nsxt/resource_nsxt_policy_tier0_gateway_interface_test.go
@@ -13,11 +13,11 @@ import (
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_0s/locale_services"
 )
 
-var nsxtPolicyTier0GatewayName = "test"
+var nsxtPolicyTier0GatewayName = getAccTestResourceName()
 
 func TestAccResourceNsxtPolicyTier0GatewayInterface_service(t *testing.T) {
-	name := "test-nsx-policy-tier0-interface-service"
-	updatedName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
+	updatedName := getAccTestResourceName()
 	mtu := "1500"
 	updatedMtu := "1800"
 	subnet := "1.1.12.2/24"
@@ -99,8 +99,8 @@ func TestAccResourceNsxtPolicyTier0GatewayInterface_service(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyTier0GatewayInterface_site(t *testing.T) {
-	name := "test-nsx-policy-tier0-interface-site"
-	updatedName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
+	updatedName := getAccTestResourceName()
 	mtu := "1500"
 	updatedMtu := "1800"
 	subnet := "1.1.12.2/24"
@@ -185,8 +185,8 @@ func TestAccResourceNsxtPolicyTier0GatewayInterface_site(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyTier0GatewayInterface_external(t *testing.T) {
-	name := "test-nsx-policy-tier0-interface-external"
-	updatedName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
+	updatedName := getAccTestResourceName()
 	mtu := "1500"
 	updatedMtu := "1800"
 	subnet := "1.1.12.2/24"
@@ -206,7 +206,7 @@ func TestAccResourceNsxtPolicyTier0GatewayInterface_external(t *testing.T) {
 		PreCheck:  func() { testAccPreCheck(t); testAccNSXVersion(t, "3.0.0") },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNsxtPolicyTier0InterfaceCheckDestroy(state, name)
+			return testAccNsxtPolicyTier0InterfaceCheckDestroy(state, updatedName)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -262,8 +262,8 @@ func TestAccResourceNsxtPolicyTier0GatewayInterface_external(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyTier0GatewayInterface_withID(t *testing.T) {
-	name := "test-nsx-policy-tier0-interface-id"
-	updatedName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
+	updatedName := getAccTestResourceName()
 	subnet := "1.1.12.2/24"
 	// Update to 2 addresses
 	ipv6Subnet := "4003::12/64"
@@ -276,7 +276,7 @@ func TestAccResourceNsxtPolicyTier0GatewayInterface_withID(t *testing.T) {
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNsxtPolicyTier0InterfaceCheckDestroy(state, name)
+			return testAccNsxtPolicyTier0InterfaceCheckDestroy(state, updatedName)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -323,8 +323,8 @@ func TestAccResourceNsxtPolicyTier0GatewayInterface_withID(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyTier0GatewayInterface_withV6(t *testing.T) {
-	name := "test-nsx-policy-tier0-interface-v6"
-	updatedName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
+	updatedName := getAccTestResourceName()
 	subnet := "1.1.12.2/24"
 	// Update to 2 addresses
 	ipv6Subnet := "4003::12/64"
@@ -337,7 +337,7 @@ func TestAccResourceNsxtPolicyTier0GatewayInterface_withV6(t *testing.T) {
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNsxtPolicyTier0InterfaceCheckDestroy(state, name)
+			return testAccNsxtPolicyTier0InterfaceCheckDestroy(state, updatedName)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -422,7 +422,7 @@ func testAccNSXPolicyTier0InterfaceImporterGetID(s *terraform.State) (string, er
 }
 
 func TestAccResourceNsxtPolicyTier0GatewayInterface_importBasic(t *testing.T) {
-	name := "test-nsx-policy-tier0-interface-import"
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_policy_tier0_gateway_interface.test"
 	subnet := "1.1.12.2/24"
 

--- a/nsxt/resource_nsxt_policy_tier0_gateway_test.go
+++ b/nsxt/resource_nsxt_policy_tier0_gateway_test.go
@@ -12,8 +12,8 @@ import (
 )
 
 func TestAccResourceNsxtPolicyTier0Gateway_basic(t *testing.T) {
-	name := "test-nsx-policy-tier0-basic"
-	updateName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
+	updateName := getAccTestResourceName()
 	testResourceName := "nsxt_policy_tier0_gateway.test"
 	failoverMode := "NON_PREEMPTIVE"
 
@@ -21,7 +21,7 @@ func TestAccResourceNsxtPolicyTier0Gateway_basic(t *testing.T) {
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNsxtPolicyTier0CheckDestroy(state, name)
+			return testAccNsxtPolicyTier0CheckDestroy(state, updateName)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -66,16 +66,16 @@ func TestAccResourceNsxtPolicyTier0Gateway_basic(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyTier0Gateway_withId(t *testing.T) {
-	name := "test-nsx-policy-tier0-id"
+	name := getAccTestResourceName()
 	id := "test-id"
-	updateName := fmt.Sprintf("%s-update", name)
+	updateName := getAccTestResourceName()
 	testResourceName := "nsxt_policy_tier0_gateway.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNsxtPolicyTier0CheckDestroy(state, name)
+			return testAccNsxtPolicyTier0CheckDestroy(state, updateName)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -103,7 +103,7 @@ func TestAccResourceNsxtPolicyTier0Gateway_withId(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyTier0Gateway_withSubnets(t *testing.T) {
-	name := "test-nsx-policy-tier0-subnets"
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_policy_tier0_gateway.test"
 
 	resource.Test(t, resource.TestCase{
@@ -130,7 +130,7 @@ func TestAccResourceNsxtPolicyTier0Gateway_withSubnets(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyTier0Gateway_withDHCP(t *testing.T) {
-	name := "test-nsx-policy-tier0-dhcp"
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_policy_tier0_gateway.test"
 
 	resource.Test(t, resource.TestCase{
@@ -169,7 +169,7 @@ func TestAccResourceNsxtPolicyTier0Gateway_withDHCP(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyTier0Gateway_redistribution(t *testing.T) {
-	name := "test-nsx-policy-tier0-redistribution"
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_policy_tier0_gateway.test"
 
 	resource.Test(t, resource.TestCase{
@@ -219,8 +219,8 @@ func TestAccResourceNsxtPolicyTier0Gateway_redistribution(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyTier0Gateway_withEdgeCluster(t *testing.T) {
-	name := "test-nsx-policy-tier0-ec"
-	updateName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
+	updateName := getAccTestResourceName()
 	testResourceName := "nsxt_policy_tier0_gateway.test"
 	edgeClusterName := getEdgeClusterName()
 
@@ -228,7 +228,7 @@ func TestAccResourceNsxtPolicyTier0Gateway_withEdgeCluster(t *testing.T) {
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNsxtPolicyTier0CheckDestroy(state, name)
+			return testAccNsxtPolicyTier0CheckDestroy(state, updateName)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -307,8 +307,7 @@ func TestAccResourceNsxtPolicyTier0Gateway_withEdgeCluster(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyTier0Gateway_createWithBGP(t *testing.T) {
-	name := "test-nsx-policy-tier0-bgp"
-	updateName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_policy_tier0_gateway.test"
 	edgeClusterName := getEdgeClusterName()
 
@@ -320,10 +319,10 @@ func TestAccResourceNsxtPolicyTier0Gateway_createWithBGP(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNsxtPolicyTier0UpdateWithEcTemplate(updateName, edgeClusterName),
+				Config: testAccNsxtPolicyTier0UpdateWithEcTemplate(name, edgeClusterName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNsxtPolicyTier0Exists(testResourceName),
-					resource.TestCheckResourceAttr(testResourceName, "display_name", updateName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", name),
 					resource.TestCheckResourceAttr(testResourceName, "description", "Acceptance Test"),
 					resource.TestCheckResourceAttrSet(testResourceName, "edge_cluster_path"),
 					resource.TestCheckResourceAttr(realizationResourceName, "state", "REALIZED"),
@@ -348,8 +347,8 @@ func TestAccResourceNsxtPolicyTier0Gateway_createWithBGP(t *testing.T) {
 
 // TODO: add route_distinguisher when VNI pool DS is exposed
 func TestAccResourceNsxtPolicyTier0Gateway_withVRF(t *testing.T) {
-	name := "test-nsx-policy-tier0-vrf"
-	updateName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
+	updateName := getAccTestResourceName()
 	testResourceName := "nsxt_policy_tier0_gateway.test"
 	testInterfaceName := "nsxt_policy_tier0_gateway_interface.test"
 
@@ -357,7 +356,7 @@ func TestAccResourceNsxtPolicyTier0Gateway_withVRF(t *testing.T) {
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t); testAccNSXVersion(t, "3.0.0") },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNsxtPolicyTier0CheckDestroy(state, name)
+			return testAccNsxtPolicyTier0CheckDestroy(state, updateName)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -400,7 +399,7 @@ func TestAccResourceNsxtPolicyTier0Gateway_withVRF(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyTier0Gateway_importBasic(t *testing.T) {
-	name := "test-nsx-policy-tier0-import"
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_policy_tier0_gateway.test"
 	failoverMode := "PREEMPTIVE"
 

--- a/nsxt/resource_nsxt_policy_tier1_gateway_gm_test.go
+++ b/nsxt/resource_nsxt_policy_tier1_gateway_gm_test.go
@@ -80,7 +80,7 @@ func TestAccResourceNsxtPolicyTier1Gateway_globalManager(t *testing.T) {
 // NOTE: This test assumes single edge cluster on both sites
 func TestAccResourceNsxtPolicyTier1Gateway_globalManagerWithQos(t *testing.T) {
 	testResourceName := "nsxt_policy_tier1_gateway.test"
-	profileName := "test-nsx-qos-profile"
+	profileName := getAccTestResourceName()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {

--- a/nsxt/resource_nsxt_policy_tier1_gateway_interface_test.go
+++ b/nsxt/resource_nsxt_policy_tier1_gateway_interface_test.go
@@ -17,8 +17,8 @@ import (
 var nsxtPolicyTier1GatewayName = "test"
 
 func TestAccResourceNsxtPolicyTier1GatewayInterface_basic(t *testing.T) {
-	name := "test-nsx-policy-tier1-interface-basic"
-	updatedName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
+	updatedName := getAccTestResourceName()
 	mtu := "1500"
 	updatedMtu := "1800"
 	subnet := "1.1.12.2/24"
@@ -90,8 +90,8 @@ func TestAccResourceNsxtPolicyTier1GatewayInterface_basic(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyTier1GatewayInterface_withID(t *testing.T) {
-	name := "test-nsx-policy-tier1-interface-id"
-	updatedName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
+	updatedName := getAccTestResourceName()
 	subnet := "1.1.12.2/24"
 	// Update to 2 addresses
 	ipv6Subnet := "4003::12/64"
@@ -102,7 +102,7 @@ func TestAccResourceNsxtPolicyTier1GatewayInterface_withID(t *testing.T) {
 		PreCheck:  func() { testAccPreCheck(t); testAccNSXVersion(t, "3.0.0") },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNsxtPolicyTier1InterfaceCheckDestroy(state, name)
+			return testAccNsxtPolicyTier1InterfaceCheckDestroy(state, updatedName)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -148,8 +148,8 @@ func TestAccResourceNsxtPolicyTier1GatewayInterface_withID(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyTier1GatewayInterface_withSite(t *testing.T) {
-	name := "test-nsx-policy-tier1-interface-site"
-	updatedName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
+	updatedName := getAccTestResourceName()
 	mtu := "1500"
 	updatedMtu := "1800"
 	subnet := "1.1.12.2/24"
@@ -224,8 +224,7 @@ func TestAccResourceNsxtPolicyTier1GatewayInterface_withSite(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyTier1GatewayInterface_withIPv6(t *testing.T) {
-	name := "test-nsx-policy-tier1-interface-ipv6"
-	updatedName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
 	subnet := "1.1.12.2/24"
 	// Update to 2 addresses
 	ipv6Subnet := "4003::12/64"
@@ -259,10 +258,10 @@ func TestAccResourceNsxtPolicyTier1GatewayInterface_withIPv6(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNsxtPolicyTier1InterfaceTemplateWithIPv6(updatedName, updatedSubnet),
+				Config: testAccNsxtPolicyTier1InterfaceTemplateWithIPv6(name, updatedSubnet),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNsxtPolicyTier1InterfaceExists(testResourceName),
-					resource.TestCheckResourceAttr(testResourceName, "display_name", updatedName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", name),
 					resource.TestCheckResourceAttr(testResourceName, "description", "Acceptance Test"),
 					resource.TestCheckResourceAttr(testResourceName, "subnets.#", "2"),
 					resource.TestCheckResourceAttr(testResourceName, "subnets.0", subnet),
@@ -301,7 +300,7 @@ func testAccNSXPolicyTier1InterfaceImporterGetID(s *terraform.State) (string, er
 }
 
 func TestAccResourceNsxtPolicyTier1GatewayInterface_importBasic(t *testing.T) {
-	name := "test-nsx-policy-tier1-interface-import"
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_policy_tier1_gateway_interface.test"
 	subnet := "1.1.12.2/24"
 

--- a/nsxt/resource_nsxt_policy_tier1_gateway_test.go
+++ b/nsxt/resource_nsxt_policy_tier1_gateway_test.go
@@ -12,8 +12,8 @@ import (
 )
 
 func TestAccResourceNsxtPolicyTier1Gateway_basic(t *testing.T) {
-	name := "test-nsx-policy-tier1-basic"
-	updateName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
+	updateName := getAccTestResourceName()
 	testResourceName := "nsxt_policy_tier1_gateway.test"
 	failoverMode := "NON_PREEMPTIVE"
 
@@ -91,8 +91,8 @@ func TestAccResourceNsxtPolicyTier1Gateway_basic(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyTier1Gateway_withPoolAllocation(t *testing.T) {
-	name := "test-nsx-policy-tier1-basic"
-	updateName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
+	updateName := getAccTestResourceName()
 	testResourceName := "nsxt_policy_tier1_gateway.test"
 	failoverMode := "NON_PREEMPTIVE"
 
@@ -100,7 +100,7 @@ func TestAccResourceNsxtPolicyTier1Gateway_withPoolAllocation(t *testing.T) {
 		PreCheck:  func() { testAccPreCheck(t); testAccNSXVersion(t, "3.0.0") },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNsxtPolicyTier1CheckDestroy(state, name)
+			return testAccNsxtPolicyTier1CheckDestroy(state, updateName)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -174,7 +174,7 @@ func TestAccResourceNsxtPolicyTier1Gateway_withPoolAllocation(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyTier1Gateway_withDHCP(t *testing.T) {
-	name := "test-nsx-policy-tier1-dhcp"
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_policy_tier1_gateway.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -212,8 +212,8 @@ func TestAccResourceNsxtPolicyTier1Gateway_withDHCP(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyTier1Gateway_withEdgeCluster(t *testing.T) {
-	name := "test-nsx-policy-tier1-ec"
-	updateName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
+	updateName := getAccTestResourceName()
 	testResourceName := "nsxt_policy_tier1_gateway.test"
 	edgeClusterName := getEdgeClusterName()
 
@@ -221,7 +221,7 @@ func TestAccResourceNsxtPolicyTier1Gateway_withEdgeCluster(t *testing.T) {
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNsxtPolicyTier1CheckDestroy(state, name)
+			return testAccNsxtPolicyTier1CheckDestroy(state, updateName)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -251,16 +251,16 @@ func TestAccResourceNsxtPolicyTier1Gateway_withEdgeCluster(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyTier1Gateway_withId(t *testing.T) {
-	name := "test-nsx-policy-tier1-id"
+	name := getAccTestResourceName()
 	id := "test-id"
-	updateName := fmt.Sprintf("%s-update", name)
+	updateName := getAccTestResourceName()
 	testResourceName := "nsxt_policy_tier1_gateway.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNsxtPolicyTier1CheckDestroy(state, name)
+			return testAccNsxtPolicyTier1CheckDestroy(state, updateName)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -291,9 +291,9 @@ func TestAccResourceNsxtPolicyTier1Gateway_withId(t *testing.T) {
 	})
 }
 func TestAccResourceNsxtPolicyTier1Gateway_withQos(t *testing.T) {
-	name := "test-nsx-policy-tier1"
-	profileName := "test-nsx-qos-profile"
-	updateName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
+	profileName := getAccTestResourceName()
+	updateName := getAccTestResourceName()
 	testResourceName := "nsxt_policy_tier1_gateway.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -303,7 +303,7 @@ func TestAccResourceNsxtPolicyTier1Gateway_withQos(t *testing.T) {
 			if err := testAccDataSourceNsxtPolicyGatewayQosProfileDeleteByName(profileName); err != nil {
 				return err
 			}
-			return testAccNsxtPolicyTier1CheckDestroy(state, name)
+			return testAccNsxtPolicyTier1CheckDestroy(state, updateName)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -336,15 +336,15 @@ func TestAccResourceNsxtPolicyTier1Gateway_withQos(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyTier1Gateway_withRules(t *testing.T) {
-	name := "test-nsx-policy-tier1-rule"
-	updateName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
+	updateName := getAccTestResourceName()
 	testResourceName := "nsxt_policy_tier1_gateway.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNsxtPolicyTier1CheckDestroy(state, name)
+			return testAccNsxtPolicyTier1CheckDestroy(state, updateName)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -376,10 +376,10 @@ func TestAccResourceNsxtPolicyTier1Gateway_withRules(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyTier1Gateway_withTier0(t *testing.T) {
-	name := "test-nsx-policy-tier1-t0"
-	updateName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
+	updateName := getAccTestResourceName()
 	testResourceName := "nsxt_policy_tier1_gateway.test"
-	tier0Name := "tier-0-test-for-tier1"
+	tier0Name := getAccTestResourceName()
 	failoverMode := "NON_PREEMPTIVE"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -387,7 +387,7 @@ func TestAccResourceNsxtPolicyTier1Gateway_withTier0(t *testing.T) {
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			err := testAccDataSourceNsxtPolicyTier0GatewayDeleteByName(tier0Name)
-			err2 := testAccNsxtPolicyTier1CheckDestroy(state, name)
+			err2 := testAccNsxtPolicyTier1CheckDestroy(state, updateName)
 			if err != nil {
 				return err
 			}
@@ -427,7 +427,7 @@ func TestAccResourceNsxtPolicyTier1Gateway_withTier0(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyTier1Gateway_importBasic(t *testing.T) {
-	name := "test-nsx-policy-tier1-import"
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_policy_tier1_gateway.test"
 	failoverMode := "PREEMPTIVE"
 

--- a/nsxt/resource_nsxt_policy_vlan_segment_test.go
+++ b/nsxt/resource_nsxt_policy_vlan_segment_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestAccResourceNsxtPolicyVlanSegment_basicImport(t *testing.T) {
-	name := "test-nsx-policy-vlan-segment"
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_policy_vlan_segment.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -32,15 +32,15 @@ func TestAccResourceNsxtPolicyVlanSegment_basicImport(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyVlanSegment_basicUpdate(t *testing.T) {
-	name := "test-nsx-policy-vlan-segment"
-	updatedName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
+	updatedName := getAccTestResourceName()
 	testResourceName := "nsxt_policy_vlan_segment.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNsxtPolicyVlanSegmentCheckDestroy(state, name)
+			return testAccNsxtPolicyVlanSegmentCheckDestroy(state, updatedName)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -70,8 +70,7 @@ func TestAccResourceNsxtPolicyVlanSegment_basicUpdate(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyVlanSegment_updateAdvConfig(t *testing.T) {
-	name := "test-nsx-policy-vlan-segment"
-	updatedName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_policy_vlan_segment.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -94,10 +93,10 @@ func TestAccResourceNsxtPolicyVlanSegment_updateAdvConfig(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNsxtPolicyVlanSegmentBasicAdvConfigUpdateTemplate(updatedName),
+				Config: testAccNsxtPolicyVlanSegmentBasicAdvConfigUpdateTemplate(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNsxtPolicyVlanSegmentExists(testResourceName),
-					resource.TestCheckResourceAttr(testResourceName, "display_name", updatedName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", name),
 					resource.TestCheckResourceAttr(testResourceName, "description", "Acceptance Test"),
 					resource.TestCheckResourceAttr(testResourceName, "domain_name", "tftest.org"),
 					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
@@ -109,9 +108,8 @@ func TestAccResourceNsxtPolicyVlanSegment_updateAdvConfig(t *testing.T) {
 	})
 }
 
-func TestAccResourceNsxtPolicyiVlanSegment_noTransportZone(t *testing.T) {
-	name := "test-nsx-policy-segment"
-	updatedName := fmt.Sprintf("%s-update", name)
+func TestAccResourceNsxtPolicyVlanSegment_noTransportZone(t *testing.T) {
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_policy_vlan_segment.test"
 	cidr := "4003::1/64"
 	updatedCidr := "4004::1/64"
@@ -138,10 +136,10 @@ func TestAccResourceNsxtPolicyiVlanSegment_noTransportZone(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNsxtPolicyVlanSegmentNoTransportZoneTemplate(updatedName, updatedCidr),
+				Config: testAccNsxtPolicyVlanSegmentNoTransportZoneTemplate(name, updatedCidr),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNsxtPolicySegmentExists(testResourceName),
-					resource.TestCheckResourceAttr(testResourceName, "display_name", updatedName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", name),
 					resource.TestCheckResourceAttr(testResourceName, "description", "Acceptance Test"),
 					resource.TestCheckResourceAttr(testResourceName, "subnet.#", "1"),
 					resource.TestCheckResourceAttr(testResourceName, "subnet.0.cidr", updatedCidr),
@@ -156,8 +154,7 @@ func TestAccResourceNsxtPolicyiVlanSegment_noTransportZone(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyVlanSegment_withDhcp(t *testing.T) {
-	name := "test-nsx-policy-vlan-segment"
-	updatedName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_policy_vlan_segment.test"
 	leaseTimes := []string{"3600", "36000"}
 	preferredTimes := []string{"3200", "32000"}
@@ -199,10 +196,10 @@ func TestAccResourceNsxtPolicyVlanSegment_withDhcp(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNsxtPolicyVlanSegmentWithDhcpTemplate(updatedName, dnsServersV4[1], dnsServersV6[1], leaseTimes[1], preferredTimes[1]),
+				Config: testAccNsxtPolicyVlanSegmentWithDhcpTemplate(name, dnsServersV4[1], dnsServersV6[1], leaseTimes[1], preferredTimes[1]),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNsxtPolicySegmentExists(testResourceName),
-					resource.TestCheckResourceAttr(testResourceName, "display_name", updatedName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", name),
 					resource.TestCheckResourceAttr(testResourceName, "subnet.#", "2"),
 					resource.TestCheckResourceAttr(testResourceName, "subnet.0.cidr", "12.12.2.1/24"),
 					resource.TestCheckResourceAttr(testResourceName, "subnet.0.dhcp_v6_config.#", "0"),
@@ -445,7 +442,7 @@ resource "nsxt_policy_vlan_segment" "test" {
 func testAccNsxtPolicyVlanSegmentNoTransportZoneTemplate(name string, cidr string) string {
 	return fmt.Sprintf(`
 
-resource "nsxt_policy_segment" "test" {
+resource "nsxt_policy_vlan_segment" "test" {
   display_name        = "%s"
   description         = "Acceptance Test"
   domain_name         = "tftest.org"

--- a/nsxt/resource_nsxt_qos_switching_profile_test.go
+++ b/nsxt/resource_nsxt_qos_switching_profile_test.go
@@ -13,8 +13,8 @@ import (
 )
 
 func TestAccResourceNsxtQosSwitchingProfile_basic(t *testing.T) {
-	name := "test-nsx-switching-profile"
-	updatedName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
+	updatedName := getAccTestResourceName()
 	testResourceName := "nsxt_qos_switching_profile.test"
 	cos := "5"
 	updatedCos := "2"
@@ -25,7 +25,7 @@ func TestAccResourceNsxtQosSwitchingProfile_basic(t *testing.T) {
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNSXQosSwitchingProfileCheckDestroy(state, name)
+			return testAccNSXQosSwitchingProfileCheckDestroy(state, updatedName)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -82,7 +82,7 @@ func TestAccResourceNsxtQosSwitchingProfile_basic(t *testing.T) {
 }
 
 func TestAccResourceNsxtQosSwitchingProfile_importBasic(t *testing.T) {
-	name := "test-nsx-application-profile"
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_qos_switching_profile.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },

--- a/nsxt/resource_nsxt_spoofguard_switching_profile_test.go
+++ b/nsxt/resource_nsxt_spoofguard_switching_profile_test.go
@@ -13,15 +13,15 @@ import (
 )
 
 func TestAccResourceNsxtSpoofGuardSwitchingProfile_basic(t *testing.T) {
-	name := "test-nsx-switching-profile"
-	updatedName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
+	updatedName := getAccTestResourceName()
 	testResourceName := "nsxt_spoofguard_switching_profile.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNSXSpoofguardSwitchingProfileCheckDestroy(state, name)
+			return testAccNSXSpoofguardSwitchingProfileCheckDestroy(state, updatedName)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -56,7 +56,7 @@ func TestAccResourceNsxtSpoofGuardSwitchingProfile_basic(t *testing.T) {
 }
 
 func TestAccResourceNsxtSpoofGuardSwitchingProfile_importBasic(t *testing.T) {
-	name := "test-nsx-application-profile"
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_spoofguard_switching_profile.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },

--- a/nsxt/resource_nsxt_static_route_test.go
+++ b/nsxt/resource_nsxt_static_route_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 var testAccResourceStaticRouteName = "nsxt_static_route.test"
+var testAccResourceStaticRouteHelperName = getAccTestResourceName()
 
 func TestAccResourceNsxtStaticRoute_basic(t *testing.T) {
 	testAccResourceNsxtStaticRoute(t, "tier1")
@@ -23,8 +24,8 @@ func TestAccResourceNsxtStaticRoute_onT0(t *testing.T) {
 }
 
 func testAccResourceNsxtStaticRoute(t *testing.T, tier string) {
-	name := "test-nsx-static-route"
-	updateName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
+	updateName := getAccTestResourceName()
 	edgeClusterName := getEdgeClusterName()
 	transportZoneName := getOverlayTransportZoneName()
 
@@ -32,7 +33,7 @@ func testAccResourceNsxtStaticRoute(t *testing.T, tier string) {
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNSXStaticRouteCheckDestroy(state, name)
+			return testAccNSXStaticRouteCheckDestroy(state, updateName)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -75,7 +76,7 @@ func TestAccResourceNsxtStaticRoute_importOnTier0(t *testing.T) {
 }
 
 func testAccResourceNsxtStaticRouteImport(t *testing.T, tier string) {
-	name := "test-nsx-static-route"
+	name := getAccTestResourceName()
 	edgeClusterName := getEdgeClusterName()
 	transportZoneName := getOverlayTransportZoneName()
 
@@ -192,7 +193,7 @@ data "nsxt_transport_zone" "tz1" {
 }
 
 resource "nsxt_logical_switch" "ls1" {
-  display_name      = "test-nsx-downlink-switch"
+  display_name      = "%s"
   admin_state       = "UP"
   replication_mode  = "MTEP"
   vlan              = "0"
@@ -200,7 +201,7 @@ resource "nsxt_logical_switch" "ls1" {
 }
 
 resource "nsxt_logical_port" "port1" {
-  display_name      = "test-nsx-logical-port-for-route"
+  display_name      = "%s"
   admin_state       = "UP"
   description       = "Acceptance Test"
   logical_switch_id = "${nsxt_logical_switch.ls1.id}"
@@ -212,7 +213,7 @@ resource "nsxt_logical_router_downlink_port" "lrp1" {
   linked_logical_switch_port_id = "${nsxt_logical_port.port1.id}"
   logical_router_id             = "${nsxt_logical_%s_router.rtr1.id}"
   ip_address                    = "8.0.0.1/24"
-}`, edgeClusterName, tier, tzName, tier)
+}`, edgeClusterName, tier, tzName, testAccResourceStaticRouteHelperName, testAccResourceStaticRouteHelperName, tier)
 }
 
 func testAccNSXStaticRouteCreateTemplate(tier string, name string, edgeClusterName string, tzName string) string {

--- a/nsxt/resource_nsxt_switch_security_switching_profile_test.go
+++ b/nsxt/resource_nsxt_switch_security_switching_profile_test.go
@@ -13,8 +13,8 @@ import (
 )
 
 func TestAccResourceNsxtSwitchSecuritySwitchingProfile_basic(t *testing.T) {
-	name := "test-nsx-switching-profile"
-	updatedName := fmt.Sprintf("%s-update", name)
+	name := getAccTestResourceName()
+	updatedName := getAccTestResourceName()
 	testResourceName := "nsxt_switch_security_switching_profile.test"
 	limit := "700"
 	updatedLimit := "400"
@@ -23,7 +23,7 @@ func TestAccResourceNsxtSwitchSecuritySwitchingProfile_basic(t *testing.T) {
 		PreCheck:  func() { testAccPreCheck(t); testAccTestMP(t); testAccOnlyLocalManager(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNSXSwitchSecuritySwitchingProfileCheckDestroy(state, name)
+			return testAccNSXSwitchSecuritySwitchingProfileCheckDestroy(state, updatedName)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -78,7 +78,7 @@ func TestAccResourceNsxtSwitchSecuritySwitchingProfile_basic(t *testing.T) {
 }
 
 func TestAccResourceNsxtSwitchSecuritySwitchingProfile_importBasic(t *testing.T) {
-	name := "test-nsx-application-profile"
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_switch_security_switching_profile.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t); testAccTestMP(t); testAccOnlyLocalManager(t) },

--- a/nsxt/resource_nsxt_vlan_logical_switch_test.go
+++ b/nsxt/resource_nsxt_vlan_logical_switch_test.go
@@ -13,8 +13,8 @@ import (
 )
 
 func TestAccResourceNsxtVlanLogicalSwitch_basic(t *testing.T) {
-	switchName := "test-nsx-logical-switch-vlan"
-	updateSwitchName := fmt.Sprintf("%s-update", switchName)
+	switchName := getAccTestResourceName()
+	updateSwitchName := getAccTestResourceName()
 	transportZoneName := getVlanTransportZoneName()
 	resourceName := "testvlan"
 	testResourceName := fmt.Sprintf("nsxt_vlan_logical_switch.%s", resourceName)
@@ -26,7 +26,7 @@ func TestAccResourceNsxtVlanLogicalSwitch_basic(t *testing.T) {
 		PreCheck:  func() { testAccPreCheck(t); testAccTestMP(t); testAccOnlyLocalManager(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNSXLogicalSwitchCheckDestroy(state, switchName, "nsxt_vlan_logical_switch")
+			return testAccNSXLogicalSwitchCheckDestroy(state, updateSwitchName, "nsxt_vlan_logical_switch")
 		},
 		Steps: []resource.TestStep{
 			{
@@ -55,8 +55,8 @@ func TestAccResourceNsxtVlanLogicalSwitch_basic(t *testing.T) {
 }
 
 func TestAccResourceNsxtVlanLogicalSwitch_withProfiles(t *testing.T) {
-	switchName := "test-nsx-logical-switch-with-profiles"
-	updateSwitchName := fmt.Sprintf("%s-update", switchName)
+	switchName := getAccTestResourceName()
+	updateSwitchName := getAccTestResourceName()
 	resourceName := "test_profiles"
 	testResourceName := fmt.Sprintf("nsxt_vlan_logical_switch.%s", resourceName)
 	transportZoneName := getVlanTransportZoneName()
@@ -68,7 +68,7 @@ func TestAccResourceNsxtVlanLogicalSwitch_withProfiles(t *testing.T) {
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			// Verify that the LS was deleted
-			err := testAccNSXLogicalSwitchCheckDestroy(state, switchName, "nsxt_vlan_logical_switch")
+			err := testAccNSXLogicalSwitchCheckDestroy(state, updateSwitchName, "nsxt_vlan_logical_switch")
 			if err != nil {
 				return err
 			}
@@ -106,7 +106,7 @@ func TestAccResourceNsxtVlanLogicalSwitch_withProfiles(t *testing.T) {
 }
 
 func TestAccResourceNsxtVlanLogicalSwitch_withMacPool(t *testing.T) {
-	switchName := "test-nsx-logical-switch-with-mac"
+	switchName := getAccTestResourceName()
 	resourceName := "test_mac_pool"
 	testResourceName := fmt.Sprintf("nsxt_vlan_logical_switch.%s", resourceName)
 	transportZoneName := getVlanTransportZoneName()
@@ -140,7 +140,7 @@ func TestAccResourceNsxtVlanLogicalSwitch_withMacPool(t *testing.T) {
 }
 
 func TestAccResourceNsxtVlanLogicalSwitch_importBasic(t *testing.T) {
-	switchName := "test-nsx-logical-switch"
+	switchName := getAccTestResourceName()
 	resourceName := "test"
 	testResourceName := fmt.Sprintf("nsxt_vlan_logical_switch.%s", resourceName)
 	vlan := "5"

--- a/nsxt/utils_test.go
+++ b/nsxt/utils_test.go
@@ -5,6 +5,7 @@ package nsxt
 
 import (
 	"fmt"
+	"math/rand"
 	"net/http"
 	"os"
 	"strings"
@@ -29,6 +30,9 @@ const macPoolDefaultName string = "DefaultMacPool"
 const realizationResourceName string = "data.nsxt_policy_realization_info.realization_info"
 const defaultTestResourceName string = "terraform-acctest"
 
+const testAccDataSourceName string = "terraform-acctest-data"
+const testAccResourceName string = "terraform-acctest-resource"
+
 const singleTag string = `
   tag {
     scope = "scope1"
@@ -44,6 +48,14 @@ const doubleTags string = `
     scope = "scope2"
     tag   = "tag2"
   }`
+
+func getAccTestDataSourceName() string {
+	return fmt.Sprintf("%s-%d", testAccDataSourceName, rand.Intn(100000))
+}
+
+func getAccTestResourceName() string {
+	return fmt.Sprintf("%s-%d", testAccResourceName, rand.Intn(100000))
+}
 
 func getTier0RouterName() string {
 	name := os.Getenv("NSXT_TEST_TIER0_ROUTER")

--- a/tools/data_source_nsxt_policy_test_template
+++ b/tools/data_source_nsxt_policy_test_template
@@ -17,7 +17,7 @@ import (
 )
 
 func TestAccDataSourceNsxtPolicy<!RESOURCE!>_basic(t *testing.T) {
-	name := "terraform_test"
+	name := getAccTestDataSourceName()
 	testResourceName := "data.nsxt_policy_<!resource_lower!>.test"
 
 	resource.Test(t, resource.TestCase{

--- a/tools/resource_nsxt_policy_test_template
+++ b/tools/resource_nsxt_policy_test_template
@@ -12,13 +12,13 @@ import (
 )
 
 var accTestPolicy<!RESOURCE!>CreateAttributes = map[string]string{
-	"display_name": "terra-test",
+	"display_name": getAccTestResourceName(),
 	"description":  "terraform created",
         <!TEST_ATTRS_CREATE!>
 }
 
 var accTestPolicy<!RESOURCE!>UpdateAttributes = map[string]string{
-	"display_name": "terra-test-updated",
+	"display_name": getAccTestResourceName(),
 	"description":  "terraform updated",
         <!TEST_ATTRS_UPDATE!>
 }
@@ -26,11 +26,11 @@ var accTestPolicy<!RESOURCE!>UpdateAttributes = map[string]string{
 func TestAccResourceNsxtPolicy<!RESOURCE!>_basic(t *testing.T) {
 	testResourceName := "nsxt_policy_<!resource_lower!>.test"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNsxtPolicy<!RESOURCE!>CheckDestroy(state, accTestPolicy<!RESOURCE!>CreateAttributes["display_name"])
+			return testAccNsxtPolicy<!RESOURCE!>CheckDestroy(state, accTestPolicy<!RESOURCE!>UpdateAttributes["display_name"])
 		},
 		Steps: []resource.TestStep{
 			{
@@ -75,10 +75,10 @@ func TestAccResourceNsxtPolicy<!RESOURCE!>_basic(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicy<!RESOURCE!>_importBasic(t *testing.T) {
-	name := "terra-test-import"
+	name := getAccTestResourceName()
 	testResourceName := "nsxt_policy_<!resource_lower!>.test"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {


### PR DESCRIPTION
This would make post-test platform cleanup easier.
In addition, remove display_name update if such update is covered
elsewhere for same resource.