### PR TITLE
Add data source for policy VMs map

### DIFF
--- a/nsxt/data_source_nsxt_policy_vm.go
+++ b/nsxt/data_source_nsxt_policy_vm.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/vmware/vsphere-automation-sdk-go/runtime/bindings"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 )
 
@@ -42,8 +41,6 @@ func getNsxtPolicyVMIDFromSchema(d *schema.ResourceData) string {
 }
 
 func dataSourceNsxtPolicyVMIDRead(d *schema.ResourceData, m interface{}) error {
-	converter := bindings.NewTypeConverter()
-	converter.SetMode(bindings.REST)
 	var vmModel model.VirtualMachine
 	connector := getPolicyConnector(m)
 

--- a/nsxt/data_source_nsxt_policy_vms.go
+++ b/nsxt/data_source_nsxt_policy_vms.go
@@ -1,0 +1,73 @@
+/* Copyright © 2022 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: MPL-2.0 */
+
+package nsxt
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+var valueTypeValues = []string{"bios_id", "external_id", "instance_id"}
+
+func dataSourceNsxtPolicyVMs() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceNsxtPolicyVMsRead,
+
+		Schema: map[string]*schema.Schema{
+			// TODO: add option to filter by display name regex
+			"value_type": {
+				Type:         schema.TypeString,
+				Description:  "Type of data populated in map value",
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice(valueTypeValues, false),
+				Default:      "bios_id",
+			},
+			"items": {
+				Type:        schema.TypeMap,
+				Description: "Mapping of VM instance ID by display name",
+				Computed:    true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+		},
+	}
+}
+
+func dataSourceNsxtPolicyVMsRead(d *schema.ResourceData, m interface{}) error {
+	connector := getPolicyConnector(m)
+
+	valueType := d.Get("value_type").(string)
+	vmMap := make(map[string]interface{})
+
+	allVMs, err := listAllPolicyVirtualMachines(connector, m)
+	if err != nil {
+		return fmt.Errorf("Error reading Virtual Machines: %v", err)
+	}
+
+	for _, vm := range allVMs {
+		if vm.DisplayName == nil {
+			continue
+		}
+		computeIDMap := collectSeparatedStringListToMap(vm.ComputeIds, ":")
+		if valueType == "instance_id" {
+			vmMap[*vm.DisplayName] = computeIDMap[nsxtPolicyInstanceUUIDKey]
+		} else if valueType == "bios_id" {
+			vmMap[*vm.DisplayName] = computeIDMap[nsxtPolicyBiosUUIDKey]
+		} else if valueType == "external_id" {
+			if vm.ExternalId == nil {
+				// skip this vm
+				continue
+			}
+			vmMap[*vm.DisplayName] = *vm.ExternalId
+		}
+	}
+
+	d.SetId(newUUID())
+	d.Set("items", vmMap)
+
+	return nil
+}

--- a/nsxt/data_source_nsxt_policy_vms_test.go
+++ b/nsxt/data_source_nsxt_policy_vms_test.go
@@ -1,0 +1,63 @@
+/* Copyright © 2022 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: MPL-2.0 */
+
+package nsxt
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccDataSourceNsxtPolicyVMs_basic(t *testing.T) {
+	testResourceName := "data.nsxt_policy_vms.test"
+	checkDataSourceName := "data.nsxt_policy_vm.check"
+	checkResourceName := "nsxt_policy_group.check"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccEnvDefined(t, "NSXT_TEST_VM_NAME")
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyVMsTemplate("bios_id"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(testResourceName, "id"),
+					resource.TestCheckResourceAttrPair(checkResourceName, "display_name", checkDataSourceName, "bios_id"),
+				),
+			},
+			{
+				Config: testAccNsxtPolicyVMsTemplate("external_id"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(testResourceName, "id"),
+					resource.TestCheckResourceAttrPair(checkResourceName, "display_name", checkDataSourceName, "external_id"),
+				),
+			},
+			{
+				Config: testAccNsxtPolicyVMsTemplate("instance_id"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(testResourceName, "id"),
+					resource.TestCheckResourceAttrPair(checkResourceName, "display_name", checkDataSourceName, "instance_id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccNsxtPolicyVMsTemplate(valueType string) string {
+	return fmt.Sprintf(`
+data "nsxt_policy_vms" "test" {
+  value_type = "%s"
+}
+
+data "nsxt_policy_vm" "check" {
+  display_name = "%s"
+}
+
+resource "nsxt_policy_group" "check" {
+  display_name = data.nsxt_policy_vms.test.items["%s"]
+}`, valueType, getTestVMName(), getTestVMName())
+}

--- a/nsxt/provider.go
+++ b/nsxt/provider.go
@@ -235,6 +235,7 @@ func Provider() *schema.Provider {
 			"nsxt_policy_segment_security_profile":  dataSourceNsxtPolicySegmentSecurityProfile(),
 			"nsxt_policy_mac_discovery_profile":     dataSourceNsxtPolicyMacDiscoveryProfile(),
 			"nsxt_policy_vm":                        dataSourceNsxtPolicyVM(),
+			"nsxt_policy_vms":                       dataSourceNsxtPolicyVMs(),
 			"nsxt_policy_lb_app_profile":            dataSourceNsxtPolicyLBAppProfile(),
 			"nsxt_policy_lb_client_ssl_profile":     dataSourceNsxtPolicyLBClientSslProfile(),
 			"nsxt_policy_lb_server_ssl_profile":     dataSourceNsxtPolicyLBServerSslProfile(),

--- a/website/docs/d/policy_vms.html.markdown
+++ b/website/docs/d/policy_vms.html.markdown
@@ -1,0 +1,37 @@
+---
+subcategory: "Policy - Grouping and Tagging"
+layout: "nsxt"
+page_title: "NSXT: nsxt_policy_vms"
+description: A Discovered Policy Virtual Machines data source.
+---
+
+# nsxt_policy_vms
+
+This data source provides map of all Policy based Virtual Machines (VMs) listed in NSX inventory, and allows look-up of the VM by `display_name` in the map. Value of the map would provide one of VM ID types, according to `value_type` argument.
+
+This data source is applicable to NSX Policy Manager and VMC.
+
+## Example Usage
+
+```hcl
+data "nsxt_policy_vms" "all" {
+  value_type = "bios_id"
+}
+
+resource "nsxt_policy_vm_tags" "test" {
+  instance_id = data.nsxt_policy_vms.all.items["vm-1"]
+
+  tag {
+    scope = "color"
+    tag   = "blue"
+  }
+}
+```
+
+## Argument Reference
+
+* `value_tupe` - (Optional) Type of VM ID the user is interested in. Possible values are `bios_id`, `external_id`, `instance_id`. Default is `bios_id`.
+
+## Attributes Reference
+
+* `items` - Map of IDs by Display Name.


### PR DESCRIPTION
This data source returns full VM inventory mapped by display
name. It allows to control type of VM ID with `value_type` argument.
The purpose of this data source is to improve efficiency and also
provide user more flexibility in dealing with VM inventory without
necessarily failing apply (such as ignoring deleted VM).

Signed-off-by: Anna Khmelnitsky <akhmelnitsky@vmware.com>