### PR TITLE
Fix policy VM data source pagination issue

### DIFF
--- a/nsxt/resource_nsxt_policy_evpn_tenant_test.go
+++ b/nsxt/resource_nsxt_policy_evpn_tenant_test.go
@@ -21,8 +21,6 @@ var accTestPolicyEvpnTenantUpdateAttributes = map[string]string{
 	"description":  "terraform updated",
 }
 
-var accTestPolicyEvpnTenantHelperName = getAccTestResourceName()
-
 func TestAccResourceNsxtPolicyEvpnTenant_basic(t *testing.T) {
 	testResourceName := "nsxt_policy_evpn_tenant.test"
 


### PR DESCRIPTION
The platform does not populate pagination values as expected,
therefore extra logic is required to make sure full set of VMs
in presented to the data source.
In addition, fix unrelated linter issue.