### PR TITLE
Support locale_service Gateway clause for LM

### DIFF
--- a/nsxt/gateway_common.go
+++ b/nsxt/gateway_common.go
@@ -278,7 +278,7 @@ func initChildLocaleService(serviceStruct *model.LocaleServices, markForDelete b
 	return dataValue.(*data.StructValue), nil
 }
 
-func initGatewayLocaleServices(d *schema.ResourceData, connector *client.RestConnector, listLocaleServicesFunc func(*client.RestConnector, string, bool) ([]model.LocaleServices, error)) ([]*data.StructValue, error) {
+func initGatewayLocaleServices(d *schema.ResourceData, connector *client.RestConnector, isGlobalManager bool, listLocaleServicesFunc func(*client.RestConnector, string, bool) ([]model.LocaleServices, error)) ([]*data.StructValue, error) {
 	var localeServices []*data.StructValue
 
 	services := d.Get("locale_service").(*schema.Set).List()
@@ -286,7 +286,7 @@ func initGatewayLocaleServices(d *schema.ResourceData, connector *client.RestCon
 	existingServices := make(map[string]model.LocaleServices)
 	if len(d.Id()) > 0 {
 		// This is an update - we might need to delete locale services
-		existingServiceObjects, errList := listLocaleServicesFunc(connector, d.Id(), true)
+		existingServiceObjects, errList := listLocaleServicesFunc(connector, d.Id(), isGlobalManager)
 		if errList != nil {
 			return nil, errList
 		}

--- a/nsxt/resource_nsxt_policy_tier0_gateway_ha_vip_config_test.go
+++ b/nsxt/resource_nsxt_policy_tier0_gateway_ha_vip_config_test.go
@@ -285,7 +285,7 @@ resource "nsxt_policy_tier0_gateway_ha_vip_config" "test" {
 		external_interface_paths = [nsxt_policy_tier0_gateway_interface.test1.path, nsxt_policy_tier0_gateway_interface.test2.path]
 		vip_subnets              = ["%s"]
 	}
-}`, tier0Name, testAccNsxtPolicyTier0EdgeClusterTemplate(),
+}`, tier0Name, testAccNsxtPolicyLocaleServiceECTemplate(),
 		subnet1, testAccNsxtPolicyTier0HAVipConfigSiteTemplate(),
 		subnet2, testAccNsxtPolicyTier0HAVipConfigSiteTemplate(), enabled, vipSubnet)
 }

--- a/nsxt/resource_nsxt_policy_tier0_gateway_interface_test.go
+++ b/nsxt/resource_nsxt_policy_tier0_gateway_interface_test.go
@@ -625,14 +625,18 @@ resource "nsxt_policy_vlan_segment" "test" {
 
 func testAccNsxtPolicyTier0EdgeClusterTemplate() string {
 	if testAccIsGlobalManager() {
-		return `
-  locale_service {
-    edge_cluster_path    = data.nsxt_policy_edge_cluster.EC.path
-  }
-`
+		return testAccNsxtPolicyLocaleServiceECTemplate()
 	}
 	return `
 	edge_cluster_path = data.nsxt_policy_edge_cluster.EC.path
+`
+}
+
+func testAccNsxtPolicyLocaleServiceECTemplate() string {
+	return `
+  locale_service {
+    edge_cluster_path    = data.nsxt_policy_edge_cluster.EC.path
+  }
 `
 }
 

--- a/nsxt/resource_nsxt_policy_tier1_gateway_interface_test.go
+++ b/nsxt/resource_nsxt_policy_tier1_gateway_interface_test.go
@@ -475,6 +475,6 @@ resource "nsxt_policy_tier1_gateway_interface" "test" {
   ipv6_ndra_profile_path = data.nsxt_policy_ipv6_ndra_profile.default.path
   urpf_mode              = "NONE"
   %s
-}`, nsxtPolicyTier1GatewayName, testAccNsxtPolicyTier0EdgeClusterTemplate(), name, subnet, testAccNsxtPolicyTier0InterfaceSiteTemplate()) +
+}`, nsxtPolicyTier1GatewayName, testAccNsxtPolicyLocaleServiceECTemplate(), name, subnet, testAccNsxtPolicyTier0InterfaceSiteTemplate()) +
 		testAccNextPolicyTier1InterfaceRealizationTemplate()
 }

