### PR TITLE
Include object scope into policy search

### DIFF
--- a/nsxt/policy_search.go
+++ b/nsxt/policy_search.go
@@ -162,6 +162,9 @@ func searchGMPolicyResources(connector *client.RestConnector, query string) ([]*
 	var cursor *string
 	total := 0
 
+	// Make sure local objects are not found (path needs to start with global-infra)
+	query = query + " AND path:\\/global-infra*"
+
 	for {
 		searchResponse, err := client.List(query, cursor, nil, nil, nil, nil)
 		if err != nil {
@@ -184,6 +187,9 @@ func searchLMPolicyResources(connector *client.RestConnector, query string) ([]*
 	var results []*data.StructValue
 	var cursor *string
 	total := 0
+
+	// Make sure global objects are not found (path needs to start with infra)
+	query = query + " AND path:\\/infra*"
 
 	for {
 		searchResponse, err := client.List(query, cursor, nil, nil, nil, nil)


### PR DESCRIPTION
When data source searches for objects, it needs to search for LM
or GM objects only. This change adds path verification to each
search - /infra for Local Manager and /global-infra for Global
Manager.