### PR TITLE
Adjust to edge node API change in NSX 3.2

### DIFF
--- a/nsxt/data_source_nsxt_policy_edge_node.go
+++ b/nsxt/data_source_nsxt_policy_edge_node.go
@@ -41,13 +41,13 @@ func dataSourceNsxtPolicyEdgeNodeRead(d *schema.ResourceData, m interface{}) err
 	// for bool types, but in this case it works and GetOk doesn't
 	memberIndex, memberIndexSet := d.GetOkExists("member_index")
 
-	if isPolicyGlobalManager(m) {
+	if isPolicyGlobalManager(m) || nsxVersionHigherOrEqual("3.2.0") {
 		query := make(map[string]string)
 		query["parent_path"] = edgeClusterPath
 		if memberIndexSet {
 			query["member_index"] = strconv.Itoa(memberIndex.(int))
 		}
-		_, err := policyDataSourceResourceReadWithValidation(d, getPolicyConnector(m), true, "PolicyEdgeNode", query, false)
+		_, err := policyDataSourceResourceReadWithValidation(d, getPolicyConnector(m), isPolicyGlobalManager(m), "PolicyEdgeNode", query, false)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Edge node id will become ordinal rather than uuid. In order to
retain backwards compatibility in provider, we search by nsx_id
rather than id for this data source.

Signed-off-by: Anna Khmelnitsky <akhmelnitsky@vmware.com>