### PR TITLE
Support bgp config resource for Local Manager

### DIFF
--- a/nsxt/gateway_common.go
+++ b/nsxt/gateway_common.go
@@ -554,3 +554,19 @@ func parseGatewayInterfacePolicyPath(path string) (bool, string, string, string)
 
 	return isT0, gwID, localeServiceID, interfaceID
 }
+
+func getComputedLocaleServiceIDSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeString,
+		Description: "NSX ID of associated Gateway Locale Service",
+		Computed:    true,
+	}
+}
+
+func getComputedGatewayIDSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeString,
+		Description: "NSX ID of associated Tier0 Gateway",
+		Computed:    true,
+	}
+}

--- a/nsxt/policy_utils.go
+++ b/nsxt/policy_utils.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/bindings"
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
-	gm_model "github.com/vmware/vsphere-automation-sdk-go/services/nsxt-gm/model"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/realized_state"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 )
@@ -108,22 +107,6 @@ func getPolicyTagsFromSchema(d *schema.ResourceData) []model.Tag {
 
 func setPolicyTagsInSchema(d *schema.ResourceData, tags []model.Tag) {
 	setCustomizedPolicyTagsInSchema(d, tags, "tag")
-}
-
-func getPolicyGlobalManagerTagsFromSchema(d *schema.ResourceData) []gm_model.Tag {
-	tags := d.Get("tag").(*schema.Set).List()
-	var tagList []gm_model.Tag
-	for _, tag := range tags {
-		data := tag.(map[string]interface{})
-		tagScope := data["scope"].(string)
-		tagTag := data["tag"].(string)
-		elem := gm_model.Tag{
-			Scope: &tagScope,
-			Tag:   &tagTag}
-
-		tagList = append(tagList, elem)
-	}
-	return tagList
 }
 
 func getPathListFromMap(data map[string]interface{}, attrName string) []string {

--- a/nsxt/resource_nsxt_policy_ospf_config.go
+++ b/nsxt/resource_nsxt_policy_ospf_config.go
@@ -83,15 +83,8 @@ func getPolicyOspfConfigSchema() map[string]*schema.Schema {
 				},
 			},
 		},
-		"locale_service_id": {
-			Type:        schema.TypeString,
-			Description: "Id of associated Gateway Locale Service on NSX",
-			Computed:    true,
-		},
-		"gateway_id": {
-			Type: schema.TypeString, Description: "Id of associated Tier0 Gateway on NSX",
-			Computed: true,
-		},
+		"locale_service_id": getComputedLocaleServiceIDSchema(),
+		"gateway_id":        getComputedGatewayIDSchema(),
 	}
 }
 

--- a/website/docs/r/policy_bgp_config.html.markdown
+++ b/website/docs/r/policy_bgp_config.html.markdown
@@ -2,18 +2,37 @@
 subcategory: "Policy - Gateways and Routing"
 layout: "nsxt"
 page_title: "NSXT: nsxt_policy_bgp_config"
-description: A resource to configure BGP Settings of Tier0 Gateway on NSX Global Manager.
+description: A resource to configure BGP Settings of Tier0 Gateway.
 ---
 
 # nsxt_policy_bgp_config
 
 This resource provides a method for the management of BGP for T0 Gateway on specific site. A single resource should be specified per T0 Gateway + Site.
 
-This resource is applicable to NSX Global Manager only. For Local Manager, use `bgp_config` clause in gateway resource configuration.
+~> **NOTE:** This resource should NOT be used together with `bgp_config` clause in gateway resource configuration - such usage may produce inconsistent experience. Please choose one way or the other to configure BGP.
 
 ~> **NOTE:** Since BGP config is auto-created on NSX, this resource will update NSX object, but never create or delete it.
 
 ## Example Usage
+
+```hcl
+resource "nsxt_policy_bgp_config" "gw1" {
+  gateway_path = nsxt_policy_tier0_gateway.gw1.path
+
+  enabled                = true
+  inter_sr_ibgp          = true
+  local_as_num           = 60001
+  graceful_restart_mode  = "HELPER_ONLY"
+  graceful_restart_timer = 2400
+
+  route_aggregation {
+    prefix       = "20.1.0.0/24"
+    summary_only = false
+  }
+}
+```
+
+## Global Manager Example Usage
 
 ```hcl
 resource "nsxt_policy_bgp_config" "gw1-paris" {
@@ -37,6 +56,7 @@ resource "nsxt_policy_bgp_config" "gw1-paris" {
 
 The following arguments are supported:
 
+* `site_path` - (Optional) Path for policy site. This attribute is required for Global Manager and is not relevant for Local Manager.
 * `ecmp` - (Optional) A boolean flag to enable/disable ECMP. Default is `true`.
 * `enabled` - (Optional) A boolean flag to enable/disable BGP. Default is `true`.
 * `inter_sr_ibgp` - (Optional) A boolean flag to enable/disable inter SR IBGP configuration. Default is `true`.


### PR DESCRIPTION
This resource should not be used together with bgp_config clause
in T0 gateway. A corresponding note was added to the doc.