### PR TITLE
Fix policy data source search to support name + id

### DIFF
--- a/nsxt/policy_search.go
+++ b/nsxt/policy_search.go
@@ -35,16 +35,20 @@ func policyDataSourceResourceFilterAndSet(d *schema.ResourceData, resultValues [
 			return nil, errors[0]
 		}
 		policyResource := dataValue.(model.PolicyResource)
-
-		if objID != "" && resourceType == *policyResource.ResourceType {
-			perfectMatch = append(perfectMatch, policySearchDataValue{StructValue: result, Resource: policyResource})
+		if resourceType != *policyResource.ResourceType {
 			continue
 		}
-		if *policyResource.DisplayName == objName {
+
+		if objID != "" {
 			perfectMatch = append(perfectMatch, policySearchDataValue{StructValue: result, Resource: policyResource})
-		}
-		if strings.HasPrefix(*policyResource.DisplayName, objName) {
-			prefixMatch = append(prefixMatch, policySearchDataValue{StructValue: result, Resource: policyResource})
+			break
+		} else {
+			if *policyResource.DisplayName == objName {
+				perfectMatch = append(perfectMatch, policySearchDataValue{StructValue: result, Resource: policyResource})
+			}
+			if strings.HasPrefix(*policyResource.DisplayName, objName) {
+				prefixMatch = append(prefixMatch, policySearchDataValue{StructValue: result, Resource: policyResource})
+			}
 		}
 	}
 

--- a/nsxt/resource_nsxt_policy_gateway_dns_forwarder_test.go
+++ b/nsxt/resource_nsxt_policy_gateway_dns_forwarder_test.go
@@ -44,7 +44,7 @@ func TestAccResourceNsxtPolicyGatewayDNSForwarder_tier1(t *testing.T) {
 
 func testAccResourceNsxtPolicyGatewayDNSForwarder(t *testing.T, isT0 bool) {
 	resourceName := testAccResourcePolicyGatewayDNSForwarderName
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t); testAccNSXVersion(t, "3.0.0") },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
@@ -98,7 +98,7 @@ func TestAccResourceNsxtPolicyGatewayDNSForwarder_importTier1(t *testing.T) {
 }
 
 func testAccResourceNsxtPolicyGatewayDNSForwarderImport(t *testing.T, isT0 bool) {
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {


### PR DESCRIPTION
When id is specified together with display_name in data source, it
should still return the object as expected.
With newer data sources, configuration of id with display_name is
rejected. This fix applies to older data sources.