### PR TITLE
Improve search performance in policy data sources

### DIFF
--- a/nsxt/data_source_nsxt_policy_service_test.go
+++ b/nsxt/data_source_nsxt_policy_service_test.go
@@ -71,6 +71,26 @@ func TestAccDataSourceNsxtPolicyService_byPrefix(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceNsxtPolicyService_spaces(t *testing.T) {
+	serviceName := "Enterprise Manager Servlet port SSL"
+	testResourceName := "data.nsxt_policy_service.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyServiceReadTemplate(serviceName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(testResourceName, "display_name", serviceName),
+					resource.TestCheckResourceAttr(testResourceName, "description", serviceName),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+				),
+			},
+		},
+	})
+}
+
 func testAccNsxtPolicyServiceReadTemplate(name string) string {
 	return fmt.Sprintf(`
 data "nsxt_policy_service" "test" {

--- a/nsxt/policy_search.go
+++ b/nsxt/policy_search.go
@@ -96,7 +96,7 @@ func policyDataSourceResourceReadWithValidation(d *schema.ResourceData, connecto
 	if objID != "" {
 		resultValues, err = listPolicyResourcesByID(connector, isGlobalManager, &objID, &additionalQueryString)
 	} else {
-		resultValues, err = listPolicyResourcesByType(connector, isGlobalManager, &resourceType, &additionalQueryString)
+		resultValues, err = listPolicyResourcesByNameAndType(connector, isGlobalManager, objName, resourceType, &additionalQueryString)
 	}
 	if err != nil {
 		return nil, err
@@ -105,8 +105,8 @@ func policyDataSourceResourceReadWithValidation(d *schema.ResourceData, connecto
 	return policyDataSourceResourceFilterAndSet(d, resultValues, resourceType)
 }
 
-func listPolicyResourcesByType(connector *client.RestConnector, isGlobalManager bool, resourceType *string, additionalQuery *string) ([]*data.StructValue, error) {
-	query := fmt.Sprintf("resource_type:%s AND marked_for_delete:false", *resourceType)
+func listPolicyResourcesByNameAndType(connector *client.RestConnector, isGlobalManager bool, displayName string, resourceType string, additionalQuery *string) ([]*data.StructValue, error) {
+	query := fmt.Sprintf("resource_type:%s AND display_name:%s* AND marked_for_delete:false", resourceType, displayName)
 	if isGlobalManager {
 		return searchGMPolicyResources(connector, *buildPolicyResourcesQuery(&query, additionalQuery))
 	}

--- a/nsxt/utils_test.go
+++ b/nsxt/utils_test.go
@@ -364,7 +364,7 @@ func testGetObjIDByName(objName string, resourceType string) (string, error) {
 		return "", fmt.Errorf("Error during test client initialization: %v", err1)
 	}
 
-	resultValues, err2 := listPolicyResourcesByType(connector, testAccIsGlobalManager(), &resourceType, nil)
+	resultValues, err2 := listPolicyResourcesByNameAndType(connector, testAccIsGlobalManager(), objName, resourceType, nil)
 	if err2 != nil {
 		return "", err2
 	}


### PR DESCRIPTION
Boost performance by adding display name to search string.
This change is in preparation of converting all policy data sources
to use search API.

Signed-off-by: Anna Khmelnitsky <akhmelnitsky@vmware.com>