### PR TITLE
Add nsxt_policy_lb_service data source as per issue #618

### DIFF
--- a/nsxt/data_source_nsxt_policy_lb_service.go
+++ b/nsxt/data_source_nsxt_policy_lb_service.go
@@ -1,0 +1,87 @@
+/* Copyright © 2019 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: MPL-2.0 */
+
+package nsxt
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/bindings"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+)
+
+func dataSourceNsxtPolicyLbService() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceNsxtPolicyLbServiceRead,
+
+		Schema: map[string]*schema.Schema{
+			"id":           getDataSourceIDSchema(),
+			"display_name": getDataSourceDisplayNameSchema(),
+			"description":  getDataSourceDescriptionSchema(),
+			"path":         getPathSchema(),
+		},
+	}
+}
+
+func dataSourceNsxtPolicyLbServiceRead(d *schema.ResourceData, m interface{}) error {
+	connector := getPolicyConnector(m)
+	client := infra.NewDefaultLbServicesClient(connector)
+	converter := bindings.NewTypeConverter()
+	converter.SetMode(bindings.REST)
+
+	objID := d.Get("id").(string)
+	objName := d.Get("display_name").(string)
+
+	var obj model.LBService
+	if objID != "" {
+		// Get by id
+		objGet, err := client.Get(objID)
+
+		if err != nil {
+			return handleDataSourceReadError(d, "LbService", objID, err)
+		}
+		obj = objGet
+	} else if objName == "" {
+		return fmt.Errorf("Error obtaining LbService name or type during read")
+	} else {
+		// Get by full name/prefix
+		includeMarkForDeleteObjectsParam := false
+		objList, err := client.List(nil, &includeMarkForDeleteObjectsParam, nil, nil, nil, nil)
+		if err != nil {
+			return handleListError("LbService", err)
+		}
+		// go over the list to find the correct one (prefer a perfect match. If not - prefix match)
+		var perfectMatch []model.LBService
+		var prefixMatch []model.LBService
+		for _, objInList := range objList.Results {
+			if strings.HasPrefix(*objInList.DisplayName, objName) {
+				prefixMatch = append(prefixMatch, objInList)
+			}
+			if *objInList.DisplayName == objName {
+				perfectMatch = append(perfectMatch, objInList)
+			}
+		}
+		if len(perfectMatch) > 0 {
+			if len(perfectMatch) > 1 {
+				return fmt.Errorf("Found multiple PolicyLbServices with name '%s'", objName)
+			}
+			obj = perfectMatch[0]
+		} else if len(prefixMatch) > 0 {
+			if len(prefixMatch) > 1 {
+				return fmt.Errorf("Found multiple PolicyLbServices with name starting with '%s'", objName)
+			}
+			obj = prefixMatch[0]
+		} else {
+			return fmt.Errorf("PolicyLbService with name '%s' was not found", objName)
+		}
+	}
+
+	d.SetId(*obj.Id)
+	d.Set("display_name", obj.DisplayName)
+	d.Set("description", obj.Description)
+	d.Set("path", obj.Path)
+	return nil
+}

--- a/nsxt/data_source_nsxt_policy_lb_service.go
+++ b/nsxt/data_source_nsxt_policy_lb_service.go
@@ -1,16 +1,10 @@
-/* Copyright © 2019 VMware, Inc. All Rights Reserved.
+/* Copyright © 2020 VMware, Inc. All Rights Reserved.
    SPDX-License-Identifier: MPL-2.0 */
 
 package nsxt
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/vmware/vsphere-automation-sdk-go/runtime/bindings"
-	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra"
-	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 )
 
 func dataSourceNsxtPolicyLbService() *schema.Resource {
@@ -19,7 +13,7 @@ func dataSourceNsxtPolicyLbService() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"id":           getDataSourceIDSchema(),
-			"display_name": getDataSourceDisplayNameSchema(),
+			"display_name": getDataSourceExtendedDisplayNameSchema(),
 			"description":  getDataSourceDescriptionSchema(),
 			"path":         getPathSchema(),
 		},
