### PR TITLE
Add importer for predefined gateway policy

### DIFF
--- a/nsxt/resource_nsxt_policy_predefined_gateway_policy.go
+++ b/nsxt/resource_nsxt_policy_predefined_gateway_policy.go
@@ -25,6 +25,9 @@ func resourceNsxtPolicyPredefinedGatewayPolicy() *schema.Resource {
 		Read:   resourceNsxtPolicyPredefinedGatewayPolicyRead,
 		Update: resourceNsxtPolicyPredefinedGatewayPolicyUpdate,
 		Delete: resourceNsxtPolicyPredefinedGatewayPolicyDelete,
+		Importer: &schema.ResourceImporter{
+			State: nsxtPredefinedPolicyImporter,
+		},
 
 		Schema: getPolicyPredefinedGatewayPolicySchema(),
 	}
@@ -488,4 +491,13 @@ func resourceNsxtPolicyPredefinedGatewayPolicyDelete(d *schema.ResourceData, m i
 		return handleUpdateError("Predefined Gateway Policy", id, err)
 	}
 	return nil
+}
+
+func nsxtPredefinedPolicyImporter(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	importPath := d.Id()
+	d.Set("path", importPath)
+	id := getPolicyIDFromPath(importPath)
+	d.SetId(id)
+
+	return []*schema.ResourceData{d}, nil
 }


### PR DESCRIPTION
VMC auto-creates a rule under default policy. In order to provide best
experience for the user, we give an option to import this rule into
terraform state.
However, the user is not required to import the policy, if the
predefined rule is present in terraform config. This change also
expands the doc to cover both approaches.