### PR TITLE
Fix CIDR validation for max subnet prefix length

### DIFF
--- a/nsxt/resource_nsxt_policy_tier0_gateway_test.go
+++ b/nsxt/resource_nsxt_policy_tier0_gateway_test.go
@@ -725,7 +725,7 @@ resource "nsxt_policy_tier0_gateway_interface" "parent-loopback" {
   type           = "LOOPBACK"
   gateway_path   = nsxt_policy_tier0_gateway.parent.path
   edge_node_path = data.nsxt_policy_edge_node.EN.path
-  subnets        = ["4.4.4.12/24"]
+  subnets        = ["4.4.4.12/32"]
 }
 
 data "nsxt_policy_edge_node" "EN" {

--- a/nsxt/validators.go
+++ b/nsxt/validators.go
@@ -87,10 +87,10 @@ func isCidr(v string, allowMaxPrefix bool, isIP bool) bool {
 	if ipnet == nil {
 		return false
 	}
-	if isIP && v == ipnet.String() {
+	if isIP && (v == ipnet.String()) && !allowMaxPrefix {
 		return false
 	}
-	if !isIP && v != ipnet.String() {
+	if !isIP && (v != ipnet.String()) {
 		return false
 	}
 


### PR DESCRIPTION
This allows to configure /32 and /128 subnets for gateway interfaces.