### PR TITLE
Make sure env vars are checked before provider init

### DIFF
--- a/nsxt/data_source_nsxt_policy_group_test.go
+++ b/nsxt/data_source_nsxt_policy_group_test.go
@@ -52,9 +52,9 @@ func TestAccDataSourceNsxtPolicyGroup_withSite(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
-			testAccPreCheck(t)
 			testAccOnlyGlobalManager(t)
 			testAccEnvDefined(t, "NSXT_TEST_SITE_NAME")
+			testAccPreCheck(t)
 		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {

--- a/nsxt/data_source_nsxt_policy_realization_info_test.go
+++ b/nsxt/data_source_nsxt_policy_realization_info_test.go
@@ -125,9 +125,9 @@ func TestAccDataSourceNsxtPolicyRealizationInfo_gmServiceDataSource(t *testing.T
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
-			testAccPreCheck(t)
-			testAccEnvDefined(t, "NSXT_TEST_SITE_NAME")
 			testAccOnlyGlobalManager(t)
+			testAccEnvDefined(t, "NSXT_TEST_SITE_NAME")
+			testAccPreCheck(t)
 		},
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{

--- a/nsxt/data_source_nsxt_policy_site_test.go
+++ b/nsxt/data_source_nsxt_policy_site_test.go
@@ -16,9 +16,9 @@ func TestAccDataSourceNsxtPolicySite_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
-			testAccPreCheck(t)
 			testAccOnlyGlobalManager(t)
 			testAccEnvDefined(t, "NSXT_TEST_SITE_NAME")
+			testAccPreCheck(t)
 		},
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{

--- a/nsxt/resource_nsxt_policy_domain_test.go
+++ b/nsxt/resource_nsxt_policy_domain_test.go
@@ -21,10 +21,10 @@ func TestAccResourceNsxtPolicyDomain_basic(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccPreCheck(t)
+			testAccOnlyGlobalManager(t)
 			testAccEnvDefined(t, "NSXT_TEST_SITE_NAME")
 			testAccEnvDefined(t, "NSXT_TEST_ANOTHER_SITE_NAME")
-			testAccOnlyGlobalManager(t)
+			testAccPreCheck(t)
 		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
@@ -82,9 +82,9 @@ func TestAccResourceNsxtPolicyDomain_importBasic(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccPreCheck(t)
-			testAccEnvDefined(t, "NSXT_TEST_SITE_NAME")
 			testAccOnlyGlobalManager(t)
+			testAccEnvDefined(t, "NSXT_TEST_SITE_NAME")
+			testAccPreCheck(t)
 		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {

--- a/nsxt/resource_nsxt_policy_group_test.go
+++ b/nsxt/resource_nsxt_policy_group_test.go
@@ -90,9 +90,9 @@ func TestAccResourceNsxtGlobalPolicyGroup_singleIPAddressCriteria(t *testing.T) 
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
-			testAccPreCheck(t)
 			testAccOnlyGlobalManager(t)
 			testAccEnvDefined(t, "NSXT_TEST_SITE_NAME")
+			testAccPreCheck(t)
 		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
@@ -138,9 +138,9 @@ func TestAccResourceNsxtGlobalPolicyGroup_withDomain(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
-			testAccPreCheck(t)
 			testAccOnlyGlobalManager(t)
 			testAccEnvDefined(t, "NSXT_TEST_SITE_NAME")
+			testAccPreCheck(t)
 		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {

--- a/nsxt/resource_nsxt_policy_segment_test.go
+++ b/nsxt/resource_nsxt_policy_segment_test.go
@@ -180,7 +180,10 @@ func TestAccResourceNsxtPolicySegment_noTransportZone(t *testing.T) {
 	updatedCidr := "4004::1/64"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t); testAccOnlyGlobalManager(t) },
+		PreCheck: func() {
+			testAccOnlyGlobalManager(t)
+			testAccPreCheck(t)
+		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNsxtPolicySegmentCheckDestroy(state, name)

--- a/nsxt/resource_nsxt_policy_tier0_gateway_gm_test.go
+++ b/nsxt/resource_nsxt_policy_tier0_gateway_gm_test.go
@@ -22,10 +22,10 @@ func TestAccResourceNsxtPolicyTier0Gateway_globalManagerBasic(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccPreCheck(t)
+			testAccOnlyGlobalManager(t)
 			testAccEnvDefined(t, "NSXT_TEST_SITE_NAME")
 			testAccEnvDefined(t, "NSXT_TEST_ANOTHER_SITE_NAME")
-			testAccOnlyGlobalManager(t)
+			testAccPreCheck(t)
 		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
@@ -91,10 +91,10 @@ func TestAccResourceNsxtPolicyTier0Gateway_globalManagerNoSubnet(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccPreCheck(t)
+			testAccOnlyGlobalManager(t)
 			testAccEnvDefined(t, "NSXT_TEST_SITE_NAME")
 			testAccEnvDefined(t, "NSXT_TEST_ANOTHER_SITE_NAME")
-			testAccOnlyGlobalManager(t)
+			testAccPreCheck(t)
 		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
@@ -145,10 +145,10 @@ func TestAccResourceNsxtPolicyTier0Gateway_globalManagerRedistribution(t *testin
 	localeService2Path := "locale_service.1."
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccPreCheck(t)
+			testAccOnlyGlobalManager(t)
 			testAccEnvDefined(t, "NSXT_TEST_SITE_NAME")
 			testAccEnvDefined(t, "NSXT_TEST_ANOTHER_SITE_NAME")
-			testAccOnlyGlobalManager(t)
+			testAccPreCheck(t)
 		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {

--- a/nsxt/resource_nsxt_policy_tier0_gateway_ha_vip_config_test.go
+++ b/nsxt/resource_nsxt_policy_tier0_gateway_ha_vip_config_test.go
@@ -26,9 +26,9 @@ func TestAccResourceNsxtPolicyTier0GatewayHaVipConfig_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		// This test works with local manager but only with 2 edge nodes
 		PreCheck: func() {
-			testAccPreCheck(t)
-			testAccEnvDefined(t, "NSXT_TEST_SITE_NAME")
 			testAccOnlyGlobalManager(t)
+			testAccEnvDefined(t, "NSXT_TEST_SITE_NAME")
+			testAccPreCheck(t)
 		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
@@ -127,9 +127,9 @@ func TestAccResourceNsxtPolicyTier0GatewayHaVipConfig_importBasic(t *testing.T) 
 	resource.Test(t, resource.TestCase{
 		// This test works with local manager but only with 2 edge nodes
 		PreCheck: func() {
-			testAccPreCheck(t)
-			testAccEnvDefined(t, "NSXT_TEST_SITE_NAME")
 			testAccOnlyGlobalManager(t)
+			testAccEnvDefined(t, "NSXT_TEST_SITE_NAME")
+			testAccPreCheck(t)
 		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {

--- a/nsxt/resource_nsxt_policy_tier1_gateway_gm_test.go
+++ b/nsxt/resource_nsxt_policy_tier1_gateway_gm_test.go
@@ -17,10 +17,10 @@ func TestAccResourceNsxtPolicyTier1Gateway_globalManager(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccPreCheck(t)
 			testAccOnlyGlobalManager(t)
 			testAccEnvDefined(t, "NSXT_TEST_SITE_NAME")
 			testAccEnvDefined(t, "NSXT_TEST_ANOTHER_SITE_NAME")
+			testAccPreCheck(t)
 		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
@@ -84,10 +84,10 @@ func TestAccResourceNsxtPolicyTier1Gateway_globalManagerWithQos(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccPreCheck(t)
 			testAccOnlyGlobalManager(t)
 			testAccEnvDefined(t, "NSXT_TEST_SITE_NAME")
 			testAccEnvDefined(t, "NSXT_TEST_ANOTHER_SITE_NAME")
+			testAccPreCheck(t)
 		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
@@ -144,10 +144,10 @@ func TestAccResourceNsxtPolicyTier1Gateway_globalManagerNoSubnet(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccPreCheck(t)
 			testAccOnlyGlobalManager(t)
 			testAccEnvDefined(t, "NSXT_TEST_SITE_NAME")
 			testAccEnvDefined(t, "NSXT_TEST_ANOTHER_SITE_NAME")
+			testAccPreCheck(t)
 		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {

--- a/nsxt/resource_nsxt_policy_vlan_segment_test.go
+++ b/nsxt/resource_nsxt_policy_vlan_segment_test.go
@@ -115,7 +115,10 @@ func TestAccResourceNsxtPolicyVlanSegment_noTransportZone(t *testing.T) {
 	updatedCidr := "4004::1/64"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t); testAccOnlyGlobalManager(t) },
+		PreCheck: func() {
+			testAccOnlyGlobalManager(t)
+			testAccPreCheck(t)
+		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNsxtPolicySegmentCheckDestroy(state, name)


### PR DESCRIPTION
This will sligtly improve test running time