### PR TITLE
Fix realization issue in gateway route map

### DIFF
--- a/nsxt/policy_common.go
+++ b/nsxt/policy_common.go
@@ -559,9 +559,7 @@ func buildQueryStringFromMap(query map[string]string) string {
 	}
 	keyValues := make([]string, 0, len(query))
 	for key, value := range query {
-		if strings.Contains(value, "/") {
-			value = strings.Replace(value, "/", "\\/", -1)
-		}
+		value = strings.Replace(value, "/", "\\/", -1)
 		keyValue := strings.Join([]string{key, value}, ":")
 		keyValues = append(keyValues, keyValue)
 	}

--- a/nsxt/resource_nsxt_policy_gateway_route_map.go
+++ b/nsxt/resource_nsxt_policy_gateway_route_map.go
@@ -198,14 +198,18 @@ func policyGatewayRouteMapBuildEntry(schemaEntry map[string]interface{}) model.R
 		weight := int64(data["weight"].(int))
 
 		entrySet := model.RouteMapEntrySet{
-			AsPathPrepend:         &asPathPrepend,
-			Community:             &community,
 			LocalPreference:       &localPreference,
 			Med:                   &med,
 			PreferGlobalV6NextHop: &globalIPv6,
 			Weight:                &weight,
 		}
 
+		if len(asPathPrepend) > 0 {
+			entrySet.AsPathPrepend = &asPathPrepend
+		}
+		if len(community) > 0 {
+			entrySet.Community = &community
+		}
 		obj.Set = &entrySet
 	}
 

--- a/website/docs/r/policy_gateway_route_map.html.markdown
+++ b/website/docs/r/policy_gateway_route_map.html.markdown
@@ -23,12 +23,12 @@ resource "nsxt_policy_gateway_route_map" "test" {
     action = "PERMIT"
     community_list_match {
       criteria       = "11:*"
-      match_operator = "MATCH_COMMUNITY_REGEX"
+      match_operator = "COMMUNITY_REGEX"
     }
 
     community_list_match {
       criteria       = "11:*"
-      match_operator = "MATCH_LARGE_COMMUNITY_REGEX"
+      match_operator = "LARGE_COMMUNITY_REGEX"
     }
   }
 


### PR DESCRIPTION
Certain empty fields are accepted by policy API by fail on
realization. Set these only if specified.
In addition, fix documentation and linter suggestion.