### PR TITLE
Fix rule_id assignment in policy resources

### DIFF
--- a/nsxt/policy_common.go
+++ b/nsxt/policy_common.go
@@ -373,6 +373,7 @@ func setPolicyRulesInSchema(d *schema.ResourceData, rules []model.Rule) error {
 		setPathListInMap(elem, "scope", rule.Scope)
 		elem["sequence_number"] = rule.SequenceNumber
 		elem["nsx_id"] = rule.Id
+		elem["rule_id"] = rule.RuleId
 
 		var tagList []map[string]string
 		for _, tag := range rule.Tags {

--- a/nsxt/resource_nsxt_policy_gateway_policy_test.go
+++ b/nsxt/resource_nsxt_policy_gateway_policy_test.go
@@ -85,6 +85,7 @@ func TestAccResourceNsxtPolicyGatewayPolicy_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(testResourceName, "rule.0.action", defaultAction),
 					resource.TestCheckResourceAttr(testResourceName, "rule.0.log_label", tag1),
 					resource.TestCheckResourceAttr(testResourceName, "rule.0.tag.#", "1"),
+					resource.TestCheckResourceAttrSet(testResourceName, "rule.0.rule_id"),
 				),
 			},
 			{

--- a/nsxt/resource_nsxt_policy_predefined_security_policy_test.go
+++ b/nsxt/resource_nsxt_policy_predefined_security_policy_test.go
@@ -112,6 +112,7 @@ func TestAccResourceNsxtPolicyPredefinedSecurityPolicy_rules(t *testing.T) {
 					resource.TestCheckResourceAttr(testResourceName, "rule.0.source_groups.#", "1"),
 					resource.TestCheckResourceAttr(testResourceName, "rule.0.log_label", "group2"),
 					resource.TestCheckResourceAttr(testResourceName, "rule.0.disabled", "true"),
+					resource.TestCheckResourceAttrSet(testResourceName, "rule.0.rule_id"),
 					resource.TestCheckResourceAttr(testResourceName, "default_rule.#", "1"),
 					resource.TestCheckResourceAttr(testResourceName, "default_rule.0.action", "ALLOW"),
 				),

--- a/nsxt/resource_nsxt_policy_security_policy_test.go
+++ b/nsxt/resource_nsxt_policy_security_policy_test.go
@@ -87,6 +87,7 @@ func TestAccResourceNsxtPolicySecurityPolicy_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(testResourceName, "rule.0.ip_version", proto1),
 					resource.TestCheckResourceAttr(testResourceName, "rule.0.action", defaultAction),
 					resource.TestCheckResourceAttr(testResourceName, "rule.0.log_label", tag1),
+					resource.TestCheckResourceAttrSet(testResourceName, "rule.0.rule_id"),
 					resource.TestCheckResourceAttr(testResourceName, "rule.0.tag.#", "1"),
 				),
 			},
@@ -191,6 +192,7 @@ func TestAccResourceNsxtPolicySecurityPolicy_withDependencies(t *testing.T) {
 					resource.TestCheckResourceAttr(testResourceName, "rule.1.destinations_excluded", "false"),
 					resource.TestCheckResourceAttr(testResourceName, "rule.1.disabled", "false"),
 					resource.TestCheckResourceAttr(testResourceName, "rule.1.services.#", "0"),
+					resource.TestCheckResourceAttrSet(testResourceName, "rule.1.rule_id"),
 				),
 			},
 			{


### PR DESCRIPTION
This is a computed field auto-assigned by the backend.