### PR TITLE
Fix T0 gateway resource for old NSX version

### DIFF
--- a/nsxt/data_source_nsxt_policy_bfd_profile_test.go
+++ b/nsxt/data_source_nsxt_policy_bfd_profile_test.go
@@ -21,7 +21,7 @@ func TestAccDataSourceNsxtPolicyBfdProfile_basic(t *testing.T) {
 	testResourceName := "data.nsxt_policy_bfd_profile.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccNSXVersion(t, "3.0.0") },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccDataSourceNsxtPolicyBfdProfileDeleteByName(name)

--- a/nsxt/data_source_nsxt_policy_dhcp_server_test.go
+++ b/nsxt/data_source_nsxt_policy_dhcp_server_test.go
@@ -15,7 +15,7 @@ func TestAccDataSourceNsxtPolicyDhcpServer_basic(t *testing.T) {
 	testResourceName := "data.nsxt_policy_dhcp_server.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccNSXVersion(t, "3.0.0") },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/nsxt/resource_nsxt_policy_dhcp_v4_static_binding_test.go
+++ b/nsxt/resource_nsxt_policy_dhcp_v4_static_binding_test.go
@@ -38,7 +38,7 @@ func TestAccResourceNsxtPolicyDhcpV4StaticBinding_basic(t *testing.T) {
 	testResourceName := testAccPolicyDhcpV4StaticBindingResourceName
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccNSXVersion(t, "3.0.0") },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNsxtPolicyDhcpV4StaticBindingCheckDestroy(state, accTestPolicyDhcpV4StaticBindingCreateAttributes["display_name"])
@@ -99,7 +99,7 @@ func TestAccResourceNsxtPolicyDhcpV4StaticBinding_importBasic(t *testing.T) {
 	name := getAccTestResourceName()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccNSXVersion(t, "3.0.0") },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNsxtPolicyDhcpV4StaticBindingCheckDestroy(state, name)

--- a/nsxt/resource_nsxt_policy_dhcp_v6_static_binding_test.go
+++ b/nsxt/resource_nsxt_policy_dhcp_v6_static_binding_test.go
@@ -42,7 +42,7 @@ func TestAccResourceNsxtPolicyDhcpV6StaticBinding_basic(t *testing.T) {
 	testResourceName := testAccPolicyDhcpV6StaticBindingResourceName
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccNSXVersion(t, "3.0.0") },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNsxtPolicyDhcpV6StaticBindingCheckDestroy(state, accTestPolicyDhcpV6StaticBindingUpdateAttributes["display_name"])
@@ -117,7 +117,7 @@ func TestAccResourceNsxtPolicyDhcpV6StaticBinding_importBasic(t *testing.T) {
 	name := getAccTestResourceName()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccNSXVersion(t, "3.0.0") },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNsxtPolicyDhcpV6StaticBindingCheckDestroy(state, name)

--- a/nsxt/resource_nsxt_policy_fixed_segment_test.go
+++ b/nsxt/resource_nsxt_policy_fixed_segment_test.go
@@ -130,7 +130,7 @@ func TestAccResourceNsxtPolicyFixedSegment_updateAdvConfig(t *testing.T) {
 	tzName := getOverlayTransportZoneName()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccNSXVersion(t, "3.0.0") },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNsxtPolicyFixedSegmentCheckDestroy(state, name)

--- a/nsxt/resource_nsxt_policy_intrusion_service_policy_test.go
+++ b/nsxt/resource_nsxt_policy_intrusion_service_policy_test.go
@@ -29,7 +29,7 @@ func TestAccResourceNsxtPolicyIntrusionServicePolicy_basic(t *testing.T) {
 	tag2 := "def"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t); testAccOnlyLocalManager(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccOnlyLocalManager(t); testAccNSXVersion(t, "3.0.0") },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNsxtPolicyIntrusionServicePolicyCheckDestroy(state, updatedName, defaultDomain)
@@ -118,7 +118,7 @@ func TestAccResourceNsxtPolicyIntrusionServicePolicy_withDependencies(t *testing
 	defaultProtocol := "IPV4_IPV6"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t); testAccOnlyLocalManager(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccOnlyLocalManager(t); testAccNSXVersion(t, "3.0.0") },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNsxtPolicyIntrusionServicePolicyCheckDestroy(state, name, defaultDomain)
@@ -193,7 +193,7 @@ func TestAccResourceNsxtPolicyIntrusionServicePolicy_importBasic(t *testing.T) {
 	testResourceName := "nsxt_policy_intrusion_service_policy.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t); testAccOnlyLocalManager(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccOnlyLocalManager(t); testAccNSXVersion(t, "3.0.0") },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNsxtPolicyIntrusionServicePolicyCheckDestroy(state, name, defaultDomain)

--- a/nsxt/resource_nsxt_policy_tier0_gateway.go
+++ b/nsxt/resource_nsxt_policy_tier0_gateway.go
@@ -739,7 +739,10 @@ func policyTier0GatewayResourceToInfraStruct(d *schema.ResourceData, connector *
 		ResourceType:           &t0Type,
 		Id:                     &id,
 		VrfConfig:              vrfConfig,
-		RdAdminField:           rdAdminField,
+	}
+
+	if nsxVersionHigherOrEqual("3.0.0") {
+		t0Struct.RdAdminField = rdAdminField
 	}
 
 	if len(d.Id()) > 0 {
@@ -905,7 +908,9 @@ func resourceNsxtPolicyTier0GatewayRead(d *schema.ResourceData, m interface{}) e
 	d.Set("internal_transit_subnets", obj.InternalTransitSubnets)
 	d.Set("transit_subnets", obj.TransitSubnets)
 	d.Set("revision", obj.Revision)
-	d.Set("rd_admin_address", obj.RdAdminField)
+	if nsxVersionHigherOrEqual("3.0.0") {
+		d.Set("rd_admin_address", obj.RdAdminField)
+	}
 	vrfErr := setPolicyVRFConfigInSchema(d, obj.VrfConfig)
 	if vrfErr != nil {
 		return vrfErr

--- a/nsxt/resource_nsxt_policy_tier0_gateway_test.go
+++ b/nsxt/resource_nsxt_policy_tier0_gateway_test.go
@@ -18,7 +18,7 @@ func TestAccResourceNsxtPolicyTier0Gateway_basic(t *testing.T) {
 	failoverMode := "NON_PREEMPTIVE"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccNSXVersion(t, "3.0.0") },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNsxtPolicyTier0CheckDestroy(state, updateName)
@@ -404,7 +404,7 @@ func TestAccResourceNsxtPolicyTier0Gateway_importBasic(t *testing.T) {
 	failoverMode := "PREEMPTIVE"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t); testAccNSXVersion(t, "3.0.0") },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNsxtPolicyTier0CheckDestroy(state, name)

--- a/website/docs/d/policy_bfd_profile.html.markdown
+++ b/website/docs/d/policy_bfd_profile.html.markdown
@@ -9,7 +9,7 @@ description: Policy BFD Profile data source.
 
 This data source provides information about policy BFD Profile configured on NSX.
 
-This data source is applicable to NSX Global Manager, NSX Policy Manager and VMC.
+This data source is applicable to NSX Global Manager, NSX Policy Manager and VMC (NSX 3.0.0 and up).
 
 ## Example Usage
 

--- a/website/docs/r/policy_dhcp_v4_static_binding.html.markdown
+++ b/website/docs/r/policy_dhcp_v4_static_binding.html.markdown
@@ -9,7 +9,7 @@ description: A resource to configure IPv4 DHCP Static Binding.
 
 This resource provides a method for the management of IPv4 DHCP Static Binding.
 
-This resource is applicable to NSX Global Manager, NSX Policy Manager and VMC.
+This resource is applicable to NSX Global Manager, NSX Policy Manager and VMC (NSX version 3.0.0 and up)
 
 ## Example Usage
 

--- a/website/docs/r/policy_dhcp_v6_static_binding.html.markdown
+++ b/website/docs/r/policy_dhcp_v6_static_binding.html.markdown
@@ -9,7 +9,7 @@ description: A resource to configure IPv6 DHCP Static Binding.
 
 This resource provides a method for the management of IPv6 DHCP Static Binding.
 
-This resource is applicable to NSX Global Manager, NSX Policy Manager and VMC.
+This resource is applicable to NSX Global Manager, NSX Policy Manager and VMC (NSX version 3.0.0 and up)
 
 ## Example Usage
 

--- a/website/docs/r/policy_intrusion_service_policy.html.markdown
+++ b/website/docs/r/policy_intrusion_service_policy.html.markdown
@@ -9,7 +9,7 @@ description: A resource to configure Intrusion Service Policy and its rules.
 
 This resource provides a method for the management of Intrusion Service (IDS) Policy and rules under it.
 
-This resource is applicable to NSX Policy Manager and VMC.
+This resource is applicable to NSX Policy Manager and VMC (NSX version 3.0.0 and up).
 
 ## Example Usage
 

--- a/website/docs/r/policy_tier0_gateway.html.markdown
+++ b/website/docs/r/policy_tier0_gateway.html.markdown
@@ -9,7 +9,7 @@ description: A resource to configure a Tier-0 gateway on NSX Policy manager.
 
 This resource provides a method for the management of a Tier-0 gateway or VRF-Lite gateway.
 
-This resource is applicable to NSX Global Manager, NSX Policy Manager and VMC.
+This resource is applicable to NSX Global Manager and NSX Policy Manager.
 
 ## Example Usage
 

--- a/website/docs/r/policy_tier1_gateway.html.markdown
+++ b/website/docs/r/policy_tier1_gateway.html.markdown
@@ -9,7 +9,7 @@ description: A resource to configure a Tier-1 gateway on NSX Policy manager.
 
 This resource provides a method for the management of a Tier-1 Gateway. A Tier-1 Gateway is often used for tenants, users and applications. There can be many Tier-1 gateways connected to a common Tier-0 provider gateway.
 
-This resource is applicable to NSX Global Manager, NSX Policy Manager and VMC.
+This resource is applicable to NSX Global Manager and NSX Policy Manager.
 
 ## Example Usage
 


### PR DESCRIPTION
In addition, make sure tests pass for NSX < 3.0.0, and add
version info in docs.