### PR TITLE
Fix default locale service

### DIFF
--- a/nsxt/resource_nsxt_policy_gateway_redistribution_config.go
+++ b/nsxt/resource_nsxt_policy_gateway_redistribution_config.go
@@ -174,7 +174,7 @@ func resourceNsxtPolicyGatewayRedistributionConfigRead(d *schema.ResourceData, m
 	} else {
 		var err error
 		client := tier_0s.NewDefaultLocaleServicesClient(connector)
-		obj, err = client.Get(gwID, defaultPolicyLocaleServiceID)
+		obj, err = client.Get(gwID, localeServiceID)
 		if err != nil {
 			return handleReadError(d, "Tier0 Redistribution Config", id, err)
 		}

--- a/nsxt/resource_nsxt_policy_tier0_gateway_ha_vip_config.go
+++ b/nsxt/resource_nsxt_policy_tier0_gateway_ha_vip_config.go
@@ -200,7 +200,7 @@ func resourceNsxtPolicyTier0GatewayHAVipConfigRead(d *schema.ResourceData, m int
 	} else {
 		var err error
 		client := tier_0s.NewDefaultLocaleServicesClient(connector)
-		obj, err = client.Get(tier0ID, defaultPolicyLocaleServiceID)
+		obj, err = client.Get(tier0ID, localeServiceID)
 		if err != nil {
 			return handleReadError(d, "Tier0 HA Vip config", id, err)
 		}

--- a/nsxt/resource_nsxt_policy_tier0_gateway_interface.go
+++ b/nsxt/resource_nsxt_policy_tier0_gateway_interface.go
@@ -390,7 +390,7 @@ func resourceNsxtPolicyTier0GatewayInterfaceRead(d *schema.ResourceData, m inter
 		d.Set("site_path", sitePath)
 	} else {
 		client := locale_services.NewDefaultInterfacesClient(connector)
-		obj, err = client.Get(tier0ID, defaultPolicyLocaleServiceID, id)
+		obj, err = client.Get(tier0ID, localeServiceID, id)
 	}
 	if err != nil {
 		return handleReadError(d, "Tier0 Interface", id, err)

--- a/nsxt/resource_nsxt_policy_tier1_gateway_interface.go
+++ b/nsxt/resource_nsxt_policy_tier1_gateway_interface.go
@@ -218,7 +218,7 @@ func resourceNsxtPolicyTier1GatewayInterfaceRead(d *schema.ResourceData, m inter
 	} else {
 		var err error
 		client := locale_services.NewDefaultInterfacesClient(connector)
-		obj, err = client.Get(tier1ID, defaultPolicyLocaleServiceID, id)
+		obj, err = client.Get(tier1ID, localeServiceID, id)
 		if err != nil {
 			return handleReadError(d, "Tier1 Interface", id, err)
 		}


### PR DESCRIPTION
 In some resources for Local Manager, default locale service id was
    coded rather than actual locale service. This resulted in read errors
    for environments with pre-created non-default locale service, especially
    with imported resources.