### PR TITLE
Fix some issues with NAT

### DIFF
--- a/nsxt/policy_utils.go
+++ b/nsxt/policy_utils.go
@@ -200,17 +200,18 @@ func collectSeparatedStringListToMap(stringList []string, separator string) map[
 	return strMap
 }
 
-func stringListToCommaSeparatedString(stringList []string) string {
-	var str string
+func stringListToCommaSeparatedString(stringList []string) *string {
 	if len(stringList) > 0 {
+		var str string
 		for i, seg := range stringList {
 			str += seg
 			if i < len(stringList)-1 {
 				str += ","
 			}
 		}
+		return &str
 	}
-	return str
+	return nil
 }
 
 func commaSeparatedStringToStringList(commaString string) []string {


### PR DESCRIPTION
Fix some issues with NAT

(1) When creating REFLEXIVE Nat rules, the destination_network should be set to nil instead of empty string (issue #758)

(2) Allow translated_network field to be optional for no_snat/no_dnat (issue #753)