### PR TITLE
Allow to specify IP cidr in dhcp option

### DIFF
--- a/nsxt/resource_nsxt_logical_dhcp_server.go
+++ b/nsxt/resource_nsxt_logical_dhcp_server.go
@@ -91,7 +91,7 @@ func getDhcpOptions121Schema() *schema.Schema {
 					Type:         schema.TypeString,
 					Description:  "Destination in cidr",
 					Required:     true,
-					ValidateFunc: validateCidr(),
+					ValidateFunc: validateIPCidr(),
 				},
 				"next_hop": {
 					Type:         schema.TypeString,

--- a/nsxt/resource_nsxt_policy_segment_test.go
+++ b/nsxt/resource_nsxt_policy_segment_test.go
@@ -657,7 +657,7 @@ resource "nsxt_policy_segment" "test" {
           next_hop = "2.3.1.3"
         }
         dhcp_option_121 {
-          network  = "3.1.1.0/24"
+          network  = "3.1.1.21/24"
           next_hop = "3.3.1.3"
         }
         dhcp_generic_option {


### PR DESCRIPTION
In dhcp option 121, platform allows to specify IP CIDR, we will
allow the same in provider.