### PR TITLE
Add rules to LB policy virtual server.

### DIFF
--- a/nsxt/resource_nsxt_policy_lb_virtual_server.go
+++ b/nsxt/resource_nsxt_policy_lb_virtual_server.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/bindings"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/data"
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
@@ -28,6 +30,107 @@ var lbServerSSLModeValues = []string{
 var lbAccessListControlActionValues = []string{
 	model.LBAccessListControl_ACTION_ALLOW,
 	model.LBAccessListControl_ACTION_DROP,
+}
+
+var lbRuleMatchStrategyValues = []string{
+	model.LBRule_MATCH_STRATEGY_ALL,
+	model.LBRule_MATCH_STRATEGY_ANY,
+}
+
+var lbRulePhaseValues = []string{
+	model.LBRule_PHASE_HTTP_REQUEST_REWRITE,
+	model.LBRule_PHASE_HTTP_FORWARDING,
+	model.LBRule_PHASE_HTTP_RESPONSE_REWRITE,
+	model.LBRule_PHASE_HTTP_ACCESS,
+	model.LBRule_PHASE_TRANSPORT,
+}
+
+var lbHttpSslConditionUsedSslCipherValues = []string{
+	model.LBHttpSslCondition_USED_SSL_CIPHER_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+	model.LBHttpSslCondition_USED_SSL_CIPHER_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+	model.LBHttpSslCondition_USED_SSL_CIPHER_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+	model.LBHttpSslCondition_USED_SSL_CIPHER_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+	model.LBHttpSslCondition_USED_SSL_CIPHER_ECDH_ECDSA_WITH_AES_256_CBC_SHA,
+	model.LBHttpSslCondition_USED_SSL_CIPHER_ECDH_RSA_WITH_AES_256_CBC_SHA,
+	model.LBHttpSslCondition_USED_SSL_CIPHER_RSA_WITH_AES_256_CBC_SHA,
+	model.LBHttpSslCondition_USED_SSL_CIPHER_RSA_WITH_AES_128_CBC_SHA,
+	model.LBHttpSslCondition_USED_SSL_CIPHER_RSA_WITH_3DES_EDE_CBC_SHA,
+	model.LBHttpSslCondition_USED_SSL_CIPHER_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+	model.LBHttpSslCondition_USED_SSL_CIPHER_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
+	model.LBHttpSslCondition_USED_SSL_CIPHER_ECDHE_RSA_WITH_AES_256_CBC_SHA384,
+	model.LBHttpSslCondition_USED_SSL_CIPHER_RSA_WITH_AES_128_CBC_SHA256,
+	model.LBHttpSslCondition_USED_SSL_CIPHER_RSA_WITH_AES_128_GCM_SHA256,
+	model.LBHttpSslCondition_USED_SSL_CIPHER_RSA_WITH_AES_256_CBC_SHA256,
+	model.LBHttpSslCondition_USED_SSL_CIPHER_RSA_WITH_AES_256_GCM_SHA384,
+	model.LBHttpSslCondition_USED_SSL_CIPHER_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+	model.LBHttpSslCondition_USED_SSL_CIPHER_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,
+	model.LBHttpSslCondition_USED_SSL_CIPHER_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+	model.LBHttpSslCondition_USED_SSL_CIPHER_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384,
+	model.LBHttpSslCondition_USED_SSL_CIPHER_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+	model.LBHttpSslCondition_USED_SSL_CIPHER_ECDH_ECDSA_WITH_AES_128_CBC_SHA,
+	model.LBHttpSslCondition_USED_SSL_CIPHER_ECDH_ECDSA_WITH_AES_128_CBC_SHA256,
+	model.LBHttpSslCondition_USED_SSL_CIPHER_ECDH_ECDSA_WITH_AES_128_GCM_SHA256,
+	model.LBHttpSslCondition_USED_SSL_CIPHER_ECDH_ECDSA_WITH_AES_256_CBC_SHA384,
+	model.LBHttpSslCondition_USED_SSL_CIPHER_ECDH_ECDSA_WITH_AES_256_GCM_SHA384,
+	model.LBHttpSslCondition_USED_SSL_CIPHER_ECDH_RSA_WITH_AES_128_CBC_SHA,
+	model.LBHttpSslCondition_USED_SSL_CIPHER_ECDH_RSA_WITH_AES_128_CBC_SHA256,
+	model.LBHttpSslCondition_USED_SSL_CIPHER_ECDH_RSA_WITH_AES_128_GCM_SHA256,
+	model.LBHttpSslCondition_USED_SSL_CIPHER_ECDH_RSA_WITH_AES_256_CBC_SHA384,
+	model.LBHttpSslCondition_USED_SSL_CIPHER_ECDH_RSA_WITH_AES_256_GCM_SHA384,
+}
+
+var lbHttpSslConditionClientSupportedSslCiphersValues = []string{
+	model.LBHttpSslCondition_CLIENT_SUPPORTED_SSL_CIPHERS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+	model.LBHttpSslCondition_CLIENT_SUPPORTED_SSL_CIPHERS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+	model.LBHttpSslCondition_CLIENT_SUPPORTED_SSL_CIPHERS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+	model.LBHttpSslCondition_CLIENT_SUPPORTED_SSL_CIPHERS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+	model.LBHttpSslCondition_CLIENT_SUPPORTED_SSL_CIPHERS_ECDH_ECDSA_WITH_AES_256_CBC_SHA,
+	model.LBHttpSslCondition_CLIENT_SUPPORTED_SSL_CIPHERS_ECDH_RSA_WITH_AES_256_CBC_SHA,
+	model.LBHttpSslCondition_CLIENT_SUPPORTED_SSL_CIPHERS_RSA_WITH_AES_256_CBC_SHA,
+	model.LBHttpSslCondition_CLIENT_SUPPORTED_SSL_CIPHERS_RSA_WITH_AES_128_CBC_SHA,
+	model.LBHttpSslCondition_CLIENT_SUPPORTED_SSL_CIPHERS_RSA_WITH_3DES_EDE_CBC_SHA,
+	model.LBHttpSslCondition_CLIENT_SUPPORTED_SSL_CIPHERS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+	model.LBHttpSslCondition_CLIENT_SUPPORTED_SSL_CIPHERS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
+	model.LBHttpSslCondition_CLIENT_SUPPORTED_SSL_CIPHERS_ECDHE_RSA_WITH_AES_256_CBC_SHA384,
+	model.LBHttpSslCondition_CLIENT_SUPPORTED_SSL_CIPHERS_RSA_WITH_AES_128_CBC_SHA256,
+	model.LBHttpSslCondition_CLIENT_SUPPORTED_SSL_CIPHERS_RSA_WITH_AES_128_GCM_SHA256,
+	model.LBHttpSslCondition_CLIENT_SUPPORTED_SSL_CIPHERS_RSA_WITH_AES_256_CBC_SHA256,
+	model.LBHttpSslCondition_CLIENT_SUPPORTED_SSL_CIPHERS_RSA_WITH_AES_256_GCM_SHA384,
+	model.LBHttpSslCondition_CLIENT_SUPPORTED_SSL_CIPHERS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+	model.LBHttpSslCondition_CLIENT_SUPPORTED_SSL_CIPHERS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,
+	model.LBHttpSslCondition_CLIENT_SUPPORTED_SSL_CIPHERS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+	model.LBHttpSslCondition_CLIENT_SUPPORTED_SSL_CIPHERS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384,
+	model.LBHttpSslCondition_CLIENT_SUPPORTED_SSL_CIPHERS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+	model.LBHttpSslCondition_CLIENT_SUPPORTED_SSL_CIPHERS_ECDH_ECDSA_WITH_AES_128_CBC_SHA,
+	model.LBHttpSslCondition_CLIENT_SUPPORTED_SSL_CIPHERS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256,
+	model.LBHttpSslCondition_CLIENT_SUPPORTED_SSL_CIPHERS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256,
+	model.LBHttpSslCondition_CLIENT_SUPPORTED_SSL_CIPHERS_ECDH_ECDSA_WITH_AES_256_CBC_SHA384,
+	model.LBHttpSslCondition_CLIENT_SUPPORTED_SSL_CIPHERS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384,
+	model.LBHttpSslCondition_CLIENT_SUPPORTED_SSL_CIPHERS_ECDH_RSA_WITH_AES_128_CBC_SHA,
+	model.LBHttpSslCondition_CLIENT_SUPPORTED_SSL_CIPHERS_ECDH_RSA_WITH_AES_128_CBC_SHA256,
+	model.LBHttpSslCondition_CLIENT_SUPPORTED_SSL_CIPHERS_ECDH_RSA_WITH_AES_128_GCM_SHA256,
+	model.LBHttpSslCondition_CLIENT_SUPPORTED_SSL_CIPHERS_ECDH_RSA_WITH_AES_256_CBC_SHA384,
+	model.LBHttpSslCondition_CLIENT_SUPPORTED_SSL_CIPHERS_ECDH_RSA_WITH_AES_256_GCM_SHA384,
+}
+
+var lbHttpSslConditionSessionReusedValues = []string{
+	model.LBHttpSslCondition_SESSION_REUSED_IGNORE,
+	model.LBHttpSslCondition_SESSION_REUSED_REUSED,
+	model.LBHttpSslCondition_SESSION_REUSED_NEW,
+}
+
+var lbHttpSslConditionUsedProtocolValues = []string{
+	model.LBHttpSslCondition_USED_PROTOCOL_SSL_V2,
+	model.LBHttpSslCondition_USED_PROTOCOL_SSL_V3,
+	model.LBHttpSslCondition_USED_PROTOCOL_TLS_V1,
+	model.LBHttpSslCondition_USED_PROTOCOL_TLS_V1_1,
+	model.LBHttpSslCondition_USED_PROTOCOL_TLS_V1_2,
+}
+
+var lbSslModeSelectionActionValues = []string{
+	model.LBSslModeSelectionAction_SSL_MODE_PASSTHROUGH,
+	model.LBSslModeSelectionAction_SSL_MODE_END_TO_END,
+	model.LBSslModeSelectionAction_SSL_MODE_OFFLOAD,
 }
 
 func resourceNsxtPolicyLBVirtualServer() *schema.Resource {
@@ -128,7 +231,13 @@ func resourceNsxtPolicyLBVirtualServer() *schema.Resource {
 				Optional:    true,
 				MaxItems:    1,
 			},
-			// TODO: add rules
+			"rule": {
+				Type:        schema.TypeList,
+				Description: "List of load balancer rules for layer 7 virtual servers with LBHttpProfile",
+				Optional:    true,
+				MaxItems:    4000,
+				Elem:        getPolicyLbRuleBindingSchema(),
+			},
 		},
 	}
 }
@@ -225,6 +334,487 @@ func getPolicyLbAccessListControlSchema() *schema.Resource {
 				Default:     true,
 			},
 			"group_path": getPolicyPathSchema(true, false, "The path of grouping object which defines the IP addresses or ranges to match the client IP"),
+		},
+	}
+}
+
+func getPolicyLbRuleBindingSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"display_name": getDisplayNameSchema(),
+			"match_strategy": {
+				Description:  "Match strategy for determining match of multiple conditions (ALL or ANY, default: ANY).",
+				Type:         schema.TypeString,
+				ValidateFunc: validation.StringInSlice(lbRuleMatchStrategyValues, false),
+				Optional:     true,
+				Default:      "ANY",
+			},
+			"phase": {
+				Description:  "Load balancer processing phase, one of HTTP_REQUEST_REWRITE, HTTP_FORWARDING (Default), HTTP_RESPONSE_REWRITE, HTTP_ACCESS, TRANSPORT.",
+				Type:         schema.TypeString,
+				ValidateFunc: validation.StringInSlice(lbRulePhaseValues, false),
+				Optional:     true,
+				Default:      "HTTP_FORWARDING",
+			},
+			/*
+			  I had this initially seperated using an "action" and "method" section but although that would map the api better,
+			  there's not really a reason to do that and looking at the manager API implementation this is much more similar
+			*/
+			// ACTIONS
+			"connection_drop_action":              getPolicyLbRuleConnectionDropActionSchema(),
+			"http_redirect_action":                getPolicyLbRuleHttpRedirectActionSchema(),
+			"http_reject_action":                  getPolicyLbRuleHttpRejectActionSchema(),
+			"http_request_header_delete_action":   getPolicyLbRuleHttpRequestHeaderDeleteActionSchema(),
+			"http_request_header_rewrite_action":  getPolicyLbRuleHttpRequestHeaderRewriteActionSchema(),
+			"http_request_uri_rewrite_action":     getPolicyLbRuleHttpRequestUriRewriteActionSchema(),
+			"http_response_header_delete_action":  getPolicyLbRuleHttpResponseHeaderDeleteActionSchema(),
+			"http_response_header_rewrite_action": getPolicyLbRuleHttpResponseHeaderRewriteActionSchema(),
+			"jwt_auth_action":                     getPolicyLbRuleJwtAuthActionSchema(),
+			"select_pool_action":                  getPolicyLbRuleSelectPoolActionSchema(),
+			"ssl_mode_selection_action":           getPolicyLbRuleSslModeSelectionSchema(),
+			"variable_assignment_action":          getPolicyLbRuleVariableAssignmentActionSchema(),
+			"variable_persistence_learn_action":   getPolicyLbRuleVariablePersistenceLearnActionSchema(),
+			"variable_persistence_on_action":      getPolicyLbRuleVariablePersistenceLearnActionSchema(),
+			// MATCH-CONDITIONS
+			"http_request_body_condition":          getPolicyLbRuleHTTPRequestBodyConditionSchema(),
+			"http_request_cookie_condition":        getPolicyLbRuleNameValueConditionSchema("cookie", "Rule condition based on HTTP cookie"),
+			"http_request_header_condition":        getPolicyLbRuleNameValueConditionSchema("header", "Rule condition based on HTTP request header"),
+			"http_request_method_condition":        getLbRuleHTTPRequestMethodConditionSchema(),
+			"http_request_uri_arguments_condition": getLbRuleHTTPRequestURIArgumentsConditionSchema(),
+			"http_request_uri_condition":           getLbRuleHTTPRequestURIConditionSchema(),
+			"http_request_version_condition":       getLbRuleHTTPVersionConditionSchema(),
+			"http_response_header_condition":       getPolicyLbRuleNameValueConditionSchema("header", "Rule condition based on HTTP response header"),
+			"http_ssl_condition":                   getPolicyLbRuleHTTPSslConditionSchema(),
+			"ip_header_condition":                  getPolicyLbRuleIPConditionSchema(),
+			"ssl_sni_condition":                    getPolicyLbRuleSslSniConditionSchema(),
+			"tcp_header_condition":                 getLbRuleTCPConditionSchema(),
+			"variable_condition":                   getPolicyLbRuleNameValueConditionSchema("variable", "Rule condition based on IP header"),
+		},
+	}
+}
+
+func getPolicyLbRuleHTTPRequestBodyConditionSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeSet,
+		Description: "Rule condition based on HTTP request body",
+		Optional:    true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"inverse": getLbRuleInverseSchema(),
+				"body_value": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"case_sensitive": getLbRuleCaseSensitiveSchema(),
+				"match_type":     getLbRuleMatchTypeSchema(),
+			},
+		},
+	}
+}
+
+func getPolicyLbRuleNameValueConditionSchema(key string, desc string) *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeSet,
+		Description: desc,
+		Optional:    true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"inverse":        getLbRuleInverseSchema(),
+				"case_sensitive": getLbRuleCaseSensitiveSchema(),
+				"match_type":     getLbRuleMatchTypeSchema(),
+				key + "_name": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				key + "_value": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+			},
+		},
+	}
+}
+
+func getPolicyLbRuleHTTPSslConditionSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeSet,
+		Description: "Rule condition based on HTTP SSL handshake and connection",
+		Optional:    true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"inverse": getLbRuleInverseSchema(),
+				"client_certificate_issuer_dn": {
+					Type: schema.TypeSet,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"issuer_dn": {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+							"case_sensitive": getLbRuleCaseSensitiveSchema(),
+							"match_type":     getLbRuleMatchTypeSchema(),
+						},
+					},
+					Optional: true,
+				},
+				"client_certificate_subject_dn": {
+					Type: schema.TypeSet,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"subject_dn": {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+							"case_sensitive": getLbRuleCaseSensitiveSchema(),
+							"match_type":     getLbRuleMatchTypeSchema(),
+						},
+					},
+					Optional: true,
+				},
+				"client_supported_ssl_ciphers": {
+					Type:        schema.TypeList,
+					Description: "Supported SSL ciphers",
+					Optional:    true,
+					Elem: &schema.Schema{
+						Type:         schema.TypeString,
+						ValidateFunc: validation.StringInSlice(lbHttpSslConditionClientSupportedSslCiphersValues, false),
+					},
+				},
+				"session_reused": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringInSlice(lbHttpSslConditionSessionReusedValues, false),
+				},
+				"used_protocol": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringInSlice(lbHttpSslConditionUsedProtocolValues, false),
+				},
+				"used_ssl_cipher": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringInSlice(lbHttpSslConditionUsedSslCipherValues, false),
+				},
+			},
+		},
+	}
+}
+
+func getPolicyLbRuleIPConditionSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeSet,
+		Description: "Rule condition based on IP settings of the message",
+		Optional:    true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"inverse": getLbRuleInverseSchema(),
+				"source_address": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: validateSingleIP(),
+				},
+				"group_path": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+			},
+		},
+	}
+}
+
+func getPolicyLbRuleSslSniConditionSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeSet,
+		Description: "Rule condition based on SSL SNI in client hello",
+		Optional:    true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"inverse": getLbRuleInverseSchema(),
+				"sni": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"case_sensitive": getLbRuleCaseSensitiveSchema(),
+				"match_type":     getLbRuleMatchTypeSchema(),
+			},
+		},
+	}
+}
+
+func getPolicyLbRuleConnectionDropActionSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeSet,
+		Description: "Action to drop the connection.",
+		Optional:    true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"_dummy": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Default:  "dummy_value_to_indicate_presence_of_section",
+				},
+			},
+		},
+	}
+}
+
+func getPolicyLbRuleHttpRedirectActionSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeSet,
+		Description: "Action to redirect HTTP request messages to a new URL.",
+		Optional:    true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"redirect_status": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"redirect_url": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+			},
+		},
+	}
+}
+
+func getPolicyLbRuleHttpRejectActionSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeSet,
+		Description: "Action to reject HTTP request messages",
+		Optional:    true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"reply_message": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"reply_status": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+			},
+		},
+	}
+}
+
+func getPolicyLbRuleHttpRequestHeaderDeleteActionSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeSet,
+		Description: "Action to delete header fields of HTTP request messages at HTTP_REQUEST_REWRITE phase.",
+		Optional:    true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"header_name": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+			},
+		},
+	}
+}
+
+func getPolicyLbRuleHttpRequestHeaderRewriteActionSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeSet,
+		Description: "Action to rewrite header fields of matched HTTP request messages to specified new values.",
+		Optional:    true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"header_name": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"header_value": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+			},
+		},
+	}
+}
+
+func getPolicyLbRuleHttpRequestUriRewriteActionSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeSet,
+		Description: "Action to rewrite URIs in matched HTTP request messages.",
+		Optional:    true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"uri": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"uri_arguments": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+			},
+		},
+	}
+}
+
+func getPolicyLbRuleHttpResponseHeaderDeleteActionSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeSet,
+		Description: "Action to delete header fields of HTTP response messages at HTTP_RESPONSE_REWRITE phase.",
+		Optional:    true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"header_name": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+			},
+		},
+	}
+}
+
+func getPolicyLbRuleHttpResponseHeaderRewriteActionSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeSet,
+		Description: "Action to rewrite header fields of HTTP response messages to specified new values at HTTP_RESPONSE_REWRITE phase.",
+		Optional:    true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"header_name": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"header_value": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+			},
+		},
+	}
+}
+
+func getPolicyLbRuleJwtAuthActionSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeSet,
+		Description: "Action  to control access to backend server resources using JSON Web Token(JWT) authentication.",
+		Optional:    true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"key": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					MaxItems: 1,
+					MinItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"certificate_path": {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+							"public_key_content": {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+							"symmetric_key": {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+						},
+					},
+				},
+				"pass_jwt_to_pool": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
+				"realm": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"tokens": {
+					Type:        schema.TypeList,
+					Description: "JWT tokens",
+					Optional:    true,
+					Elem: &schema.Schema{
+						Type: schema.TypeString,
+					},
+				},
+			},
+		},
+	}
+}
+
+func getPolicyLbRuleSelectPoolActionSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeSet,
+		Description: "Action to select a pool for matched HTTP request messages.",
+		Optional:    true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"pool_id": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+			},
+		},
+	}
+}
+
+func getPolicyLbRuleSslModeSelectionSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeSet,
+		Description: "Action to select SSL mode.",
+		Optional:    true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"ssl_mode": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringInSlice(lbSslModeSelectionActionValues, false),
+				},
+			},
+		},
+	}
+}
+
+func getPolicyLbRuleVariableAssignmentActionSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeSet,
+		Description: "Action to create a new variable and assign value to it.",
+		Optional:    true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"variable_name": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"variable_value": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+			},
+		},
+	}
+}
+
+func getPolicyLbRuleVariablePersistenceLearnActionSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeSet,
+		Description: "Action to create a new variable and assign value to it.",
+		Optional:    true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"persistence_profile_path": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"variable_hash_enabled": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
+				"variable_name": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+			},
 		},
 	}
 }
@@ -372,7 +962,494 @@ func setPolicyAccessListControlInSchema(d *schema.ResourceData, control *model.L
 	}
 }
 
