### PR TITLE
Initialize VMC NSX version to 3.0.0

### DIFF
--- a/nsxt/provider.go
+++ b/nsxt/provider.go
@@ -344,7 +344,6 @@ func configureNsxtClient(d *schema.ResourceData, clients *nsxtClients) error {
 	vmcToken := d.Get("vmc_token").(string)
 
 	if len(vmcToken) > 0 {
-		initNSXVersionVMC()
 		return nil
 	}
 
@@ -618,6 +617,10 @@ func configurePolicyConnectorData(d *schema.ResourceData, clients *nsxtClients) 
 	clients.PolicyEnforcementPoint = policyEnforcementPoint
 	clients.PolicyGlobalManager = policyGlobalManager
 
+	if len(vmcAccessToken) > 0 {
+		// Special treatment for VMC since MP API is not available there
+		initNSXVersionVMC(*clients)
+	}
 	return nil
 }
 

--- a/nsxt/provider.go
+++ b/nsxt/provider.go
@@ -344,6 +344,7 @@ func configureNsxtClient(d *schema.ResourceData, clients *nsxtClients) error {
 	vmcToken := d.Get("vmc_token").(string)
 
 	if len(vmcToken) > 0 {
+		initNSXVersionVMC()
 		return nil
 	}
 

--- a/nsxt/utils.go
+++ b/nsxt/utils.go
@@ -16,6 +16,8 @@ import (
 	api "github.com/vmware/go-vmware-nsxt"
 	"github.com/vmware/go-vmware-nsxt/common"
 	"github.com/vmware/go-vmware-nsxt/manager"
+
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/search"
 )
 
 var adminStateValues = []string{"UP", "DOWN"}
@@ -530,9 +532,32 @@ func initNSXVersion(nsxClient *api.APIClient) error {
 	return err
 }
 
-func initNSXVersionVMC() {
-	// TODO: find a way to retrieve NSX version on VMC
+func initNSXVersionVMC(clients interface{}) {
+	// TODO: find a ireliable way to retrieve NSX version on VMC
+	// For now, we need to determine whether the deployment is 3.0.0 and up, or below
+	// For this purpose, we fire indicator search API (introduced in 3.0.0)
 	nsxVersion = "3.0.0"
+
+	connector := getPolicyConnector(clients)
+	client := search.NewDefaultQueryClient(connector)
+	var cursor *string
+	query := "resource_type:dummy"
+	_, err := client.List(query, cursor, nil, nil, nil, nil)
+	if err == nil {
+		// we are 3.0.0 and above
+		log.Printf("[INFO] Assuming NSX version >= 3.0.0 in VMC environment")
+		return
+	}
+
+	if isNotFoundError(err) {
+		// search API not supported
+		log.Printf("[INFO] Assuming NSX version < 3.0.0 in VMC environment")
+		nsxVersion = "2.5.0"
+		return
+	}
+
+	// Connectivity error - alert the user
+	log.Printf("[ERROR] Failed to determine NSX version in VMC environment: %s", err)
 }
 
 func nsxVersionLower(ver string) bool {

--- a/nsxt/utils.go
+++ b/nsxt/utils.go
@@ -530,6 +530,11 @@ func initNSXVersion(nsxClient *api.APIClient) error {
 	return err
 }
 
+func initNSXVersionVMC() {
+	// TODO: find a way to retrieve NSX version on VMC
+	nsxVersion = "3.0.0"
+}
+
 func nsxVersionLower(ver string) bool {
 
 	requestedVersion, err1 := version.NewVersion(ver)

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/search/DefaultDslClient.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/search/DefaultDslClient.go
@@ -1,0 +1,182 @@
+
+/* Copyright © 2019 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: BSD-2-Clause */
+
+// Code generated. DO NOT EDIT.
+
+/*
+ * Client stubs for service: Dsl
+ * Functions that implement the generated DslClient interface
+ */
+
+
+package search
+
+import (
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+	"github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/bindings"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/core"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/data"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/lib"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/log"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
+)
+
+type DefaultDslClient struct {
+	interfaceName       string
+	interfaceDefinition core.InterfaceDefinition
+	methodIdentifiers   []core.MethodIdentifier
+	methodNameToDefMap  map[string]*core.MethodDefinition
+	errorBindingMap     map[string]bindings.BindingType
+	interfaceIdentifier core.InterfaceIdentifier
+	connector           client.Connector
+}
+
+func NewDefaultDslClient(connector client.Connector) *DefaultDslClient {
+	interfaceName := "com.vmware.nsx_policy.search.dsl"
+	interfaceIdentifier := core.NewInterfaceIdentifier(interfaceName)
+	methodIdentifiers := []core.MethodIdentifier{
+		core.NewMethodIdentifier(interfaceIdentifier, "list"),
+	}
+	interfaceDefinition := core.NewInterfaceDefinition(interfaceIdentifier, methodIdentifiers)
+	errorBindingMap := make(map[string]bindings.BindingType)
+	errorBindingMap[errors.AlreadyExists{}.Error()] = errors.AlreadyExistsBindingType()
+	errorBindingMap[errors.AlreadyInDesiredState{}.Error()] = errors.AlreadyInDesiredStateBindingType()
+	errorBindingMap[errors.Canceled{}.Error()] = errors.CanceledBindingType()
+	errorBindingMap[errors.ConcurrentChange{}.Error()] = errors.ConcurrentChangeBindingType()
+	errorBindingMap[errors.Error{}.Error()] = errors.ErrorBindingType()
+	errorBindingMap[errors.FeatureInUse{}.Error()] = errors.FeatureInUseBindingType()
+	errorBindingMap[errors.InternalServerError{}.Error()] = errors.InternalServerErrorBindingType()
+	errorBindingMap[errors.InvalidArgument{}.Error()] = errors.InvalidArgumentBindingType()
+	errorBindingMap[errors.InvalidElementConfiguration{}.Error()] = errors.InvalidElementConfigurationBindingType()
+	errorBindingMap[errors.InvalidElementType{}.Error()] = errors.InvalidElementTypeBindingType()
+	errorBindingMap[errors.InvalidRequest{}.Error()] = errors.InvalidRequestBindingType()
+	errorBindingMap[errors.NotFound{}.Error()] = errors.NotFoundBindingType()
+	errorBindingMap[errors.NotAllowedInCurrentState{}.Error()] = errors.NotAllowedInCurrentStateBindingType()
+	errorBindingMap[errors.OperationNotFound{}.Error()] = errors.OperationNotFoundBindingType()
+	errorBindingMap[errors.ResourceBusy{}.Error()] = errors.ResourceBusyBindingType()
+	errorBindingMap[errors.ResourceInUse{}.Error()] = errors.ResourceInUseBindingType()
+	errorBindingMap[errors.ResourceInaccessible{}.Error()] = errors.ResourceInaccessibleBindingType()
+	errorBindingMap[errors.ServiceUnavailable{}.Error()] = errors.ServiceUnavailableBindingType()
+	errorBindingMap[errors.TimedOut{}.Error()] = errors.TimedOutBindingType()
+	errorBindingMap[errors.UnableToAllocateResource{}.Error()] = errors.UnableToAllocateResourceBindingType()
+	errorBindingMap[errors.Unauthenticated{}.Error()] = errors.UnauthenticatedBindingType()
+	errorBindingMap[errors.Unauthorized{}.Error()] = errors.UnauthorizedBindingType()
+	errorBindingMap[errors.UnexpectedInput{}.Error()] = errors.UnexpectedInputBindingType()
+	errorBindingMap[errors.Unsupported{}.Error()] = errors.UnsupportedBindingType()
+	errorBindingMap[errors.UnverifiedPeer{}.Error()] = errors.UnverifiedPeerBindingType()
+
+
+	dIface := DefaultDslClient{interfaceName: interfaceName, methodIdentifiers: methodIdentifiers, interfaceDefinition: interfaceDefinition, errorBindingMap: errorBindingMap, interfaceIdentifier: interfaceIdentifier, connector: connector}
+	dIface.methodNameToDefMap = make(map[string]*core.MethodDefinition)
+	dIface.methodNameToDefMap["list"] = dIface.listMethodDefinition()
+	return &dIface
+}
+
+func (dIface *DefaultDslClient) List(queryParam string, cursorParam *string, includedFieldsParam *string, pageSizeParam *int64, sortAscendingParam *bool, sortByParam *string) (model.SearchResponse, error) {
+	typeConverter := dIface.connector.TypeConverter()
+	methodIdentifier := core.NewMethodIdentifier(dIface.interfaceIdentifier, "list")
+	sv := bindings.NewStructValueBuilder(dslListInputType(), typeConverter)
+	sv.AddStructField("Query", queryParam)
+	sv.AddStructField("Cursor", cursorParam)
+	sv.AddStructField("IncludedFields", includedFieldsParam)
+	sv.AddStructField("PageSize", pageSizeParam)
+	sv.AddStructField("SortAscending", sortAscendingParam)
+	sv.AddStructField("SortBy", sortByParam)
+	inputDataValue, inputError := sv.GetStructValue()
+	if inputError != nil {
+		var emptyOutput model.SearchResponse
+		return emptyOutput, bindings.VAPIerrorsToError(inputError)
+	}
+	operationRestMetaData := dslListRestMetadata()
+	connectionMetadata := map[string]interface{}{lib.REST_METADATA: operationRestMetaData}
+	connectionMetadata["isStreamingResponse"] = false
+	dIface.connector.SetConnectionMetadata(connectionMetadata)
+	executionContext := dIface.connector.NewExecutionContext()
+	methodResult := dIface.Invoke(executionContext, methodIdentifier, inputDataValue)
+	var emptyOutput model.SearchResponse
+	if methodResult.IsSuccess() {
+		output, errorInOutput := typeConverter.ConvertToGolang(methodResult.Output(), dslListOutputType())
+		if errorInOutput != nil {
+			return emptyOutput, bindings.VAPIerrorsToError(errorInOutput)
+		}
+		return output.(model.SearchResponse), nil
+	} else {
+		methodError, errorInError := typeConverter.ConvertToGolang(methodResult.Error(), dIface.errorBindingMap[methodResult.Error().Name()])
+		if errorInError != nil {
+			return emptyOutput, bindings.VAPIerrorsToError(errorInError)
+		}
+		return emptyOutput, methodError.(error)
+	}
+}
+
+
+func (dIface *DefaultDslClient) Invoke(ctx *core.ExecutionContext, methodId core.MethodIdentifier, inputDataValue data.DataValue) core.MethodResult {
+	methodResult := dIface.connector.GetApiProvider().Invoke(dIface.interfaceName, methodId.Name(), inputDataValue, ctx)
+	return methodResult
+}
+
+
+func (dIface *DefaultDslClient) listMethodDefinition() *core.MethodDefinition {
+	interfaceIdentifier := core.NewInterfaceIdentifier(dIface.interfaceName)
+	typeConverter := dIface.connector.TypeConverter()
+
+	input, inputError := typeConverter.ConvertToDataDefinition(dslListInputType())
+	output, outputError := typeConverter.ConvertToDataDefinition(dslListOutputType())
+	if inputError != nil {
+		log.Errorf("Error in ConvertToDataDefinition for DefaultDslClient.list method's input - %s",
+			bindings.VAPIerrorsToError(inputError).Error())
+		return nil
+	}
+	if outputError != nil {
+		log.Errorf("Error in ConvertToDataDefinition for DefaultDslClient.list method's output - %s",
+			bindings.VAPIerrorsToError(outputError).Error())
+		return nil
+	}
+	methodIdentifier := core.NewMethodIdentifier(interfaceIdentifier, "list")
+	errorDefinitions := make([]data.ErrorDefinition, 0)
+	dIface.errorBindingMap[errors.InvalidRequest{}.Error()] = errors.InvalidRequestBindingType()
+	errDef1, errError1 := typeConverter.ConvertToDataDefinition(errors.InvalidRequestBindingType())
+	if errError1 != nil {
+		log.Errorf("Error in ConvertToDataDefinition for DefaultDslClient.list method's errors.InvalidRequest error - %s",
+			bindings.VAPIerrorsToError(errError1).Error())
+		return nil
+	}
+	errorDefinitions = append(errorDefinitions, errDef1.(data.ErrorDefinition))
+	dIface.errorBindingMap[errors.Unauthorized{}.Error()] = errors.UnauthorizedBindingType()
+	errDef2, errError2 := typeConverter.ConvertToDataDefinition(errors.UnauthorizedBindingType())
+	if errError2 != nil {
+		log.Errorf("Error in ConvertToDataDefinition for DefaultDslClient.list method's errors.Unauthorized error - %s",
+			bindings.VAPIerrorsToError(errError2).Error())
+		return nil
+	}
+	errorDefinitions = append(errorDefinitions, errDef2.(data.ErrorDefinition))
+	dIface.errorBindingMap[errors.ServiceUnavailable{}.Error()] = errors.ServiceUnavailableBindingType()
+	errDef3, errError3 := typeConverter.ConvertToDataDefinition(errors.ServiceUnavailableBindingType())
+	if errError3 != nil {
+		log.Errorf("Error in ConvertToDataDefinition for DefaultDslClient.list method's errors.ServiceUnavailable error - %s",
+			bindings.VAPIerrorsToError(errError3).Error())
+		return nil
+	}
+	errorDefinitions = append(errorDefinitions, errDef3.(data.ErrorDefinition))
+	dIface.errorBindingMap[errors.InternalServerError{}.Error()] = errors.InternalServerErrorBindingType()
+	errDef4, errError4 := typeConverter.ConvertToDataDefinition(errors.InternalServerErrorBindingType())
+	if errError4 != nil {
+		log.Errorf("Error in ConvertToDataDefinition for DefaultDslClient.list method's errors.InternalServerError error - %s",
+			bindings.VAPIerrorsToError(errError4).Error())
+		return nil
+	}
+	errorDefinitions = append(errorDefinitions, errDef4.(data.ErrorDefinition))
+	dIface.errorBindingMap[errors.NotFound{}.Error()] = errors.NotFoundBindingType()
+	errDef5, errError5 := typeConverter.ConvertToDataDefinition(errors.NotFoundBindingType())
+	if errError5 != nil {
+		log.Errorf("Error in ConvertToDataDefinition for DefaultDslClient.list method's errors.NotFound error - %s",
+			bindings.VAPIerrorsToError(errError5).Error())
+		return nil
+	}
+	errorDefinitions = append(errorDefinitions, errDef5.(data.ErrorDefinition))
+
+	methodDefinition := core.NewMethodDefinition(methodIdentifier, input, output, errorDefinitions)
+	return &methodDefinition
+}

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/search/DefaultQueryClient.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/search/DefaultQueryClient.go
@@ -1,0 +1,182 @@
+
+/* Copyright © 2019 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: BSD-2-Clause */
+
+// Code generated. DO NOT EDIT.
+
+/*
+ * Client stubs for service: Query
+ * Functions that implement the generated QueryClient interface
+ */
+
+
+package search
+
+import (
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+	"github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/bindings"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/core"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/data"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/lib"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/log"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
+)
+
+type DefaultQueryClient struct {
+	interfaceName       string
+	interfaceDefinition core.InterfaceDefinition
+	methodIdentifiers   []core.MethodIdentifier
+	methodNameToDefMap  map[string]*core.MethodDefinition
+	errorBindingMap     map[string]bindings.BindingType
+	interfaceIdentifier core.InterfaceIdentifier
+	connector           client.Connector
+}
+
+func NewDefaultQueryClient(connector client.Connector) *DefaultQueryClient {
+	interfaceName := "com.vmware.nsx_policy.search.query"
+	interfaceIdentifier := core.NewInterfaceIdentifier(interfaceName)
+	methodIdentifiers := []core.MethodIdentifier{
+		core.NewMethodIdentifier(interfaceIdentifier, "list"),
+	}
+	interfaceDefinition := core.NewInterfaceDefinition(interfaceIdentifier, methodIdentifiers)
+	errorBindingMap := make(map[string]bindings.BindingType)
+	errorBindingMap[errors.AlreadyExists{}.Error()] = errors.AlreadyExistsBindingType()
+	errorBindingMap[errors.AlreadyInDesiredState{}.Error()] = errors.AlreadyInDesiredStateBindingType()
+	errorBindingMap[errors.Canceled{}.Error()] = errors.CanceledBindingType()
+	errorBindingMap[errors.ConcurrentChange{}.Error()] = errors.ConcurrentChangeBindingType()
+	errorBindingMap[errors.Error{}.Error()] = errors.ErrorBindingType()
+	errorBindingMap[errors.FeatureInUse{}.Error()] = errors.FeatureInUseBindingType()
+	errorBindingMap[errors.InternalServerError{}.Error()] = errors.InternalServerErrorBindingType()
+	errorBindingMap[errors.InvalidArgument{}.Error()] = errors.InvalidArgumentBindingType()
+	errorBindingMap[errors.InvalidElementConfiguration{}.Error()] = errors.InvalidElementConfigurationBindingType()
+	errorBindingMap[errors.InvalidElementType{}.Error()] = errors.InvalidElementTypeBindingType()
+	errorBindingMap[errors.InvalidRequest{}.Error()] = errors.InvalidRequestBindingType()
+	errorBindingMap[errors.NotFound{}.Error()] = errors.NotFoundBindingType()
+	errorBindingMap[errors.NotAllowedInCurrentState{}.Error()] = errors.NotAllowedInCurrentStateBindingType()
+	errorBindingMap[errors.OperationNotFound{}.Error()] = errors.OperationNotFoundBindingType()
+	errorBindingMap[errors.ResourceBusy{}.Error()] = errors.ResourceBusyBindingType()
+	errorBindingMap[errors.ResourceInUse{}.Error()] = errors.ResourceInUseBindingType()
+	errorBindingMap[errors.ResourceInaccessible{}.Error()] = errors.ResourceInaccessibleBindingType()
+	errorBindingMap[errors.ServiceUnavailable{}.Error()] = errors.ServiceUnavailableBindingType()
+	errorBindingMap[errors.TimedOut{}.Error()] = errors.TimedOutBindingType()
+	errorBindingMap[errors.UnableToAllocateResource{}.Error()] = errors.UnableToAllocateResourceBindingType()
+	errorBindingMap[errors.Unauthenticated{}.Error()] = errors.UnauthenticatedBindingType()
+	errorBindingMap[errors.Unauthorized{}.Error()] = errors.UnauthorizedBindingType()
+	errorBindingMap[errors.UnexpectedInput{}.Error()] = errors.UnexpectedInputBindingType()
+	errorBindingMap[errors.Unsupported{}.Error()] = errors.UnsupportedBindingType()
+	errorBindingMap[errors.UnverifiedPeer{}.Error()] = errors.UnverifiedPeerBindingType()
+
+
+	qIface := DefaultQueryClient{interfaceName: interfaceName, methodIdentifiers: methodIdentifiers, interfaceDefinition: interfaceDefinition, errorBindingMap: errorBindingMap, interfaceIdentifier: interfaceIdentifier, connector: connector}
+	qIface.methodNameToDefMap = make(map[string]*core.MethodDefinition)
+	qIface.methodNameToDefMap["list"] = qIface.listMethodDefinition()
+	return &qIface
+}
+
+func (qIface *DefaultQueryClient) List(queryParam string, cursorParam *string, includedFieldsParam *string, pageSizeParam *int64, sortAscendingParam *bool, sortByParam *string) (model.SearchResponse, error) {
+	typeConverter := qIface.connector.TypeConverter()
+	methodIdentifier := core.NewMethodIdentifier(qIface.interfaceIdentifier, "list")
+	sv := bindings.NewStructValueBuilder(queryListInputType(), typeConverter)
+	sv.AddStructField("Query", queryParam)
+	sv.AddStructField("Cursor", cursorParam)
+	sv.AddStructField("IncludedFields", includedFieldsParam)
+	sv.AddStructField("PageSize", pageSizeParam)
+	sv.AddStructField("SortAscending", sortAscendingParam)
+	sv.AddStructField("SortBy", sortByParam)
+	inputDataValue, inputError := sv.GetStructValue()
+	if inputError != nil {
+		var emptyOutput model.SearchResponse
+		return emptyOutput, bindings.VAPIerrorsToError(inputError)
+	}
+	operationRestMetaData := queryListRestMetadata()
+	connectionMetadata := map[string]interface{}{lib.REST_METADATA: operationRestMetaData}
+	connectionMetadata["isStreamingResponse"] = false
+	qIface.connector.SetConnectionMetadata(connectionMetadata)
+	executionContext := qIface.connector.NewExecutionContext()
+	methodResult := qIface.Invoke(executionContext, methodIdentifier, inputDataValue)
+	var emptyOutput model.SearchResponse
+	if methodResult.IsSuccess() {
+		output, errorInOutput := typeConverter.ConvertToGolang(methodResult.Output(), queryListOutputType())
+		if errorInOutput != nil {
+			return emptyOutput, bindings.VAPIerrorsToError(errorInOutput)
+		}
+		return output.(model.SearchResponse), nil
+	} else {
+		methodError, errorInError := typeConverter.ConvertToGolang(methodResult.Error(), qIface.errorBindingMap[methodResult.Error().Name()])
+		if errorInError != nil {
+			return emptyOutput, bindings.VAPIerrorsToError(errorInError)
+		}
+		return emptyOutput, methodError.(error)
+	}
+}
+
+
+func (qIface *DefaultQueryClient) Invoke(ctx *core.ExecutionContext, methodId core.MethodIdentifier, inputDataValue data.DataValue) core.MethodResult {
+	methodResult := qIface.connector.GetApiProvider().Invoke(qIface.interfaceName, methodId.Name(), inputDataValue, ctx)
+	return methodResult
+}
+
+
+func (qIface *DefaultQueryClient) listMethodDefinition() *core.MethodDefinition {
+	interfaceIdentifier := core.NewInterfaceIdentifier(qIface.interfaceName)
+	typeConverter := qIface.connector.TypeConverter()
+
+	input, inputError := typeConverter.ConvertToDataDefinition(queryListInputType())
+	output, outputError := typeConverter.ConvertToDataDefinition(queryListOutputType())
+	if inputError != nil {
+		log.Errorf("Error in ConvertToDataDefinition for DefaultQueryClient.list method's input - %s",
+			bindings.VAPIerrorsToError(inputError).Error())
+		return nil
+	}
+	if outputError != nil {
+		log.Errorf("Error in ConvertToDataDefinition for DefaultQueryClient.list method's output - %s",
+			bindings.VAPIerrorsToError(outputError).Error())
+		return nil
+	}
+	methodIdentifier := core.NewMethodIdentifier(interfaceIdentifier, "list")
+	errorDefinitions := make([]data.ErrorDefinition, 0)
+	qIface.errorBindingMap[errors.InvalidRequest{}.Error()] = errors.InvalidRequestBindingType()
+	errDef1, errError1 := typeConverter.ConvertToDataDefinition(errors.InvalidRequestBindingType())
+	if errError1 != nil {
+		log.Errorf("Error in ConvertToDataDefinition for DefaultQueryClient.list method's errors.InvalidRequest error - %s",
+			bindings.VAPIerrorsToError(errError1).Error())
+		return nil
+	}
+	errorDefinitions = append(errorDefinitions, errDef1.(data.ErrorDefinition))
+	qIface.errorBindingMap[errors.Unauthorized{}.Error()] = errors.UnauthorizedBindingType()
+	errDef2, errError2 := typeConverter.ConvertToDataDefinition(errors.UnauthorizedBindingType())
+	if errError2 != nil {
+		log.Errorf("Error in ConvertToDataDefinition for DefaultQueryClient.list method's errors.Unauthorized error - %s",
+			bindings.VAPIerrorsToError(errError2).Error())
+		return nil
+	}
+	errorDefinitions = append(errorDefinitions, errDef2.(data.ErrorDefinition))
+	qIface.errorBindingMap[errors.ServiceUnavailable{}.Error()] = errors.ServiceUnavailableBindingType()
+	errDef3, errError3 := typeConverter.ConvertToDataDefinition(errors.ServiceUnavailableBindingType())
+	if errError3 != nil {
+		log.Errorf("Error in ConvertToDataDefinition for DefaultQueryClient.list method's errors.ServiceUnavailable error - %s",
+			bindings.VAPIerrorsToError(errError3).Error())
+		return nil
+	}
+	errorDefinitions = append(errorDefinitions, errDef3.(data.ErrorDefinition))
+	qIface.errorBindingMap[errors.InternalServerError{}.Error()] = errors.InternalServerErrorBindingType()
+	errDef4, errError4 := typeConverter.ConvertToDataDefinition(errors.InternalServerErrorBindingType())
+	if errError4 != nil {
+		log.Errorf("Error in ConvertToDataDefinition for DefaultQueryClient.list method's errors.InternalServerError error - %s",
+			bindings.VAPIerrorsToError(errError4).Error())
+		return nil
+	}
+	errorDefinitions = append(errorDefinitions, errDef4.(data.ErrorDefinition))
+	qIface.errorBindingMap[errors.NotFound{}.Error()] = errors.NotFoundBindingType()
+	errDef5, errError5 := typeConverter.ConvertToDataDefinition(errors.NotFoundBindingType())
+	if errError5 != nil {
+		log.Errorf("Error in ConvertToDataDefinition for DefaultQueryClient.list method's errors.NotFound error - %s",
+			bindings.VAPIerrorsToError(errError5).Error())
+		return nil
+	}
+	errorDefinitions = append(errorDefinitions, errDef5.(data.ErrorDefinition))
+
+	methodDefinition := core.NewMethodDefinition(methodIdentifier, input, output, errorDefinitions)
+	return &methodDefinition
+}

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/search/DslClient.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/search/DslClient.go
@@ -1,0 +1,34 @@
+/* Copyright © 2019 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: BSD-2-Clause */
+
+// Code generated. DO NOT EDIT.
+
+/*
+ * Interface file for service: Dsl
+ * Used by client-side stubs.
+ */
+
+package search
+
+import (
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+)
+
+type DslClient interface {
+
+    // DSL (Domain Specific Language) search API
+    //
+    // @param queryParam Search query (required)
+    // @param cursorParam Opaque cursor to be used for getting next page of records (supplied by current result page) (optional)
+    // @param includedFieldsParam Comma separated list of fields that should be included in query result (optional)
+    // @param pageSizeParam Maximum number of results to return in this page (server may return fewer) (optional, default to 1000)
+    // @param sortAscendingParam (optional)
+    // @param sortByParam Field by which records are sorted (optional)
+    // @return com.vmware.nsx_policy.model.SearchResponse
+    // @throws InvalidRequest  Bad Request, Precondition Failed
+    // @throws Unauthorized  Forbidden
+    // @throws ServiceUnavailable  Service Unavailable
+    // @throws InternalServerError  Internal Server Error
+    // @throws NotFound  Not Found
+	List(queryParam string, cursorParam *string, includedFieldsParam *string, pageSizeParam *int64, sortAscendingParam *bool, sortByParam *string) (model.SearchResponse, error)
+}

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/search/DslTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/search/DslTypes.go
@@ -1,0 +1,106 @@
+/* Copyright © 2019 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: BSD-2-Clause */
+
+// Code generated. DO NOT EDIT.
+
+/*
+ * Data type definitions file for service: Dsl.
+ * Includes binding types of a structures and enumerations defined in the service.
+ * Shared by client-side stubs and server-side skeletons to ensure type
+ * compatibility.
+ */
+
+package search
+
+import (
+	"reflect"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/bindings"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/data"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol"
+)
+
+
+
+
+
+func dslListInputType() bindings.StructType {
+	fields := make(map[string]bindings.BindingType)
+	fieldNameMap := make(map[string]string)
+	fields["query"] = bindings.NewStringType()
+	fields["cursor"] = bindings.NewOptionalType(bindings.NewStringType())
+	fields["included_fields"] = bindings.NewOptionalType(bindings.NewStringType())
+	fields["page_size"] = bindings.NewOptionalType(bindings.NewIntegerType())
+	fields["sort_ascending"] = bindings.NewOptionalType(bindings.NewBooleanType())
+	fields["sort_by"] = bindings.NewOptionalType(bindings.NewStringType())
+	fieldNameMap["query"] = "Query"
+	fieldNameMap["cursor"] = "Cursor"
+	fieldNameMap["included_fields"] = "IncludedFields"
+	fieldNameMap["page_size"] = "PageSize"
+	fieldNameMap["sort_ascending"] = "SortAscending"
+	fieldNameMap["sort_by"] = "SortBy"
+	var validators = []bindings.Validator{}
+	return bindings.NewStructType("operation-input", fields, reflect.TypeOf(data.StructValue{}), fieldNameMap, validators)
+}
+
+func dslListOutputType() bindings.BindingType {
+	return bindings.NewReferenceType(model.SearchResponseBindingType)
+}
+
+func dslListRestMetadata() protocol.OperationRestMetadata {
+	fields := map[string]bindings.BindingType{}
+	fieldNameMap := map[string]string{}
+	paramsTypeMap := map[string]bindings.BindingType{}
+	pathParams := map[string]string{}
+	queryParams := map[string]string{}
+	headerParams := map[string]string{}
+	dispatchHeaderParams := map[string]string{}
+	bodyFieldsMap := map[string]string{}
+	fields["query"] = bindings.NewStringType()
+	fields["cursor"] = bindings.NewOptionalType(bindings.NewStringType())
+	fields["included_fields"] = bindings.NewOptionalType(bindings.NewStringType())
+	fields["page_size"] = bindings.NewOptionalType(bindings.NewIntegerType())
+	fields["sort_ascending"] = bindings.NewOptionalType(bindings.NewBooleanType())
+	fields["sort_by"] = bindings.NewOptionalType(bindings.NewStringType())
+	fieldNameMap["query"] = "Query"
+	fieldNameMap["cursor"] = "Cursor"
+	fieldNameMap["included_fields"] = "IncludedFields"
+	fieldNameMap["page_size"] = "PageSize"
+	fieldNameMap["sort_ascending"] = "SortAscending"
+	fieldNameMap["sort_by"] = "SortBy"
+	paramsTypeMap["query"] = bindings.NewStringType()
+	paramsTypeMap["included_fields"] = bindings.NewOptionalType(bindings.NewStringType())
+	paramsTypeMap["page_size"] = bindings.NewOptionalType(bindings.NewIntegerType())
+	paramsTypeMap["cursor"] = bindings.NewOptionalType(bindings.NewStringType())
+	paramsTypeMap["sort_by"] = bindings.NewOptionalType(bindings.NewStringType())
+	paramsTypeMap["sort_ascending"] = bindings.NewOptionalType(bindings.NewBooleanType())
+	queryParams["cursor"] = "cursor"
+	queryParams["sort_ascending"] = "sort_ascending"
+	queryParams["included_fields"] = "included_fields"
+	queryParams["query"] = "query"
+	queryParams["sort_by"] = "sort_by"
+	queryParams["page_size"] = "page_size"
+	resultHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
+	return protocol.NewOperationRestMetadata(
+		fields,
+		fieldNameMap,
+		paramsTypeMap,
+		pathParams,
+		queryParams,
+		headerParams,
+		dispatchHeaderParams,
+		bodyFieldsMap,
+		"",
+		"",
+		"GET",
+		"/policy/api/v1/search/dsl",
+		"",
+		resultHeaders,
+		200,
+		"",
+		errorHeaders,
+		map[string]int{"com.vmware.vapi.std.errors.invalid_request": 400,"com.vmware.vapi.std.errors.unauthorized": 403,"com.vmware.vapi.std.errors.service_unavailable": 503,"com.vmware.vapi.std.errors.internal_server_error": 500,"com.vmware.vapi.std.errors.not_found": 404})
+}
+
+

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/search/QueryClient.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/search/QueryClient.go
@@ -1,0 +1,34 @@
+/* Copyright © 2019 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: BSD-2-Clause */
+
+// Code generated. DO NOT EDIT.
+
+/*
+ * Interface file for service: Query
+ * Used by client-side stubs.
+ */
+
+package search
+
+import (
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+)
+
+type QueryClient interface {
+
+    // Full text search API
+    //
+    // @param queryParam Search query (required)
+    // @param cursorParam Opaque cursor to be used for getting next page of records (supplied by current result page) (optional)
+    // @param includedFieldsParam Comma separated list of fields that should be included in query result (optional)
+    // @param pageSizeParam Maximum number of results to return in this page (server may return fewer) (optional, default to 1000)
+    // @param sortAscendingParam (optional)
+    // @param sortByParam Field by which records are sorted (optional)
+    // @return com.vmware.nsx_policy.model.SearchResponse
+    // @throws InvalidRequest  Bad Request, Precondition Failed
+    // @throws Unauthorized  Forbidden
+    // @throws ServiceUnavailable  Service Unavailable
+    // @throws InternalServerError  Internal Server Error
+    // @throws NotFound  Not Found
+	List(queryParam string, cursorParam *string, includedFieldsParam *string, pageSizeParam *int64, sortAscendingParam *bool, sortByParam *string) (model.SearchResponse, error)
+}

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/search/QueryTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/search/QueryTypes.go
@@ -1,0 +1,106 @@
+/* Copyright © 2019 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: BSD-2-Clause */
+
+// Code generated. DO NOT EDIT.
+
+/*
+ * Data type definitions file for service: Query.
+ * Includes binding types of a structures and enumerations defined in the service.
+ * Shared by client-side stubs and server-side skeletons to ensure type
+ * compatibility.
+ */
+
+package search
+
+import (
+	"reflect"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/bindings"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/data"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol"
+)
+
+
+
+
+
+func queryListInputType() bindings.StructType {
+	fields := make(map[string]bindings.BindingType)
+	fieldNameMap := make(map[string]string)
+	fields["query"] = bindings.NewStringType()
+	fields["cursor"] = bindings.NewOptionalType(bindings.NewStringType())
+	fields["included_fields"] = bindings.NewOptionalType(bindings.NewStringType())
+	fields["page_size"] = bindings.NewOptionalType(bindings.NewIntegerType())
+	fields["sort_ascending"] = bindings.NewOptionalType(bindings.NewBooleanType())
+	fields["sort_by"] = bindings.NewOptionalType(bindings.NewStringType())
+	fieldNameMap["query"] = "Query"
+	fieldNameMap["cursor"] = "Cursor"
+	fieldNameMap["included_fields"] = "IncludedFields"
+	fieldNameMap["page_size"] = "PageSize"
+	fieldNameMap["sort_ascending"] = "SortAscending"
+	fieldNameMap["sort_by"] = "SortBy"
+	var validators = []bindings.Validator{}
+	return bindings.NewStructType("operation-input", fields, reflect.TypeOf(data.StructValue{}), fieldNameMap, validators)
+}
+
+func queryListOutputType() bindings.BindingType {
+	return bindings.NewReferenceType(model.SearchResponseBindingType)
+}
+
+func queryListRestMetadata() protocol.OperationRestMetadata {
+	fields := map[string]bindings.BindingType{}
+	fieldNameMap := map[string]string{}
+	paramsTypeMap := map[string]bindings.BindingType{}
+	pathParams := map[string]string{}
+	queryParams := map[string]string{}
+	headerParams := map[string]string{}
+	dispatchHeaderParams := map[string]string{}
+	bodyFieldsMap := map[string]string{}
+	fields["query"] = bindings.NewStringType()
+	fields["cursor"] = bindings.NewOptionalType(bindings.NewStringType())
+	fields["included_fields"] = bindings.NewOptionalType(bindings.NewStringType())
+	fields["page_size"] = bindings.NewOptionalType(bindings.NewIntegerType())
+	fields["sort_ascending"] = bindings.NewOptionalType(bindings.NewBooleanType())
+	fields["sort_by"] = bindings.NewOptionalType(bindings.NewStringType())
+	fieldNameMap["query"] = "Query"
+	fieldNameMap["cursor"] = "Cursor"
+	fieldNameMap["included_fields"] = "IncludedFields"
+	fieldNameMap["page_size"] = "PageSize"
+	fieldNameMap["sort_ascending"] = "SortAscending"
+	fieldNameMap["sort_by"] = "SortBy"
+	paramsTypeMap["query"] = bindings.NewStringType()
+	paramsTypeMap["included_fields"] = bindings.NewOptionalType(bindings.NewStringType())
+	paramsTypeMap["page_size"] = bindings.NewOptionalType(bindings.NewIntegerType())
+	paramsTypeMap["cursor"] = bindings.NewOptionalType(bindings.NewStringType())
+	paramsTypeMap["sort_by"] = bindings.NewOptionalType(bindings.NewStringType())
+	paramsTypeMap["sort_ascending"] = bindings.NewOptionalType(bindings.NewBooleanType())
+	queryParams["cursor"] = "cursor"
+	queryParams["sort_ascending"] = "sort_ascending"
+	queryParams["included_fields"] = "included_fields"
+	queryParams["query"] = "query"
+	queryParams["sort_by"] = "sort_by"
+	queryParams["page_size"] = "page_size"
+	resultHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
+	return protocol.NewOperationRestMetadata(
+		fields,
+		fieldNameMap,
+		paramsTypeMap,
+		pathParams,
+		queryParams,
+		headerParams,
+		dispatchHeaderParams,
+		bodyFieldsMap,
+		"",
+		"",
+		"GET",
+		"/policy/api/v1/search/query",
+		"",
+		resultHeaders,
+		200,
+		"",
+		errorHeaders,
+		map[string]int{"com.vmware.vapi.std.errors.invalid_request": 400,"com.vmware.vapi.std.errors.unauthorized": 403,"com.vmware.vapi.std.errors.service_unavailable": 503,"com.vmware.vapi.std.errors.internal_server_error": 500,"com.vmware.vapi.std.errors.not_found": 404})
+}
+
+

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/search/SearchPackageTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/search/SearchPackageTypes.go
@@ -1,0 +1,19 @@
+/* Copyright © 2019 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: BSD-2-Clause */
+
+// Code generated. DO NOT EDIT.
+
+/*
+ * Data type definitions file for package: com.vmware.nsx_policy.search.
+ * Includes binding types of a top level structures and enumerations.
+ * Shared by client-side stubs and server-side skeletons to ensure type
+ * compatibility.
+ */
+
+package search
+
+
+
+
+
+

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -310,6 +310,7 @@ github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_1s
 github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_1s/locale_services
 github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_1s/nat
 github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model
+github.com/vmware/vsphere-automation-sdk-go/services/nsxt/search
 # github.com/vmware/vsphere-automation-sdk-go/services/nsxt-gm v0.2.0
 ## explicit
 github.com/vmware/vsphere-automation-sdk-go/services/nsxt-gm


### PR DESCRIPTION
This si required for version-dependant code paths.
In future, we need to find a way to either find out underlying
NSX version in VMC deployment, or maintain a mapping of VMC version
to NSX version.