### PR TITLE
For new data sources, disallow setting id and name

### DIFF
--- a/nsxt/data_source_nsxt_policy_bfd_profile.go
+++ b/nsxt/data_source_nsxt_policy_bfd_profile.go
@@ -13,7 +13,7 @@ func dataSourceNsxtPolicyBfdProfile() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"id":           getDataSourceIDSchema(),
-			"display_name": getDataSourceDisplayNameSchema(),
+			"display_name": getDataSourceExtendedDisplayNameSchema(),
 			"description":  getDataSourceDescriptionSchema(),
 			"path":         getPathSchema(),
 		},

--- a/nsxt/data_source_nsxt_policy_dhcp_server.go
+++ b/nsxt/data_source_nsxt_policy_dhcp_server.go
@@ -4,12 +4,7 @@
 package nsxt
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra"
-	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 )
 
 func dataSourceNsxtPolicyDhcpServer() *schema.Resource {
@@ -18,7 +13,7 @@ func dataSourceNsxtPolicyDhcpServer() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"id":           getDataSourceIDSchema(),
-			"display_name": getDataSourceDisplayNameSchema(),
+			"display_name": getDataSourceExtendedDisplayNameSchema(),
 			"description":  getDataSourceDescriptionSchema(),
 			"path":         getPathSchema(),
 		},
@@ -28,69 +23,10 @@ func dataSourceNsxtPolicyDhcpServer() *schema.Resource {
 func dataSourceNsxtPolicyDhcpServerRead(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
 
-	if isPolicyGlobalManager(m) {
-		_, err := policyDataSourceResourceRead(d, connector, true, "DhcpServerConfig", nil)
-		if err != nil {
-			return err
-		}
-
-		return nil
+	_, err := policyDataSourceResourceRead(d, connector, isPolicyGlobalManager(m), "DhcpServerConfig", nil)
+	if err != nil {
+		return err
 	}
-
-	objID := d.Get("id").(string)
-	objName := d.Get("display_name").(string)
-	client := infra.NewDefaultDhcpServerConfigsClient(connector)
-	var obj model.DhcpServerConfig
-	if objID != "" {
-		// Get by id
-		objGet, err := client.Get(objID)
-		if isNotFoundError(err) {
-			return fmt.Errorf("DHCP Server with ID %s was not found", objID)
-		}
-
-		if err != nil {
-			return fmt.Errorf("Error while reading DHCP Server %s: %v", objID, err)
-		}
-		obj = objGet
-	} else if objName == "" {
-		return fmt.Errorf("Error obtaining DHCP Server ID or name during read")
-	} else {
-		// Get by full name/prefix
-		includeMarkForDeleteObjectsParam := false
-		objList, err := client.List(nil, &includeMarkForDeleteObjectsParam, nil, nil, nil, nil)
-		if err != nil {
-			return fmt.Errorf("Error while reading DHCP Servers: %v", err)
-		}
-		// go over the list to find the correct one (prefer a perfect match. If not - prefix match)
-		var perfectMatch []model.DhcpServerConfig
-		var prefixMatch []model.DhcpServerConfig
-		for _, objInList := range objList.Results {
-			if strings.HasPrefix(*objInList.DisplayName, objName) {
-				prefixMatch = append(prefixMatch, objInList)
-			}
-			if *objInList.DisplayName == objName {
-				perfectMatch = append(perfectMatch, objInList)
-			}
-		}
-		if len(perfectMatch) > 0 {
-			if len(perfectMatch) > 1 {
-				return fmt.Errorf("Found multiple DHCP Servers with name '%s'", objName)
-			}
-			obj = perfectMatch[0]
-		} else if len(prefixMatch) > 0 {
-			if len(prefixMatch) > 1 {
-				return fmt.Errorf("Found multiple DHCP Servers with name starting with '%s'", objName)
-			}
-			obj = prefixMatch[0]
-		} else {
-			return fmt.Errorf("DHCP Server with name '%s' was not found", objName)
-		}
-	}
-
-	d.SetId(*obj.Id)
-	d.Set("display_name", obj.DisplayName)
-	d.Set("description", obj.Description)
-	d.Set("path", obj.Path)
 
 	return nil
 }

--- a/nsxt/data_source_nsxt_policy_intrusion_service_profile.go
+++ b/nsxt/data_source_nsxt_policy_intrusion_service_profile.go
@@ -13,7 +13,7 @@ func dataSourceNsxtPolicyIntrusionServiceProfile() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"id":           getDataSourceIDSchema(),
-			"display_name": getDataSourceDisplayNameSchema(),
+			"display_name": getDataSourceExtendedDisplayNameSchema(),
 			"description":  getDataSourceDescriptionSchema(),
 			"path":         getPathSchema(),
 		},

--- a/nsxt/policy_common.go
+++ b/nsxt/policy_common.go
@@ -456,6 +456,16 @@ func getDataSourceDisplayNameSchema() *schema.Schema {
 	return getDataSourceStringSchema("Display name of this resource")
 }
 
+func getDataSourceExtendedDisplayNameSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:          schema.TypeString,
+		Description:   "Display name of this resource",
+		ConflictsWith: []string{"id"},
+		Optional:      true,
+		Computed:      true,
+	}
+}
+
 func getDataSourceDescriptionSchema() *schema.Schema {
 	return getDataSourceStringSchema("Description for this resource")
 }


### PR DESCRIPTION
In standard policy data source, when ID is specified, no further
input is needed. To avoid confision, procider will error out if both
id and display_name are specified. This change is for new data sources
only in order not to break backwards compatibility.