### PR TITLE
gateway_route_map(doc): fix missing MATCH to match_operator

### DIFF
--- a/website/docs/r/policy_gateway_route_map.html.markdown
+++ b/website/docs/r/policy_gateway_route_map.html.markdown
@@ -23,12 +23,12 @@ resource "nsxt_policy_gateway_route_map" "test" {
     action = "PERMIT"
     community_list_match {
       criteria       = "11:*"
-      match_operator = "COMMUNITY_REGEX"
+      match_operator = "MATCH_COMMUNITY_REGEX"
     }
 
     community_list_match {
       criteria       = "11:*"
-      match_operator = "LARGE_COMMUNITY_REGEX"
+      match_operator = "MATCH_LARGE_COMMUNITY_REGEX"
     }
   }
 
@@ -56,7 +56,7 @@ The following arguments are supported:
   * `action` - (Optional) Action for the route map entry, either `PERMIT` or `DENY`, with default being `PERMIT`.
   * `community_list_match` - (Optional) List of Prefix List match criteria for route map. Cannot be configured together with `prefix_list_matches`. If configured together, `prefix_list_matches` will be ignored.
     * `criteria` - (Required) Community list path or a regular expression.
-    * `match_operator` - (Required) Match operator for the criteria, one of `ANY`, `ALL`, `EXACT`, `COMMUNITY_REGEX`, `LARGE_COMMUNITY_REGEX`. Only last two operators can be used together with regular expression criteria.
+    * `match_operator` - (Required) Match operator for the criteria, one of `MATCH_ANY`, `MATCH_ALL`, `MATCH_EXACT`, `MATCH_COMMUNITY_REGEX`, `MATCH_LARGE_COMMUNITY_REGEX`. Only last two operators can be used together with regular expression criteria.
   * `prefix_list_matches` - (Optional) List of policy paths for Prefix Lists configured on this Gateway. Cannot be configured together with `community_list_match`. If configured together, `prefix_list_matches` will be ignored.
   * `set` - (Optional) Set criteria for route map entry.
     * `as_path_prepend` - (Optional) Autonomous System (AS) path prepend to influence route selection.


### PR DESCRIPTION
See https://vdc-download.vmware.com/vmwb-repository/dcr-public/ce4128ae-8334-4f91-871b-ecce254cf69e/488f1280-204c-441d-8520-8279ac33d54b/api_includes/types_CommunityMatchCriteria.html

Fix #704

Signed-off-by: Alexis La Goutte <alexis.lagoutte@gmail.com>