### PR TITLE
TZ should not be required for fixed segments

### DIFF
--- a/nsxt/resource_nsxt_policy_fixed_segment_test.go
+++ b/nsxt/resource_nsxt_policy_fixed_segment_test.go
@@ -320,7 +320,6 @@ resource "nsxt_policy_fixed_segment" "test" {
   display_name        = "%s"
   description         = "Acceptance Test"
   connectivity_path   = nsxt_policy_tier1_gateway.tier1ForSegments.path
-  transport_zone_path = data.nsxt_policy_transport_zone.test.path
 
   subnet {
      cidr = "12.12.2.1/24"
@@ -337,7 +336,6 @@ resource "nsxt_policy_fixed_segment" "test" {
   description         = "Acceptance Test"
   domain_name         = "tftest.org"
   overlay_id          = 1011
-  transport_zone_path = data.nsxt_policy_transport_zone.test.path
   connectivity_path   = nsxt_policy_tier1_gateway.tier1ForSegments.path
 
   subnet {
@@ -360,7 +358,6 @@ resource "nsxt_policy_fixed_segment" "test" {
   description         = "Acceptance Test2"
   domain_name         = "tftest2.org"
   overlay_id          = 1011
-  transport_zone_path = data.nsxt_policy_transport_zone.test.path
   connectivity_path   = nsxt_policy_tier1_gateway.tier1ForSegments.path
 
   subnet {
@@ -387,7 +384,6 @@ resource "nsxt_policy_fixed_segment" "test" {
   description         = "Acceptance Test2"
   domain_name         = "tftest2.org"
   overlay_id          = 1011
-  transport_zone_path = data.nsxt_policy_transport_zone.test.path
   connectivity_path   = nsxt_policy_tier1_gateway.anotherTier1ForSegments.path
 
   subnet {
@@ -417,7 +413,6 @@ resource "nsxt_policy_fixed_segment" "test" {
   vlan_ids     = ["101", "102"]
 
   connectivity_path   = nsxt_policy_tier1_gateway.anotherTier1ForSegments.path
-  transport_zone_path = data.nsxt_policy_transport_zone.test.path
 
   subnet {
      cidr = "12.12.2.1/24"
@@ -447,7 +442,6 @@ resource "nsxt_policy_fixed_segment" "test" {
   vlan_ids     = ["101-104"]
 
   connectivity_path   = nsxt_policy_tier1_gateway.anotherTier1ForSegments.path
-  transport_zone_path = data.nsxt_policy_transport_zone.test.path
 
   subnet {
      cidr = "12.12.2.1/24"

--- a/nsxt/segment_common.go
+++ b/nsxt/segment_common.go
@@ -270,6 +270,7 @@ func getPolicyCommonSegmentSchema(vlanRequired bool, isFixed bool) map[string]*s
 			Type:         schema.TypeString,
 			Description:  "Policy path to the transport zone",
 			Optional:     true,
+			ForceNew:     true,
 			ValidateFunc: validatePolicyPath(),
 		},
 		"vlan_ids": {
@@ -643,8 +644,8 @@ func policySegmentResourceToInfraStruct(id string, d *schema.ResourceData, isVla
 	revision := int64(d.Get("revision").(int))
 	resourceType := "Segment"
 
-	if (tzPath == "") && !isGlobalManager {
-		return model.Infra{}, fmt.Errorf("transport_zone_path needs to be specified for segment on local manager")
+	if (tzPath == "") && !isGlobalManager && !isFixed {
+		return model.Infra{}, fmt.Errorf("transport_zone_path needs to be specified for infra segment on local manager")
 	}
 
 	obj := model.Segment{


### PR DESCRIPTION
In fact, requiring TZ is causing issues with fixed segment import.
In addition, mark TZ as ForceNew in all segments, since updating is
not allowed on the platform.