### PR TITLE
Introduce timeout and delay realization parameters

### DIFF
--- a/website/docs/d/policy_realization_info.html.markdown
+++ b/website/docs/d/policy_realization_info.html.markdown
@@ -21,6 +21,7 @@ data "nsxt_policy_tier1_gateway" "tier1_gw" {
 data "nsxt_policy_realization_info" "info" {
   path        = data.nsxt_policy_tier1_gateway.tier1_gw.path
   entity_type = "RealizedLogicalRouter"
+  timeout     = 60
 }
 ```
 
@@ -45,15 +46,14 @@ data "nsxt_policy_realization_info" "info" {
 ## Argument Reference
 
 * `path` - (Required) The policy path of the resource.
-
 * `entity_type` - (Optional) The entity type of realized resource. If not set, on of the realized resources of the policy resource will be retrieved.
-
 * `site_path` - (Optional) The path of the site which the resource belongs to, this configuration is required for global manager only. `path` field of the existing `nsxt_policy_site` can be used here.
+* `delay` - (Optional) Delay (in seconds) before realization polling is started. Default is set to 1.
+* `timeout` - (Optional) Timeout (in seconds) for realization polling. Default is set to 1200.
 
 ## Attributes Reference
 
 In addition to arguments listed above, the following attributes are exported:
 
 * `state` - The realization state of the resource: "REALIZED", "UNKNOWN", "UNREALIZED" or "ERROR".
-
 * `realized_id` - The id of the realized object.


### PR DESCRIPTION
Realization data source can now be fine-tuned with two new params:
* delay defines wait time befor realization polling begins
* timeout defines the timeout for realization polling