--- a/website/docs/r/policy_bgp_config.html.markdown
+++ b/website/docs/r/policy_bgp_config.html.markdown
@@ -23,7 +23,6 @@ resource "nsxt_policy_bgp_config" "gw1" {
   inter_sr_ibgp          = true
   local_as_num           = 60001
   graceful_restart_mode  = "HELPER_ONLY"
-  graceful_restart_timer = 2400
 
   route_aggregation {
     prefix       = "20.1.0.0/24"

--- a/website/docs/r/policy_tier0_gateway.html.markdown
+++ b/website/docs/r/policy_tier0_gateway.html.markdown
@@ -119,8 +119,8 @@ The following arguments are supported:
 * `description` - (Optional) Description of the resource.
 * `tag` - (Optional) A list of scope + tag pairs to associate with this Tier-0 gateway.
 * `nsx_id` - (Optional) The NSX ID of this resource. If set, this ID will be used to create the policy resource.
-* `edge_cluster_path` - (Optional) The path of the edge cluster where the Tier-0 is placed. Must be specified when `bgp_config` is enabled. This argument is not applicable to NSX Global Manager - use locale-services clause instead.
-* `locale_service` - (Optional) This is required for NSX Global Manager only. Multiple locale services can be specified for multiple locations.
+* `edge_cluster_path` - (Optional) The path of the edge cluster where the Tier-0 is placed.For advanced configuration and on Global Manager, use `locale_service` clause instead. Note that for some configurations (such as BGP) setting edge cluster is required.
+* `locale_service` - (Optional) This is required on NSX Global Manager. Multiple locale services can be specified for multiple locations.
   * `edge_cluster_path` - (Required) The path of the edge cluster where the Tier-0 is placed.
   * `preferred_edge_paths` - (Optional) Policy paths to edge nodes. Specified edge is used as preferred edge cluster member when failover mode is set to `PREEMPTIVE`.
 * `failover_mode` - (Optional) This failover mode determines, whether the preferred service router instance for given logical router will preempt the peer. Accepted values are PREEMPTIVE/NON_PREEMPTIVE.
@@ -190,6 +190,8 @@ terraform import nsxt_policy_tier0_gateway.tier0_gw ID
 ```
 
 The above command imports the policy Tier-0 gateway named `tier0_gw` with the NSX Policy ID `ID`.
+
+~> **NOTE:** When importing Gateway, `edge_cluster_path` will be assigned rather than `locale_service`. In order to switch to `locale_service` configuration, additional apply will be required.
 
 ~> **NOTE:** Redistribution config on Tier-0 resource is deprecated and thus will not be imported. Please import this configuration with `policy_gateway_redistribution_config` resource.
 

--- a/website/docs/r/policy_tier1_gateway.html.markdown
+++ b/website/docs/r/policy_tier1_gateway.html.markdown
@@ -84,8 +84,8 @@ The following arguments are supported:
 * `description` - (Optional) Description of the resource.
 * `tag` - (Optional) A list of scope + tag pairs to associate with this Tier-1 gateway.
 * `nsx_id` - (Optional) The NSX ID of this resource. If set, this ID will be used to create the policy resource.
-* `edge_cluster_path` - (Optional) The path of the edge cluster where the Tier-1 is placed.
-* `locale_service` - (Optional) This argument is applicable for NSX Global Manager only. Multiple locale services can be specified for multiple locations.
+* `edge_cluster_path` - (Optional) The path of the edge cluster where the Tier-1 is placed.For advanced configuration, use `locale_service` clause instead. 
+* `locale_service` - (Optional) This argument is required on NSX Global Manager. Multiple locale services can be specified for multiple locations.
   * `edge_cluster_path` - (Required) The path of the edge cluster where the Tier-0 is placed.
   * `preferred_edge_paths` - (Optional) Policy paths to edge nodes. Specified edge is used as preferred edge cluster member when failover mode is set to `PREEMPTIVE`.
 * `failover_mode` - (Optional) This failover mode determines, whether the preferred service router instance for given logical router will preempt the peer. Accepted values are PREEMPTIVE/NON_PREEMPTIVE.
@@ -131,3 +131,5 @@ terraform import nsxt_policy_tier1_gateway.tier1_gw ID
 ```
 
 The above command imports the policy Tier-1 gateway named `tier1_gw` with the NSX Policy ID `ID`.
+
+~> **NOTE:** When importing Gateway, `edge_cluster_path` will be assigned rather than `locale_service`. In order to switch to `locale_service` configuration, additional apply will be required.


### PR DESCRIPTION
Today, locale service clause is only supported on Global Manager.
This change allows to configure it for Local Manager as well. This
configuration conflicts with edge_cluster_path and allows more
flexibility.
When importing Gateway, edge_cluster_path will be initialized rather
than locale_service, and additional apply is required to switch to
locale_service configuration.

Signed-off-by: Anna Khmelnitsky <akhmelnitsky@vmware.com>