### PR TITLE
Fix reading redistribution config for LM

### DIFF
--- a/nsxt/resource_nsxt_policy_tier0_gateway.go
+++ b/nsxt/resource_nsxt_policy_tier0_gateway.go
@@ -935,11 +935,13 @@ func resourceNsxtPolicyTier0GatewayRead(d *schema.ResourceData, m interface{}) e
 					if err != nil {
 						return handleReadError(d, "BGP Configuration for T0", id, err)
 					}
+
+					redistributionConfigs := getLocaleServiceRedistributionConfig(&service)
+					if d.Get("redistribution_set").(bool) {
+						d.Set("redistribution_config", redistributionConfigs)
+					}
 					break
 				}
-
-				redistributionConfigs := getLocaleServiceRedistributionConfig(&service)
-				d.Set("redistribution_config", redistributionConfigs)
 			}
 		}
 

--- a/website/docs/r/policy_tier0_gateway.html.markdown
+++ b/website/docs/r/policy_tier0_gateway.html.markdown
@@ -198,3 +198,6 @@ terraform import nsxt_policy_tier0_gateway.tier0_gw ID
 ```
 
 The above command imports the policy Tier-0 gateway named `tier0_gw` with the NSX Policy ID `ID`.
+
+~> **NOTE:** Redistribution config on Tier-0 resource is deprecated and thus will not be imported. Please import this configuration with `policy_gateway_redistribution_config` resource.
+


### PR DESCRIPTION
In addition, clarify that deprecated redistribution config is not
set with import command.