### PR TITLE
Allow IP CIDR Range or Any as Source and/or Destination Policy Groups

### DIFF
--- a/nsxt/policy_common.go
+++ b/nsxt/policy_common.go
@@ -162,7 +162,7 @@ func getSecurityPolicyAndGatewayRulesSchema(scopeRequired bool, isIds bool) *sch
 			Description: "List of destination groups",
 			Elem: &schema.Schema{
 				Type:         schema.TypeString,
-				ValidateFunc: validatePolicyPath(),
+				ValidateFunc: validatePolicySourceDestinationGroups(),
 			},
 			Optional: true,
 		},
@@ -241,7 +241,7 @@ func getSecurityPolicyAndGatewayRulesSchema(scopeRequired bool, isIds bool) *sch
 			Description: "List of source groups",
 			Elem: &schema.Schema{
 				Type:         schema.TypeString,
-				ValidateFunc: validatePolicyPath(),
+				ValidateFunc: validatePolicySourceDestinationGroups(),
 			},
 			Optional: true,
 		},

--- a/nsxt/resource_nsxt_policy_gateway_policy_test.go
+++ b/nsxt/resource_nsxt_policy_gateway_policy_test.go
@@ -384,6 +384,147 @@ func TestAccResourceNsxtGlobalPolicyGatewayPolicy_withDomain(t *testing.T) {
 	})
 }
 