-func policyLBVirtualServerVersionDepenantSet(d *schema.ResourceData, obj *model.LBVirtualServer) {
+func setPolicyLbRulesInSchema(d *schema.ResourceData, rules []model.LBRule) {
+	converter := bindings.NewTypeConverter()
+	converter.SetMode(bindings.REST)
+
+	var ruleList []interface{}
+	for _, rule := range rules {
+
+		elem := make(map[string]interface{})
+		if rule.DisplayName != nil {
+			elem["display_name"] = *rule.DisplayName
+		}
+		if rule.MatchStrategy != nil {
+			elem["match_strategy"] = *rule.MatchStrategy
+		}
+		if rule.Phase != nil {
+			elem["phase"] = *rule.Phase
+		}
+
+		// Actions
+		var connectionDropActionList []interface{}
+		var selectPoolActionList []interface{}
+		var httpRedirectActionList []interface{}
+		var httpRequestUriRewriteActionList []interface{}
+		var httpRequestHeaderRewriteActionList []interface{}
+		var httpRejectActionList []interface{}
+		var httpResponseHeaderRewriteActionList []interface{}
+		var httpRequestHeaderDeleteActionList []interface{}
+		var httpResponseHeaderDeleteActionList []interface{}
+		var variableAssignmentActionList []interface{}
+		var variablePersistenceOnActionList []interface{}
+		var variablePersistenceLearnActionList []interface{}
+		var jwtAuthActionList []interface{}
+		var sslModeSelectionActionList []interface{}
+
+		for _, action := range rule.Actions {
+			actionElem := make(map[string]interface{})
+
+			basicType, _ := converter.ConvertToGolang(action, model.LBRuleActionBindingType())
+			actionType := basicType.(model.LBRuleAction).Type_
+
+			if actionType == model.LBRuleAction_TYPE_LBCONNECTIONDROPACTION {
+				actionElem["_dummy"] = "dummy_value_to_indicate_presence_of_section"
+				connectionDropActionList = append(connectionDropActionList, actionElem)
+			} else if actionType == model.LBRuleAction_TYPE_LBSELECTPOOLACTION {
+				specificType, _ := converter.ConvertToGolang(action, model.LBSelectPoolActionBindingType())
+				actionElem["pool_id"] = specificType.(model.LBSelectPoolAction).PoolId
+				selectPoolActionList = append(selectPoolActionList, actionElem)
+			} else if actionType == model.LBRuleAction_TYPE_LBHTTPREDIRECTACTION {
+				specificType, _ := converter.ConvertToGolang(action, model.LBHttpRedirectActionBindingType())
+				actionElem["redirect_status"] = specificType.(model.LBHttpRedirectAction).RedirectStatus
+				actionElem["redirect_url"] = specificType.(model.LBHttpRedirectAction).RedirectUrl
+				httpRedirectActionList = append(httpRedirectActionList, actionElem)
+			} else if actionType == model.LBRuleAction_TYPE_LBHTTPREQUESTURIREWRITEACTION {
+				specificType, _ := converter.ConvertToGolang(action, model.LBHttpRequestUriRewriteActionBindingType())
+				actionElem["uri"] = specificType.(model.LBHttpRequestUriRewriteAction).Uri
+				actionElem["uri_arguments"] = specificType.(model.LBHttpRequestUriRewriteAction).UriArguments
+				httpRequestUriRewriteActionList = append(httpRequestUriRewriteActionList, actionElem)
+			} else if actionType == model.LBRuleAction_TYPE_LBHTTPREQUESTHEADERREWRITEACTION {
+				specificType, _ := converter.ConvertToGolang(action, model.LBHttpRequestHeaderRewriteActionBindingType())
+				actionElem["header_name"] = specificType.(model.LBHttpRequestHeaderRewriteAction).HeaderName
+				actionElem["header_value"] = specificType.(model.LBHttpRequestHeaderRewriteAction).HeaderValue
+				httpRequestHeaderRewriteActionList = append(httpRequestHeaderRewriteActionList, actionElem)
+			} else if actionType == model.LBRuleAction_TYPE_LBHTTPREJECTACTION {
+				specificType, _ := converter.ConvertToGolang(action, model.LBHttpRejectActionBindingType())
+				actionElem["reply_message"] = specificType.(model.LBHttpRejectAction).ReplyMessage
+				actionElem["reply_status"] = specificType.(model.LBHttpRejectAction).ReplyStatus
+				httpRejectActionList = append(httpRejectActionList, actionElem)
+			} else if actionType == model.LBRuleAction_TYPE_LBHTTPRESPONSEHEADERREWRITEACTION {
+				specificType, _ := converter.ConvertToGolang(action, model.LBHttpResponseHeaderRewriteActionBindingType())
+				actionElem["header_name"] = specificType.(model.LBHttpResponseHeaderRewriteAction).HeaderName
+				actionElem["header_value"] = specificType.(model.LBHttpResponseHeaderRewriteAction).HeaderValue
+				httpResponseHeaderRewriteActionList = append(httpResponseHeaderRewriteActionList, actionElem)
+			} else if actionType == model.LBRuleAction_TYPE_LBHTTPREQUESTHEADERDELETEACTION {
+				specificType, _ := converter.ConvertToGolang(action, model.LBHttpRequestHeaderDeleteActionBindingType())
+				actionElem["header_name"] = specificType.(model.LBHttpRequestHeaderDeleteAction).HeaderName
+				httpRequestHeaderDeleteActionList = append(httpRequestHeaderDeleteActionList, actionElem)
+			} else if actionType == model.LBRuleAction_TYPE_LBHTTPRESPONSEHEADERDELETEACTION {
+				specificType, _ := converter.ConvertToGolang(action, model.LBHttpResponseHeaderDeleteActionBindingType())
+				actionElem["header_name"] = specificType.(model.LBHttpResponseHeaderDeleteAction).HeaderName
+				httpResponseHeaderDeleteActionList = append(httpResponseHeaderDeleteActionList, actionElem)
+			} else if actionType == model.LBRuleAction_TYPE_LBVARIABLEASSIGNMENTACTION {
+				specificType, _ := converter.ConvertToGolang(action, model.LBVariableAssignmentActionBindingType())
+				actionElem["variable_name"] = specificType.(model.LBVariableAssignmentAction).VariableName
+				actionElem["variable_value"] = specificType.(model.LBVariableAssignmentAction).VariableValue
+				variableAssignmentActionList = append(variableAssignmentActionList, actionElem)
+			} else if actionType == model.LBRuleAction_TYPE_LBVARIABLEPERSISTENCEONACTION {
+				specificType, _ := converter.ConvertToGolang(action, model.LBVariablePersistenceOnActionBindingType())
+				actionElem["persistence_profile_path"] = specificType.(model.LBVariablePersistenceOnAction).PersistenceProfilePath
+				actionElem["variable_hash_enabled"] = specificType.(model.LBVariablePersistenceOnAction).VariableHashEnabled
+				actionElem["variable_name"] = specificType.(model.LBVariablePersistenceOnAction).VariableName
+				variablePersistenceOnActionList = append(variablePersistenceOnActionList, actionElem)
+			} else if actionType == model.LBRuleAction_TYPE_LBVARIABLEPERSISTENCELEARNACTION {
+				specificType, _ := converter.ConvertToGolang(action, model.LBVariablePersistenceLearnActionBindingType())
+				actionElem["persistence_profile_path"] = specificType.(model.LBVariablePersistenceLearnAction).PersistenceProfilePath
+				actionElem["variable_hash_enabled"] = specificType.(model.LBVariablePersistenceLearnAction).VariableHashEnabled
+				actionElem["variable_name"] = specificType.(model.LBVariablePersistenceLearnAction).VariableName
+				variablePersistenceLearnActionList = append(variablePersistenceLearnActionList, actionElem)
+			} else if actionType == model.LBRuleAction_TYPE_LBSSLMODESELECTIONACTION {
+				specificType, _ := converter.ConvertToGolang(action, model.LBSslModeSelectionActionBindingType())
+				actionElem["ssl_mode"] = specificType.(model.LBSslModeSelectionAction).SslMode
+				sslModeSelectionActionList = append(sslModeSelectionActionList, actionElem)
+			} else if actionType == model.LBRuleAction_TYPE_LBJWTAUTHACTION {
+				specificType, _ := converter.ConvertToGolang(action, model.LBJwtAuthActionBindingType())
+				actionElem["pass_jwt_to_pool"] = specificType.(model.LBJwtAuthAction).PassJwtToPool
+				actionElem["realm"] = specificType.(model.LBJwtAuthAction).Realm
+
+				var keyList []interface{}
+				keyElem := make(map[string]interface{})
+
+				key := specificType.(model.LBJwtAuthAction).Key
+				basicKeyType, _ := converter.ConvertToGolang(key, model.LBJwtKeyBindingType())
+				keyType := basicKeyType.(model.LBJwtKey).Type_
+
+				if keyType == model.LBJwtKey_TYPE_LBJWTCERTIFICATEKEY {
+					specificKeyType, _ := converter.ConvertToGolang(key, model.LBJwtCertificateKeyBindingType())
+					keyElem["certificate_path"] = specificKeyType.(model.LBJwtCertificateKey).CertificatePath
+				} else if keyType == model.LBJwtKey_TYPE_LBJWTSYMMETRICKEY {
+					keyElem["symmetric_key"] = "dummy"
+				} else if keyType == model.LBJwtKey_TYPE_LBJWTPUBLICKEY {
+					specificKeyType, _ := converter.ConvertToGolang(key, model.LBJwtPublicKeyBindingType())
+					keyElem["public_key_content"] = specificKeyType.(model.LBJwtPublicKey).PublicKeyContent
+				}
+
+				keyList = append(keyList, keyElem)
+				actionElem["key"] = schema.NewSet(resourceKeyValueHash, keyList)
+
+				var tokens []interface{}
+				for _, v := range specificType.(model.LBJwtAuthAction).Tokens {
+					tokens = append(tokens, v)
+				}
+				actionElem["tokens"] = tokens
+
+				jwtAuthActionList = append(jwtAuthActionList, actionElem)
+			}
+		}
+
+		elem["connection_drop_action"] = schema.NewSet(resourceKeyValueHash, connectionDropActionList)
+		elem["select_pool_action"] = schema.NewSet(resourceKeyValueHash, selectPoolActionList)
+		elem["http_redirect_action"] = schema.NewSet(resourceKeyValueHash, httpRedirectActionList)
+		elem["http_request_uri_rewrite_action"] = schema.NewSet(resourceKeyValueHash, httpRequestUriRewriteActionList)
+		elem["http_request_header_rewrite_action"] = schema.NewSet(resourceKeyValueHash, httpRequestHeaderRewriteActionList)
+		elem["http_reject_action"] = schema.NewSet(resourceKeyValueHash, httpRejectActionList)
+		elem["http_response_header_rewrite_action"] = schema.NewSet(resourceKeyValueHash, httpResponseHeaderRewriteActionList)
+		elem["http_request_header_delete_action"] = schema.NewSet(resourceKeyValueHash, httpRequestHeaderDeleteActionList)
+		elem["http_response_header_delete_action"] = schema.NewSet(resourceKeyValueHash, httpResponseHeaderDeleteActionList)
+		elem["variable_assignment_action"] = schema.NewSet(resourceKeyValueHash, variableAssignmentActionList)
+		elem["variable_persistence_on_action"] = schema.NewSet(resourceKeyValueHash, variablePersistenceOnActionList)
+		elem["variable_persistence_learn_action"] = schema.NewSet(resourceKeyValueHash, variablePersistenceLearnActionList)
+		elem["jwt_auth_action"] = schema.NewSet(resourceKeyValueHash, jwtAuthActionList)
+		elem["ssl_mode_selection_action"] = schema.NewSet(resourceKeyValueHash, sslModeSelectionActionList)
+
+		// MatchConditions
+		var httpRequestBodyConditionList []interface{}
+		var httpRequestUriConditionList []interface{}
+		var httpRequestHeaderConditionList []interface{}
+		var httpRequestMethodConditionList []interface{}
+		var httpRequestUriArgumentsConditionList []interface{}
+		var httpRequestVersionConditionList []interface{}
+		var httpRequestCookieConditionList []interface{}
+		var httpResponseHeaderConditionList []interface{}
+		var tcpHeaderConditionList []interface{}
+		var ipHeaderConditionList []interface{}
+		var variableConditionList []interface{}
+		var httpSslConditionList []interface{}
+		var sslSniConditionList []interface{}
+
+		for _, condition := range rule.MatchConditions {
+			conditionElem := make(map[string]interface{})
+
+			basicType, _ := converter.ConvertToGolang(condition, model.LBRuleConditionBindingType())
+			conditionType := basicType.(model.LBRuleCondition).Type_
+
+			if conditionType == model.LBRuleCondition_TYPE_LBHTTPREQUESTBODYCONDITION {
+				specificType, _ := converter.ConvertToGolang(condition, model.LBHttpRequestBodyConditionBindingType())
+				conditionElem["case_sensitive"] = specificType.(model.LBHttpRequestBodyCondition).CaseSensitive
+				conditionElem["inverse"] = specificType.(model.LBHttpRequestBodyCondition).Inverse
+				conditionElem["match_type"] = specificType.(model.LBHttpRequestBodyCondition).MatchType
+				conditionElem["body_value"] = specificType.(model.LBHttpRequestBodyCondition).BodyValue
+				httpRequestBodyConditionList = append(httpRequestBodyConditionList, conditionElem)
+			} else if conditionType == model.LBRuleCondition_TYPE_LBHTTPREQUESTURICONDITION {
+				specificType, _ := converter.ConvertToGolang(condition, model.LBHttpRequestUriConditionBindingType())
+				conditionElem["case_sensitive"] = specificType.(model.LBHttpRequestUriCondition).CaseSensitive
+				conditionElem["inverse"] = specificType.(model.LBHttpRequestUriCondition).Inverse
+				conditionElem["match_type"] = specificType.(model.LBHttpRequestUriCondition).MatchType
+				conditionElem["uri"] = specificType.(model.LBHttpRequestUriCondition).Uri
+				httpRequestUriConditionList = append(httpRequestUriConditionList, conditionElem)
+			} else if conditionType == model.LBRuleCondition_TYPE_LBHTTPREQUESTHEADERCONDITION {
+				specificType, _ := converter.ConvertToGolang(condition, model.LBHttpRequestHeaderConditionBindingType())
+				conditionElem["case_sensitive"] = specificType.(model.LBHttpRequestHeaderCondition).CaseSensitive
+				conditionElem["header_name"] = specificType.(model.LBHttpRequestHeaderCondition).HeaderName
+				conditionElem["header_value"] = specificType.(model.LBHttpRequestHeaderCondition).HeaderValue
+				conditionElem["inverse"] = specificType.(model.LBHttpRequestHeaderCondition).Inverse
+				conditionElem["match_type"] = specificType.(model.LBHttpRequestHeaderCondition).MatchType
+				httpRequestHeaderConditionList = append(httpRequestHeaderConditionList, conditionElem)
+			} else if conditionType == model.LBRuleCondition_TYPE_LBHTTPREQUESTMETHODCONDITION {
+				specificType, _ := converter.ConvertToGolang(condition, model.LBHttpRequestMethodConditionBindingType())
+				conditionElem["inverse"] = specificType.(model.LBHttpRequestMethodCondition).Inverse
+				conditionElem["method"] = specificType.(model.LBHttpRequestMethodCondition).Method
+				httpRequestMethodConditionList = append(httpRequestMethodConditionList, conditionElem)
+			} else if conditionType == model.LBRuleCondition_TYPE_LBHTTPREQUESTURIARGUMENTSCONDITION {
+				specificType, _ := converter.ConvertToGolang(condition, model.LBHttpRequestUriArgumentsConditionBindingType())
+				conditionElem["case_sensitive"] = specificType.(model.LBHttpRequestUriArgumentsCondition).CaseSensitive
+				conditionElem["inverse"] = specificType.(model.LBHttpRequestUriArgumentsCondition).Inverse
+				conditionElem["match_type"] = specificType.(model.LBHttpRequestUriArgumentsCondition).MatchType
+				conditionElem["uri_arguments"] = specificType.(model.LBHttpRequestUriArgumentsCondition).UriArguments
+				httpRequestUriArgumentsConditionList = append(httpRequestUriArgumentsConditionList, conditionElem)
+			} else if conditionType == model.LBRuleCondition_TYPE_LBHTTPREQUESTVERSIONCONDITION {
+				specificType, _ := converter.ConvertToGolang(condition, model.LBHttpRequestVersionConditionBindingType())
+				conditionElem["inverse"] = specificType.(model.LBHttpRequestVersionCondition).Inverse
+				conditionElem["version"] = specificType.(model.LBHttpRequestVersionCondition).Version
+				httpRequestVersionConditionList = append(httpRequestVersionConditionList, conditionElem)
+			} else if conditionType == model.LBRuleCondition_TYPE_LBHTTPREQUESTCOOKIECONDITION {
+				specificType, _ := converter.ConvertToGolang(condition, model.LBHttpRequestCookieConditionBindingType())
+				conditionElem["case_sensitive"] = specificType.(model.LBHttpRequestCookieCondition).CaseSensitive
+				conditionElem["cookie_name"] = specificType.(model.LBHttpRequestCookieCondition).CookieName
+				conditionElem["cookie_value"] = specificType.(model.LBHttpRequestCookieCondition).CookieValue
+				conditionElem["inverse"] = specificType.(model.LBHttpRequestCookieCondition).Inverse
+				conditionElem["match_type"] = specificType.(model.LBHttpRequestCookieCondition).MatchType
+				httpRequestCookieConditionList = append(httpRequestCookieConditionList, conditionElem)
+			} else if conditionType == model.LBRuleCondition_TYPE_LBHTTPRESPONSEHEADERCONDITION {
+				specificType, _ := converter.ConvertToGolang(condition, model.LBHttpResponseHeaderConditionBindingType())
+				conditionElem["case_sensitive"] = specificType.(model.LBHttpResponseHeaderCondition).CaseSensitive
+				conditionElem["header_name"] = specificType.(model.LBHttpResponseHeaderCondition).HeaderName
+				conditionElem["header_value"] = specificType.(model.LBHttpResponseHeaderCondition).HeaderValue
+				conditionElem["inverse"] = specificType.(model.LBHttpResponseHeaderCondition).Inverse
+				conditionElem["match_type"] = specificType.(model.LBHttpResponseHeaderCondition).MatchType
+				httpResponseHeaderConditionList = append(httpResponseHeaderConditionList, conditionElem)
+			} else if conditionType == model.LBRuleCondition_TYPE_LBTCPHEADERCONDITION {
+				specificType, _ := converter.ConvertToGolang(condition, model.LBTcpHeaderConditionBindingType())
+				conditionElem["inverse"] = specificType.(model.LBTcpHeaderCondition).Inverse
+				conditionElem["source_port"] = specificType.(model.LBTcpHeaderCondition).SourcePort
+				tcpHeaderConditionList = append(tcpHeaderConditionList, conditionElem)
+			} else if conditionType == model.LBRuleCondition_TYPE_LBIPHEADERCONDITION {
+				specificType, _ := converter.ConvertToGolang(condition, model.LBIpHeaderConditionBindingType())
+				conditionElem["group_path"] = specificType.(model.LBIpHeaderCondition).GroupPath
+				conditionElem["inverse"] = specificType.(model.LBIpHeaderCondition).Inverse
+				conditionElem["source_address"] = specificType.(model.LBIpHeaderCondition).SourceAddress
+				ipHeaderConditionList = append(ipHeaderConditionList, conditionElem)
+			} else if conditionType == model.LBRuleCondition_TYPE_LBVARIABLECONDITION {
+				specificType, _ := converter.ConvertToGolang(condition, model.LBVariableConditionBindingType())
+				conditionElem["case_sensitive"] = specificType.(model.LBVariableCondition).CaseSensitive
+				conditionElem["inverse"] = specificType.(model.LBVariableCondition).Inverse
+				conditionElem["match_type"] = specificType.(model.LBVariableCondition).MatchType
+				conditionElem["variable_name"] = specificType.(model.LBVariableCondition).VariableName
+				conditionElem["variable_value"] = specificType.(model.LBVariableCondition).VariableValue
+				variableConditionList = append(variableConditionList, conditionElem)
+			} else if conditionType == model.LBRuleCondition_TYPE_LBSSLSNICONDITION {
+				specificType, _ := converter.ConvertToGolang(condition, model.LBSslSniConditionBindingType())
+				conditionElem["case_sensitive"] = specificType.(model.LBSslSniCondition).CaseSensitive
+				conditionElem["inverse"] = specificType.(model.LBSslSniCondition).Inverse
+				conditionElem["match_type"] = specificType.(model.LBSslSniCondition).MatchType
+				conditionElem["sni"] = specificType.(model.LBSslSniCondition).Sni
+				sslSniConditionList = append(sslSniConditionList, conditionElem)
+			} else if conditionType == model.LBRuleCondition_TYPE_LBHTTPSSLCONDITION {
+				specificType, _ := converter.ConvertToGolang(condition, model.LBHttpSslConditionBindingType())
+				conditionElem["inverse"] = specificType.(model.LBHttpSslCondition).Inverse
+				conditionElem["session_reused"] = specificType.(model.LBHttpSslCondition).SessionReused
+				conditionElem["used_protocol"] = specificType.(model.LBHttpSslCondition).UsedProtocol
+				conditionElem["used_ssl_cipher"] = specificType.(model.LBHttpSslCondition).UsedSslCipher
+
+				issuer_dn := specificType.(model.LBHttpSslCondition).ClientCertificateIssuerDn
+				var issuerDnList []interface{}
+				issuerElem := make(map[string]interface{})
+				issuerElem["case_sensitive"] = issuer_dn.CaseSensitive
+				issuerElem["issuer_dn"] = issuer_dn.IssuerDn
+				issuerElem["match_type"] = issuer_dn.MatchType
+				issuerDnList = append(issuerDnList, issuerElem)
+				conditionElem["client_certificate_issuer_dn"] = schema.NewSet(resourceKeyValueHash, issuerDnList)
+
+				subject_dn := specificType.(model.LBHttpSslCondition).ClientCertificateSubjectDn
+				var subjectDnList []interface{}
+				subjectElem := make(map[string]interface{})
+				subjectElem["case_sensitive"] = subject_dn.CaseSensitive
+				subjectElem["subject_dn"] = subject_dn.SubjectDn
+				subjectElem["match_type"] = subject_dn.MatchType
+				subjectDnList = append(subjectDnList, subjectElem)
+				conditionElem["client_certificate_subject_dn"] = schema.NewSet(resourceKeyValueHash, subjectDnList)
+
+				var ssl_ciphers []interface{}
+				for _, v := range specificType.(model.LBHttpSslCondition).ClientSupportedSslCiphers {
+					ssl_ciphers = append(ssl_ciphers, v)
+				}
+				conditionElem["client_supported_ssl_ciphers"] = ssl_ciphers
+
+				httpSslConditionList = append(httpSslConditionList, conditionElem)
+			}
+		}
+
+		elem["http_request_body_condition"] = schema.NewSet(resourceKeyValueHash, httpRequestBodyConditionList)
+		elem["http_request_uri_condition"] = schema.NewSet(resourceKeyValueHash, httpRequestUriConditionList)
+		elem["http_request_header_condition"] = schema.NewSet(resourceKeyValueHash, httpRequestHeaderConditionList)
+		elem["http_request_method_condition"] = schema.NewSet(resourceKeyValueHash, httpRequestMethodConditionList)
+		elem["http_request_uri_arguments_condition"] = schema.NewSet(resourceKeyValueHash, httpRequestUriArgumentsConditionList)
+		elem["http_request_version_condition"] = schema.NewSet(resourceKeyValueHash, httpRequestVersionConditionList)
+		elem["http_request_cookie_condition"] = schema.NewSet(resourceKeyValueHash, httpRequestCookieConditionList)
+		elem["http_response_header_condition"] = schema.NewSet(resourceKeyValueHash, httpResponseHeaderConditionList)
+		elem["tcp_header_condition"] = schema.NewSet(resourceKeyValueHash, tcpHeaderConditionList)
+		elem["ip_header_condition"] = schema.NewSet(resourceKeyValueHash, ipHeaderConditionList)
+		elem["variable_condition"] = schema.NewSet(resourceKeyValueHash, variableConditionList)
+		elem["http_ssl_condition"] = schema.NewSet(resourceKeyValueHash, httpSslConditionList)
+		elem["ssl_sni_condition"] = schema.NewSet(resourceKeyValueHash, sslSniConditionList)
+
+		ruleList = append(ruleList, elem)
+	}
+
+	err := d.Set("rule", ruleList)
+	if err != nil {
+		log.Printf("[WARNING] Failed to set rule list in schema: %v", err)
+	}
+
+}
+
+func getRuleActionOrMethod(ruleData map[string]interface{}, key string, string_fields []string, bool_fields []string, internal_type string) []*data.StructValue {
+	var result []*data.StructValue
+	for _, object := range ruleData[key].(*schema.Set).List() {
+		object_data := object.(map[string]interface{})
+		var fields = make(map[string]data.DataValue)
+		fields["type"] = data.NewStringValue(internal_type)
+		for _, field := range string_fields {
+			if object_data[field] != nil && object_data[field].(string) != "" {
+				fields[field] = data.NewStringValue(object_data[field].(string))
+			}
+		}
+		for _, field := range bool_fields {
+			if object_data[field] != nil {
+				fields[field] = data.NewBooleanValue(object_data[field].(bool))
+			}
+		}
+		elem := data.NewStructValue("", fields)
+		result = append(result, elem)
+	}
+	return result
+}
+
+func getPolicyLbRulesFromSchema(d *schema.ResourceData) []model.LBRule {
+	var ruleList []model.LBRule
+	rules := d.Get("rule").([]interface{})
+
+	for _, rule := range rules {
+		rule_data := rule.(map[string]interface{})
+
+		displayName := rule_data["display_name"].(string)
+		matchStrategy := rule_data["match_strategy"].(string)
+		phase := rule_data["phase"].(string)
+
+		var actions []*data.StructValue
+
+		// Just strings and booleans, we use a helper function for there
+		actions = append(actions, getRuleActionOrMethod(rule_data, "connection_drop_action", []string{}, []string{}, model.LBRuleAction_TYPE_LBCONNECTIONDROPACTION)...)
+		actions = append(actions, getRuleActionOrMethod(rule_data, "http_redirect_action", []string{"redirect_status", "redirect_url"}, []string{}, model.LBRuleAction_TYPE_LBHTTPREDIRECTACTION)...)
+		actions = append(actions, getRuleActionOrMethod(rule_data, "http_reject_action", []string{"reply_message", "reply_status"}, []string{}, model.LBRuleAction_TYPE_LBHTTPREJECTACTION)...)
+		actions = append(actions, getRuleActionOrMethod(rule_data, "http_request_header_delete_action", []string{"header_name"}, []string{}, model.LBRuleAction_TYPE_LBHTTPREQUESTHEADERDELETEACTION)...)
+		actions = append(actions, getRuleActionOrMethod(rule_data, "http_request_header_rewrite_action", []string{"header_name", "header_value"}, []string{}, model.LBRuleAction_TYPE_LBHTTPREQUESTHEADERREWRITEACTION)...)
+		actions = append(actions, getRuleActionOrMethod(rule_data, "http_request_uri_rewrite_action", []string{"uri", "uri_arguments"}, []string{}, model.LBRuleAction_TYPE_LBHTTPREQUESTURIREWRITEACTION)...)
+		actions = append(actions, getRuleActionOrMethod(rule_data, "http_response_header_delete_action", []string{"header_name"}, []string{}, model.LBRuleAction_TYPE_LBHTTPRESPONSEHEADERDELETEACTION)...)
+		actions = append(actions, getRuleActionOrMethod(rule_data, "http_response_header_rewrite_action", []string{"header_name", "header_value"}, []string{}, model.LBRuleAction_TYPE_LBHTTPRESPONSEHEADERREWRITEACTION)...)
+		actions = append(actions, getRuleActionOrMethod(rule_data, "select_pool_action", []string{"pool_id"}, []string{}, model.LBRuleAction_TYPE_LBSELECTPOOLACTION)...)
+		actions = append(actions, getRuleActionOrMethod(rule_data, "ssl_mode_selection_action", []string{"ssl_mode"}, []string{}, model.LBRuleAction_TYPE_LBSSLMODESELECTIONACTION)...)
+		actions = append(actions, getRuleActionOrMethod(rule_data, "variable_assignment_action", []string{"variable_name", "variable_value"}, []string{}, model.LBRuleAction_TYPE_LBVARIABLEASSIGNMENTACTION)...)
+		actions = append(actions, getRuleActionOrMethod(rule_data, "variable_persistence_learn_action", []string{"persistence_profile_path", "variable_name"}, []string{"variable_hash_enabled"}, model.LBRuleAction_TYPE_LBVARIABLEPERSISTENCELEARNACTION)...)
+		actions = append(actions, getRuleActionOrMethod(rule_data, "variable_persistence_on_action", []string{"persistence_profile_path", "variable_name"}, []string{"variable_hash_enabled"}, model.LBRuleAction_TYPE_LBVARIABLEPERSISTENCEONACTION)...)
+
+		// more complicated actions
+		for _, action := range rule_data["jwt_auth_action"].(*schema.Set).List() {
+			action_data := action.(map[string]interface{})
+			var fields = make(map[string]data.DataValue)
+			fields["type"] = data.NewStringValue(model.LBRuleAction_TYPE_LBJWTAUTHACTION)
+			if action_data["realm"] != nil {
+				fields["realm"] = data.NewStringValue(action_data["realm"].(string))
+			}
+			if action_data["pass_jwt_to_pool"] != nil {
+				fields["pass_jwt_to_pool"] = data.NewBooleanValue(action_data["pass_jwt_to_pool"].(bool))
+			}
+			// I still haven't fully figured out why key comes as a (*schema.Set) but that's what we want,
+			// a set where no key can be there more than once
+			for _, key := range action_data["key"].(*schema.Set).List() {
+				key_data := key.(map[string]interface{})
+				var key_fields = make(map[string]data.DataValue)
+				if key_data["certificate_path"] != nil && key_data["certificate_path"].(string) != "" {
+					key_fields["certificate_path"] = data.NewStringValue(key_data["certificate_path"].(string))
+					key_fields["type"] = data.NewStringValue(model.LBJwtKey_TYPE_LBJWTCERTIFICATEKEY)
+				} else if key_data["public_key_content"] != nil && key_data["public_key_content"].(string) != "" {
+					key_fields["public_key_content"] = data.NewStringValue(key_data["public_key_content"].(string))
+					key_fields["type"] = data.NewStringValue(model.LBJwtKey_TYPE_LBJWTPUBLICKEY)
+				} else if key_data["symmetric_key"] != nil && key_data["symmetric_key"].(string) != "" {
+					// the API only wants the marker id, no actual content parameters
+					key_fields["type"] = data.NewStringValue(model.LBJwtKey_TYPE_LBJWTSYMMETRICKEY)
+				}
+				fields["key"] = data.NewStructValue("", key_fields)
+			}
+			if action_data["tokens"] != nil {
+				token_list := data.NewListValue()
+				for _, token := range action_data["tokens"].([]interface{}) {
+					token_list.Add(data.NewStringValue(token.(string)))
+				}
+				fields["tokens"] = token_list
+			}
+			elem := data.NewStructValue("", fields)
+			actions = append(actions, elem)
+		}
+
+		var matchConditions []*data.StructValue
+
+		// Just strings and booleans, we use a helper function for there
+		matchConditions = append(matchConditions, getRuleActionOrMethod(rule_data, "http_request_body_condition", []string{"body_value", "match_type"}, []string{"case_sensitive", "inverse"}, model.LBRuleCondition_TYPE_LBHTTPREQUESTBODYCONDITION)...)
+		matchConditions = append(matchConditions, getRuleActionOrMethod(rule_data, "http_request_cookie_condition", []string{"cookie_name", "cookie_value", "match_type"}, []string{"case_sensitive", "inverse"}, model.LBRuleCondition_TYPE_LBHTTPREQUESTCOOKIECONDITION)...)
+		matchConditions = append(matchConditions, getRuleActionOrMethod(rule_data, "http_request_header_condition", []string{"header_name", "header_value", "match_type"}, []string{"case_sensitive", "inverse"}, model.LBRuleCondition_TYPE_LBHTTPREQUESTHEADERCONDITION)...)
+		matchConditions = append(matchConditions, getRuleActionOrMethod(rule_data, "http_request_method_condition", []string{"method"}, []string{}, model.LBRuleCondition_TYPE_LBHTTPREQUESTMETHODCONDITION)...)
+		matchConditions = append(matchConditions, getRuleActionOrMethod(rule_data, "http_request_uri_arguments_condition", []string{"uri_arguments", "match_type"}, []string{"case_sensitive", "inverse"}, model.LBRuleCondition_TYPE_LBHTTPREQUESTURIARGUMENTSCONDITION)...)
+		matchConditions = append(matchConditions, getRuleActionOrMethod(rule_data, "http_request_uri_condition", []string{"uri", "match_type"}, []string{"case_sensitive", "inverse"}, model.LBRuleCondition_TYPE_LBHTTPREQUESTURICONDITION)...)
+		matchConditions = append(matchConditions, getRuleActionOrMethod(rule_data, "http_request_version_condition", []string{"version"}, []string{"inverse"}, model.LBRuleCondition_TYPE_LBHTTPREQUESTVERSIONCONDITION)...)
+		matchConditions = append(matchConditions, getRuleActionOrMethod(rule_data, "http_response_header_condition", []string{"header_name", "header_value", "match_type"}, []string{"case_sensitive", "inverse"}, model.LBRuleCondition_TYPE_LBHTTPRESPONSEHEADERCONDITION)...)
+		matchConditions = append(matchConditions, getRuleActionOrMethod(rule_data, "ip_header_condition", []string{"group_path", "source_address"}, []string{"inverse"}, model.LBRuleCondition_TYPE_LBIPHEADERCONDITION)...)
+		matchConditions = append(matchConditions, getRuleActionOrMethod(rule_data, "ssl_sni_condition", []string{"sni", "match_type"}, []string{"case_sensitive", "inverse"}, model.LBRuleCondition_TYPE_LBSSLSNICONDITION)...)
+		matchConditions = append(matchConditions, getRuleActionOrMethod(rule_data, "tcp_header_condition", []string{"source_port"}, []string{"inverse"}, model.LBRuleCondition_TYPE_LBTCPHEADERCONDITION)...)
+		matchConditions = append(matchConditions, getRuleActionOrMethod(rule_data, "variable_condition", []string{"match_type", "variable_name", "variable_value"}, []string{"case_sensitive", "inverse"}, model.LBRuleCondition_TYPE_LBVARIABLECONDITION)...)
+
+		// more complicated conditions
+		for _, condition := range rule_data["http_ssl_condition"].(*schema.Set).List() {
+			condition_data := condition.(map[string]interface{})
+			var fields = make(map[string]data.DataValue)
+			fields["type"] = data.NewStringValue(model.LBRuleCondition_TYPE_LBHTTPSSLCONDITION)
+			// Not actually a list but that's what the Schems says
+			for _, issuer_dn := range condition_data["client_certificate_issuer_dn"].(*schema.Set).List() {
+				issuer_dn_data := issuer_dn.(map[string]interface{})
+				var issuer_dn_fields = make(map[string]data.DataValue)
+				if issuer_dn_data["case_sensitive"] != nil {
+					issuer_dn_fields["case_sensitive"] = data.NewBooleanValue(issuer_dn_data["case_sensitive"].(bool))
+				}
+				if issuer_dn_data["issuer_dn"] != nil {
+					issuer_dn_fields["issuer_dn"] = data.NewStringValue(issuer_dn_data["issuer_dn"].(string))
+				}
+				if issuer_dn_data["match_type"] != nil {
+					issuer_dn_fields["match_type"] = data.NewStringValue(issuer_dn_data["match_type"].(string))
+				}
+				fields["client_certificate_issuer_dn"] = data.NewStructValue("", issuer_dn_fields)
+			}
+			// Not actually a list but that's what the Schems says
+			for _, subject_dn := range condition_data["client_certificate_subject_dn"].(*schema.Set).List() {
+				subject_dn_data := subject_dn.(map[string]interface{})
+				var subject_dn_fields = make(map[string]data.DataValue)
+				if subject_dn_data["case_sensitive"] != nil {
+					subject_dn_fields["case_sensitive"] = data.NewBooleanValue(subject_dn_data["case_sensitive"].(bool))
+				}
+				if subject_dn_data["subject_dn"] != nil {
+					subject_dn_fields["subject_dn"] = data.NewStringValue(subject_dn_data["subject_dn"].(string))
+				}
+				if subject_dn_data["match_type"] != nil {
+					subject_dn_fields["match_type"] = data.NewStringValue(subject_dn_data["match_type"].(string))
+				}
+				fields["client_certificate_subject_dn"] = data.NewStructValue("", subject_dn_fields)
+			}
+			if condition_data["client_supported_ssl_ciphers"] != nil {
+				cipher_list := data.NewListValue()
+				for _, cipher := range condition_data["client_supported_ssl_ciphers"].([]interface{}) {
+					cipher_list.Add(data.NewStringValue(cipher.(string)))
+				}
+				fields["client_supported_ssl_ciphers"] = cipher_list
+			}
+			if condition_data["inverse"] != nil {
+				fields["inverse"] = data.NewBooleanValue(condition_data["inverse"].(bool))
+			}
+			if condition_data["session_reused"] != nil {
+				fields["session_reused"] = data.NewStringValue(condition_data["session_reused"].(string))
+			}
+			if condition_data["used_protocol"] != nil {
+				fields["used_protocol"] = data.NewStringValue(condition_data["used_protocol"].(string))
+			}
+			if condition_data["used_ssl_cipher"] != nil {
+				fields["used_ssl_cipher"] = data.NewStringValue(condition_data["used_ssl_cipher"].(string))
+			}
+			elem := data.NewStructValue("", fields)
+			matchConditions = append(matchConditions, elem)
+		}
+
+		elem := model.LBRule{
+			DisplayName:     &displayName,
+			MatchStrategy:   &matchStrategy,
+			Phase:           &phase,
+			Actions:         actions,
+			MatchConditions: matchConditions,
+		}
+		ruleList = append(ruleList, elem)
+	}
+	return ruleList
+}
+
+func policyLBVirtualServerVersionDependantSet(d *schema.ResourceData, obj *model.LBVirtualServer) {
 	if nsxVersionHigherOrEqual("3.0.0") {
 		logSignificantOnly := d.Get("log_significant_event_only").(bool)
 		obj.LogSignificantEventOnly = &logSignificantOnly
@@ -426,6 +1503,7 @@ func resourceNsxtPolicyLBVirtualServerCreate(d *schema.ResourceData, m interface
 	ports := getStringListFromSchemaList(d, "ports")
 	serverSSLProfileBinding := getPolicyServerSSLBindingFromSchema(d)
 	sorryPoolPath := d.Get("sorry_pool_path").(string)
+	rules := getPolicyLbRulesFromSchema(d)
 
 	obj := model.LBVirtualServer{
 		DisplayName:              &displayName,
@@ -443,9 +1521,10 @@ func resourceNsxtPolicyLBVirtualServerCreate(d *schema.ResourceData, m interface
 		Ports:                    ports,
 		ServerSslProfileBinding:  serverSSLProfileBinding,
 		SorryPoolPath:            &sorryPoolPath,
+		Rules:                    rules,
 	}
 
-	policyLBVirtualServerVersionDepenantSet(d, &obj)
+	policyLBVirtualServerVersionDependantSet(d, &obj)
 
 	if maxNewConnectionRate > 0 {
 		obj.MaxNewConnectionRate = &maxNewConnectionRate
@@ -509,6 +1588,8 @@ func resourceNsxtPolicyLBVirtualServerRead(d *schema.ResourceData, m interface{}
 	d.Set("sorry_pool_path", obj.SorryPoolPath)
 	d.Set("log_significant_event_only", obj.LogSignificantEventOnly)
 	setPolicyAccessListControlInSchema(d, obj.AccessListControl)
+	setPolicyLbRulesInSchema(d, obj.Rules)
+
 	return nil
 }
 
@@ -543,6 +1624,7 @@ func resourceNsxtPolicyLBVirtualServerUpdate(d *schema.ResourceData, m interface
 	ports := getStringListFromSchemaList(d, "ports")
 	serverSSLProfileBinding := getPolicyServerSSLBindingFromSchema(d)
 	sorryPoolPath := d.Get("sorry_pool_path").(string)
+	rules := getPolicyLbRulesFromSchema(d)
 
 	obj := model.LBVirtualServer{
 		DisplayName:              &displayName,
@@ -560,9 +1642,10 @@ func resourceNsxtPolicyLBVirtualServerUpdate(d *schema.ResourceData, m interface
 		Ports:                    ports,
 		ServerSslProfileBinding:  serverSSLProfileBinding,
 		SorryPoolPath:            &sorryPoolPath,
+		Rules:                    rules,
 	}
 
-	policyLBVirtualServerVersionDepenantSet(d, &obj)
+	policyLBVirtualServerVersionDependantSet(d, &obj)
 
 	// The user might have defined the rules outside terraform, lets keep these
 	existingObj, err := client.Get(id)

--- a/nsxt/resource_nsxt_policy_lb_virtual_server.go
+++ b/nsxt/resource_nsxt_policy_lb_virtual_server.go
@@ -45,7 +45,7 @@ var lbRulePhaseValues = []string{
 	model.LBRule_PHASE_TRANSPORT,
 }
 
-var lbHttpSslConditionUsedSslCipherValues = []string{
+var lbHTTPSslConditionUsedSslCipherValues = []string{
 	model.LBHttpSslCondition_USED_SSL_CIPHER_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
 	model.LBHttpSslCondition_USED_SSL_CIPHER_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
 	model.LBHttpSslCondition_USED_SSL_CIPHER_ECDHE_RSA_WITH_AES_256_CBC_SHA,
@@ -79,7 +79,7 @@ var lbHttpSslConditionUsedSslCipherValues = []string{
 	model.LBHttpSslCondition_USED_SSL_CIPHER_ECDH_RSA_WITH_AES_256_GCM_SHA384,
 }
 
-var lbHttpSslConditionClientSupportedSslCiphersValues = []string{
+var lbHTTPSslConditionClientSupportedSslCiphersValues = []string{
 	model.LBHttpSslCondition_CLIENT_SUPPORTED_SSL_CIPHERS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
 	model.LBHttpSslCondition_CLIENT_SUPPORTED_SSL_CIPHERS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
 	model.LBHttpSslCondition_CLIENT_SUPPORTED_SSL_CIPHERS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
@@ -113,13 +113,13 @@ var lbHttpSslConditionClientSupportedSslCiphersValues = []string{
 	model.LBHttpSslCondition_CLIENT_SUPPORTED_SSL_CIPHERS_ECDH_RSA_WITH_AES_256_GCM_SHA384,
 }
 
-var lbHttpSslConditionSessionReusedValues = []string{
+var lbHTTPSslConditionSessionReusedValues = []string{
 	model.LBHttpSslCondition_SESSION_REUSED_IGNORE,
 	model.LBHttpSslCondition_SESSION_REUSED_REUSED,
 	model.LBHttpSslCondition_SESSION_REUSED_NEW,
 }
 
-var lbHttpSslConditionUsedProtocolValues = []string{
+var lbHTTPSslConditionUsedProtocolValues = []string{
 	model.LBHttpSslCondition_USED_PROTOCOL_SSL_V2,
 	model.LBHttpSslCondition_USED_PROTOCOL_SSL_V3,
 	model.LBHttpSslCondition_USED_PROTOCOL_TLS_V1,
@@ -377,13 +377,13 @@ func getPolicyLbRuleActionsSchema() *schema.Resource {
 	return &schema.Resource{
 		Schema: map[string]*schema.Schema{
 			"connection_drop":              getPolicyLbRuleConnectionDropActionSchema(),
-			"http_redirect":                getPolicyLbRuleHttpRedirectActionSchema(),
-			"http_reject":                  getPolicyLbRuleHttpRejectActionSchema(),
-			"http_request_header_delete":   getPolicyLbRuleHttpMessageHeaderDeleteActionSchema("Action to delete header fields of HTTP request messages at HTTP_REQUEST_REWRITE phase."),
-			"http_request_header_rewrite":  getPolicyLbRuleHttpMessageHeaderRewriteActionSchema("Action to rewrite header fields of HTTP request messages to specified new values at HTTP_REQUEST_REWRITE phase."),
-			"http_request_uri_rewrite":     getPolicyLbRuleHttpRequestUriRewriteActionSchema(),
-			"http_response_header_delete":  getPolicyLbRuleHttpMessageHeaderDeleteActionSchema("Action to delete header fields of HTTP response messages at HTTP_RESPONSE_REWRITE phase."),
-			"http_response_header_rewrite": getPolicyLbRuleHttpMessageHeaderRewriteActionSchema("Action to rewrite header fields of HTTP response messages to specified new values at HTTP_RESPONSE_REWRITE phase."),
+			"http_redirect":                getPolicyLbRuleHTTPRedirectActionSchema(),
+			"http_reject":                  getPolicyLbRuleHTTPRejectActionSchema(),
+			"http_request_header_delete":   getPolicyLbRuleHTTPMessageHeaderDeleteActionSchema("Action to delete header fields of HTTP request messages at HTTP_REQUEST_REWRITE phase."),
+			"http_request_header_rewrite":  getPolicyLbRuleHTTPMessageHeaderRewriteActionSchema("Action to rewrite header fields of HTTP request messages to specified new values at HTTP_REQUEST_REWRITE phase."),
+			"http_request_uri_rewrite":     getPolicyLbRuleHTTPRequestURIRewriteActionSchema(),
+			"http_response_header_delete":  getPolicyLbRuleHTTPMessageHeaderDeleteActionSchema("Action to delete header fields of HTTP response messages at HTTP_RESPONSE_REWRITE phase."),
+			"http_response_header_rewrite": getPolicyLbRuleHTTPMessageHeaderRewriteActionSchema("Action to rewrite header fields of HTTP response messages to specified new values at HTTP_RESPONSE_REWRITE phase."),
 			"jwt_auth":                     getPolicyLbRuleJwtAuthActionSchema(),
 			"select_pool":                  getPolicyLbRuleSelectPoolActionSchema(),
 			"ssl_mode_selection":           getPolicyLbRuleSslModeSelectionSchema(),
@@ -591,23 +591,23 @@ func getPolicyLbRuleHTTPSslConditionSchema() *schema.Schema {
 					Optional:    true,
 					Elem: &schema.Schema{
 						Type:         schema.TypeString,
-						ValidateFunc: validation.StringInSlice(lbHttpSslConditionClientSupportedSslCiphersValues, false),
+						ValidateFunc: validation.StringInSlice(lbHTTPSslConditionClientSupportedSslCiphersValues, false),
 					},
 				},
 				"session_reused": {
 					Type:         schema.TypeString,
 					Optional:     true,
-					ValidateFunc: validation.StringInSlice(lbHttpSslConditionSessionReusedValues, false),
+					ValidateFunc: validation.StringInSlice(lbHTTPSslConditionSessionReusedValues, false),
 				},
 				"used_protocol": {
 					Type:         schema.TypeString,
 					Optional:     true,
-					ValidateFunc: validation.StringInSlice(lbHttpSslConditionUsedProtocolValues, false),
+					ValidateFunc: validation.StringInSlice(lbHTTPSslConditionUsedProtocolValues, false),
 				},
 				"used_ssl_cipher": {
 					Type:         schema.TypeString,
 					Optional:     true,
-					ValidateFunc: validation.StringInSlice(lbHttpSslConditionUsedSslCipherValues, false),
+					ValidateFunc: validation.StringInSlice(lbHTTPSslConditionUsedSslCipherValues, false),
 				},
 			},
 		},
@@ -672,7 +672,7 @@ func getPolicyLbRuleConnectionDropActionSchema() *schema.Schema {
 	}
 }
 
-func getPolicyLbRuleHttpRedirectActionSchema() *schema.Schema {
+func getPolicyLbRuleHTTPRedirectActionSchema() *schema.Schema {
 	return &schema.Schema{
 		Type:        schema.TypeList,
 		Description: "Action to redirect HTTP request messages to a new URL.",
@@ -692,7 +692,7 @@ func getPolicyLbRuleHttpRedirectActionSchema() *schema.Schema {
 	}
 }
 
-func getPolicyLbRuleHttpRejectActionSchema() *schema.Schema {
+func getPolicyLbRuleHTTPRejectActionSchema() *schema.Schema {
 	return &schema.Schema{
 		Type:        schema.TypeList,
 		Description: "Action to reject HTTP request messages",
@@ -712,7 +712,7 @@ func getPolicyLbRuleHttpRejectActionSchema() *schema.Schema {
 	}
 }
 
-func getPolicyLbRuleHttpRequestUriRewriteActionSchema() *schema.Schema {
+func getPolicyLbRuleHTTPRequestURIRewriteActionSchema() *schema.Schema {
 	return &schema.Schema{
 		Type:        schema.TypeList,
 		Description: "Action to rewrite URIs in matched HTTP request messages.",
@@ -732,7 +732,7 @@ func getPolicyLbRuleHttpRequestUriRewriteActionSchema() *schema.Schema {
 	}
 }
 
-func getPolicyLbRuleHttpMessageHeaderDeleteActionSchema(description string) *schema.Schema {
+func getPolicyLbRuleHTTPMessageHeaderDeleteActionSchema(description string) *schema.Schema {
 	return &schema.Schema{
 		Type:        schema.TypeList,
 		Description: description,
@@ -748,7 +748,7 @@ func getPolicyLbRuleHttpMessageHeaderDeleteActionSchema(description string) *sch
 	}
 }
 
-func getPolicyLbRuleHttpMessageHeaderRewriteActionSchema(description string) *schema.Schema {
+func getPolicyLbRuleHTTPMessageHeaderRewriteActionSchema(description string) *schema.Schema {
 	return &schema.Schema{
 		Type:        schema.TypeList,
 		Description: description,
@@ -1061,7 +1061,7 @@ func setPolicyLbRulesInSchema(d *schema.ResourceData, rules []model.LBRule) {
 		var connectionDropActionList []interface{}
 		var selectPoolActionList []interface{}
 		var httpRedirectActionList []interface{}
-		var httpRequestUriRewriteActionList []interface{}
+		var httpRequestURIRewriteActionList []interface{}
 		var httpRequestHeaderRewriteActionList []interface{}
 		var httpRejectActionList []interface{}
 		var httpResponseHeaderRewriteActionList []interface{}
@@ -1095,7 +1095,7 @@ func setPolicyLbRulesInSchema(d *schema.ResourceData, rules []model.LBRule) {
 				specificType, _ := converter.ConvertToGolang(action, model.LBHttpRequestUriRewriteActionBindingType())
 				actionElem["uri"] = specificType.(model.LBHttpRequestUriRewriteAction).Uri
 				actionElem["uri_arguments"] = specificType.(model.LBHttpRequestUriRewriteAction).UriArguments
-				httpRequestUriRewriteActionList = append(httpRequestUriRewriteActionList, actionElem)
+				httpRequestURIRewriteActionList = append(httpRequestURIRewriteActionList, actionElem)
 			} else if actionType == model.LBRuleAction_TYPE_LBHTTPREQUESTHEADERREWRITEACTION {
 				specificType, _ := converter.ConvertToGolang(action, model.LBHttpRequestHeaderRewriteActionBindingType())
 				actionElem["header_name"] = specificType.(model.LBHttpRequestHeaderRewriteAction).HeaderName
@@ -1179,7 +1179,7 @@ func setPolicyLbRulesInSchema(d *schema.ResourceData, rules []model.LBRule) {
 		actionElem["connection_drop"] = connectionDropActionList
 		actionElem["select_pool"] = selectPoolActionList
 		actionElem["http_redirect"] = httpRedirectActionList
-		actionElem["http_request_uri_rewrite"] = httpRequestUriRewriteActionList
+		actionElem["http_request_uri_rewrite"] = httpRequestURIRewriteActionList
 		actionElem["http_request_header_rewrite"] = httpRequestHeaderRewriteActionList
 		actionElem["http_reject"] = httpRejectActionList
 		actionElem["http_response_header_rewrite"] = httpResponseHeaderRewriteActionList
@@ -1197,10 +1197,10 @@ func setPolicyLbRulesInSchema(d *schema.ResourceData, rules []model.LBRule) {
 
 		// MatchConditions
 		var httpRequestBodyConditionList []interface{}
-		var httpRequestUriConditionList []interface{}
+		var httpRequestURIConditionList []interface{}
 		var httpRequestHeaderConditionList []interface{}
 		var httpRequestMethodConditionList []interface{}
-		var httpRequestUriArgumentsConditionList []interface{}
+		var httpRequestURIArgumentsConditionList []interface{}
 		var httpRequestVersionConditionList []interface{}
 		var httpRequestCookieConditionList []interface{}
 		var httpResponseHeaderConditionList []interface{}
@@ -1231,7 +1231,7 @@ func setPolicyLbRulesInSchema(d *schema.ResourceData, rules []model.LBRule) {
 				conditionElem["inverse"] = specificType.(model.LBHttpRequestUriCondition).Inverse
 				conditionElem["match_type"] = specificType.(model.LBHttpRequestUriCondition).MatchType
 				conditionElem["uri"] = specificType.(model.LBHttpRequestUriCondition).Uri
-				httpRequestUriConditionList = append(httpRequestUriConditionList, conditionElem)
+				httpRequestURIConditionList = append(httpRequestURIConditionList, conditionElem)
 			} else if conditionType == model.LBRuleCondition_TYPE_LBHTTPREQUESTHEADERCONDITION {
 				specificType, _ := converter.ConvertToGolang(condition, model.LBHttpRequestHeaderConditionBindingType())
 				conditionElem["case_sensitive"] = specificType.(model.LBHttpRequestHeaderCondition).CaseSensitive
@@ -1251,7 +1251,7 @@ func setPolicyLbRulesInSchema(d *schema.ResourceData, rules []model.LBRule) {
 				conditionElem["inverse"] = specificType.(model.LBHttpRequestUriArgumentsCondition).Inverse
 				conditionElem["match_type"] = specificType.(model.LBHttpRequestUriArgumentsCondition).MatchType
 				conditionElem["uri_arguments"] = specificType.(model.LBHttpRequestUriArgumentsCondition).UriArguments
-				httpRequestUriArgumentsConditionList = append(httpRequestUriArgumentsConditionList, conditionElem)
+				httpRequestURIArgumentsConditionList = append(httpRequestURIArgumentsConditionList, conditionElem)
 			} else if conditionType == model.LBRuleCondition_TYPE_LBHTTPREQUESTVERSIONCONDITION {
 				specificType, _ := converter.ConvertToGolang(condition, model.LBHttpRequestVersionConditionBindingType())
 				conditionElem["inverse"] = specificType.(model.LBHttpRequestVersionCondition).Inverse
@@ -1306,29 +1306,29 @@ func setPolicyLbRulesInSchema(d *schema.ResourceData, rules []model.LBRule) {
 				conditionElem["used_protocol"] = specificType.(model.LBHttpSslCondition).UsedProtocol
 				conditionElem["used_ssl_cipher"] = specificType.(model.LBHttpSslCondition).UsedSslCipher
 
-				issuer_dn := specificType.(model.LBHttpSslCondition).ClientCertificateIssuerDn
+				issuerDn := specificType.(model.LBHttpSslCondition).ClientCertificateIssuerDn
 				var issuerDnList []interface{}
 				issuerElem := make(map[string]interface{})
-				issuerElem["case_sensitive"] = issuer_dn.CaseSensitive
-				issuerElem["issuer_dn"] = issuer_dn.IssuerDn
-				issuerElem["match_type"] = issuer_dn.MatchType
+				issuerElem["case_sensitive"] = issuerDn.CaseSensitive
+				issuerElem["issuer_dn"] = issuerDn.IssuerDn
+				issuerElem["match_type"] = issuerDn.MatchType
 				issuerDnList = append(issuerDnList, issuerElem)
 				conditionElem["client_certificate_issuer_dn"] = schema.NewSet(resourceKeyValueHash, issuerDnList)
 
-				subject_dn := specificType.(model.LBHttpSslCondition).ClientCertificateSubjectDn
+				subjectDn := specificType.(model.LBHttpSslCondition).ClientCertificateSubjectDn
 				var subjectDnList []interface{}
 				subjectElem := make(map[string]interface{})
-				subjectElem["case_sensitive"] = subject_dn.CaseSensitive
-				subjectElem["subject_dn"] = subject_dn.SubjectDn
-				subjectElem["match_type"] = subject_dn.MatchType
+				subjectElem["case_sensitive"] = subjectDn.CaseSensitive
+				subjectElem["subject_dn"] = subjectDn.SubjectDn
+				subjectElem["match_type"] = subjectDn.MatchType
 				subjectDnList = append(subjectDnList, subjectElem)
 				conditionElem["client_certificate_subject_dn"] = schema.NewSet(resourceKeyValueHash, subjectDnList)
 
-				var ssl_ciphers []interface{}
+				var sslCiphers []interface{}
 				for _, v := range specificType.(model.LBHttpSslCondition).ClientSupportedSslCiphers {
-					ssl_ciphers = append(ssl_ciphers, v)
+					sslCiphers = append(sslCiphers, v)
 				}
-				conditionElem["client_supported_ssl_ciphers"] = ssl_ciphers
+				conditionElem["client_supported_ssl_ciphers"] = sslCiphers
 
 				httpSslConditionList = append(httpSslConditionList, conditionElem)
 			}
@@ -1338,10 +1338,10 @@ func setPolicyLbRulesInSchema(d *schema.ResourceData, rules []model.LBRule) {
 		if conditionCount > 0 {
 			conditionElem := make((map[string]interface{}))
 			conditionElem["http_request_body"] = httpRequestBodyConditionList
-			conditionElem["http_request_uri"] = httpRequestUriConditionList
+			conditionElem["http_request_uri"] = httpRequestURIConditionList
 			conditionElem["http_request_header"] = httpRequestHeaderConditionList
 			conditionElem["http_request_method"] = httpRequestMethodConditionList
-			conditionElem["http_request_uri_arguments"] = httpRequestUriArgumentsConditionList
+			conditionElem["http_request_uri_arguments"] = httpRequestURIArgumentsConditionList
 			conditionElem["http_request_version"] = httpRequestVersionConditionList
 			conditionElem["http_request_cookie"] = httpRequestCookieConditionList
 			conditionElem["http_response_header"] = httpResponseHeaderConditionList
@@ -1366,20 +1366,20 @@ func setPolicyLbRulesInSchema(d *schema.ResourceData, rules []model.LBRule) {
 
 }
 
-func getRuleActionOrMethod(ruleData map[string]interface{}, key string, string_fields []string, bool_fields []string, internal_type string) []*data.StructValue {
+func getRuleActionOrMethod(ruleData map[string]interface{}, key string, stringFields []string, boolFields []string, internalType string) []*data.StructValue {
 	var result []*data.StructValue
 	for _, object := range ruleData[key].([]interface{}) {
-		object_data := object.(map[string]interface{})
+		objectData := object.(map[string]interface{})
 		var fields = make(map[string]data.DataValue)
-		fields["type"] = data.NewStringValue(internal_type)
-		for _, field := range string_fields {
-			if object_data[field] != nil && object_data[field].(string) != "" {
-				fields[field] = data.NewStringValue(object_data[field].(string))
+		fields["type"] = data.NewStringValue(internalType)
+		for _, field := range stringFields {
+			if objectData[field] != nil && objectData[field].(string) != "" {
+				fields[field] = data.NewStringValue(objectData[field].(string))
 			}
 		}
-		for _, field := range bool_fields {
-			if object_data[field] != nil {
-				fields[field] = data.NewBooleanValue(object_data[field].(bool))
+		for _, field := range boolFields {
+			if objectData[field] != nil {
+				fields[field] = data.NewBooleanValue(objectData[field].(bool))
 			}
 		}
 		elem := data.NewStructValue("", fields)
@@ -1393,68 +1393,68 @@ func getPolicyLbRulesFromSchema(d *schema.ResourceData) []model.LBRule {
 	rules := d.Get("rule").([]interface{})
 
 	for _, rule := range rules {
-		rule_data := rule.(map[string]interface{})
+		ruleData := rule.(map[string]interface{})
 
-		displayName := rule_data["display_name"].(string)
-		matchStrategy := rule_data["match_strategy"].(string)
-		phase := rule_data["phase"].(string)
+		displayName := ruleData["display_name"].(string)
+		matchStrategy := ruleData["match_strategy"].(string)
+		phase := ruleData["phase"].(string)
 
 		var actions []*data.StructValue
 
-		rule_actions := rule_data["action"]
-		for _, rule_action := range rule_actions.([]interface{}) {
+		ruleActions := ruleData["action"]
+		for _, ruleAction := range ruleActions.([]interface{}) {
 
-			rule_action := rule_action.(map[string]interface{})
+			ruleAction := ruleAction.(map[string]interface{})
 
 			// Just strings and booleans, we use a helper function for there
-			actions = append(actions, getRuleActionOrMethod(rule_action, "connection_drop", []string{}, []string{}, model.LBRuleAction_TYPE_LBCONNECTIONDROPACTION)...)
-			actions = append(actions, getRuleActionOrMethod(rule_action, "http_redirect", []string{"redirect_status", "redirect_url"}, []string{}, model.LBRuleAction_TYPE_LBHTTPREDIRECTACTION)...)
-			actions = append(actions, getRuleActionOrMethod(rule_action, "http_reject", []string{"reply_message", "reply_status"}, []string{}, model.LBRuleAction_TYPE_LBHTTPREJECTACTION)...)
-			actions = append(actions, getRuleActionOrMethod(rule_action, "http_request_header_delete", []string{"header_name"}, []string{}, model.LBRuleAction_TYPE_LBHTTPREQUESTHEADERDELETEACTION)...)
-			actions = append(actions, getRuleActionOrMethod(rule_action, "http_request_header_rewrite", []string{"header_name", "header_value"}, []string{}, model.LBRuleAction_TYPE_LBHTTPREQUESTHEADERREWRITEACTION)...)
-			actions = append(actions, getRuleActionOrMethod(rule_action, "http_request_uri_rewrite", []string{"uri", "uri_arguments"}, []string{}, model.LBRuleAction_TYPE_LBHTTPREQUESTURIREWRITEACTION)...)
-			actions = append(actions, getRuleActionOrMethod(rule_action, "http_response_header_delete", []string{"header_name"}, []string{}, model.LBRuleAction_TYPE_LBHTTPRESPONSEHEADERDELETEACTION)...)
-			actions = append(actions, getRuleActionOrMethod(rule_action, "http_response_header_rewrite", []string{"header_name", "header_value"}, []string{}, model.LBRuleAction_TYPE_LBHTTPRESPONSEHEADERREWRITEACTION)...)
-			actions = append(actions, getRuleActionOrMethod(rule_action, "select_pool", []string{"pool_id"}, []string{}, model.LBRuleAction_TYPE_LBSELECTPOOLACTION)...)
-			actions = append(actions, getRuleActionOrMethod(rule_action, "ssl_mode_selection", []string{"ssl_mode"}, []string{}, model.LBRuleAction_TYPE_LBSSLMODESELECTIONACTION)...)
-			actions = append(actions, getRuleActionOrMethod(rule_action, "variable_assignment", []string{"variable_name", "variable_value"}, []string{}, model.LBRuleAction_TYPE_LBVARIABLEASSIGNMENTACTION)...)
-			actions = append(actions, getRuleActionOrMethod(rule_action, "variable_persistence_learn", []string{"persistence_profile_path", "variable_name"}, []string{"variable_hash_enabled"}, model.LBRuleAction_TYPE_LBVARIABLEPERSISTENCELEARNACTION)...)
-			actions = append(actions, getRuleActionOrMethod(rule_action, "variable_persistence_on", []string{"persistence_profile_path", "variable_name"}, []string{"variable_hash_enabled"}, model.LBRuleAction_TYPE_LBVARIABLEPERSISTENCEONACTION)...)
+			actions = append(actions, getRuleActionOrMethod(ruleAction, "connection_drop", []string{}, []string{}, model.LBRuleAction_TYPE_LBCONNECTIONDROPACTION)...)
+			actions = append(actions, getRuleActionOrMethod(ruleAction, "http_redirect", []string{"redirect_status", "redirect_url"}, []string{}, model.LBRuleAction_TYPE_LBHTTPREDIRECTACTION)...)
+			actions = append(actions, getRuleActionOrMethod(ruleAction, "http_reject", []string{"reply_message", "reply_status"}, []string{}, model.LBRuleAction_TYPE_LBHTTPREJECTACTION)...)
+			actions = append(actions, getRuleActionOrMethod(ruleAction, "http_request_header_delete", []string{"header_name"}, []string{}, model.LBRuleAction_TYPE_LBHTTPREQUESTHEADERDELETEACTION)...)
+			actions = append(actions, getRuleActionOrMethod(ruleAction, "http_request_header_rewrite", []string{"header_name", "header_value"}, []string{}, model.LBRuleAction_TYPE_LBHTTPREQUESTHEADERREWRITEACTION)...)
+			actions = append(actions, getRuleActionOrMethod(ruleAction, "http_request_uri_rewrite", []string{"uri", "uri_arguments"}, []string{}, model.LBRuleAction_TYPE_LBHTTPREQUESTURIREWRITEACTION)...)
+			actions = append(actions, getRuleActionOrMethod(ruleAction, "http_response_header_delete", []string{"header_name"}, []string{}, model.LBRuleAction_TYPE_LBHTTPRESPONSEHEADERDELETEACTION)...)
+			actions = append(actions, getRuleActionOrMethod(ruleAction, "http_response_header_rewrite", []string{"header_name", "header_value"}, []string{}, model.LBRuleAction_TYPE_LBHTTPRESPONSEHEADERREWRITEACTION)...)
+			actions = append(actions, getRuleActionOrMethod(ruleAction, "select_pool", []string{"pool_id"}, []string{}, model.LBRuleAction_TYPE_LBSELECTPOOLACTION)...)
+			actions = append(actions, getRuleActionOrMethod(ruleAction, "ssl_mode_selection", []string{"ssl_mode"}, []string{}, model.LBRuleAction_TYPE_LBSSLMODESELECTIONACTION)...)
+			actions = append(actions, getRuleActionOrMethod(ruleAction, "variable_assignment", []string{"variable_name", "variable_value"}, []string{}, model.LBRuleAction_TYPE_LBVARIABLEASSIGNMENTACTION)...)
+			actions = append(actions, getRuleActionOrMethod(ruleAction, "variable_persistence_learn", []string{"persistence_profile_path", "variable_name"}, []string{"variable_hash_enabled"}, model.LBRuleAction_TYPE_LBVARIABLEPERSISTENCELEARNACTION)...)
+			actions = append(actions, getRuleActionOrMethod(ruleAction, "variable_persistence_on", []string{"persistence_profile_path", "variable_name"}, []string{"variable_hash_enabled"}, model.LBRuleAction_TYPE_LBVARIABLEPERSISTENCEONACTION)...)
 
 			// more complicated actions
-			for _, action := range rule_action["jwt_auth"].([]interface{}) {
-				action_data := action.(map[string]interface{})
+			for _, action := range ruleAction["jwt_auth"].([]interface{}) {
+				actionData := action.(map[string]interface{})
 				var fields = make(map[string]data.DataValue)
 				fields["type"] = data.NewStringValue(model.LBRuleAction_TYPE_LBJWTAUTHACTION)
-				if action_data["realm"] != nil {
-					fields["realm"] = data.NewStringValue(action_data["realm"].(string))
+				if actionData["realm"] != nil {
+					fields["realm"] = data.NewStringValue(actionData["realm"].(string))
 				}
-				if action_data["pass_jwt_to_pool"] != nil {
-					fields["pass_jwt_to_pool"] = data.NewBooleanValue(action_data["pass_jwt_to_pool"].(bool))
+				if actionData["pass_jwt_to_pool"] != nil {
+					fields["pass_jwt_to_pool"] = data.NewBooleanValue(actionData["pass_jwt_to_pool"].(bool))
 				}
 				// I still haven't fully figured out why key comes as a (*schema.Set) but that's what we want,
 				// a set where no key can be there more than once
-				for _, key := range action_data["key"].(*schema.Set).List() {
-					key_data := key.(map[string]interface{})
-					var key_fields = make(map[string]data.DataValue)
-					if key_data["certificate_path"] != nil && key_data["certificate_path"].(string) != "" {
-						key_fields["certificate_path"] = data.NewStringValue(key_data["certificate_path"].(string))
-						key_fields["type"] = data.NewStringValue(model.LBJwtKey_TYPE_LBJWTCERTIFICATEKEY)
-					} else if key_data["public_key_content"] != nil && key_data["public_key_content"].(string) != "" {
-						key_fields["public_key_content"] = data.NewStringValue(key_data["public_key_content"].(string))
-						key_fields["type"] = data.NewStringValue(model.LBJwtKey_TYPE_LBJWTPUBLICKEY)
-					} else if key_data["symmetric_key"] != nil && key_data["symmetric_key"].(string) != "" {
+				for _, key := range actionData["key"].(*schema.Set).List() {
+					keyData := key.(map[string]interface{})
+					var keyFields = make(map[string]data.DataValue)
+					if keyData["certificate_path"] != nil && keyData["certificate_path"].(string) != "" {
+						keyFields["certificate_path"] = data.NewStringValue(keyData["certificate_path"].(string))
+						keyFields["type"] = data.NewStringValue(model.LBJwtKey_TYPE_LBJWTCERTIFICATEKEY)
+					} else if keyData["public_key_content"] != nil && keyData["public_key_content"].(string) != "" {
+						keyFields["public_key_content"] = data.NewStringValue(keyData["public_key_content"].(string))
+						keyFields["type"] = data.NewStringValue(model.LBJwtKey_TYPE_LBJWTPUBLICKEY)
+					} else if keyData["symmetric_key"] != nil && keyData["symmetric_key"].(string) != "" {
 						// the API only wants the marker id, no actual content parameters
-						key_fields["type"] = data.NewStringValue(model.LBJwtKey_TYPE_LBJWTSYMMETRICKEY)
+						keyFields["type"] = data.NewStringValue(model.LBJwtKey_TYPE_LBJWTSYMMETRICKEY)
 					}
-					fields["key"] = data.NewStructValue("", key_fields)
+					fields["key"] = data.NewStructValue("", keyFields)
 				}
-				if action_data["tokens"] != nil {
-					token_list := data.NewListValue()
-					for _, token := range action_data["tokens"].([]interface{}) {
-						token_list.Add(data.NewStringValue(token.(string)))
+				if actionData["tokens"] != nil {
+					tokenList := data.NewListValue()
+					for _, token := range actionData["tokens"].([]interface{}) {
+						tokenList.Add(data.NewStringValue(token.(string)))
 					}
-					fields["tokens"] = token_list
+					fields["tokens"] = tokenList
 				}
 				elem := data.NewStructValue("", fields)
 				actions = append(actions, elem)
@@ -1463,78 +1463,78 @@ func getPolicyLbRulesFromSchema(d *schema.ResourceData) []model.LBRule {
 
 		var matchConditions []*data.StructValue
 
-		rule_conditions := rule_data["condition"]
-		for _, rule_condition := range rule_conditions.([]interface{}) {
+		ruleConditions := ruleData["condition"]
+		for _, ruleCondition := range ruleConditions.([]interface{}) {
 
-			rule_condition := rule_condition.(map[string]interface{})
+			ruleCondition := ruleCondition.(map[string]interface{})
 
 			// Just strings and booleans, we use a helper function for there
-			matchConditions = append(matchConditions, getRuleActionOrMethod(rule_condition, "http_request_body", []string{"body_value", "match_type"}, []string{"case_sensitive", "inverse"}, model.LBRuleCondition_TYPE_LBHTTPREQUESTBODYCONDITION)...)
-			matchConditions = append(matchConditions, getRuleActionOrMethod(rule_condition, "http_request_cookie", []string{"cookie_name", "cookie_value", "match_type"}, []string{"case_sensitive", "inverse"}, model.LBRuleCondition_TYPE_LBHTTPREQUESTCOOKIECONDITION)...)
-			matchConditions = append(matchConditions, getRuleActionOrMethod(rule_condition, "http_request_header", []string{"header_name", "header_value", "match_type"}, []string{"case_sensitive", "inverse"}, model.LBRuleCondition_TYPE_LBHTTPREQUESTHEADERCONDITION)...)
-			matchConditions = append(matchConditions, getRuleActionOrMethod(rule_condition, "http_request_method", []string{"method"}, []string{}, model.LBRuleCondition_TYPE_LBHTTPREQUESTMETHODCONDITION)...)
-			matchConditions = append(matchConditions, getRuleActionOrMethod(rule_condition, "http_request_uri_arguments", []string{"uri_arguments", "match_type"}, []string{"case_sensitive", "inverse"}, model.LBRuleCondition_TYPE_LBHTTPREQUESTURIARGUMENTSCONDITION)...)
-			matchConditions = append(matchConditions, getRuleActionOrMethod(rule_condition, "http_request_uri", []string{"uri", "match_type"}, []string{"case_sensitive", "inverse"}, model.LBRuleCondition_TYPE_LBHTTPREQUESTURICONDITION)...)
-			matchConditions = append(matchConditions, getRuleActionOrMethod(rule_condition, "http_request_version", []string{"version"}, []string{"inverse"}, model.LBRuleCondition_TYPE_LBHTTPREQUESTVERSIONCONDITION)...)
-			matchConditions = append(matchConditions, getRuleActionOrMethod(rule_condition, "http_response_header", []string{"header_name", "header_value", "match_type"}, []string{"case_sensitive", "inverse"}, model.LBRuleCondition_TYPE_LBHTTPRESPONSEHEADERCONDITION)...)
-			matchConditions = append(matchConditions, getRuleActionOrMethod(rule_condition, "ip_header", []string{"group_path", "source_address"}, []string{"inverse"}, model.LBRuleCondition_TYPE_LBIPHEADERCONDITION)...)
-			matchConditions = append(matchConditions, getRuleActionOrMethod(rule_condition, "ssl_sni", []string{"sni", "match_type"}, []string{"case_sensitive", "inverse"}, model.LBRuleCondition_TYPE_LBSSLSNICONDITION)...)
-			matchConditions = append(matchConditions, getRuleActionOrMethod(rule_condition, "tcp_header", []string{"source_port"}, []string{"inverse"}, model.LBRuleCondition_TYPE_LBTCPHEADERCONDITION)...)
-			matchConditions = append(matchConditions, getRuleActionOrMethod(rule_condition, "variable", []string{"match_type", "variable_name", "variable_value"}, []string{"case_sensitive", "inverse"}, model.LBRuleCondition_TYPE_LBVARIABLECONDITION)...)
+			matchConditions = append(matchConditions, getRuleActionOrMethod(ruleCondition, "http_request_body", []string{"body_value", "match_type"}, []string{"case_sensitive", "inverse"}, model.LBRuleCondition_TYPE_LBHTTPREQUESTBODYCONDITION)...)
+			matchConditions = append(matchConditions, getRuleActionOrMethod(ruleCondition, "http_request_cookie", []string{"cookie_name", "cookie_value", "match_type"}, []string{"case_sensitive", "inverse"}, model.LBRuleCondition_TYPE_LBHTTPREQUESTCOOKIECONDITION)...)
+			matchConditions = append(matchConditions, getRuleActionOrMethod(ruleCondition, "http_request_header", []string{"header_name", "header_value", "match_type"}, []string{"case_sensitive", "inverse"}, model.LBRuleCondition_TYPE_LBHTTPREQUESTHEADERCONDITION)...)
+			matchConditions = append(matchConditions, getRuleActionOrMethod(ruleCondition, "http_request_method", []string{"method"}, []string{}, model.LBRuleCondition_TYPE_LBHTTPREQUESTMETHODCONDITION)...)
+			matchConditions = append(matchConditions, getRuleActionOrMethod(ruleCondition, "http_request_uri_arguments", []string{"uri_arguments", "match_type"}, []string{"case_sensitive", "inverse"}, model.LBRuleCondition_TYPE_LBHTTPREQUESTURIARGUMENTSCONDITION)...)
+			matchConditions = append(matchConditions, getRuleActionOrMethod(ruleCondition, "http_request_uri", []string{"uri", "match_type"}, []string{"case_sensitive", "inverse"}, model.LBRuleCondition_TYPE_LBHTTPREQUESTURICONDITION)...)
+			matchConditions = append(matchConditions, getRuleActionOrMethod(ruleCondition, "http_request_version", []string{"version"}, []string{"inverse"}, model.LBRuleCondition_TYPE_LBHTTPREQUESTVERSIONCONDITION)...)
+			matchConditions = append(matchConditions, getRuleActionOrMethod(ruleCondition, "http_response_header", []string{"header_name", "header_value", "match_type"}, []string{"case_sensitive", "inverse"}, model.LBRuleCondition_TYPE_LBHTTPRESPONSEHEADERCONDITION)...)
+			matchConditions = append(matchConditions, getRuleActionOrMethod(ruleCondition, "ip_header", []string{"group_path", "source_address"}, []string{"inverse"}, model.LBRuleCondition_TYPE_LBIPHEADERCONDITION)...)
+			matchConditions = append(matchConditions, getRuleActionOrMethod(ruleCondition, "ssl_sni", []string{"sni", "match_type"}, []string{"case_sensitive", "inverse"}, model.LBRuleCondition_TYPE_LBSSLSNICONDITION)...)
+			matchConditions = append(matchConditions, getRuleActionOrMethod(ruleCondition, "tcp_header", []string{"source_port"}, []string{"inverse"}, model.LBRuleCondition_TYPE_LBTCPHEADERCONDITION)...)
+			matchConditions = append(matchConditions, getRuleActionOrMethod(ruleCondition, "variable", []string{"match_type", "variable_name", "variable_value"}, []string{"case_sensitive", "inverse"}, model.LBRuleCondition_TYPE_LBVARIABLECONDITION)...)
 
 			// more complicated conditions
-			for _, condition := range rule_condition["http_ssl"].([]interface{}) {
-				condition_data := condition.(map[string]interface{})
+			for _, condition := range ruleCondition["http_ssl"].([]interface{}) {
+				conditionData := condition.(map[string]interface{})
 				var fields = make(map[string]data.DataValue)
 				fields["type"] = data.NewStringValue(model.LBRuleCondition_TYPE_LBHTTPSSLCONDITION)
 				// Not actually a list but that's what the Schems says
-				for _, issuer_dn := range condition_data["client_certificate_issuer_dn"].(*schema.Set).List() {
-					issuer_dn_data := issuer_dn.(map[string]interface{})
-					var issuer_dn_fields = make(map[string]data.DataValue)
-					if issuer_dn_data["case_sensitive"] != nil {
-						issuer_dn_fields["case_sensitive"] = data.NewBooleanValue(issuer_dn_data["case_sensitive"].(bool))
+				for _, issuerDn := range conditionData["client_certificate_issuer_dn"].(*schema.Set).List() {
+					issuerDnData := issuerDn.(map[string]interface{})
+					var issuerDnFields = make(map[string]data.DataValue)
+					if issuerDnData["case_sensitive"] != nil {
+						issuerDnFields["case_sensitive"] = data.NewBooleanValue(issuerDnData["case_sensitive"].(bool))
 					}
-					if issuer_dn_data["issuer_dn"] != nil {
-						issuer_dn_fields["issuer_dn"] = data.NewStringValue(issuer_dn_data["issuer_dn"].(string))
+					if issuerDnData["issuer_dn"] != nil {
+						issuerDnFields["issuer_dn"] = data.NewStringValue(issuerDnData["issuer_dn"].(string))
 					}
-					if issuer_dn_data["match_type"] != nil {
-						issuer_dn_fields["match_type"] = data.NewStringValue(issuer_dn_data["match_type"].(string))
+					if issuerDnData["match_type"] != nil {
+						issuerDnFields["match_type"] = data.NewStringValue(issuerDnData["match_type"].(string))
 					}
-					fields["client_certificate_issuer_dn"] = data.NewStructValue("", issuer_dn_fields)
+					fields["client_certificate_issuer_dn"] = data.NewStructValue("", issuerDnFields)
 				}
 				// Not actually a list but that's what the Schems says
-				for _, subject_dn := range condition_data["client_certificate_subject_dn"].(*schema.Set).List() {
-					subject_dn_data := subject_dn.(map[string]interface{})
-					var subject_dn_fields = make(map[string]data.DataValue)
-					if subject_dn_data["case_sensitive"] != nil {
-						subject_dn_fields["case_sensitive"] = data.NewBooleanValue(subject_dn_data["case_sensitive"].(bool))
+				for _, subjectDn := range conditionData["client_certificate_subject_dn"].(*schema.Set).List() {
+					subjectDnData := subjectDn.(map[string]interface{})
+					var subjectDnFields = make(map[string]data.DataValue)
+					if subjectDnData["case_sensitive"] != nil {
+						subjectDnFields["case_sensitive"] = data.NewBooleanValue(subjectDnData["case_sensitive"].(bool))
 					}
-					if subject_dn_data["subject_dn"] != nil {
-						subject_dn_fields["subject_dn"] = data.NewStringValue(subject_dn_data["subject_dn"].(string))
+					if subjectDnData["subject_dn"] != nil {
+						subjectDnFields["subject_dn"] = data.NewStringValue(subjectDnData["subject_dn"].(string))
 					}
-					if subject_dn_data["match_type"] != nil {
-						subject_dn_fields["match_type"] = data.NewStringValue(subject_dn_data["match_type"].(string))
+					if subjectDnData["match_type"] != nil {
+						subjectDnFields["match_type"] = data.NewStringValue(subjectDnData["match_type"].(string))
 					}
-					fields["client_certificate_subject_dn"] = data.NewStructValue("", subject_dn_fields)
+					fields["client_certificate_subject_dn"] = data.NewStructValue("", subjectDnFields)
 				}
-				if condition_data["client_supported_ssl_ciphers"] != nil {
-					cipher_list := data.NewListValue()
-					for _, cipher := range condition_data["client_supported_ssl_ciphers"].([]interface{}) {
-						cipher_list.Add(data.NewStringValue(cipher.(string)))
+				if conditionData["client_supported_ssl_ciphers"] != nil {
+					cipherList := data.NewListValue()
+					for _, cipher := range conditionData["client_supported_ssl_ciphers"].([]interface{}) {
+						cipherList.Add(data.NewStringValue(cipher.(string)))
 					}
-					fields["client_supported_ssl_ciphers"] = cipher_list
+					fields["client_supported_ssl_ciphers"] = cipherList
 				}
-				if condition_data["inverse"] != nil {
-					fields["inverse"] = data.NewBooleanValue(condition_data["inverse"].(bool))
+				if conditionData["inverse"] != nil {
+					fields["inverse"] = data.NewBooleanValue(conditionData["inverse"].(bool))
 				}
-				if condition_data["session_reused"] != nil {
-					fields["session_reused"] = data.NewStringValue(condition_data["session_reused"].(string))
+				if conditionData["session_reused"] != nil {
+					fields["session_reused"] = data.NewStringValue(conditionData["session_reused"].(string))
 				}
-				if condition_data["used_protocol"] != nil {
-					fields["used_protocol"] = data.NewStringValue(condition_data["used_protocol"].(string))
+				if conditionData["used_protocol"] != nil {
+					fields["used_protocol"] = data.NewStringValue(conditionData["used_protocol"].(string))
 				}
-				if condition_data["used_ssl_cipher"] != nil {
-					fields["used_ssl_cipher"] = data.NewStringValue(condition_data["used_ssl_cipher"].(string))
+				if conditionData["used_ssl_cipher"] != nil {
+					fields["used_ssl_cipher"] = data.NewStringValue(conditionData["used_ssl_cipher"].(string))
 				}
 				elem := data.NewStructValue("", fields)
 				matchConditions = append(matchConditions, elem)

--- a/nsxt/resource_nsxt_policy_lb_virtual_server_test.go
+++ b/nsxt/resource_nsxt_policy_lb_virtual_server_test.go
@@ -281,12 +281,175 @@ func TestAccResourceNsxtPolicyLBVirtualServer_withRules(t *testing.T) {
 					resource.TestCheckResourceAttrSet(testResourceName, "pool_path"),
 					resource.TestCheckResourceAttr(testResourceName, "ports.#", "1"),
 					resource.TestCheckResourceAttr(testResourceName, "ports.0", "80"),
-
-					resource.TestCheckResourceAttr(testResourceName, "rule.#", "14"),
-
 					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
 					resource.TestCheckResourceAttrSet(testResourceName, "path"),
 					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+
+					resource.TestCheckResourceAttr(testResourceName, "rule.#", "14"),
+
+					resource.TestCheckResourceAttr(testResourceName, "rule.0.display_name", "connection_drop_test"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.0.action.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.0.action.0.connection_drop.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.0.condition.#", "0"),
+
+					resource.TestCheckResourceAttr(testResourceName, "rule.1.display_name", "http_redirect_test"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.1.action.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.1.action.0.http_redirect.#", "2"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.1.action.0.http_redirect.0.redirect_status", "301"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.1.action.0.http_redirect.0.redirect_url", "dummy"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.1.action.0.http_redirect.1.redirect_status", "302"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.1.action.0.http_redirect.1.redirect_url", "other_dummy"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.1.condition.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.1.condition.0.http_request_body.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.1.condition.0.http_request_body.0.body_value", "xyz"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.1.condition.0.http_request_body.0.match_type", "REGEX"),
+
+					resource.TestCheckResourceAttr(testResourceName, "rule.2.display_name", "http_reject_test"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.2.action.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.2.action.0.http_reject.#", "2"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.2.action.0.http_reject.0.reply_status", "404"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.2.action.0.http_reject.1.reply_status", "400"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.2.condition.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.2.condition.0.http_request_cookie.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.2.condition.0.http_request_cookie.0.cookie_name", "is"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.2.condition.0.http_request_cookie.0.cookie_value", "brownie"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.2.condition.0.http_request_cookie.0.match_type", "REGEX"),
+
+					resource.TestCheckResourceAttr(testResourceName, "rule.3.display_name", "http_request_header_delete_test"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.3.phase", "HTTP_REQUEST_REWRITE"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.3.action.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.3.action.0.http_request_header_delete.#", "2"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.3.action.0.http_request_header_delete.0.header_name", "clever"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.3.action.0.http_request_header_delete.1.header_name", "smart"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.3.condition.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.3.condition.0.http_request_header.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.3.condition.0.http_request_header.0.header_name", "my_head"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.3.condition.0.http_request_header.0.header_value", "has_hair"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.3.condition.0.http_request_header.0.match_type", "REGEX"),
+
+					resource.TestCheckResourceAttr(testResourceName, "rule.4.display_name", "http_request_header_rewrite_test"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.4.phase", "HTTP_REQUEST_REWRITE"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.4.action.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.4.action.0.http_request_header_rewrite.#", "2"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.4.action.0.http_request_header_rewrite.0.header_name", "clever"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.4.action.0.http_request_header_rewrite.0.header_value", "and"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.4.action.0.http_request_header_rewrite.1.header_name", "smart"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.4.action.0.http_request_header_rewrite.1.header_value", "!"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.4.condition.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.4.condition.0.http_request_uri_arguments.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.4.condition.0.http_request_uri_arguments.0.uri_arguments", "foo=bar"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.4.condition.0.http_request_uri_arguments.0.match_type", "REGEX"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.4.condition.0.http_request_uri.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.4.condition.0.http_request_uri.0.uri", "xyz"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.4.condition.0.http_request_uri.0.match_type", "REGEX"),
+
+					resource.TestCheckResourceAttr(testResourceName, "rule.5.display_name", "http_request_uri_rewrite_test"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.5.phase", "HTTP_REQUEST_REWRITE"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.5.action.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.5.action.0.http_request_uri_rewrite.#", "2"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.5.action.0.http_request_uri_rewrite.0.uri", "uri_test"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.5.action.0.http_request_uri_rewrite.1.uri", "uri_test2"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.5.action.0.http_request_uri_rewrite.1.uri_arguments", "foo=bar"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.5.condition.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.5.condition.0.http_request_version.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.5.condition.0.http_request_version.0.version", "HTTP_VERSION_1_0"),
+
+					resource.TestCheckResourceAttr(testResourceName, "rule.6.display_name", "http_response_header_delete_test"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.6.phase", "HTTP_RESPONSE_REWRITE"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.6.action.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.6.action.0.http_response_header_delete.#", "2"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.6.action.0.http_response_header_delete.0.header_name", "clever"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.6.action.0.http_response_header_delete.1.header_name", "smart"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.6.condition.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.6.condition.0.http_response_header.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.6.condition.0.http_response_header.0.header_name", "clever"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.6.condition.0.http_response_header.0.header_value", "smart"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.6.condition.0.http_response_header.0.match_type", "REGEX"),
+
+					resource.TestCheckResourceAttr(testResourceName, "rule.7.display_name", "http_response_header_rewrite_test"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.7.phase", "HTTP_RESPONSE_REWRITE"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.7.action.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.7.action.0.http_response_header_rewrite.#", "2"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.7.action.0.http_response_header_rewrite.0.header_name", "clever"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.7.action.0.http_response_header_rewrite.0.header_value", "and"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.7.action.0.http_response_header_rewrite.1.header_name", "smart"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.7.action.0.http_response_header_rewrite.1.header_value", "!"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.7.condition.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.7.condition.0.ip_header.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.7.condition.0.ip_header.0.source_address", "1.1.1.1"),
+
+					resource.TestCheckResourceAttr(testResourceName, "rule.8.display_name", "select_pool_test"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.8.phase", "HTTP_FORWARDING"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.8.action.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.8.action.0.select_pool.#", "1"),
+					resource.TestCheckResourceAttrSet(testResourceName, "rule.8.action.0.select_pool.0.pool_id"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.8.condition.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.8.condition.0.ssl_sni.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.8.condition.0.ssl_sni.0.match_type", "REGEX"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.8.condition.0.ssl_sni.0.sni", "HELO"),
+
+					resource.TestCheckResourceAttr(testResourceName, "rule.9.display_name", "ssl_mode_selection_test"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.9.phase", "TRANSPORT"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.9.action.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.9.action.0.ssl_mode_selection.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.9.action.0.ssl_mode_selection.0.ssl_mode", "SSL_PASSTHROUGH"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.9.condition.#", "0"),
+
+					resource.TestCheckResourceAttr(testResourceName, "rule.10.display_name", "variable_assignment_test"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.10.phase", "HTTP_ACCESS"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.10.action.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.10.action.0.variable_assignment.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.10.action.0.variable_assignment.0.variable_name", "foo"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.10.action.0.variable_assignment.0.variable_value", "bar"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.10.condition.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.10.condition.0.variable.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.10.condition.0.variable.0.variable_name", "my_var"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.10.condition.0.variable.0.variable_value", "my_value"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.10.condition.0.variable.0.match_type", "REGEX"),
+
+					resource.TestCheckResourceAttr(testResourceName, "rule.11.display_name", "variable_persistence_learn_test"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.11.phase", "HTTP_RESPONSE_REWRITE"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.11.action.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.11.action.0.variable_persistence_learn.#", "1"),
+					resource.TestCheckResourceAttrSet(testResourceName, "rule.11.action.0.variable_persistence_learn.0.persistence_profile_path"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.11.action.0.variable_persistence_learn.0.variable_hash_enabled", "true"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.11.action.0.variable_persistence_learn.0.variable_name", "my_name"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.11.condition.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.11.condition.0.http_ssl.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.11.condition.0.http_ssl.0.session_reused", "IGNORE"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.11.condition.0.http_ssl.0.used_protocol", "SSL_V2"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.11.condition.0.http_ssl.0.used_ssl_cipher", "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.11.condition.0.http_ssl.0.session_reused", "IGNORE"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.11.condition.0.http_ssl.0.used_protocol", "SSL_V2"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.11.condition.0.http_ssl.0.client_certificate_issuer_dn.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.11.condition.0.http_ssl.0.client_certificate_issuer_dn.0.issuer_dn", "something"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.11.condition.0.http_ssl.0.client_certificate_issuer_dn.0.match_type", "REGEX"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.11.condition.0.http_ssl.0.client_certificate_subject_dn.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.11.condition.0.http_ssl.0.client_certificate_subject_dn.0.subject_dn", "something"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.11.condition.0.http_ssl.0.client_certificate_subject_dn.0.match_type", "REGEX"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.11.condition.0.http_ssl.0.client_supported_ssl_ciphers.#", "2"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.11.condition.0.http_ssl.0.client_supported_ssl_ciphers.0", "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.11.condition.0.http_ssl.0.client_supported_ssl_ciphers.1", "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"),
+
+					resource.TestCheckResourceAttr(testResourceName, "rule.12.display_name", "variable_persistence_on_test"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.12.phase", "HTTP_FORWARDING"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.12.action.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.12.action.0.variable_persistence_on.#", "1"),
+					resource.TestCheckResourceAttrSet(testResourceName, "rule.12.action.0.variable_persistence_on.0.persistence_profile_path"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.12.action.0.variable_persistence_on.0.variable_hash_enabled", "false"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.12.action.0.variable_persistence_on.0.variable_name", "my_name"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.12.condition.#", "0"),
+
+					resource.TestCheckResourceAttr(testResourceName, "rule.13.display_name", "jwt_auth_test"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.13.phase", "HTTP_ACCESS"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.13.action.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.13.action.0.jwt_auth.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.13.action.0.jwt_auth.0.key.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.13.action.0.jwt_auth.0.key.0.public_key_content", "xxx"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.13.action.0.jwt_auth.0.pass_jwt_to_pool", "true"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.13.action.0.jwt_auth.0.realm", "realm"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.13.action.0.jwt_auth.0.tokens.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.13.action.0.jwt_auth.0.tokens.0", "a"),
 				),
 			},
 			{
@@ -298,12 +461,185 @@ func TestAccResourceNsxtPolicyLBVirtualServer_withRules(t *testing.T) {
 					resource.TestCheckResourceAttrSet(testResourceName, "pool_path"),
 					resource.TestCheckResourceAttr(testResourceName, "ports.#", "1"),
 					resource.TestCheckResourceAttr(testResourceName, "ports.0", "80"),
-
-					resource.TestCheckResourceAttr(testResourceName, "rule.#", "14"),
-
 					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
 					resource.TestCheckResourceAttrSet(testResourceName, "path"),
 					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+
+					resource.TestCheckResourceAttr(testResourceName, "rule.#", "14"),
+
+					resource.TestCheckResourceAttr(testResourceName, "rule.0.display_name", "connection_drop_test"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.0.action.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.0.action.0.connection_drop.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.0.condition.#", "0"),
+
+					resource.TestCheckResourceAttr(testResourceName, "rule.1.display_name", "http_redirect_test"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.1.action.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.1.action.0.http_redirect.#", "2"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.1.action.0.http_redirect.0.redirect_status", "301"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.1.action.0.http_redirect.0.redirect_url", "dummy"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.1.action.0.http_redirect.1.redirect_status", "302"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.1.action.0.http_redirect.1.redirect_url", "other_dummy"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.1.condition.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.1.condition.0.http_request_body.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.1.condition.0.http_request_body.0.body_value", "xyz"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.1.condition.0.http_request_body.0.match_type", "REGEX"),
+
+					resource.TestCheckResourceAttr(testResourceName, "rule.2.display_name", "http_reject_test"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.2.action.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.2.action.0.http_reject.#", "2"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.2.action.0.http_reject.0.reply_status", "404"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.2.action.0.http_reject.1.reply_status", "400"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.2.condition.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.2.condition.0.http_request_cookie.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.2.condition.0.http_request_cookie.0.cookie_name", "is"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.2.condition.0.http_request_cookie.0.cookie_value", "brownie"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.2.condition.0.http_request_cookie.0.match_type", "REGEX"),
+
+					resource.TestCheckResourceAttr(testResourceName, "rule.3.display_name", "http_request_header_delete_test"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.3.phase", "HTTP_REQUEST_REWRITE"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.3.action.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.3.action.0.http_request_header_delete.#", "2"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.3.action.0.http_request_header_delete.0.header_name", "clever"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.3.action.0.http_request_header_delete.1.header_name", "smart"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.3.condition.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.3.condition.0.http_request_header.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.3.condition.0.http_request_header.0.header_name", "my_head"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.3.condition.0.http_request_header.0.header_value", "has_hair"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.3.condition.0.http_request_header.0.match_type", "REGEX"),
+
+					resource.TestCheckResourceAttr(testResourceName, "rule.4.display_name", "http_request_header_rewrite_test"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.4.phase", "HTTP_REQUEST_REWRITE"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.4.action.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.4.action.0.http_request_header_rewrite.#", "2"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.4.action.0.http_request_header_rewrite.0.header_name", "clever"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.4.action.0.http_request_header_rewrite.0.header_value", "and"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.4.action.0.http_request_header_rewrite.1.header_name", "smart"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.4.action.0.http_request_header_rewrite.1.header_value", "!"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.4.condition.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.4.condition.0.http_request_uri_arguments.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.4.condition.0.http_request_uri_arguments.0.uri_arguments", "foo=bar"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.4.condition.0.http_request_uri_arguments.0.match_type", "REGEX"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.4.condition.0.http_request_uri.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.4.condition.0.http_request_uri.0.uri", "xyz"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.4.condition.0.http_request_uri.0.match_type", "REGEX"),
+
+					resource.TestCheckResourceAttr(testResourceName, "rule.5.display_name", "http_request_uri_rewrite_test"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.5.phase", "HTTP_REQUEST_REWRITE"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.5.action.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.5.action.0.http_request_uri_rewrite.#", "2"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.5.action.0.http_request_uri_rewrite.0.uri", "uri_test"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.5.action.0.http_request_uri_rewrite.1.uri", "uri_test2"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.5.action.0.http_request_uri_rewrite.1.uri_arguments", "foo=bar"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.5.condition.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.5.condition.0.http_request_version.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.5.condition.0.http_request_version.0.version", "HTTP_VERSION_1_0"),
+
+					resource.TestCheckResourceAttr(testResourceName, "rule.6.display_name", "http_response_header_delete_test"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.6.phase", "HTTP_RESPONSE_REWRITE"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.6.action.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.6.action.0.http_response_header_delete.#", "2"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.6.action.0.http_response_header_delete.0.header_name", "clever"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.6.action.0.http_response_header_delete.1.header_name", "smart"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.6.condition.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.6.condition.0.http_response_header.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.6.condition.0.http_response_header.0.header_name", "clever"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.6.condition.0.http_response_header.0.header_value", "smart"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.6.condition.0.http_response_header.0.match_type", "REGEX"),
+
+					resource.TestCheckResourceAttr(testResourceName, "rule.7.display_name", "http_response_header_rewrite_test"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.7.phase", "HTTP_RESPONSE_REWRITE"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.7.action.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.7.action.0.http_response_header_rewrite.#", "2"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.7.action.0.http_response_header_rewrite.0.header_name", "clever"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.7.action.0.http_response_header_rewrite.0.header_value", "and"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.7.action.0.http_response_header_rewrite.1.header_name", "smart"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.7.action.0.http_response_header_rewrite.1.header_value", "!"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.7.condition.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.7.condition.0.ip_header.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.7.condition.0.ip_header.0.source_address", "1.1.1.1"),
+
+					resource.TestCheckResourceAttr(testResourceName, "rule.8.display_name", "select_pool_test"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.8.phase", "HTTP_FORWARDING"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.8.action.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.8.action.0.select_pool.#", "1"),
+					resource.TestCheckResourceAttrSet(testResourceName, "rule.8.action.0.select_pool.0.pool_id"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.8.condition.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.8.condition.0.ssl_sni.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.8.condition.0.ssl_sni.0.match_type", "REGEX"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.8.condition.0.ssl_sni.0.sni", "HELO"),
+
+					resource.TestCheckResourceAttr(testResourceName, "rule.9.display_name", "ssl_mode_selection_test"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.9.phase", "TRANSPORT"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.9.action.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.9.action.0.ssl_mode_selection.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.9.action.0.ssl_mode_selection.0.ssl_mode", "SSL_PASSTHROUGH"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.9.condition.#", "0"),
+
+					resource.TestCheckResourceAttr(testResourceName, "rule.10.display_name", "variable_assignment_test"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.10.phase", "HTTP_ACCESS"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.10.action.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.10.action.0.variable_assignment.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.10.action.0.variable_assignment.0.variable_name", "foo"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.10.action.0.variable_assignment.0.variable_value", "bar"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.10.condition.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.10.condition.0.variable.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.10.condition.0.variable.0.variable_name", "my_var"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.10.condition.0.variable.0.variable_value", "my_value"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.10.condition.0.variable.0.match_type", "REGEX"),
+
+					resource.TestCheckResourceAttr(testResourceName, "rule.11.display_name", "variable_persistence_learn_test"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.11.phase", "HTTP_RESPONSE_REWRITE"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.11.action.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.11.action.0.variable_persistence_learn.#", "1"),
+					resource.TestCheckResourceAttrSet(testResourceName, "rule.11.action.0.variable_persistence_learn.0.persistence_profile_path"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.11.action.0.variable_persistence_learn.0.variable_hash_enabled", "true"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.11.action.0.variable_persistence_learn.0.variable_name", "my_name"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.11.condition.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.11.condition.0.http_ssl.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.11.condition.0.http_ssl.0.session_reused", "IGNORE"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.11.condition.0.http_ssl.0.used_protocol", "SSL_V2"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.11.condition.0.http_ssl.0.used_ssl_cipher", "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.11.condition.0.http_ssl.0.session_reused", "IGNORE"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.11.condition.0.http_ssl.0.used_protocol", "SSL_V2"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.11.condition.0.http_ssl.0.client_certificate_issuer_dn.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.11.condition.0.http_ssl.0.client_certificate_issuer_dn.0.issuer_dn", "something"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.11.condition.0.http_ssl.0.client_certificate_issuer_dn.0.match_type", "REGEX"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.11.condition.0.http_ssl.0.client_certificate_subject_dn.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.11.condition.0.http_ssl.0.client_certificate_subject_dn.0.subject_dn", "something"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.11.condition.0.http_ssl.0.client_certificate_subject_dn.0.match_type", "REGEX"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.11.condition.0.http_ssl.0.client_supported_ssl_ciphers.#", "2"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.11.condition.0.http_ssl.0.client_supported_ssl_ciphers.0", "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.11.condition.0.http_ssl.0.client_supported_ssl_ciphers.1", "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"),
+
+					resource.TestCheckResourceAttr(testResourceName, "rule.12.display_name", "variable_persistence_on_test"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.12.phase", "HTTP_FORWARDING"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.12.action.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.12.action.0.variable_persistence_on.#", "1"),
+					resource.TestCheckResourceAttrSet(testResourceName, "rule.12.action.0.variable_persistence_on.0.persistence_profile_path"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.12.action.0.variable_persistence_on.0.variable_hash_enabled", "false"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.12.action.0.variable_persistence_on.0.variable_name", "my_name"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.12.condition.#", "0"),
+
+					resource.TestCheckResourceAttr(testResourceName, "rule.13.display_name", "jwt_auth_test"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.13.phase", "HTTP_ACCESS"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.13.action.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.13.action.0.jwt_auth.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.13.action.0.jwt_auth.0.key.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.13.action.0.jwt_auth.0.key.0.public_key_content", "xxx"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.13.action.0.jwt_auth.0.pass_jwt_to_pool", "true"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.13.action.0.jwt_auth.0.realm", "realm"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.13.action.0.jwt_auth.0.tokens.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.13.action.0.jwt_auth.0.tokens.0", "a"),
+				),
+			},
+			{
+				Config: testAccNsxtPolicyLBVirtualServerMinimalistic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicyLBVirtualServerExists(testResourceName),
+					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.#", "0"),
 				),
 			},
 		},
@@ -582,199 +918,246 @@ resource "nsxt_policy_lb_virtual_server" "test" {
   pool_path                  = nsxt_policy_lb_pool.pool.path
 
   rule {
-	display_name = "connection_drop_action_test"
-	connection_drop_action {}
-	connection_drop_action {}
-  } 
-  rule {
-	display_name = "http_redirect_action_test"
-	http_redirect_action {
-      redirect_status = "301"
-      redirect_url = "dummy"
-	}
-	http_redirect_action {
-      redirect_status = "302"
-      redirect_url = "other_dummy"
-	}
-	http_request_body_condition {
-	  body_value = "xyz"	
-	  match_type = "REGEX"
+	display_name = "connection_drop_test"
+	action {
+	  connection_drop {}
 	}
   }
   rule {
-	display_name = "http_reject_action_test"
-	http_reject_action {
-	  reply_status = "404"
+	display_name = "http_redirect_test"
+	action {
+	  http_redirect {
+        redirect_status = "301"
+        redirect_url = "dummy"
+	  }
+	  http_redirect {
+        redirect_status = "302"
+        redirect_url = "other_dummy"
+	  }
 	}
-	http_reject_action {
-	  reply_status = "400"
-	}
-	http_request_cookie_condition {
-	  cookie_name = "is"
-	  cookie_value = "brownie"
-	  match_type = "REGEX"
+	condition {
+	  http_request_body {
+  	    body_value = "xyz"	
+	    match_type = "REGEX"
+	  }
 	}
   }
   rule {
-	display_name = "http_request_header_delete_action_test"
+	display_name = "http_reject_test"
+	action {
+	  http_reject {
+  	    reply_status = "404"
+	  }
+	  http_reject {
+  	    reply_status = "400"
+	  }
+	}
+	condition {
+	  http_request_cookie {
+        cookie_name = "is"
+	    cookie_value = "brownie"
+	    match_type = "REGEX"
+	  }
+	}
+  }
+  rule {
+	display_name = "http_request_header_delete_test"
 	phase = "HTTP_REQUEST_REWRITE"
-	http_request_header_delete_action {
-	  header_name = "clever"
+	action {
+	  http_request_header_delete {
+	    header_name = "clever"
+	  }
+	  http_request_header_delete {
+	    header_name = "smart"
+	  }
 	}
-	http_request_header_delete_action {
-	  header_name = "smart"
-	}
-	http_request_header_condition {
-	  header_name = "my_head"	
-	  header_value = "has_hair"
-	  match_type = "REGEX"
+	condition {
+	  http_request_header {
+	    header_name = "my_head"	
+	    header_value = "has_hair"
+	    match_type = "REGEX"
+	  }
 	}
   }
   rule {
-	display_name = "http_request_header_rewrite_action_test"
+	display_name = "http_request_header_rewrite_test"
 	phase = "HTTP_REQUEST_REWRITE"
-	http_request_header_rewrite_action {
-	  header_name = "clever"
-	  header_value = "and"
+	action {
+	  http_request_header_rewrite {
+	    header_name = "clever"
+	    header_value = "and"
+	  }
+	  http_request_header_rewrite {
+	    header_name = "smart"
+	    header_value = "!"
+	  }
 	}
-	http_request_header_rewrite_action {
-	  header_name = "smart"
-	  header_value = "!"
-	}
-	http_request_uri_arguments_condition {
-	  uri_arguments = "foo=bar"
-	  match_type = "REGEX"	
-	}
-	http_request_uri_condition {
-	  uri = "xyz"
-	  match_type = "REGEX"	
+	condition {
+	  http_request_uri_arguments {
+	    uri_arguments = "foo=bar"
+	    match_type = "REGEX"	
+	  }
+	  http_request_uri {
+	    uri = "xyz"
+	    match_type = "REGEX"	
+	  }
 	}
   }
   rule {
-	display_name = "http_request_uri_rewrite_action_test"
+	display_name = "http_request_uri_rewrite_test"
 	phase = "HTTP_REQUEST_REWRITE"
-	http_request_uri_rewrite_action {
-	  uri = "uri_test"
+	action {
+	  http_request_uri_rewrite {
+	    uri = "uri_test"
+	  }
+	  http_request_uri_rewrite {
+        uri = "uri_test2"
+	    uri_arguments = "foo=bar"
+	  }
 	}
-	http_request_uri_rewrite_action {
-      uri = "uri_test2"
-	  uri_arguments = "foo=bar"
-	}
-	http_request_version_condition {
-	  version = "HTTP_VERSION_1_0"
+	condition {
+	  http_request_version {
+	    version = "HTTP_VERSION_1_0"
+	  }
 	}
   }
   rule {
-	display_name = "http_response_header_delete_action_test"
+	display_name = "http_response_header_delete_test"
 	phase = "HTTP_RESPONSE_REWRITE"
-	http_response_header_delete_action {
-	  header_name = "clever"
-    }
-    http_response_header_delete_action {
-	  header_name = "smart"
-    }
-	http_response_header_condition {
-	  header_name = "clever"
-	  header_value = "smart"
-	  match_type = "REGEX"
+	action {
+	  http_response_header_delete {
+	    header_name = "clever"
+      }
+      http_response_header_delete {
+	    header_name = "smart"
+      }
+	}
+	condition {
+	  http_response_header {
+	    header_name = "clever"
+	    header_value = "smart"
+	    match_type = "REGEX"
+	  }
 	}
   }
   rule {
-	display_name = "http_response_header_rewrite_action_test"
+	display_name = "http_response_header_rewrite_test"
 	phase = "HTTP_RESPONSE_REWRITE"
-	http_response_header_rewrite_action {
-	  header_name = "clever"
-	  header_value = "and"
+	action {
+	  http_response_header_rewrite {
+	    header_name = "clever"
+	    header_value = "and"
+	  }
+	  http_response_header_rewrite {
+	    header_name = "smart"
+	    header_value = "!"
+	  }
 	}
-	http_response_header_rewrite_action {
-	  header_name = "smart"
-	  header_value = "!"
-	}
-	ip_header_condition {
-	  source_address = "1.1.1.1"
+	condition {
+	  ip_header {
+	    source_address = "1.1.1.1"
+	  }
 	}
   }
   rule {
-	display_name = "select_pool_action_test"
+	display_name = "select_pool_test"
 	phase = "HTTP_FORWARDING"
-	select_pool_action {
-      pool_id = nsxt_policy_lb_pool.pool.path
-	} 
-	ssl_sni_condition {
-	  match_type = "REGEX"
-	  sni = "HELO"
-	} 
+	action {
+	  select_pool {
+        pool_id = nsxt_policy_lb_pool.pool.path
+	  } 
+	}
+    condition {
+	  ssl_sni {
+	    match_type = "REGEX"
+	    sni = "HELO"
+	  } 
+	}
   }
   rule {
-	display_name = "ssl_mode_selection_action_test"
+	display_name = "ssl_mode_selection_test"
 	phase = "TRANSPORT"
-	ssl_mode_selection_action {
-      ssl_mode = "SSL_PASSTHROUGH"
+	action {
+	  ssl_mode_selection {
+        ssl_mode = "SSL_PASSTHROUGH"
+  	  }
 	}
   }
   rule {
-	display_name = "variable_assignment_action_test"
+	display_name = "variable_assignment_test"
 	phase = "HTTP_ACCESS"
-	variable_assignment_action {
-      variable_name = "foo"
-	  variable_value = "bar"
+	action {
+	  variable_assignment {
+        variable_name = "foo"
+	    variable_value = "bar"
+	  }
 	}
-	variable_condition {
-	  variable_name = "my_var"
-	  variable_value = "my_value"
-	  match_type = "REGEX"	
-	}  
-	tcp_header_condition {
+	condition {
+	  variable {
+	    variable_name = "my_var"
+	    variable_value = "my_value"
+	    match_type = "REGEX"	
+	  }  
+	  tcp_header {
 		source_port = "80"	
-	}  
-  }
-  rule {
-	display_name = "variable_persistence_learn_action_test"
-	phase = "HTTP_RESPONSE_REWRITE"
-	variable_persistence_learn_action {
-      persistence_profile_path = data.nsxt_policy_lb_persistence_profile.generic.path
-	  variable_hash_enabled = true
-	  variable_name = "my_name"
-	}  
-	http_ssl_condition {
-	  session_reused = "IGNORE"
-	  used_protocol = "SSL_V2"
-	  used_ssl_cipher = "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"	
-	  client_certificate_issuer_dn {
-		issuer_dn = "something"
-		match_type = "REGEX"
-	  }
-	  client_certificate_subject_dn {
-		subject_dn = "something"  
-		match_type = "REGEX"
-	  }
-	  client_supported_ssl_ciphers = [ "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256", "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384" ]
+	  }  
 	}
   }
   rule {
-	display_name = "variable_persistence_on_action_test"
-	phase = "HTTP_FORWARDING"
-	variable_persistence_on_action {
-      persistence_profile_path = data.nsxt_policy_lb_persistence_profile.generic.path
-	  variable_hash_enabled = false
-	  variable_name = "my_name"
-	}  
+	display_name = "variable_persistence_learn_test"
+	phase = "HTTP_RESPONSE_REWRITE"
+	action {
+	  variable_persistence_learn {
+        persistence_profile_path = data.nsxt_policy_lb_persistence_profile.generic.path
+	    variable_hash_enabled = true
+	    variable_name = "my_name"
+	  }  
+	}
+	condition {
+	  http_ssl {
+	    session_reused = "IGNORE"
+	    used_protocol = "SSL_V2"
+	    used_ssl_cipher = "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"	
+	    client_certificate_issuer_dn {
+		  issuer_dn = "something"
+		  match_type = "REGEX"
+	    }
+	    client_certificate_subject_dn {
+		  subject_dn = "something"  
+		  match_type = "REGEX"
+	    }
+	    client_supported_ssl_ciphers = [ "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256", "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384" ]
+	  }
+	}
   }
   rule {
-	display_name = "jwt_auth_action_test"
+	display_name = "variable_persistence_on_test"
+	phase = "HTTP_FORWARDING"
+	action {
+	  variable_persistence_on {
+        persistence_profile_path = data.nsxt_policy_lb_persistence_profile.generic.path
+	    variable_hash_enabled = false
+	    variable_name = "my_name"
+	  }  
+	}
+  }
+  rule {
+	display_name = "jwt_auth_test"
 	phase = "HTTP_ACCESS"
-	jwt_auth_action {
-	  key {
-		// one of ...
-		public_key_content = "xxx"
-		//certificate_path = "/path/to/cert"
-		// this one only indicates presence, the value is discarded
-		//symmetric_key = "dummy_value"
+	action {
+	  jwt_auth {
+	    key {
+	  	  // one of ...
+		  public_key_content = "xxx"
+		  //certificate_path = "/path/to/cert"
+		  // this one only indicates presence, the value is discarded
+		  //symmetric_key = "dummy_value"
+	    }
+	    pass_jwt_to_pool = true
+	    realm = "realm"
+	    // only one token allowed currently
+	    tokens = [ "a" ]
 	  }
-	  pass_jwt_to_pool = true
-	  realm = "realm"
-	  // only one token allowed currently
-	  tokens = [ "a" ]
 	}
   }
 }

--- a/nsxt/resource_nsxt_policy_lb_virtual_server_test.go
+++ b/nsxt/resource_nsxt_policy_lb_virtual_server_test.go
@@ -49,7 +49,10 @@ func TestAccResourceNsxtPolicyLBVirtualServer_basic(t *testing.T) {
 	testResourceName := "nsxt_policy_lb_virtual_server.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccOnlyLocalManager(t)
+			testAccPreCheck(t)
+		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNsxtPolicyLBVirtualServerCheckDestroy(state, accTestPolicyLBVirtualServerCreateAttributes["display_name"])
@@ -250,6 +253,57 @@ func TestAccResourceNsxtPolicyLBVirtualServer_withAccessList(t *testing.T) {
 					resource.TestCheckResourceAttrSet(testResourceName, "path"),
 					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
 					resource.TestCheckResourceAttr(testResourceName, "pool_path", ""),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceNsxtPolicyLBVirtualServer_withRules(t *testing.T) {
+	testResourceName := "nsxt_policy_lb_virtual_server.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccOnlyLocalManager(t)
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyLBVirtualServerCheckDestroy(state, accTestPolicyLBVirtualServerCreateAttributes["display_name"])
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyLBVirtualServerWithRules(true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicyLBVirtualServerExists(testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestPolicyLBVirtualServerCreateAttributes["display_name"]),
+					resource.TestCheckResourceAttr(testResourceName, "ip_address", accTestPolicyLBVirtualServerCreateAttributes["ip_address"]),
+					resource.TestCheckResourceAttrSet(testResourceName, "pool_path"),
+					resource.TestCheckResourceAttr(testResourceName, "ports.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "ports.0", "80"),
+
+					resource.TestCheckResourceAttr(testResourceName, "rule.#", "14"),
+
+					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+				),
+			},
+			{
+				Config: testAccNsxtPolicyLBVirtualServerWithRules(false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicyLBVirtualServerExists(testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestPolicyLBVirtualServerUpdateAttributes["display_name"]),
+					resource.TestCheckResourceAttr(testResourceName, "ip_address", accTestPolicyLBVirtualServerUpdateAttributes["ip_address"]),
+					resource.TestCheckResourceAttrSet(testResourceName, "pool_path"),
+					resource.TestCheckResourceAttr(testResourceName, "ports.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "ports.0", "80"),
+
+					resource.TestCheckResourceAttr(testResourceName, "rule.#", "14"),
+
+					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
 				),
 			},
 		},
@@ -490,4 +544,242 @@ resource "nsxt_policy_lb_virtual_server" "test" {
 data "nsxt_policy_realization_info" "realization_info" {
   path = nsxt_policy_lb_virtual_server.test.path
 }`, attrMap["display_name"], attrMap["ip_address"], attrMap["ports"], attrMap["log_significant_event_only"], attrMap["access_list_control_action"], attrMap["access_list_control_enabled"])
+}
+
+func testAccNsxtPolicyLBVirtualServerWithRules(createFlow bool) string {
+	var attrMap map[string]string
+	if createFlow {
+		attrMap = accTestPolicyLBVirtualServerCreateAttributes
+	} else {
+		attrMap = accTestPolicyLBVirtualServerUpdateAttributes
+	}
+	return fmt.Sprintf(`
+data "nsxt_policy_lb_app_profile" "default_http"{
+  type = "HTTP"
+}
+
+data "nsxt_policy_lb_persistence_profile" "default" {
+  type = "SOURCE_IP"
+}
+
+data "nsxt_policy_lb_persistence_profile" "generic" {
+  type = "GENERIC"
+}
+
+resource "nsxt_policy_lb_pool" "pool" {
+  display_name = "terraform-vs-test-pool"
+}
+
+resource "nsxt_policy_group" "group1" {
+  display_name = "terraform-vs-test-group1"
+}
+
+resource "nsxt_policy_lb_virtual_server" "test" {
+  display_name             = "%s"
+  application_profile_path = data.nsxt_policy_lb_app_profile.default_http.path
+  ip_address               = "%s"
+  ports                    = [ "80" ]
+  pool_path                  = nsxt_policy_lb_pool.pool.path
+
+  rule {
+	display_name = "connection_drop_action_test"
+	connection_drop_action {}
+	connection_drop_action {}
+  } 
+  rule {
+	display_name = "http_redirect_action_test"
+	http_redirect_action {
+      redirect_status = "301"
+      redirect_url = "dummy"
+	}
+	http_redirect_action {
+      redirect_status = "302"
+      redirect_url = "other_dummy"
+	}
+	http_request_body_condition {
+	  body_value = "xyz"	
+	  match_type = "REGEX"
+	}
+  }
+  rule {
+	display_name = "http_reject_action_test"
+	http_reject_action {
+	  reply_status = "404"
+	}
+	http_reject_action {
+	  reply_status = "400"
+	}
+	http_request_cookie_condition {
+	  cookie_name = "is"
+	  cookie_value = "brownie"
+	  match_type = "REGEX"
+	}
+  }
+  rule {
+	display_name = "http_request_header_delete_action_test"
+	phase = "HTTP_REQUEST_REWRITE"
+	http_request_header_delete_action {
+	  header_name = "clever"
+	}
+	http_request_header_delete_action {
+	  header_name = "smart"
+	}
+	http_request_header_condition {
+	  header_name = "my_head"	
+	  header_value = "has_hair"
+	  match_type = "REGEX"
+	}
+  }
+  rule {
+	display_name = "http_request_header_rewrite_action_test"
+	phase = "HTTP_REQUEST_REWRITE"
+	http_request_header_rewrite_action {
+	  header_name = "clever"
+	  header_value = "and"
+	}
+	http_request_header_rewrite_action {
+	  header_name = "smart"
+	  header_value = "!"
+	}
+	http_request_uri_arguments_condition {
+	  uri_arguments = "foo=bar"
+	  match_type = "REGEX"	
+	}
+	http_request_uri_condition {
+	  uri = "xyz"
+	  match_type = "REGEX"	
+	}
+  }
+  rule {
+	display_name = "http_request_uri_rewrite_action_test"
+	phase = "HTTP_REQUEST_REWRITE"
+	http_request_uri_rewrite_action {
+	  uri = "uri_test"
+	}
+	http_request_uri_rewrite_action {
+      uri = "uri_test2"
+	  uri_arguments = "foo=bar"
+	}
+	http_request_version_condition {
+	  version = "HTTP_VERSION_1_0"
+	}
+  }
+  rule {
+	display_name = "http_response_header_delete_action_test"
+	phase = "HTTP_RESPONSE_REWRITE"
+	http_response_header_delete_action {
+	  header_name = "clever"
+    }
+    http_response_header_delete_action {
+	  header_name = "smart"
+    }
+	http_response_header_condition {
+	  header_name = "clever"
+	  header_value = "smart"
+	  match_type = "REGEX"
+	}
+  }
+  rule {
+	display_name = "http_response_header_rewrite_action_test"
+	phase = "HTTP_RESPONSE_REWRITE"
+	http_response_header_rewrite_action {
+	  header_name = "clever"
+	  header_value = "and"
+	}
+	http_response_header_rewrite_action {
+	  header_name = "smart"
+	  header_value = "!"
+	}
+	ip_header_condition {
+	  source_address = "1.1.1.1"
+	}
+  }
+  rule {
+	display_name = "select_pool_action_test"
+	phase = "HTTP_FORWARDING"
+	select_pool_action {
+      pool_id = nsxt_policy_lb_pool.pool.path
+	} 
+	ssl_sni_condition {
+	  match_type = "REGEX"
+	  sni = "HELO"
+	} 
+  }
+  rule {
+	display_name = "ssl_mode_selection_action_test"
+	phase = "TRANSPORT"
+	ssl_mode_selection_action {
+      ssl_mode = "SSL_PASSTHROUGH"
+	}
+  }
+  rule {
+	display_name = "variable_assignment_action_test"
+	phase = "HTTP_ACCESS"
+	variable_assignment_action {
+      variable_name = "foo"
+	  variable_value = "bar"
+	}
+	variable_condition {
+	  variable_name = "my_var"
+	  variable_value = "my_value"
+	  match_type = "REGEX"	
+	}  
+	tcp_header_condition {
+		source_port = "80"	
+	}  
+  }
+  rule {
+	display_name = "variable_persistence_learn_action_test"
+	phase = "HTTP_RESPONSE_REWRITE"
+	variable_persistence_learn_action {
+      persistence_profile_path = data.nsxt_policy_lb_persistence_profile.generic.path
+	  variable_hash_enabled = true
+	  variable_name = "my_name"
+	}  
+	http_ssl_condition {
+	  session_reused = "IGNORE"
+	  used_protocol = "SSL_V2"
+	  used_ssl_cipher = "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"	
+	  client_certificate_issuer_dn {
+		issuer_dn = "something"
+		match_type = "REGEX"
+	  }
+	  client_certificate_subject_dn {
+		subject_dn = "something"  
+		match_type = "REGEX"
+	  }
+	  client_supported_ssl_ciphers = [ "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256", "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384" ]
+	}
+  }
+  rule {
+	display_name = "variable_persistence_on_action_test"
+	phase = "HTTP_FORWARDING"
+	variable_persistence_on_action {
+      persistence_profile_path = data.nsxt_policy_lb_persistence_profile.generic.path
+	  variable_hash_enabled = false
+	  variable_name = "my_name"
+	}  
+  }
+  rule {
+	display_name = "jwt_auth_action_test"
+	phase = "HTTP_ACCESS"
+	jwt_auth_action {
+	  key {
+		// one of ...
+		public_key_content = "xxx"
+		//certificate_path = "/path/to/cert"
+		// this one only indicates presence, the value is discarded
+		//symmetric_key = "dummy_value"
+	  }
+	  pass_jwt_to_pool = true
+	  realm = "realm"
+	  // only one token allowed currently
+	  tokens = [ "a" ]
+	}
+  }
+}
+
+data "nsxt_policy_realization_info" "realization_info" {
+  path = nsxt_policy_lb_virtual_server.test.path
+}`, attrMap["display_name"], attrMap["ip_address"])
 }

--- a/nsxt/utils.go
+++ b/nsxt/utils.go
@@ -387,6 +387,22 @@ func resourceReferenceHash(v interface{}) int {
 	return result
 }
 
+func resourceKeyValueHash(v interface{}) int {
+	var buf bytes.Buffer
+
+	if v != nil {
+		m := v.(map[string]interface{})
+		for k, v := range m {
+			buf.WriteString(fmt.Sprintf("%s-%s", k, v))
+		}
+	}
+	result := int(crc32.ChecksumIEEE(buf.Bytes()))
+	if result < 0 {
+		return -result
+	}
+	return result
+}
+
 func returnResourceReferencesSet(references []common.ResourceReference) *schema.Set {
 	var referenceList []interface{}
 	for _, reference := range references {

--- a/website/docs/r/policy_lb_virtual_server.html.markdown
+++ b/website/docs/r/policy_lb_virtual_server.html.markdown
@@ -43,6 +43,25 @@ resource "nsxt_policy_lb_virtual_server" "test" {
     certificate_chain_depth = 3
     ssl_profile_path        = data.nsxt_policy_lb_server_ssl_profile.lb_profile.path
   }
+
+  rule {
+  	display_name   = "rule_test"
+    match_strategy = "ALL"
+    phase          = "HTTP_REQUEST_REWRITE"
+
+	  http_redirect_action {
+      redirect_status = "301"
+      redirect_url    = "dummy"
+	  }
+	  http_redirect_action {
+      redirect_status = "302"
+      redirect_url    = "other_dummy"
+	  }
+	  http_request_body_condition {
+	    body_value    = "xyz"	
+	    match_type    = "REGEX"
+	  }
+  }
 }
 ```
 
@@ -54,7 +73,7 @@ The following arguments are supported:
 * `description` - (Optional) Description of the resource.
 * `tag` - (Optional) A list of scope + tag pairs to associate with this resource.
 * `nsx_id` - (Optional) The NSX ID of this resource. If set, this ID will be used to create the resource.
-* `application_profile_path` - (Required) Application profile path for this virtual server.
+* `application_profile_path` - (Required) Application profile path for this virtual server. Note that this also differentiates between Layer 4 TCP/UDP and Layer 7 HTTP virtual servers. 
 * `access_log_enabled` - (Optional) If set, all connections/requests sent to the virtual server are logged to access log.
 * `default_pool_member_ports` - (Optional) Default pool member ports to use when member port is not defined on the pool.
 * `enabled` - (Optional) Flag to enable this Virtual Server.
@@ -89,6 +108,151 @@ The following arguments are supported:
   * `group_path` - (Required) The path of grouping object which defines the IP addresses or ranges to match client IP.
   * `enabled` - (Optional) Indicates whether to enable access list control option. Default is true.
 
+* `rule` - (Optional) Specifies one or more rules to manipulate traffic passing through HTTP or HTTPS virtual server.
+  * `display_name` - (Optional) Display name of the rule.
+  * `match_strategy` - (Optional) Match strategy for determining match of multiple conditions, one of `ALL`, `ANY`. Default is `ANY`.
+  * `phase` - (Optional) Load balancer processing phase, one of `HTTP_REQUEST_REWRITE`, `HTTP_FORWARDING`, `HTTP_RESPONSE_REWRITE`, `HTTP_ACCESS` or `TRANSPORT`. Default is `HTTP_FORWARDING`.
+
+  * `connection_drop_action` - (Optional) Action to drop the connections. (There is no argument to this action)
+
+  * `http_redirect_acion` - (Optional) Action to redirect HTTP request message toto a new URL.
+    * `redirect_status` - (Required) HTTP response status code.
+    * `redirect_url` - (Required) The URL that the HTTP request is redirected to.
+
+  * `http_reject_action` - (Optional) Action to reject HTTP request message.
+    * `reply_message` - (Optional) Response message.
+    * `reply_status` - (Required) HTTP response status code.
+
+  * `http_request_header_delete_action` - (Optional) Action to delete header fields of HTTP request messages.
+    * `header_name`- (Required) Name of a header field of HTTP request message.
+
+  * `http_request_header_rewrite_action` - (Optional) Action to rewrite header fields of matched HTTP request messages to specified new values.
+    * `header_name` - (Required) Name of HTTP request header.
+    * `header_value`  - (Required) Value of HTTP request header.
+
+  * `http_request_uri_rewrite_action` - (Optional) Action to rewrite URIs in matched HTTP request messages.
+    * `uri` - (Required) URI of HTTP request.
+    * `uri_arguments` - (Optional) URI arguments.
+
+  * `http_response_header_delete_action` - (Optional) Action to delete header fields of HTTP response messages.
+    * `header_name` - (Required) Name of a header field of HTTP response messages.
+
+  * `http_response_header_rewrite_action` - (Optional) Action to rewrite header fields of matched HTTP request message to specified new values.
+    * `header_name` - (Required) Name of HTTP request header.
+    * `header_value` - (Required) Value of HTTp request header.
+
+  * `jwt_auth_action` - (Optional) Action to control access to backend server resources using JSON Web Token (JWT) authentication.
+    * `pass_jwt_to_pool` - (Optional) Whether to pass JWT to backend server or remove it, Boolean, Default `false`.
+    * `realm` - (Optional) JWT realm.
+    * `tokens` - (Optional) List of JWT tokens.
+    * `key` - (Optional) Key to verify signature of JWT token, specify exactly one of the arguments.
+      * `certificate_path` - (Optional) Use certficate to verify signature of JWT token.
+      * `public_key_content` - (Optional) Use public key to verify signature of JWT token.
+      * `symmetric_key` - (Optional) Use symmetric key to verify signature of JWT token, this argument indicates presence only, the value is discarded.
+
+  * `select_pool_action` - (Optional) Action used to select a pool for matched HTTP request messages.
+    * `pool_id` - (Required) Path of load balancer pool.
+
+  * `ssl_mode_selection_action` - (Optional) Action to select SSL mode.
+    * `ssl_mode` - (Required) Type of SSL mode, one of `SSL_PASSTHROUGH`, `SSL_END_TO_END` or `SSL_OFFLOAD`.
+
+  * `variable_assignment_action` - (Optional) Action to create new variable and assign value to it.
+    * `variable_name` - (Required) Name of the variable to be assigned.
+    * `variable_value` - (Required) Value of variable.
+
+  * `variable_persistence_learn_action` - (Optional) Action to learn the value of variable from the HTTP response.
+    * `persistence_profile_path` - (Optional) Path to nsxt_policy_persistence_profile.
+    * `variable_hash_enabled` - (Optional) Whether to enable a hash operation for variable value, Boolean, Default `false`.
+    * `variable_name` - (Required) Variable name.
+
+  * `variable_persistence_on_action` - (Optional) Action to inspect the variable of HTTP request.
+    * `persistence_profile_path` - (Optional) Path to nsxt_policy_persistence_profile.
+    * `variable_hash_enabled` - (Optional) Whether to enable a hash operation for variable value, Boolean, Default `false`.
+    * `variable_name` - (Required) Variable name.
+
+  * `http_request_body_condition` - (Optional) Condition to match the message body of an HTTP request.
+    * `body_value` - (Required) HTTP request body.
+    * `case_sensitive` - (Optional) A case senstive flag for HTTP body comparison, Boolean, Default `true`.
+    * `inverse` - (Optional) A flag to indicate whether to reverse the match result of this condition, Boolean, Default `false`
+    * `match_type` - (Optional) Match type of HTTP body, one of `REGEX`, `STARTS_WITH`, `ENDS_WITH`. `EQUALS` or `CONTAINS`. Default is `REGEX`.
+
+  * `http_request_cookie_condition` - (Optional) Condition to match HTTP request messages by cookie.
+    * `cookie_name` - (Required) Name of cookie.
+    * `cookie_value` - (Required) Value of cookie.
+    * `case_sensitive` - (Optional) A case senstive flag for cookie comparison, Boolean, Default `true`.
+    * `inverse` - (Optional) A flag to indicate whether to reverse the match result of this condition, Boolean, Default `false`
+    * `match_type` - (Optional) Match type of cookie, one of `REGEX`, `STARTS_WITH`, `ENDS_WITH`. `EQUALS` or `CONTAINS`. Default is `REGEX`.
+
+  * `http_request_header_condition` - (Optional) Condition to match HTTP request messages by HTTP header fields.
+    * `header_name` - (Required) Name of HTTP header.
+    * `header_value` - (Required) Value of HTTP header.
+    * `case_sensitive` - (Optional) A case senstive flag for HTTP header comparison, Boolean, Default `true`.
+    * `inverse` - (Optional) A flag to indicate whether to reverse the match result of this condition, Boolean, Default `false`
+    * `match_type` - (Optional) Match type of HTTP header, one of `REGEX`, `STARTS_WITH`, `ENDS_WITH`. `EQUALS` or `CONTAINS`. Default is `REGEX`.
+
+  * `http_request_method_condition` - (Optional) Condition to match method of HTTP requests.
+    * `method` - (Required) Type of HTTP request method, one of `GET`, `OPTIONS`, `POST`, `HEAD` or `PUT`.
+    * `inverse` - (Optional) A flag to indicate whether to reverse the match result of this condition, Boolean, Default `false`
+
+  * `http_request_uri_arguments_condition` - (Optional) Condition to match URI arguments.
+    * `uri_arguments` - (Required) URI arguments.
+    * `case_sensitive` - (Optional) A case senstive flag for HTTP uri arguments comparison, Boolean, Default `true`.
+    * `inverse` - (Optional) A flag to indicate whether to reverse the match result of this condition, Boolean, Default `false`
+    * `match_type` - (Optional) Match type of HTTP uri arguments, one of `REGEX`, `STARTS_WITH`, `ENDS_WITH`. `EQUALS` or `CONTAINS`. Default is `REGEX`.
+
+  * `http_request_uri_condition` - (Optional) Condition to match URIs of HTTP requests messages.
+    * `uri` - (Required) A string used to identify resource.
+    * `case_sensitive` - (Optional) A case senstive flag for HTTP uri comparison, Boolean, Default `true`.
+    * `inverse` - (Optional) A flag to indicate whether to reverse the match result of this condition, Boolean, Default `false`
+    * `match_type` - (Optional) Match type of HTTP uri, one of `REGEX`, `STARTS_WITH`, `ENDS_WITH`. `EQUALS` or `CONTAINS`. Default is `REGEX`.
+
+  * `http_request_version_condition` - (Optional) Condition to match the HTTP protocol version of the HTTP request messages.
+    * `version` (Required) HTTP version, one of `HTTP_VERSION_1_0` or `HTTP_VERSION_1_1`.
+    * `inverse` - (Optional) A flag to indicate whether to reverse the match result of this condition, Boolean, Default `false`
+
+  * `http_response_header_condition` - (Optional) Condition to match HTTP response messages from backend servers by HTTP header fields.
+    * `header_name` - (Required) Name of HTTP header field.
+    * `header_value` - (Required) Value of HTTP header field.
+    * `case_sensitive` - (Optional) A case senstive flag for HTTP header comparison, Boolean, Default `true`.
+    * `inverse` - (Optional) A flag to indicate whether to reverse the match result of this condition, Boolean, Default `false`
+    * `match_type` - (Optional) Match type of HTTP header, one of `REGEX`, `STARTS_WITH`, `ENDS_WITH`. `EQUALS` or `CONTAINS`. Default is `REGEX`.
+
+  * `http_ssl_condition` - (Optional) Condition to match SSL handshake and SSL connection.
+    * `client_certificate_issuer_dn` - (Optional) The issuer DN match condition of the client certificate.
+      * `issuer_dn` - (Required) Value of issuer DN.
+      * `case_sensitive` - (Optional) A case senstive flag for issuer DN comparison, Boolean, Default `true`.
+      * `match_type` - (Optional) Match type of issuer DN, one of `REGEX`, `STARTS_WITH`, `ENDS_WITH`. `EQUALS` or `CONTAINS`. Default is `REGEX`.
+    * `client_certificate_subject_dn` - (Optional) The subject DN match condition of the client certificate.
+      * `subject_dn` - (Required) Value of subject DN.
+      * `case_sensitive` - (Optional) A case senstive flag for subject DN comparison, Boolean, Default `true`.
+      * `match_type` - (Optional) Match type of subject DN, one of `REGEX`, `STARTS_WITH`, `ENDS_WITH`. `EQUALS` or `CONTAINS`. Default is `REGEX`.
+    * `client_support_ssl_ciphers` - (Optional) List of ciphers supported by client (see documentation for possible values).
+    * `inverse` - (Optional) A flag to indicate whether to reverse the match result of this condition, Boolean, Default `false`
+    * `session_reused` - (Optional) The type of SSL session reused, one of `IGNORE`, `REUSED` or `NEW`. Default is `IGNORE`.
+    * `used_protocol` - (Optional) Protocol of an established SSL connection, one of `SSL_V2`, `SSL_V3`, `TLS_V1`, `TLS_V1_1` or `TLS_V1_2`.
+    * `used_ssl_cipher` - (Optional) Cypher used for an established SSL connection (see documentation for possible values).
+
+  * `ip_header_condition` - (Optional) Condition to match IP header fields.
+    * `group_path` - (Optional) Grouping object path.
+    * `source_address`  - (Optional) Source IP address, range or subnet of HTTP message.
+    * `inverse` - (Optional) A flag to indicate whether to reverse the match result of this condition, Boolean, Default `false`
+
+  * `ssl_sni_condition` - (Optional) Condition to match SSL SNI in client hello.
+    * `sni` - (Required) The server name indication.
+    * `case_sensitive` - (Optional) A case senstive flag for SNI comparison, Boolean, Default `true`.
+    * `inverse` - (Optional) A flag to indicate whether to reverse the match result of this condition, Boolean, Default `false`
+    * `match_type` - (Optional) Match type of SNI, one of `REGEX`, `STARTS_WITH`, `ENDS_WITH`. `EQUALS` or `CONTAINS`. Default is `REGEX`.
+
+  * `tcp_header_condition` - (Optional) Condition to match TCP header fields.
+    * `source_port` - (Required) TCP source port or port range of HTTP message.
+    * `inverse` - (Optional) A flag to indicate whether to reverse the match result of this condition, Boolean, Default `false`
+
+  * `variable_condition` - (Optional) Condition to match variable's name and value.
+    * `variable_name` - (Required) Name of the variable to be matched.
+    * `variable_value` - (Required) Value of the variable to be matched.
+    * `case_sensitive` - (Optional) A case senstive flag for variable comparison, Boolean, Default `true`.
+    * `inverse` - (Optional) A flag to indicate whether to reverse the match result of this condition, Boolean, Default `false`
+    * `match_type` - (Optional) Match type of variable, one of `REGEX`, `STARTS_WITH`, `ENDS_WITH`. `EQUALS` or `CONTAINS`. Default is `REGEX`.
 
 ## Attributes Reference
 

--- a/website/docs/r/policy_lb_virtual_server.html.markdown
+++ b/website/docs/r/policy_lb_virtual_server.html.markdown
@@ -11,6 +11,8 @@ This resource provides a method for the management of a Load Balancer Virtual Se
 
 This resource is applicable to NSX Policy Manager.
 
+Note that the 'rule' section has been added at a later date. In order to preserve backward compatibility for users that have created rules manually, existing ("live") rules will not be changed if there is no 'rule' section present in the resource definition. If you want to delete manually created rules from a managed resource, you might have to initially add a 'rule' section and subsequentially delete it again. 
+
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/policy_lb_virtual_server.html.markdown
+++ b/website/docs/r/policy_lb_virtual_server.html.markdown
@@ -49,18 +49,22 @@ resource "nsxt_policy_lb_virtual_server" "test" {
     match_strategy = "ALL"
     phase          = "HTTP_REQUEST_REWRITE"
 
-	  http_redirect_action {
-      redirect_status = "301"
-      redirect_url    = "dummy"
-	  }
-	  http_redirect_action {
-      redirect_status = "302"
-      redirect_url    = "other_dummy"
-	  }
-	  http_request_body_condition {
-	    body_value    = "xyz"	
-	    match_type    = "REGEX"
-	  }
+    action {
+      http_redirect {
+        redirect_status = "301"
+        redirect_url    = "dummy"
+      }
+      http_redirect {
+        redirect_status = "302"
+        redirect_url    = "other_dummy"
+      }
+    }
+    condition {
+      http_request_body {
+        body_value    = "xyz"	
+        match_type    = "REGEX"
+      }
+    }
   }
 }
 ```
@@ -113,146 +117,150 @@ The following arguments are supported:
   * `match_strategy` - (Optional) Match strategy for determining match of multiple conditions, one of `ALL`, `ANY`. Default is `ANY`.
   * `phase` - (Optional) Load balancer processing phase, one of `HTTP_REQUEST_REWRITE`, `HTTP_FORWARDING`, `HTTP_RESPONSE_REWRITE`, `HTTP_ACCESS` or `TRANSPORT`. Default is `HTTP_FORWARDING`.
 
-  * `connection_drop_action` - (Optional) Action to drop the connections. (There is no argument to this action)
+  * `action` - (Required) A list of actions to be executed at specified phase when load balancer rule matches.
 
-  * `http_redirect_acion` - (Optional) Action to redirect HTTP request message toto a new URL.
-    * `redirect_status` - (Required) HTTP response status code.
-    * `redirect_url` - (Required) The URL that the HTTP request is redirected to.
+    * `connection_drop` - (Optional) Action to drop the connections. (There is no argument to this action)
 
-  * `http_reject_action` - (Optional) Action to reject HTTP request message.
-    * `reply_message` - (Optional) Response message.
-    * `reply_status` - (Required) HTTP response status code.
+    * `http_redirect_acion` - (Optional) Action to redirect HTTP request message toto a new URL.
+      * `redirect_status` - (Required) HTTP response status code.
+      * `redirect_url` - (Required) The URL that the HTTP request is redirected to.
 
-  * `http_request_header_delete_action` - (Optional) Action to delete header fields of HTTP request messages.
-    * `header_name`- (Required) Name of a header field of HTTP request message.
+    * `http_reject` - (Optional) Action to reject HTTP request message.
+      * `reply_message` - (Optional) Response message.
+      * `reply_status` - (Required) HTTP response status code.
 
-  * `http_request_header_rewrite_action` - (Optional) Action to rewrite header fields of matched HTTP request messages to specified new values.
-    * `header_name` - (Required) Name of HTTP request header.
-    * `header_value`  - (Required) Value of HTTP request header.
+    * `http_request_header_delete` - (Optional) Action to delete header fields of HTTP request messages.
+      * `header_name`- (Required) Name of a header field of HTTP request message.
 
-  * `http_request_uri_rewrite_action` - (Optional) Action to rewrite URIs in matched HTTP request messages.
-    * `uri` - (Required) URI of HTTP request.
-    * `uri_arguments` - (Optional) URI arguments.
+    * `http_request_header_rewrite` - (Optional) Action to rewrite header fields of matched HTTP request messages to specified new values.
+      * `header_name` - (Required) Name of HTTP request header.
+      * `header_value`  - (Required) Value of HTTP request header.
 
-  * `http_response_header_delete_action` - (Optional) Action to delete header fields of HTTP response messages.
-    * `header_name` - (Required) Name of a header field of HTTP response messages.
+    * `http_request_uri_rewrite` - (Optional) Action to rewrite URIs in matched HTTP request messages.
+      * `uri` - (Required) URI of HTTP request.
+      * `uri_arguments` - (Optional) URI arguments.
 
-  * `http_response_header_rewrite_action` - (Optional) Action to rewrite header fields of matched HTTP request message to specified new values.
-    * `header_name` - (Required) Name of HTTP request header.
-    * `header_value` - (Required) Value of HTTp request header.
+    * `http_response_header_delete` - (Optional) Action to delete header fields of HTTP response messages.
+      * `header_name` - (Required) Name of a header field of HTTP response messages.
 
-  * `jwt_auth_action` - (Optional) Action to control access to backend server resources using JSON Web Token (JWT) authentication.
-    * `pass_jwt_to_pool` - (Optional) Whether to pass JWT to backend server or remove it, Boolean, Default `false`.
-    * `realm` - (Optional) JWT realm.
-    * `tokens` - (Optional) List of JWT tokens.
-    * `key` - (Optional) Key to verify signature of JWT token, specify exactly one of the arguments.
-      * `certificate_path` - (Optional) Use certficate to verify signature of JWT token.
-      * `public_key_content` - (Optional) Use public key to verify signature of JWT token.
-      * `symmetric_key` - (Optional) Use symmetric key to verify signature of JWT token, this argument indicates presence only, the value is discarded.
+    * `http_response_header_rewrite` - (Optional) Action to rewrite header fields of matched HTTP request message to specified new values.
+      * `header_name` - (Required) Name of HTTP request header.
+      * `header_value` - (Required) Value of HTTp request header.
 
-  * `select_pool_action` - (Optional) Action used to select a pool for matched HTTP request messages.
-    * `pool_id` - (Required) Path of load balancer pool.
+    * `jwt_auth` - (Optional) Action to control access to backend server resources using JSON Web Token (JWT) authentication.
+      * `pass_jwt_to_pool` - (Optional) Whether to pass JWT to backend server or remove it, Boolean, Default `false`.
+      * `realm` - (Optional) JWT realm.
+      * `tokens` - (Optional) List of JWT tokens.
+      * `key` - (Optional) Key to verify signature of JWT token, specify exactly one of the arguments.
+        * `certificate_path` - (Optional) Use certficate to verify signature of JWT token.
+        * `public_key_content` - (Optional) Use public key to verify signature of JWT token.
+        * `symmetric_key` - (Optional) Use symmetric key to verify signature of JWT token, this argument indicates presence only, the value is discarded.
 
-  * `ssl_mode_selection_action` - (Optional) Action to select SSL mode.
-    * `ssl_mode` - (Required) Type of SSL mode, one of `SSL_PASSTHROUGH`, `SSL_END_TO_END` or `SSL_OFFLOAD`.
+    * `select_pool` - (Optional) Action used to select a pool for matched HTTP request messages.
+      * `pool_id` - (Required) Path of load balancer pool.
 
-  * `variable_assignment_action` - (Optional) Action to create new variable and assign value to it.
-    * `variable_name` - (Required) Name of the variable to be assigned.
-    * `variable_value` - (Required) Value of variable.
+    * `ssl_mode_selection` - (Optional) Action to select SSL mode.
+      * `ssl_mode` - (Required) Type of SSL mode, one of `SSL_PASSTHROUGH`, `SSL_END_TO_END` or `SSL_OFFLOAD`.
 
-  * `variable_persistence_learn_action` - (Optional) Action to learn the value of variable from the HTTP response.
-    * `persistence_profile_path` - (Optional) Path to nsxt_policy_persistence_profile.
-    * `variable_hash_enabled` - (Optional) Whether to enable a hash operation for variable value, Boolean, Default `false`.
-    * `variable_name` - (Required) Variable name.
+    * `variable_assignment` - (Optional) Action to create new variable and assign value to it.
+      * `variable_name` - (Required) Name of the variable to be assigned.
+      * `variable_value` - (Required) Value of variable.
 
-  * `variable_persistence_on_action` - (Optional) Action to inspect the variable of HTTP request.
-    * `persistence_profile_path` - (Optional) Path to nsxt_policy_persistence_profile.
-    * `variable_hash_enabled` - (Optional) Whether to enable a hash operation for variable value, Boolean, Default `false`.
-    * `variable_name` - (Required) Variable name.
+    * `variable_persistence_learn` - (Optional) Action to learn the value of variable from the HTTP response.
+      * `persistence_profile_path` - (Optional) Path to nsxt_policy_persistence_profile.
+      * `variable_hash_enabled` - (Optional) Whether to enable a hash operation for variable value, Boolean, Default `false`.
+      * `variable_name` - (Required) Variable name.
 
-  * `http_request_body_condition` - (Optional) Condition to match the message body of an HTTP request.
-    * `body_value` - (Required) HTTP request body.
-    * `case_sensitive` - (Optional) A case senstive flag for HTTP body comparison, Boolean, Default `true`.
-    * `inverse` - (Optional) A flag to indicate whether to reverse the match result of this condition, Boolean, Default `false`
-    * `match_type` - (Optional) Match type of HTTP body, one of `REGEX`, `STARTS_WITH`, `ENDS_WITH`. `EQUALS` or `CONTAINS`. Default is `REGEX`.
+    * `variable_persistence_on` - (Optional) Action to inspect the variable of HTTP request.
+      * `persistence_profile_path` - (Optional) Path to nsxt_policy_persistence_profile.
+      * `variable_hash_enabled` - (Optional) Whether to enable a hash operation for variable value, Boolean, Default `false`.
+      * `variable_name` - (Required) Variable name.
 
-  * `http_request_cookie_condition` - (Optional) Condition to match HTTP request messages by cookie.
-    * `cookie_name` - (Required) Name of cookie.
-    * `cookie_value` - (Required) Value of cookie.
-    * `case_sensitive` - (Optional) A case senstive flag for cookie comparison, Boolean, Default `true`.
-    * `inverse` - (Optional) A flag to indicate whether to reverse the match result of this condition, Boolean, Default `false`
-    * `match_type` - (Optional) Match type of cookie, one of `REGEX`, `STARTS_WITH`, `ENDS_WITH`. `EQUALS` or `CONTAINS`. Default is `REGEX`.
+  * `condition` - (Optional) A list of match conditions used to match application traffic.
 
-  * `http_request_header_condition` - (Optional) Condition to match HTTP request messages by HTTP header fields.
-    * `header_name` - (Required) Name of HTTP header.
-    * `header_value` - (Required) Value of HTTP header.
-    * `case_sensitive` - (Optional) A case senstive flag for HTTP header comparison, Boolean, Default `true`.
-    * `inverse` - (Optional) A flag to indicate whether to reverse the match result of this condition, Boolean, Default `false`
-    * `match_type` - (Optional) Match type of HTTP header, one of `REGEX`, `STARTS_WITH`, `ENDS_WITH`. `EQUALS` or `CONTAINS`. Default is `REGEX`.
+    * `http_request_body` - (Optional) Condition to match the message body of an HTTP request.
+      * `body_value` - (Required) HTTP request body.
+      * `case_sensitive` - (Optional) A case senstive flag for HTTP body comparison, Boolean, Default `true`.
+      * `inverse` - (Optional) A flag to indicate whether to reverse the match result of this condition, Boolean, Default `false`
+      * `match_type` - (Optional) Match type of HTTP body, one of `REGEX`, `STARTS_WITH`, `ENDS_WITH`. `EQUALS` or `CONTAINS`. Default is `REGEX`.
 
-  * `http_request_method_condition` - (Optional) Condition to match method of HTTP requests.
-    * `method` - (Required) Type of HTTP request method, one of `GET`, `OPTIONS`, `POST`, `HEAD` or `PUT`.
-    * `inverse` - (Optional) A flag to indicate whether to reverse the match result of this condition, Boolean, Default `false`
+    * `http_request_cookie` - (Optional) Condition to match HTTP request messages by cookie.
+      * `cookie_name` - (Required) Name of cookie.
+      * `cookie_value` - (Required) Value of cookie.
+      * `case_sensitive` - (Optional) A case senstive flag for cookie comparison, Boolean, Default `true`.
+      * `inverse` - (Optional) A flag to indicate whether to reverse the match result of this condition, Boolean, Default `false`
+      * `match_type` - (Optional) Match type of cookie, one of `REGEX`, `STARTS_WITH`, `ENDS_WITH`. `EQUALS` or `CONTAINS`. Default is `REGEX`.
 
-  * `http_request_uri_arguments_condition` - (Optional) Condition to match URI arguments.
-    * `uri_arguments` - (Required) URI arguments.
-    * `case_sensitive` - (Optional) A case senstive flag for HTTP uri arguments comparison, Boolean, Default `true`.
-    * `inverse` - (Optional) A flag to indicate whether to reverse the match result of this condition, Boolean, Default `false`
-    * `match_type` - (Optional) Match type of HTTP uri arguments, one of `REGEX`, `STARTS_WITH`, `ENDS_WITH`. `EQUALS` or `CONTAINS`. Default is `REGEX`.
+    * `http_request_header` - (Optional) Condition to match HTTP request messages by HTTP header fields.
+      * `header_name` - (Required) Name of HTTP header.
+      * `header_value` - (Required) Value of HTTP header.
+      * `case_sensitive` - (Optional) A case senstive flag for HTTP header comparison, Boolean, Default `true`.
+      * `inverse` - (Optional) A flag to indicate whether to reverse the match result of this condition, Boolean, Default `false`
+      * `match_type` - (Optional) Match type of HTTP header, one of `REGEX`, `STARTS_WITH`, `ENDS_WITH`. `EQUALS` or `CONTAINS`. Default is `REGEX`.
 
-  * `http_request_uri_condition` - (Optional) Condition to match URIs of HTTP requests messages.
-    * `uri` - (Required) A string used to identify resource.
-    * `case_sensitive` - (Optional) A case senstive flag for HTTP uri comparison, Boolean, Default `true`.
-    * `inverse` - (Optional) A flag to indicate whether to reverse the match result of this condition, Boolean, Default `false`
-    * `match_type` - (Optional) Match type of HTTP uri, one of `REGEX`, `STARTS_WITH`, `ENDS_WITH`. `EQUALS` or `CONTAINS`. Default is `REGEX`.
+    * `http_request_method` - (Optional) Condition to match method of HTTP requests.
+      * `method` - (Required) Type of HTTP request method, one of `GET`, `OPTIONS`, `POST`, `HEAD` or `PUT`.
+      * `inverse` - (Optional) A flag to indicate whether to reverse the match result of this condition, Boolean, Default `false`
 
-  * `http_request_version_condition` - (Optional) Condition to match the HTTP protocol version of the HTTP request messages.
-    * `version` (Required) HTTP version, one of `HTTP_VERSION_1_0` or `HTTP_VERSION_1_1`.
-    * `inverse` - (Optional) A flag to indicate whether to reverse the match result of this condition, Boolean, Default `false`
+    * `http_request_uri_arguments` - (Optional) Condition to match URI arguments.
+      * `uri_arguments` - (Required) URI arguments.
+      * `case_sensitive` - (Optional) A case senstive flag for HTTP uri arguments comparison, Boolean, Default `true`.
+      * `inverse` - (Optional) A flag to indicate whether to reverse the match result of this condition, Boolean, Default `false`
+      * `match_type` - (Optional) Match type of HTTP uri arguments, one of `REGEX`, `STARTS_WITH`, `ENDS_WITH`. `EQUALS` or `CONTAINS`. Default is `REGEX`.
 
-  * `http_response_header_condition` - (Optional) Condition to match HTTP response messages from backend servers by HTTP header fields.
-    * `header_name` - (Required) Name of HTTP header field.
-    * `header_value` - (Required) Value of HTTP header field.
-    * `case_sensitive` - (Optional) A case senstive flag for HTTP header comparison, Boolean, Default `true`.
-    * `inverse` - (Optional) A flag to indicate whether to reverse the match result of this condition, Boolean, Default `false`
-    * `match_type` - (Optional) Match type of HTTP header, one of `REGEX`, `STARTS_WITH`, `ENDS_WITH`. `EQUALS` or `CONTAINS`. Default is `REGEX`.
+    * `http_request_uri` - (Optional) Condition to match URIs of HTTP requests messages.
+      * `uri` - (Required) A string used to identify resource.
+      * `case_sensitive` - (Optional) A case senstive flag for HTTP uri comparison, Boolean, Default `true`.
+      * `inverse` - (Optional) A flag to indicate whether to reverse the match result of this condition, Boolean, Default `false`
+      * `match_type` - (Optional) Match type of HTTP uri, one of `REGEX`, `STARTS_WITH`, `ENDS_WITH`. `EQUALS` or `CONTAINS`. Default is `REGEX`.
 
-  * `http_ssl_condition` - (Optional) Condition to match SSL handshake and SSL connection.
-    * `client_certificate_issuer_dn` - (Optional) The issuer DN match condition of the client certificate.
-      * `issuer_dn` - (Required) Value of issuer DN.
-      * `case_sensitive` - (Optional) A case senstive flag for issuer DN comparison, Boolean, Default `true`.
-      * `match_type` - (Optional) Match type of issuer DN, one of `REGEX`, `STARTS_WITH`, `ENDS_WITH`. `EQUALS` or `CONTAINS`. Default is `REGEX`.
-    * `client_certificate_subject_dn` - (Optional) The subject DN match condition of the client certificate.
-      * `subject_dn` - (Required) Value of subject DN.
-      * `case_sensitive` - (Optional) A case senstive flag for subject DN comparison, Boolean, Default `true`.
-      * `match_type` - (Optional) Match type of subject DN, one of `REGEX`, `STARTS_WITH`, `ENDS_WITH`. `EQUALS` or `CONTAINS`. Default is `REGEX`.
-    * `client_support_ssl_ciphers` - (Optional) List of ciphers supported by client (see documentation for possible values).
-    * `inverse` - (Optional) A flag to indicate whether to reverse the match result of this condition, Boolean, Default `false`
-    * `session_reused` - (Optional) The type of SSL session reused, one of `IGNORE`, `REUSED` or `NEW`. Default is `IGNORE`.
-    * `used_protocol` - (Optional) Protocol of an established SSL connection, one of `SSL_V2`, `SSL_V3`, `TLS_V1`, `TLS_V1_1` or `TLS_V1_2`.
-    * `used_ssl_cipher` - (Optional) Cypher used for an established SSL connection (see documentation for possible values).
+    * `http_request_version` - (Optional) Condition to match the HTTP protocol version of the HTTP request messages.
+      * `version` (Required) HTTP version, one of `HTTP_VERSION_1_0` or `HTTP_VERSION_1_1`.
+      * `inverse` - (Optional) A flag to indicate whether to reverse the match result of this condition, Boolean, Default `false`
 
-  * `ip_header_condition` - (Optional) Condition to match IP header fields.
-    * `group_path` - (Optional) Grouping object path.
-    * `source_address`  - (Optional) Source IP address, range or subnet of HTTP message.
-    * `inverse` - (Optional) A flag to indicate whether to reverse the match result of this condition, Boolean, Default `false`
+    * `http_response_header` - (Optional) Condition to match HTTP response messages from backend servers by HTTP header fields.
+      * `header_name` - (Required) Name of HTTP header field.
+      * `header_value` - (Required) Value of HTTP header field.
+      * `case_sensitive` - (Optional) A case senstive flag for HTTP header comparison, Boolean, Default `true`.
+      * `inverse` - (Optional) A flag to indicate whether to reverse the match result of this condition, Boolean, Default `false`
+      * `match_type` - (Optional) Match type of HTTP header, one of `REGEX`, `STARTS_WITH`, `ENDS_WITH`. `EQUALS` or `CONTAINS`. Default is `REGEX`.
 
-  * `ssl_sni_condition` - (Optional) Condition to match SSL SNI in client hello.
-    * `sni` - (Required) The server name indication.
-    * `case_sensitive` - (Optional) A case senstive flag for SNI comparison, Boolean, Default `true`.
-    * `inverse` - (Optional) A flag to indicate whether to reverse the match result of this condition, Boolean, Default `false`
-    * `match_type` - (Optional) Match type of SNI, one of `REGEX`, `STARTS_WITH`, `ENDS_WITH`. `EQUALS` or `CONTAINS`. Default is `REGEX`.
+    * `http_ssl` - (Optional) Condition to match SSL handshake and SSL connection.
+      * `client_certificate_issuer_dn` - (Optional) The issuer DN match condition of the client certificate.
+        * `issuer_dn` - (Required) Value of issuer DN.
+        * `case_sensitive` - (Optional) A case senstive flag for issuer DN comparison, Boolean, Default `true`.
+        * `match_type` - (Optional) Match type of issuer DN, one of `REGEX`, `STARTS_WITH`, `ENDS_WITH`. `EQUALS` or `CONTAINS`. Default is `REGEX`.
+      * `client_certificate_subject_dn` - (Optional) The subject DN match condition of the client certificate.
+        * `subject_dn` - (Required) Value of subject DN.
+        * `case_sensitive` - (Optional) A case senstive flag for subject DN comparison, Boolean, Default `true`.
+        * `match_type` - (Optional) Match type of subject DN, one of `REGEX`, `STARTS_WITH`, `ENDS_WITH`. `EQUALS` or `CONTAINS`. Default is `REGEX`.
+      * `client_support_ssl_ciphers` - (Optional) List of ciphers supported by client (see documentation for possible values).
+      * `inverse` - (Optional) A flag to indicate whether to reverse the match result of this condition, Boolean, Default `false`
+      * `session_reused` - (Optional) The type of SSL session reused, one of `IGNORE`, `REUSED` or `NEW`. Default is `IGNORE`.
+      * `used_protocol` - (Optional) Protocol of an established SSL connection, one of `SSL_V2`, `SSL_V3`, `TLS_V1`, `TLS_V1_1` or `TLS_V1_2`.
+      * `used_ssl_cipher` - (Optional) Cypher used for an established SSL connection (see documentation for possible values).
 
-  * `tcp_header_condition` - (Optional) Condition to match TCP header fields.
-    * `source_port` - (Required) TCP source port or port range of HTTP message.
-    * `inverse` - (Optional) A flag to indicate whether to reverse the match result of this condition, Boolean, Default `false`
+    * `ip_header` - (Optional) Condition to match IP header fields.
+      * `group_path` - (Optional) Grouping object path.
+      * `source_address`  - (Optional) Source IP address, range or subnet of HTTP message.
+      * `inverse` - (Optional) A flag to indicate whether to reverse the match result of this condition, Boolean, Default `false`
 
-  * `variable_condition` - (Optional) Condition to match variable's name and value.
-    * `variable_name` - (Required) Name of the variable to be matched.
-    * `variable_value` - (Required) Value of the variable to be matched.
-    * `case_sensitive` - (Optional) A case senstive flag for variable comparison, Boolean, Default `true`.
-    * `inverse` - (Optional) A flag to indicate whether to reverse the match result of this condition, Boolean, Default `false`
-    * `match_type` - (Optional) Match type of variable, one of `REGEX`, `STARTS_WITH`, `ENDS_WITH`. `EQUALS` or `CONTAINS`. Default is `REGEX`.
+    * `ssl_sni` - (Optional) Condition to match SSL SNI in client hello.
+      * `sni` - (Required) The server name indication.
+      * `case_sensitive` - (Optional) A case senstive flag for SNI comparison, Boolean, Default `true`.
+      * `inverse` - (Optional) A flag to indicate whether to reverse the match result of this condition, Boolean, Default `false`
+      * `match_type` - (Optional) Match type of SNI, one of `REGEX`, `STARTS_WITH`, `ENDS_WITH`. `EQUALS` or `CONTAINS`. Default is `REGEX`.
+
+    * `tcp_header` - (Optional) Condition to match TCP header fields.
+      * `source_port` - (Required) TCP source port or port range of HTTP message.
+      * `inverse` - (Optional) A flag to indicate whether to reverse the match result of this condition, Boolean, Default `false`
+
+    * `variable` - (Optional) Condition to match variable's name and value.
+      * `variable_name` - (Required) Name of the variable to be matched.
+      * `variable_value` - (Required) Value of the variable to be matched.
+      * `case_sensitive` - (Optional) A case senstive flag for variable comparison, Boolean, Default `true`.
+      * `inverse` - (Optional) A flag to indicate whether to reverse the match result of this condition, Boolean, Default `false`
+      * `match_type` - (Optional) Match type of variable, one of `REGEX`, `STARTS_WITH`, `ENDS_WITH`. `EQUALS` or `CONTAINS`. Default is `REGEX`.
 
 ## Attributes Reference
 

--- a/website/docs/r/policy_lb_virtual_server.html.markdown
+++ b/website/docs/r/policy_lb_virtual_server.html.markdown
@@ -45,7 +45,7 @@ resource "nsxt_policy_lb_virtual_server" "test" {
   }
 
   rule {
-  	display_name   = "rule_test"
+    display_name   = "rule_test"
     match_strategy = "ALL"
     phase          = "HTTP_REQUEST_REWRITE"
 


### PR DESCRIPTION
The nsxt_policy_lb_virtual_server is still missing support for rules which my client could really use so I started working on this.

I modelled the interface along the lines of the manager resource nsxt_lb_http_request_rewrite_rule so you simply include one or more rule blocks and can add one or more action- and condition-types beneath it, for example:

```
resource "nsxt_policy_lb_virtual_server" "test" {
  display_name             = "test"
  application_profile_path = data.nsxt_policy_lb_app_profile.default_http.path
  ip_address               = "1.1.1.1"
  ports                    = [ "80" ]
  pool_path                  = nsxt_policy_lb_pool.pool.path

  rule {
    display_name = "http_redirect_action_test"

    http_redirect_action {
      redirect_status = "301"
      redirect_url = "dummy"
    }
    http_request_body_condition {
      body_value = "xyz"	
      match_type = "REGEX"
    }
  }
  rule {
    ...
  }
}
```

(Of course, you could also group rules in a "rules" block with a list of rules and/or do the same with "actions" and "conditions" but I quite like how this turned out.)

Please let me know if/what needs to be changed for this to be accepted as I would really like to see this in the offical release (before I can use it in production) 

Note that this also potentially closes issues #444 and #579.

Signed-off-by: Martin Rohrbach <martin.rohrbach@dell.com>