### PR TITLE
Do not set AS number in BGP unless specified

### DIFF
--- a/nsxt/resource_nsxt_policy_bgp_config.go
+++ b/nsxt/resource_nsxt_policy_bgp_config.go
@@ -128,7 +128,9 @@ func resourceNsxtPolicyBgpConfigToStruct(d *schema.ResourceData, isVRF bool) (*m
 
 		routeStruct.Tags = tags
 		routeStruct.InterSrIbgp = &interSrIbgp
-		routeStruct.LocalAsNum = &localAsNum
+		if len(localAsNum) > 0 {
+			routeStruct.LocalAsNum = &localAsNum
+		}
 		routeStruct.MultipathRelax = &multipathRelax
 		routeStruct.GracefulRestartConfig = &restartConfigStruct
 	}

--- a/nsxt/resource_nsxt_policy_tier0_gateway.go
+++ b/nsxt/resource_nsxt_policy_tier0_gateway.go
@@ -172,6 +172,7 @@ func getPolicyBGPConfigSchema() map[string]*schema.Schema {
 			Description:  "BGP AS number in ASPLAIN/ASDOT Format",
 			Optional:     true,
 			ValidateFunc: validateASPlainOrDot,
+			Computed:     true,
 		},
 		"multipath_relax": {
 			Type:        schema.TypeBool,


### PR DESCRIPTION
Due to platform validations, AS number needs to remain nil
unless specified. In order to avoid non-empty diff when AS
is set by platform, we need to define this attribute as
computed.

Signed-off-by: Anna Khmelnitsky <akhmelnitsky@vmware.com>