+func TestAccResourceNsxtPolicyGatewayPolicy_withIPCidrRange(t *testing.T) {
+	name := getAccTestResourceName()
+	testResourceName := "nsxt_policy_gateway_policy.test"
+	defaultDirection := "IN_OUT"
+	defaultProtocol := "IPV4_IPV6"
+	policyIP := "10.10.20.5"
+	policyCidr := "10.10.20.0/22"
+	policyRange := "10.10.20.6-10.10.20.7"
+	updatedPolicyIP := "10.10.40.5"
+	updatedPolicyCidr := "10.10.40.0/22"
+	updatedPolicyRange := "10.10.40.6-10.10.40.7"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyGatewayPolicyCheckDestroy(state, name, defaultDomain)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyGatewayPolicyWithIPCidrRange(name, policyIP, policyCidr, policyRange, policyIP, policyCidr, policyRange),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicyGatewayPolicyExists(testResourceName, defaultDomain),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", name),
+					resource.TestCheckResourceAttr(testResourceName, "description", "Acceptance Test"),
+					resource.TestCheckResourceAttr(testResourceName, "category", "LocalGatewayRules"),
+					resource.TestCheckResourceAttr(testResourceName, "domain", defaultDomain),
+					resource.TestCheckResourceAttr(testResourceName, "comments", ""),
+					resource.TestCheckResourceAttr(testResourceName, "locked", "false"),
+					resource.TestCheckResourceAttr(testResourceName, "sequence_number", "3"),
+					resource.TestCheckResourceAttr(testResourceName, "stateful", "true"),
+					resource.TestCheckResourceAttr(testResourceName, "tcp_strict", "false"),
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.#", "6"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.0.display_name", "rule1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.0.direction", defaultDirection),
+					resource.TestCheckResourceAttr(testResourceName, "rule.0.ip_version", defaultProtocol),
+					resource.TestCheckResourceAttr(testResourceName, "rule.0.action", "ALLOW"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.0.source_groups.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.0.destination_groups.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.0.destination_groups.0", policyIP),
+					resource.TestCheckResourceAttr(testResourceName, "rule.1.display_name", "rule2"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.1.direction", defaultDirection),
+					resource.TestCheckResourceAttr(testResourceName, "rule.1.ip_version", defaultProtocol),
+					resource.TestCheckResourceAttr(testResourceName, "rule.1.action", "ALLOW"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.1.source_groups.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.1.destination_groups.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.1.destination_groups.0", policyCidr),
+					resource.TestCheckResourceAttr(testResourceName, "rule.2.display_name", "rule3"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.2.direction", defaultDirection),
+					resource.TestCheckResourceAttr(testResourceName, "rule.2.ip_version", defaultProtocol),
+					resource.TestCheckResourceAttr(testResourceName, "rule.2.action", "ALLOW"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.2.source_groups.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.2.destination_groups.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.2.destination_groups.0", policyRange),
+					resource.TestCheckResourceAttr(testResourceName, "rule.3.display_name", "rule4"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.3.direction", defaultDirection),
+					resource.TestCheckResourceAttr(testResourceName, "rule.3.ip_version", defaultProtocol),
+					resource.TestCheckResourceAttr(testResourceName, "rule.3.action", "ALLOW"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.3.source_groups.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.3.source_groups.0", policyIP),
+					resource.TestCheckResourceAttr(testResourceName, "rule.3.destination_groups.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.4.display_name", "rule5"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.4.direction", defaultDirection),
+					resource.TestCheckResourceAttr(testResourceName, "rule.4.ip_version", defaultProtocol),
+					resource.TestCheckResourceAttr(testResourceName, "rule.4.action", "ALLOW"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.4.source_groups.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.4.source_groups.0", policyCidr),
+					resource.TestCheckResourceAttr(testResourceName, "rule.4.destination_groups.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.5.display_name", "rule6"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.5.direction", defaultDirection),
+					resource.TestCheckResourceAttr(testResourceName, "rule.5.ip_version", defaultProtocol),
+					resource.TestCheckResourceAttr(testResourceName, "rule.5.action", "ALLOW"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.5.source_groups.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.5.source_groups.0", policyRange),
+					resource.TestCheckResourceAttr(testResourceName, "rule.5.destination_groups.#", "1"),
+				),
+			},
+			{
+				Config: testAccNsxtPolicyGatewayPolicyWithIPCidrRange(name, updatedPolicyIP, updatedPolicyCidr, updatedPolicyRange, updatedPolicyIP, updatedPolicyCidr, updatedPolicyRange),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicyGatewayPolicyExists(testResourceName, defaultDomain),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", name),
+					resource.TestCheckResourceAttr(testResourceName, "description", "Acceptance Test"),
+					resource.TestCheckResourceAttr(testResourceName, "category", "LocalGatewayRules"),
+					resource.TestCheckResourceAttr(testResourceName, "domain", defaultDomain),
+					resource.TestCheckResourceAttr(testResourceName, "comments", ""),
+					resource.TestCheckResourceAttr(testResourceName, "locked", "false"),
+					resource.TestCheckResourceAttr(testResourceName, "sequence_number", "3"),
+					resource.TestCheckResourceAttr(testResourceName, "stateful", "true"),
+					resource.TestCheckResourceAttr(testResourceName, "tcp_strict", "false"),
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.#", "6"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.0.display_name", "rule1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.0.direction", defaultDirection),
+					resource.TestCheckResourceAttr(testResourceName, "rule.0.ip_version", defaultProtocol),
+					resource.TestCheckResourceAttr(testResourceName, "rule.0.action", "ALLOW"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.0.source_groups.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.0.destination_groups.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.0.destination_groups.0", updatedPolicyIP),
+					resource.TestCheckResourceAttr(testResourceName, "rule.1.display_name", "rule2"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.1.direction", defaultDirection),
+					resource.TestCheckResourceAttr(testResourceName, "rule.1.ip_version", defaultProtocol),
+					resource.TestCheckResourceAttr(testResourceName, "rule.1.action", "ALLOW"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.1.source_groups.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.1.destination_groups.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.1.destination_groups.0", updatedPolicyCidr),
+					resource.TestCheckResourceAttr(testResourceName, "rule.2.display_name", "rule3"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.2.direction", defaultDirection),
+					resource.TestCheckResourceAttr(testResourceName, "rule.2.ip_version", defaultProtocol),
+					resource.TestCheckResourceAttr(testResourceName, "rule.2.action", "ALLOW"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.2.source_groups.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.2.destination_groups.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.2.destination_groups.0", updatedPolicyRange),
+					resource.TestCheckResourceAttr(testResourceName, "rule.3.display_name", "rule4"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.3.direction", defaultDirection),
+					resource.TestCheckResourceAttr(testResourceName, "rule.3.ip_version", defaultProtocol),
+					resource.TestCheckResourceAttr(testResourceName, "rule.3.action", "ALLOW"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.3.source_groups.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.3.source_groups.0", updatedPolicyIP),
+					resource.TestCheckResourceAttr(testResourceName, "rule.3.destination_groups.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.4.display_name", "rule5"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.4.direction", defaultDirection),
+					resource.TestCheckResourceAttr(testResourceName, "rule.4.ip_version", defaultProtocol),
+					resource.TestCheckResourceAttr(testResourceName, "rule.4.action", "ALLOW"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.4.source_groups.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.4.source_groups.0", updatedPolicyCidr),
+					resource.TestCheckResourceAttr(testResourceName, "rule.4.destination_groups.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.5.display_name", "rule6"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.5.direction", defaultDirection),
+					resource.TestCheckResourceAttr(testResourceName, "rule.5.ip_version", defaultProtocol),
+					resource.TestCheckResourceAttr(testResourceName, "rule.5.action", "ALLOW"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.5.source_groups.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.5.source_groups.0", updatedPolicyRange),
+					resource.TestCheckResourceAttr(testResourceName, "rule.5.destination_groups.#", "1"),
+				),
+			},
+		},
+	})
+}
+
 func testAccNsxtPolicyGatewayPolicyExists(resourceName string, domainName string) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
 
@@ -702,4 +843,99 @@ resource "nsxt_policy_gateway_policy" "test" {
     }
   }
 }`, name, name, direction, protocol, ruleTag)
+}
+
+func testAccNsxtPolicyGatewayPolicyDeps() string {
+	return `
+resource "nsxt_policy_tier1_gateway" "gwt1test" {
+	display_name      = "tf-t1-gw"
+	description       = "Acceptance Test"
+}
+
+resource "nsxt_policy_group" "group1" {
+  display_name = "terraform testacc 1"
+}
+
+resource "nsxt_policy_group" "group2" {
+  display_name = "terraform testacc 2"
+}
+
+resource "nsxt_policy_service" "icmp" {
+    display_name = "security-policy-test-icmp"
+    icmp_entry {
+        protocol = "ICMPv4"
+    }
+}`
+}
+
+func testAccNsxtPolicyGatewayPolicyWithIPCidrRange(name string, destIP string, destCidr string, destIPRange string, sourceIP string, sourceCidr string, sourceIPRange string) string {
+	return testAccNsxtPolicyGatewayPolicyDeps() + fmt.Sprintf(`
+	resource "nsxt_policy_gateway_policy" "test" {
+		display_name    = "%s"
+		description     = "Acceptance Test"
+		category        = "LocalGatewayRules"
+		sequence_number = 3
+		locked          = false
+		stateful        = true
+		tcp_strict      = false
+	  
+		tag {
+		  scope = "color"
+		  tag   = "orange"
+		}
+	  
+		rule {
+		  display_name          = "rule1"
+		  source_groups         = [nsxt_policy_group.group1.path]
+		  destination_groups    = ["%s"]
+		  services              = [nsxt_policy_service.icmp.path]
+		  scope                 = [nsxt_policy_tier1_gateway.gwt1test.path]
+		  action                = "ALLOW"
+		}
+
+		rule {
+			display_name          = "rule2"
+			source_groups         = [nsxt_policy_group.group1.path]			
+			destination_groups    = ["%s"]
+			services              = [nsxt_policy_service.icmp.path]
+			scope                 = [nsxt_policy_tier1_gateway.gwt1test.path]			
+			action                = "ALLOW"
+		  }
+
+		  rule {
+			display_name          = "rule3"
+			source_groups         = [nsxt_policy_group.group1.path]
+			destination_groups    = ["%s"]
+			services              = [nsxt_policy_service.icmp.path]
+			scope                 = [nsxt_policy_tier1_gateway.gwt1test.path]			
+			action                = "ALLOW"
+		  }
+
+		  rule {
+			display_name          = "rule4"
+			source_groups         = ["%s"]
+			destination_groups    = [nsxt_policy_group.group2.path]
+			services              = [nsxt_policy_service.icmp.path]
+			scope                 = [nsxt_policy_tier1_gateway.gwt1test.path]		  
+			action                = "ALLOW"
+		  }
+  
+		  rule {
+			  display_name          = "rule5"
+			  source_groups         = ["%s"]			
+			  destination_groups    = [nsxt_policy_group.group2.path]
+			  services              = [nsxt_policy_service.icmp.path]
+			  scope                 = [nsxt_policy_tier1_gateway.gwt1test.path]			
+			  action                = "ALLOW"
+			}
+  
+			rule {
+			  display_name          = "rule6"
+			  source_groups         = ["%s"]
+			  destination_groups    = [nsxt_policy_group.group2.path]
+			  services              = [nsxt_policy_service.icmp.path]
+			  scope                 = [nsxt_policy_tier1_gateway.gwt1test.path]			
+			  action                = "ALLOW"
+			}
+}`, name, destIP, destCidr, destIPRange, sourceIP, sourceCidr, sourceIPRange)
 }

--- a/nsxt/resource_nsxt_policy_security_policy_test.go
+++ b/nsxt/resource_nsxt_policy_security_policy_test.go
@@ -225,6 +225,148 @@ func TestAccResourceNsxtPolicySecurityPolicy_withDependencies(t *testing.T) {
 		},
 	})
 }
+
+func TestAccResourceNsxtPolicySecurityPolicy_withIPCidrRange(t *testing.T) {
+	name := getAccTestResourceName()
+	testResourceName := "nsxt_policy_security_policy.test"
+	defaultDirection := "IN_OUT"
+	defaultProtocol := "IPV4_IPV6"
+	policyIP := "10.10.20.5"
+	policyCidr := "10.10.20.0/22"
+	policyRange := "10.10.20.6-10.10.20.7"
+	updatedPolicyIP := "10.10.40.5"
+	updatedPolicyCidr := "10.10.40.0/22"
+	updatedPolicyRange := "10.10.40.6-10.10.40.7"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicySecurityPolicyCheckDestroy(state, name, defaultDomain)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicySecurityPolicyWithIPCidrRange(name, policyIP, policyCidr, policyRange, policyIP, policyCidr, policyRange),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicySecurityPolicyExists(testResourceName, defaultDomain),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", name),
+					resource.TestCheckResourceAttr(testResourceName, "description", "Acceptance Test"),
+					resource.TestCheckResourceAttr(testResourceName, "category", "Application"),
+					resource.TestCheckResourceAttr(testResourceName, "domain", defaultDomain),
+					resource.TestCheckResourceAttr(testResourceName, "comments", ""),
+					resource.TestCheckResourceAttr(testResourceName, "locked", "false"),
+					resource.TestCheckResourceAttr(testResourceName, "sequence_number", "3"),
+					resource.TestCheckResourceAttr(testResourceName, "stateful", "true"),
+					resource.TestCheckResourceAttr(testResourceName, "tcp_strict", "false"),
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.#", "6"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.0.display_name", "rule1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.0.direction", defaultDirection),
+					resource.TestCheckResourceAttr(testResourceName, "rule.0.ip_version", defaultProtocol),
+					resource.TestCheckResourceAttr(testResourceName, "rule.0.action", "ALLOW"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.0.source_groups.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.0.destination_groups.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.0.destination_groups.0", policyIP),
+					resource.TestCheckResourceAttr(testResourceName, "rule.1.display_name", "rule2"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.1.direction", defaultDirection),
+					resource.TestCheckResourceAttr(testResourceName, "rule.1.ip_version", defaultProtocol),
+					resource.TestCheckResourceAttr(testResourceName, "rule.1.action", "ALLOW"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.1.source_groups.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.1.destination_groups.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.1.destination_groups.0", policyCidr),
+					resource.TestCheckResourceAttr(testResourceName, "rule.2.display_name", "rule3"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.2.direction", defaultDirection),
+					resource.TestCheckResourceAttr(testResourceName, "rule.2.ip_version", defaultProtocol),
+					resource.TestCheckResourceAttr(testResourceName, "rule.2.action", "ALLOW"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.2.source_groups.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.2.destination_groups.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.2.destination_groups.0", policyRange),
+					resource.TestCheckResourceAttr(testResourceName, "rule.3.display_name", "rule4"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.3.direction", defaultDirection),
+					resource.TestCheckResourceAttr(testResourceName, "rule.3.ip_version", defaultProtocol),
+					resource.TestCheckResourceAttr(testResourceName, "rule.3.action", "ALLOW"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.3.source_groups.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.3.source_groups.0", policyIP),
+					resource.TestCheckResourceAttr(testResourceName, "rule.3.destination_groups.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.4.display_name", "rule5"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.4.direction", defaultDirection),
+					resource.TestCheckResourceAttr(testResourceName, "rule.4.ip_version", defaultProtocol),
+					resource.TestCheckResourceAttr(testResourceName, "rule.4.action", "ALLOW"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.4.source_groups.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.4.source_groups.0", policyCidr),
+					resource.TestCheckResourceAttr(testResourceName, "rule.4.destination_groups.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.5.display_name", "rule6"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.5.direction", defaultDirection),
+					resource.TestCheckResourceAttr(testResourceName, "rule.5.ip_version", defaultProtocol),
+					resource.TestCheckResourceAttr(testResourceName, "rule.5.action", "ALLOW"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.5.source_groups.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.5.source_groups.0", policyRange),
+					resource.TestCheckResourceAttr(testResourceName, "rule.5.destination_groups.#", "1"),
+				),
+			},
+			{
+				Config: testAccNsxtPolicySecurityPolicyWithIPCidrRange(name, updatedPolicyIP, updatedPolicyCidr, updatedPolicyRange, updatedPolicyIP, updatedPolicyCidr, updatedPolicyRange),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicySecurityPolicyExists(testResourceName, defaultDomain),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", name),
+					resource.TestCheckResourceAttr(testResourceName, "description", "Acceptance Test"),
+					resource.TestCheckResourceAttr(testResourceName, "category", "Application"),
+					resource.TestCheckResourceAttr(testResourceName, "domain", defaultDomain),
+					resource.TestCheckResourceAttr(testResourceName, "comments", ""),
+					resource.TestCheckResourceAttr(testResourceName, "locked", "false"),
+					resource.TestCheckResourceAttr(testResourceName, "sequence_number", "3"),
+					resource.TestCheckResourceAttr(testResourceName, "stateful", "true"),
+					resource.TestCheckResourceAttr(testResourceName, "tcp_strict", "false"),
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.#", "6"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.0.display_name", "rule1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.0.direction", defaultDirection),
+					resource.TestCheckResourceAttr(testResourceName, "rule.0.ip_version", defaultProtocol),
+					resource.TestCheckResourceAttr(testResourceName, "rule.0.action", "ALLOW"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.0.source_groups.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.0.destination_groups.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.0.destination_groups.0", updatedPolicyIP),
+					resource.TestCheckResourceAttr(testResourceName, "rule.1.display_name", "rule2"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.1.direction", defaultDirection),
+					resource.TestCheckResourceAttr(testResourceName, "rule.1.ip_version", defaultProtocol),
+					resource.TestCheckResourceAttr(testResourceName, "rule.1.action", "ALLOW"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.1.source_groups.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.1.destination_groups.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.1.destination_groups.0", updatedPolicyCidr),
+					resource.TestCheckResourceAttr(testResourceName, "rule.2.display_name", "rule3"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.2.direction", defaultDirection),
+					resource.TestCheckResourceAttr(testResourceName, "rule.2.ip_version", defaultProtocol),
+					resource.TestCheckResourceAttr(testResourceName, "rule.2.action", "ALLOW"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.2.source_groups.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.2.destination_groups.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.2.destination_groups.0", updatedPolicyRange),
+					resource.TestCheckResourceAttr(testResourceName, "rule.3.display_name", "rule4"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.3.direction", defaultDirection),
+					resource.TestCheckResourceAttr(testResourceName, "rule.3.ip_version", defaultProtocol),
+					resource.TestCheckResourceAttr(testResourceName, "rule.3.action", "ALLOW"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.3.source_groups.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.3.source_groups.0", updatedPolicyIP),
+					resource.TestCheckResourceAttr(testResourceName, "rule.3.destination_groups.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.4.display_name", "rule5"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.4.direction", defaultDirection),
+					resource.TestCheckResourceAttr(testResourceName, "rule.4.ip_version", defaultProtocol),
+					resource.TestCheckResourceAttr(testResourceName, "rule.4.action", "ALLOW"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.4.source_groups.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.4.source_groups.0", updatedPolicyCidr),
+					resource.TestCheckResourceAttr(testResourceName, "rule.4.destination_groups.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.5.display_name", "rule6"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.5.direction", defaultDirection),
+					resource.TestCheckResourceAttr(testResourceName, "rule.5.ip_version", defaultProtocol),
+					resource.TestCheckResourceAttr(testResourceName, "rule.5.action", "ALLOW"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.5.source_groups.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.5.source_groups.0", updatedPolicyRange),
+					resource.TestCheckResourceAttr(testResourceName, "rule.5.destination_groups.#", "1"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccResourceNsxtPolicySecurityPolicy_importBasic(t *testing.T) {
 	name := getAccTestResourceName()
 	testResourceName := "nsxt_policy_security_policy.test"
@@ -624,6 +766,71 @@ resource "nsxt_policy_security_policy" "test" {
   }
 
 }`, name)
+}
+
+func testAccNsxtPolicySecurityPolicyWithIPCidrRange(name string, destIP string, destCidr string, destIPRange string, sourceIP string, sourceCidr string, sourceIPRange string) string {
+	return testAccNsxtPolicySecurityPolicyDeps() + fmt.Sprintf(`
+	resource "nsxt_policy_security_policy" "test" {
+		display_name    = "%s"
+		description     = "Acceptance Test"
+		category        = "Application"
+		sequence_number = 3
+		locked          = false
+		stateful        = true
+		tcp_strict      = false
+	  
+		tag {
+		  scope = "color"
+		  tag   = "orange"
+		}
+	  
+		rule {
+		  display_name          = "rule1"
+		  source_groups         = [nsxt_policy_group.group1.path]
+		  destination_groups    = ["%s"]
+		  services              = [nsxt_policy_service.icmp.path]
+		  action                = "ALLOW"
+		}
+
+		rule {
+			display_name          = "rule2"
+			source_groups         = [nsxt_policy_group.group1.path]			
+			destination_groups    = ["%s"]
+			services              = [nsxt_policy_service.icmp.path]
+			action                = "ALLOW"
+		  }
+
+		  rule {
+			display_name          = "rule3"
+			source_groups         = [nsxt_policy_group.group1.path]
+			destination_groups    = ["%s"]
+			services              = [nsxt_policy_service.icmp.path]
+			action                = "ALLOW"
+		  }
+		  rule {
+			display_name          = "rule4"
+			source_groups         = ["%s"]
+			destination_groups    = [nsxt_policy_group.group2.path]
+			services              = [nsxt_policy_service.icmp.path]
+			action                = "ALLOW"
+		  }
+  
+		  rule {
+			  display_name          = "rule5"
+			  source_groups         = ["%s"]			
+			  destination_groups    = [nsxt_policy_group.group2.path]
+			  services              = [nsxt_policy_service.icmp.path]
+			  action                = "ALLOW"
+			}
+  
+			rule {
+			  display_name          = "rule6"
+			  source_groups         = ["%s"]
+			  destination_groups    = [nsxt_policy_group.group2.path]
+			  services              = [nsxt_policy_service.icmp.path]
+			  action                = "ALLOW"
+			}
+}`, name, destIP, destCidr, destIPRange, sourceIP, sourceCidr, sourceIPRange)
 }
 
 func testAccNsxtPolicySecurityPolicyWithProfiles(name string, direction string, protocol string, ruleTag string, domainName string) string {

--- a/nsxt/validators.go
+++ b/nsxt/validators.go
@@ -361,6 +361,23 @@ func validateSSLCiphers() schema.SchemaValidateFunc {
 	return validation.StringInSlice(supportedSSLCiphers, false)
 }
 
+func validatePolicySourceDestinationGroups() schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (s []string, es []error) {
+		v, ok := i.(string)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be string", k))
+			return
+		}
+
+		if !isCidr(v, true, false) && !isSingleIP(v) && !isIPRange(v) && !isPolicyPath(v) {
+			es = append(es, fmt.Errorf(
+				"expected %s to contain a valid IP, Range, CIDR, or Group Path. Got: %s", k, v))
+		}
+		return
+
+	}
+}
+
 func validatePolicyPath() schema.SchemaValidateFunc {
 	return func(i interface{}, k string) (s []string, es []error) {
 		v, ok := i.(string)

--- a/website/docs/r/policy_gateway_policy.html.markdown
+++ b/website/docs/r/policy_gateway_policy.html.markdown
@@ -93,7 +93,7 @@ The following arguments are supported:
 * `rule` (Optional) A repeatable block to specify rules for the Gateway Policy. Each rule includes the following fields:
   * `display_name` - (Required) Display name of the resource.
   * `description` - (Optional) Description of the resource.
-  * `destination_groups` - (Optional) A list of destination group paths to use for the policy.
+  * `destination_groups` - (Optional) Set of group paths that serve as the destination for this rule. IPs, IP ranges, or CIDRs may also be used starting in NSX-T 3.0. An empty set can be used to specify "Any".
   * `destinations_excluded` - (Optional) A boolean value indicating negation of destination groups.
   * `direction` - (Optional) The traffic direction for the policy. Must be one of: `IN`, `OUT` or `IN_OUT`. Defaults to `IN_OUT`.
   * `disabled` - (Optional) A boolean value to indicate the rule is disabled. Defaults to `false`.
@@ -103,7 +103,7 @@ The following arguments are supported:
   * `profiles` - (Optional) A list of context profiles for the rule. Note: due to platform issue, this setting is only supported with NSX 3.2 onwards.
   * `scope` - (Required) List of policy paths where the rule is applied.
   * `services` - (Optional) List of services to match.
-  * `source_groups` - (Optional) A list of source group paths to use for the policy.
+  * `source_groups` - (Optional) Set of group paths that serve as the source for this rule. IPs, IP ranges, or CIDRs may also be used starting in NSX-T 3.0. An empty set can be used to specify "Any".
   * `source_excluded` - (Optional) A boolean value indicating negation of source groups.
   * `log_label` - (Optional) Additional information (string) which will be propagated to the rule syslog.
   * `tag` - (Optional) A list of scope + tag pairs to associate with this Rule.

--- a/website/docs/r/policy_predefined_gateway_policy.html.markdown
+++ b/website/docs/r/policy_predefined_gateway_policy.html.markdown
@@ -79,7 +79,7 @@ The following arguments are supported:
 * `rule` (Optional) A repeatable block to specify rules for the Gateway Policy. This setting is not applicable to policy belonging to `DEFAULT` category. Each rule includes the following fields:
   * `display_name` - (Required) Display name of the resource.
   * `description` - (Optional) Description of the resource.
-  * `destination_groups` - (Optional) A list of destination group paths to use for the policy.
+  * `destination_groups` - (Optional) Set of group paths that serve as the destination for this rule. IPs, IP ranges, or CIDRs may also be used starting in NSX-T 3.0. An empty set can be used to specify "Any".
   * `destinations_excluded` - (Optional) A boolean value indicating negation of destination groups.
   * `direction` - (Optional) The traffic direction for the policy. Must be one of: `IN`, `OUT` or `IN_OUT`. Defaults to `IN_OUT`.
   * `disabled` - (Optional) A boolean value to indicate the rule is disabled. Defaults to `false`.
@@ -89,7 +89,7 @@ The following arguments are supported:
   * `profiles` - (Optional) A list of context profiles for the rule. Note: due to platform issue, this setting is only supported with NSX 3.2 onwards.
   * `scope` - (Required) List of policy paths where the rule is applied.
   * `services` - (Optional) List of services to match.
-  * `source_groups` - (Optional) A list of source group paths to use for the policy.
+  * `source_groups` - (Optional) Set of group paths that serve as the source for this rule. IPs, IP ranges, or CIDRs may also be used starting in NSX-T 3.0. An empty set can be used to specify "Any".
   * `source_excluded` - (Optional) A boolean value indicating negation of source groups.
   * `log_label` - (Optional) Additional information (string) which will be propagated to the rule syslog.
   * `tag` - (Optional) A list of scope + tag pairs to associate with this Rule.

--- a/website/docs/r/policy_predefined_security_policy.html.markdown
+++ b/website/docs/r/policy_predefined_security_policy.html.markdown
@@ -67,7 +67,7 @@ The following arguments are supported:
 * `rule` (Optional) A repeatable block to specify rules for the Security Policy. This setting is applicable to non-Default policies only. Each rule includes the following fields:
   * `display_name` - (Required) Display name of the resource.
   * `description` - (Optional) Description of the resource.
-  * `destination_groups` - (Optional) A list of destination group paths to use for the policy.
+  * `destination_groups` - (Optional) Set of group paths that serve as the destination for this rule. IPs, IP ranges, or CIDRs may also be used starting in NSX-T 3.0. An empty set can be used to specify "Any".
   * `destinations_excluded` - (Optional) A boolean value indicating negation of destination groups.
   * `direction` - (Optional) The traffic direction for the policy. Must be one of: `IN`, `OUT` or `IN_OUT`. Defaults to `IN_OUT`.
   * `disabled` - (Optional) A boolean value to indicate the rule is disabled. Defaults to `false`.
@@ -77,7 +77,7 @@ The following arguments are supported:
   * `profiles` - (Optional) A list of profiles for the rule.
   * `scope` - (Required) List of policy paths where the rule is applied.
   * `services` - (Optional) List of services to match.
-  * `source_groups` - (Optional) A list of source group paths to use for the policy.
+  * `source_groups` - (Optional) Set of group paths that serve as the source for this rule. IPs, IP ranges, or CIDRs may also be used starting in NSX-T 3.0. An empty set can be used to specify "Any".
   * `source_excluded` - (Optional) A boolean value indicating negation of source groups.
   * `log_label` - (Optional) Additional information (string) which will be propagated to the rule syslog.
   * `tag` - (Optional) A list of scope + tag pairs to associate with this Rule.

--- a/website/docs/r/policy_security_policy.html.markdown
+++ b/website/docs/r/policy_security_policy.html.markdown
@@ -103,8 +103,8 @@ The following arguments are supported:
   * `display_name` - (Required) Display name of the resource.
   * `description` - (Optional) Description of the resource.
   * `action` - (Optional) Rule action, one of `ALLOW`, `DROP`, `REJECT` and `JUMP_TO_APPLICATION`. Default is `ALLOW`. `JUMP_TO_APPLICATION` is only applicable in `Environment` category.
-  * `destination_groups` - (Optional) Set of group paths that serve as destination for this rule.
-  * `source_groups` - (Optional) Set of group paths that serve as source for this rule.
+  * `destination_groups` - (Optional) Set of group paths that serve as the destination for this rule. IPs, IP ranges, or CIDRs may also be used starting in NSX-T 3.0. An empty set can be used to specify "Any".
+  * `source_groups` - (Optional) Set of group paths that serve as the source for this rule. IPs, IP ranges, or CIDRs may also be used starting in NSX-T 3.0. An empty set can be used to specify "Any".
   * `destinations_excluded` - (Optional) A boolean value indicating negation of destination groups.
   * `sources_excluded` - (Optional) A boolean value indicating negation of source groups.
   * `direction` - (Optional) Traffic direction, one of `IN`, `OUT` or `IN_OUT`. Default is `IN_OUT`.


### PR DESCRIPTION
Adds a new validator specific to source and destination policy groups.
NSX-T can accept an IP, Range, CIDR, or a Group Path as a source
and/or destination group through the security policy interface.

Updates the getSecurityPolicyAndGatewayRulesSchema function to use the
new validator.

Resolves: Issue #584