### PR TITLE
Add Documentation for enable_pim in Tier0 GW Interface

### DIFF
--- a/nsxt/resource_nsxt_policy_tier0_gateway_interface.go
+++ b/nsxt/resource_nsxt_policy_tier0_gateway_interface.go
@@ -63,7 +63,7 @@ func resourceNsxtPolicyTier0GatewayInterface() *schema.Resource {
 			"edge_node_path": getPolicyPathSchema(false, false, "Policy path for edge node"),
 			"enable_pim": {
 				Type:        schema.TypeBool,
-				Description: "Enable Protocol Independent Multicast on Interface",
+				Description: "Enable Protocol Independent Multicast on Interface, applicable only when interface type is EXTERNAL",
 				Optional:    true,
 				Default:     false,
 			},

--- a/website/docs/r/policy_tier0_gateway_interface.html.markdown
+++ b/website/docs/r/policy_tier0_gateway_interface.html.markdown
@@ -73,7 +73,7 @@ The following arguments are supported:
 * `edge_node_path` - (Optional) Path of edge node for this interface, relevant for interfaces of type `EXTERNAL`.
 * `mtu` - (Optional) Maximum Transmission Unit for this interface.
 * `ipv6_ndra_profile_path` - (Optional) IPv6 NDRA profile to be associated with this interface.
-* `enable_pim` - (Optional) Flag to enable Protocol Independent Multicast, relevant only for interfaces of type `EXTERNAL`. This attribute is supported with NSX 3.0.0 onwards, and only for local managers.
+* `enable_pim` - (Optional) Flag to enable Protocol Independent Multicast, relevant only for interfaces of type `EXTERNAL`. This attribute will always be `false` for other interface types. This attribute is supported with NSX 3.0.0 onwards, and only for local managers.
 * `access_vlan_id`- (Optional) Access VLAN ID, relevant only for VRF interfaces. This attribute is supported with NSX 3.0.0 onwards.
 * `urpf_mode` - (Optional) Unicast Reverse Path Forwarding mode, one of `NONE`, `STRICT`. Default is `STRICT`. This attribute is supported with NSX 3.0.0 onwards.
 * `site_path` - (Required for global manager only) Path of the site the Tier0 edge cluster belongs to. This configuration is required for global manager only. `path` field of the existing `nsxt_policy_site` can be used here.


### PR DESCRIPTION
Enable_pim is not applicable for types other than "EXTERNAL", hence
adding more documentation for that.