### PR TITLE
Adjust the provider for NSX 3.2 release

### DIFF
--- a/nsxt/resource_nsxt_policy_gateway_prefix_list.go
+++ b/nsxt/resource_nsxt_policy_gateway_prefix_list.go
@@ -90,7 +90,7 @@ func setPrefixesInSchema(d *schema.ResourceData, prefixes []model.PrefixEntry) {
 		elem["action"] = *prefix.Action
 		elem["ge"] = prefix.Ge
 		elem["le"] = prefix.Le
-		if *prefix.Network == "ANY" {
+		if *prefix.Network == "ANY" || *prefix.Network == "any" {
 			elem["network"] = ""
 		} else {
 			elem["network"] = prefix.Network

--- a/nsxt/segment_common.go
+++ b/nsxt/segment_common.go
@@ -1320,7 +1320,10 @@ func nsxtPolicySegmentRead(d *schema.ResourceData, m interface{}, isVlan bool, i
 		// This is a list with 1 element
 		var advConfigList []map[string]interface{}
 		advConfigList = append(advConfigList, advConfig)
-		d.Set("advanced_config", advConfigList)
+		userConfig := d.Get("advanced_config").([]interface{})
+		if len(userConfig) > 0 {
+			d.Set("advanced_config", advConfigList)
+		}
 	}
 
 	if obj.L2Extension != nil {


### PR DESCRIPTION
Some breaking changes were introduced in new release, including:
* always populating advanced config in segments
* changing default to lowercase in gateway route map

In order to avoid non-empty diff, segment resource would now rely
on terraform config in order to determine whether advanced settings
should be brought into state.

Signed-off-by: Anna Khmelnitsky <akhmelnitsky@vmware.com>