@@ -28,60 +22,11 @@ func dataSourceNsxtPolicyLbService() *schema.Resource {
 
 func dataSourceNsxtPolicyLbServiceRead(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
-	client := infra.NewDefaultLbServicesClient(connector)
-	converter := bindings.NewTypeConverter()
-	converter.SetMode(bindings.REST)
 
-	objID := d.Get("id").(string)
-	objName := d.Get("display_name").(string)
-
-	var obj model.LBService
-	if objID != "" {
-		// Get by id
-		objGet, err := client.Get(objID)
-
-		if err != nil {
-			return handleDataSourceReadError(d, "LbService", objID, err)
-		}
-		obj = objGet
-	} else if objName == "" {
-		return fmt.Errorf("Error obtaining LbService name or type during read")
-	} else {
-		// Get by full name/prefix
-		includeMarkForDeleteObjectsParam := false
-		objList, err := client.List(nil, &includeMarkForDeleteObjectsParam, nil, nil, nil, nil)
-		if err != nil {
-			return handleListError("LbService", err)
-		}
-		// go over the list to find the correct one (prefer a perfect match. If not - prefix match)
-		var perfectMatch []model.LBService
-		var prefixMatch []model.LBService
-		for _, objInList := range objList.Results {
-			if strings.HasPrefix(*objInList.DisplayName, objName) {
-				prefixMatch = append(prefixMatch, objInList)
-			}
-			if *objInList.DisplayName == objName {
-				perfectMatch = append(perfectMatch, objInList)
-			}
-		}
-		if len(perfectMatch) > 0 {
-			if len(perfectMatch) > 1 {
-				return fmt.Errorf("Found multiple PolicyLbServices with name '%s'", objName)
-			}
-			obj = perfectMatch[0]
-		} else if len(prefixMatch) > 0 {
-			if len(prefixMatch) > 1 {
-				return fmt.Errorf("Found multiple PolicyLbServices with name starting with '%s'", objName)
-			}
-			obj = prefixMatch[0]
-		} else {
-			return fmt.Errorf("PolicyLbService with name '%s' was not found", objName)
-		}
+	_, err := policyDataSourceResourceRead(d, connector, isPolicyGlobalManager(m), "LBService", nil)
+	if err != nil {
+		return err
 	}
 
-	d.SetId(*obj.Id)
-	d.Set("display_name", obj.DisplayName)
-	d.Set("description", obj.Description)
-	d.Set("path", obj.Path)
 	return nil
 }

--- a/nsxt/data_source_nsxt_policy_lb_service_test.go
+++ b/nsxt/data_source_nsxt_policy_lb_service_test.go
@@ -1,0 +1,41 @@
+/* Copyright © 2019 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: MPL-2.0 */
+
+package nsxt
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccDataSourceNsxtPolicyLBService(t *testing.T) {
+	name := getTestLBServiceName()
+	testResourceName := "data.nsxt_policy_lb_service.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccEnvDefined(t, "NSXT_TEST_LB_SERVICE_NAME")
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyLBServiceReadTemplate(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(testResourceName, "display_name", name),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+				),
+			},
+		},
+	})
+}
+
+func testAccNsxtPolicyLBServiceReadTemplate(name string) string {
+	return fmt.Sprintf(`
+data "nsxt_policy_lb_service" "test" {
+  display_name = "%s"
+}`, name)
+
+}

--- a/nsxt/provider.go
+++ b/nsxt/provider.go
@@ -245,6 +245,7 @@ func Provider() *schema.Provider {
 			"nsxt_policy_dhcp_server":               dataSourceNsxtPolicyDhcpServer(),
 			"nsxt_policy_bfd_profile":               dataSourceNsxtPolicyBfdProfile(),
 			"nsxt_policy_intrusion_service_profile": dataSourceNsxtPolicyIntrusionServiceProfile(),
+			"nsxt_policy_lb_service":                dataSourceNsxtPolicyLbService(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{

--- a/nsxt/utils_test.go
+++ b/nsxt/utils_test.go
@@ -141,6 +141,10 @@ func getTestCertificateName(isClient bool) string {
 	return os.Getenv("NSXT_TEST_CERTIFICATE_NAME")
 }
 
+func getTestLBServiceName() string {
+	return os.Getenv("NSXT_TEST_LB_SERVICE_NAME")
+}
+
 func testAccEnvDefined(t *testing.T, envVar string) {
 	if len(os.Getenv(envVar)) == 0 {
 		t.Skipf("This test requires %s environment variable to be set", envVar)

--- a/website/docs/d/policy_lb_service.html.markdown
+++ b/website/docs/d/policy_lb_service.html.markdown
@@ -1,0 +1,34 @@
+---
+subcategory: "Policy - Load Balancer"
+layout: "nsxt"
+page_title: "NSXT: policy_lb_service"
+description: Policy Load Balancer Service data source.
+---
+
+# nsxt_policy_lb_service
+
+This data source provides information about Policy Service for Load Balancer configured on NSX.
+
+This data source is applicable to NSX Policy Manager.
+
+## Example Usage
+
+```hcl
+data "nsxt_policy_lb_service" "test" {
+  display_name = "myservice"
+}
+```
+
+## Argument Reference
+
+* `id` - (Optional) The ID of Service to retrieve.
+
+* `display_name` - (Optional) The Display Name prefix of the Service to retrieve.
+
+## Attributes Reference
+
+In addition to arguments listed above, the following attributes are exported:
+
+* `description` - The description of the resource.
+
+* `path` - The NSX path of the policy resource.

--- a/website/docs/d/policy_lb_service.html.markdown
+++ b/website/docs/d/policy_lb_service.html.markdown
@@ -9,7 +9,7 @@ description: Policy Load Balancer Service data source.
 
 This data source provides information about Policy Service for Load Balancer configured on NSX.
 
-This data source is applicable to NSX Policy Manager.
+This data source is applicable to NSX Global Manager, NSX Policy Manager and VMC (NSX version 3.0.0 onwards).
 
 ## Example Usage
 


### PR DESCRIPTION
This is my attempt to work on #618 which is marked as "good first issue". 

I've created the new data source which is pretty straight forward for this resource and added the appropriate basic tests as well. 

I ran the acceptance tests in the lab and they look fine (see below). I also used the development provider to run some actual terraform plan/apply's using the new resource and everything looks good so far. 

```
martin@ubuntu20:~/devel/terraform-provider-nsxt$ make testacc TESTARGS="-run=TestAccDataSourceNsxtPolicyLBService"
==> Checking that code complies with gofmt requirements...
GO111MODULE=on TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccDataSourceNsxtPolicyLBService -timeout 360m
?   	github.com/vmware/terraform-provider-nsxt	[no test files]
=== RUN   TestAccDataSourceNsxtPolicyLBService
=== PAUSE TestAccDataSourceNsxtPolicyLBService
=== CONT  TestAccDataSourceNsxtPolicyLBService
--- PASS: TestAccDataSourceNsxtPolicyLBService (11.09s)
PASS
ok  	github.com/vmware/terraform-provider-nsxt/nsxt	11.137s
martin@ubuntu20:~/devel/terraform-provider-nsxt$ 
```

Signed-off-by: Martin Rohrbach <martin.rohrbach@dell.com>