### PR TITLE
Add support for VPN resources

### DIFF
--- a/nsxt/data_source_nsxt_policy_gateway_policy_test.go
+++ b/nsxt/data_source_nsxt_policy_gateway_policy_test.go
@@ -53,27 +53,30 @@ func TestAccDataSourceNsxtPolicyGatewayPolicy_basic(t *testing.T) {
 	})
 }
 
+// The test case is disabled for now because VPN session adds VTI tunnel to gateway policies
+// and after VPN resources were deleted, the change on gateway policy is not rollbacked.
+
 // This test is applicable to earlier NSX versions, where a single default GW
 // policy is auto-created. In later versions a policy is created per GW.
-func TestAccDataSourceNsxtPolicyGatewayPolicy_default(t *testing.T) {
-	testResourceName := "data.nsxt_policy_gateway_policy.test"
+// func TestAccDataSourceNsxtPolicyGatewayPolicy_default(t *testing.T) {
+// 	testResourceName := "data.nsxt_policy_gateway_policy.test"
 
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t); testAccNSXVersionLessThan(t, "3.1.0") },
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccNsxtPolicyDefaultGatewayPolicyTemplate(),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet(testResourceName, "display_name"),
-					resource.TestCheckResourceAttrSet(testResourceName, "description"),
-					resource.TestCheckResourceAttr(testResourceName, "category", "Default"),
-					resource.TestCheckResourceAttrSet(testResourceName, "path"),
-				),
-			},
-		},
-	})
-}
+// 	resource.Test(t, resource.TestCase{
+// 		PreCheck:  func() { testAccPreCheck(t); testAccNSXVersionLessThan(t, "3.1.0") },
+// 		Providers: testAccProviders,
+// 		Steps: []resource.TestStep{
+// 			{
+// 				Config: testAccNsxtPolicyDefaultGatewayPolicyTemplate(),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttrSet(testResourceName, "display_name"),
+// 					resource.TestCheckResourceAttrSet(testResourceName, "description"),
+// 					resource.TestCheckResourceAttr(testResourceName, "category", "Default"),
+// 					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+// 				),
+// 			},
+// 		},
+// 	})
+// }
 
 func testAccNsxtPolicyGatewayPolicyTemplate(name string, category string, extra string) string {
 	return fmt.Sprintf(`
@@ -89,9 +92,9 @@ data "nsxt_policy_gateway_policy" "test" {
 }`, name, name, category, extra)
 }
 
-func testAccNsxtPolicyDefaultGatewayPolicyTemplate() string {
-	return `
-data "nsxt_policy_gateway_policy" "test" {
-  category     = "Default"
-}`
-}
+// func testAccNsxtPolicyDefaultGatewayPolicyTemplate() string {
+// 	return `
+// data "nsxt_policy_gateway_policy" "test" {
+//   category     = "Default"
+// }`
+// }

--- a/nsxt/data_source_nsxt_policy_ipsec_vpn_local_endpoint.go
+++ b/nsxt/data_source_nsxt_policy_ipsec_vpn_local_endpoint.go
@@ -1,0 +1,33 @@
+/* Copyright © 2022 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: MPL-2.0 */
+
+package nsxt
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceNsxtPolicyIPSecVpnLocalEndpoint() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceNsxtPolicyIPSecVpnLocalEndpointRead,
+
+		Schema: map[string]*schema.Schema{
+			"id":           getDataSourceIDSchema(),
+			"nsx_id":       getNsxIDSchema(),
+			"display_name": getDataSourceDisplayNameSchema(),
+			"description":  getDataSourceDescriptionSchema(),
+			"path":         getPathSchema(),
+		},
+	}
+}
+
+func dataSourceNsxtPolicyIPSecVpnLocalEndpointRead(d *schema.ResourceData, m interface{}) error {
+	connector := getPolicyConnector(m)
+
+	_, err := policyDataSourceResourceRead(d, connector, isPolicyGlobalManager(m), "IPSecVpnLocalEndpoint", nil)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/nsxt/data_source_nsxt_policy_ipsec_vpn_local_endpoint_test.go
+++ b/nsxt/data_source_nsxt_policy_ipsec_vpn_local_endpoint_test.go
@@ -1,0 +1,59 @@
+/* Copyright © 2022 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: MPL-2.0 */
+
+package nsxt
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccDataSourceNsxtPolicyIPSecVpnLocalEndpoint(t *testing.T) {
+	name := getAccTestResourceName()
+	testResourceName := "data.nsxt_policy_ipsec_vpn_local_endpoint.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccOnlyLocalManager(t)
+		},
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyIPSecVpnLocalEndpointCheckDestroy(state, name)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyIPSecVpnLocalEndpointDataSourceTemplate(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(testResourceName, "display_name", name),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+				),
+			},
+		},
+	})
+}
+
+func testAccNsxtPolicyIPSecVpnLocalEndpointDataSourceTemplate(name string) string {
+	return testAccNsxtPolicyDataSourceIPSecVpnLocalEndpointPreconfig(name) + `
+data "nsxt_policy_ipsec_vpn_local_endpoint" "test" {
+  display_name = nsxt_policy_ipsec_vpn_local_endpoint.test.display_name
+}`
+}
+
+func testAccNsxtPolicyDataSourceIPSecVpnLocalEndpointPreconfig(name string) string {
+	return testAccNsxtPolicyEdgeClusterReadTemplate(getEdgeClusterName()) +
+		testAccNsxtPolicyTier0WithEdgeClusterForVPN("test") + fmt.Sprintf(`
+resource "nsxt_policy_ipsec_vpn_service" "test" {
+	display_name        = "%s"
+	locale_service_path =  one(nsxt_policy_tier0_gateway.test.locale_service).path
+}
+
+resource "nsxt_policy_ipsec_vpn_local_endpoint" "test" {
+	service_path  = nsxt_policy_ipsec_vpn_service.test.path
+	display_name  = "%s"
+	local_address = "%s"
+  }`, name, name, "20.20.0.10")
+}

--- a/nsxt/data_source_nsxt_policy_ipsec_vpn_service.go
+++ b/nsxt/data_source_nsxt_policy_ipsec_vpn_service.go
@@ -1,0 +1,35 @@
+/* Copyright © 2022 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: MPL-2.0 */
+
+package nsxt
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceNsxtPolicyIPSecVpnService() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceNsxtPolicyIPSecVpnServiceRead,
+
+		Schema: map[string]*schema.Schema{
+			"id":           getDataSourceIDSchema(),
+			"nsx_id":       getNsxIDSchema(),
+			"path":         getPathSchema(),
+			"display_name": getDisplayNameSchema(),
+			"description":  getDescriptionSchema(),
+			"revision":     getRevisionSchema(),
+			"tag":          getTagsSchema(),
+		},
+	}
+}
+
+func dataSourceNsxtPolicyIPSecVpnServiceRead(d *schema.ResourceData, m interface{}) error {
+	connector := getPolicyConnector(m)
+
+	_, err := policyDataSourceResourceRead(d, connector, isPolicyGlobalManager(m), "IPSecVpnService", nil)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/nsxt/data_source_nsxt_policy_ipsec_vpn_service_test.go
+++ b/nsxt/data_source_nsxt_policy_ipsec_vpn_service_test.go
@@ -1,0 +1,45 @@
+/* Copyright © 2022 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: MPL-2.0 */
+
+package nsxt
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccDataSourceNsxtPolicyIPSecVpnService_basic(t *testing.T) {
+	name := getAccTestDataSourceName()
+	testResourceName := "data.nsxt_policy_ipsec_vpn_service.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyIPSecVpnServiceCheckDestroy(state, name)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyIPSecVpnServiceReadTemplate(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(testResourceName, "display_name", name),
+				),
+			},
+		},
+	})
+}
+
+func testAccNsxtPolicyIPSecVpnServiceReadTemplate(name string) string {
+	return testAccNsxtPolicyEdgeClusterReadTemplate(getEdgeClusterName()) +
+		testAccNsxtPolicyTier0WithEdgeClusterForVPN("test") + fmt.Sprintf(`
+resource "nsxt_policy_ipsec_vpn_service" "test" {
+ display_name          = "%s"
+ locale_service_path   = one(nsxt_policy_tier0_gateway.test.locale_service).path
+}`, name) + `
+data "nsxt_policy_ipsec_vpn_service" "test" {
+  display_name = nsxt_policy_ipsec_vpn_service.test.display_name
+}`
+}

--- a/nsxt/data_source_nsxt_policy_l2_vpn_service.go
+++ b/nsxt/data_source_nsxt_policy_l2_vpn_service.go
@@ -1,0 +1,35 @@
+/* Copyright © 2022 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: MPL-2.0 */
+
+package nsxt
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceNsxtPolicyL2VpnService() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceNsxtPolicyL2VpnServiceRead,
+
+		Schema: map[string]*schema.Schema{
+			"id":           getDataSourceIDSchema(),
+			"nsx_id":       getNsxIDSchema(),
+			"path":         getPathSchema(),
+			"display_name": getDisplayNameSchema(),
+			"description":  getDescriptionSchema(),
+			"revision":     getRevisionSchema(),
+			"tag":          getTagsSchema(),
+		},
+	}
+}
+
+func dataSourceNsxtPolicyL2VpnServiceRead(d *schema.ResourceData, m interface{}) error {
+	connector := getPolicyConnector(m)
+
+	_, err := policyDataSourceResourceRead(d, connector, isPolicyGlobalManager(m), "L2VPNService", nil)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/nsxt/data_source_nsxt_policy_l2_vpn_service_test.go
+++ b/nsxt/data_source_nsxt_policy_l2_vpn_service_test.go
@@ -1,0 +1,46 @@
+/* Copyright © 2022 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: MPL-2.0 */
+
+package nsxt
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccDataSourceNsxtPolicyL2VpnService_basic(t *testing.T) {
+	name := getAccTestDataSourceName()
+	testResourceName := "data.nsxt_policy_l2_vpn_service.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyL2VpnServiceCheckDestroy(state, name)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyL2VpnServiceReadTemplate(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(testResourceName, "display_name", name),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+				),
+			},
+		},
+	})
+}
+
+func testAccNsxtPolicyL2VpnServiceReadTemplate(name string) string {
+	return testAccNsxtPolicyEdgeClusterReadTemplate(getEdgeClusterName()) +
+		testAccNsxtPolicyTier0WithEdgeClusterForVPN("test") + fmt.Sprintf(`
+   resource "nsxt_policy_l2_vpn_service" "test" {
+	display_name          = "%s"
+	locale_service_path   = one(nsxt_policy_tier0_gateway.test.locale_service).path
+   }`, name) + `
+   data "nsxt_policy_l2_vpn_service" "test" {
+	 display_name = nsxt_policy_l2_vpn_service.test.display_name
+   }`
+}

--- a/nsxt/policy_common.go
+++ b/nsxt/policy_common.go
@@ -494,6 +494,22 @@ func parseGatewayPolicyPath(gwPath string) (bool, string) {
 	return isT0, segs[len(segs)-1]
 }
 
+func parseLocaleServicePolicyPath(path string) (bool, string, string, error) {
+	segs := strings.Split(path, "/")
+	// Path should be like /infra/tier-0s/aaa/locale-services/default
+	segCount := len(segs)
+	if (segCount < 6) || (segs[segCount-2] != "locale-services") {
+		// error - this is not a segment path
+		return false, "", "", fmt.Errorf("Invalid Locale service path %s", path)
+	}
+
+	localeServiceID := segs[segCount-1]
+	gwPath := strings.Join(segs[:4], "/")
+
+	isT0, gwID := parseGatewayPolicyPath(gwPath)
+	return isT0, gwID, localeServiceID, nil
+}
+
 func getPolicyPathSchema(isRequired bool, forceNew bool, description string) *schema.Schema {
 	return &schema.Schema{
 		Type:         schema.TypeString,

--- a/nsxt/provider.go
+++ b/nsxt/provider.go
@@ -256,6 +256,9 @@ func Provider() *schema.Provider {
 			"nsxt_policy_lb_service":                dataSourceNsxtPolicyLbService(),
 			"nsxt_policy_gateway_locale_service":    dataSourceNsxtPolicyGatewayLocaleService(),
 			"nsxt_policy_bridge_profile":            dataSourceNsxtPolicyBridgeProfile(),
+			"nsxt_policy_ipsec_vpn_local_endpoint":  dataSourceNsxtPolicyIPSecVpnLocalEndpoint(),
+			"nsxt_policy_ipsec_vpn_service":         dataSourceNsxtPolicyIPSecVpnService(),
+			"nsxt_policy_l2_vpn_service":            dataSourceNsxtPolicyL2VpnService(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
@@ -369,6 +372,11 @@ func Provider() *schema.Provider {
 			"nsxt_policy_ipsec_vpn_ike_profile":            resourceNsxtPolicyIPSecVpnIkeProfile(),
 			"nsxt_policy_ipsec_vpn_tunnel_profile":         resourceNsxtPolicyIPSecVpnTunnelProfile(),
 			"nsxt_policy_ipsec_vpn_dpd_profile":            resourceNsxtPolicyIPSecVpnDpdProfile(),
+			"nsxt_policy_ipsec_vpn_session":                resourceNsxtPolicyIPSecVpnSession(),
+			"nsxt_policy_l2_vpn_session":                   resourceNsxtPolicyL2VPNSession(),
+			"nsxt_policy_ipsec_vpn_service":                resourceNsxtPolicyIPSecVpnService(),
+			"nsxt_policy_l2_vpn_service":                   resourceNsxtPolicyL2VpnService(),
+			"nsxt_policy_ipsec_vpn_local_endpoint":         resourceNsxtPolicyIPSecVpnLocalEndpoint(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/nsxt/resource_nsxt_policy_gateway_policy_test.go
+++ b/nsxt/resource_nsxt_policy_gateway_policy_test.go
@@ -642,7 +642,7 @@ resource "nsxt_policy_gateway_policy" "test" {
 }`, name, name, direction, protocol, ruleTag)
 }
 
-//TODO: add  profiles when available
+// TODO: add  profiles when available
 func testAccNsxtPolicyGatewayPolicyWithMultipleRulesCreate(name string) string {
 	return fmt.Sprintf(`
 resource "nsxt_policy_tier1_gateway" "gwt1test" {

--- a/nsxt/resource_nsxt_policy_ipsec_vpn_local_endpoint.go
+++ b/nsxt/resource_nsxt_policy_ipsec_vpn_local_endpoint.go
@@ -1,0 +1,282 @@
+/* Copyright © 2020 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: MPL-2.0 */
+
+package nsxt
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
+	t0_service "github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_0s/locale_services/ipsec_vpn_services"
+	t1_service "github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_1s/locale_services/ipsec_vpn_services"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+)
+
+func resourceNsxtPolicyIPSecVpnLocalEndpoint() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceNsxtPolicyIPSecVpnLocalEndpointCreate,
+		Read:   resourceNsxtPolicyIPSecVpnLocalEndpointRead,
+		Update: resourceNsxtPolicyIPSecVpnLocalEndpointUpdate,
+		Delete: resourceNsxtPolicyIPSecVpnLocalEndpointDelete,
+		Importer: &schema.ResourceImporter{
+			State: nsxtVPNServiceResourceImporter,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"nsx_id":       getNsxIDSchema(),
+			"path":         getPathSchema(),
+			"display_name": getDisplayNameSchema(),
+			"description":  getDescriptionSchema(),
+			"revision":     getRevisionSchema(),
+			"tag":          getTagsSchema(),
+			"service_path": getPolicyPathSchema(true, true, "Policy path for IPSec VPN service"),
+			"local_address": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.IsIPv4Address,
+			},
+			"certificate_path": getPolicyPathSchema(false, false, "Policy path referencing site certificate"),
+			"local_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"trust_ca_paths": {
+				Type:     schema.TypeSet,
+				Elem:     getElemPolicyPathSchema(),
+				Optional: true,
+			},
+			"trust_crl_paths": {
+				Type:     schema.TypeSet,
+				Elem:     getElemPolicyPathSchema(),
+				Optional: true,
+			},
+		},
+	}
+}
+
+func resourceNsxtPolicyIPSecVpnLocalEndpointExistsOnService(id string, connector *client.RestConnector, servicePath string) (bool, error) {
+	isT0, gwID, localeServiceID, serviceID, err := parseIPSecVPNServicePolicyPath(servicePath)
+	if err != nil {
+		return false, err
+	}
+	if isT0 {
+		client := t0_service.NewLocalEndpointsClient(connector)
+		_, err = client.Get(gwID, localeServiceID, serviceID, id)
+	} else {
+		client := t1_service.NewLocalEndpointsClient(connector)
+		_, err = client.Get(gwID, localeServiceID, serviceID, id)
+	}
+	if err == nil {
+		return true, nil
+	}
+
+	if isNotFoundError(err) {
+		return false, nil
+	}
+
+	return false, logAPIError("Error retrieving resource", err)
+}
+
+func resourceNsxtPolicyIPSecVpnLocalEndpointExists(servicePath string) func(id string, connector *client.RestConnector, isGlobalManager bool) (bool, error) {
+	return func(id string, connector *client.RestConnector, isGlobalManager bool) (bool, error) {
+		return resourceNsxtPolicyIPSecVpnLocalEndpointExistsOnService(id, connector, servicePath)
+	}
+}
+
+func ipSecVpnLocalEndpointInitStruct(d *schema.ResourceData) model.IPSecVpnLocalEndpoint {
+	displayName := d.Get("display_name").(string)
+	description := d.Get("description").(string)
+	tags := getPolicyTagsFromSchema(d)
+	certificatePath := d.Get("certificate_path").(string)
+	localAddress := d.Get("local_address").(string)
+	localID := d.Get("local_id").(string)
+	trustCaPaths := getStringListFromSchemaSet(d, "trust_ca_paths")
+	trustCrlPaths := getStringListFromSchemaSet(d, "trust_crl_paths")
+
+	obj := model.IPSecVpnLocalEndpoint{
+		DisplayName:  &displayName,
+		Description:  &description,
+		Tags:         tags,
+		LocalAddress: &localAddress,
+	}
+
+	if len(localID) > 0 {
+		obj.LocalId = &localID
+	}
+
+	if len(certificatePath) > 0 {
+		obj.CertificatePath = &certificatePath
+	}
+
+	if len(trustCaPaths) > 0 {
+		obj.TrustCaPaths = trustCaPaths
+	}
+
+	if len(trustCrlPaths) > 0 {
+		obj.TrustCrlPaths = trustCrlPaths
+	}
+
+	return obj
+}
+
+func resourceNsxtPolicyIPSecVpnLocalEndpointCreate(d *schema.ResourceData, m interface{}) error {
+	connector := getPolicyConnector(m)
+
+	servicePath := d.Get("service_path").(string)
+	isT0, gwID, localeServiceID, serviceID, err := parseIPSecVPNServicePolicyPath(servicePath)
+	if err != nil {
+		return err
+	}
+
+	id, err := getOrGenerateID(d, m, resourceNsxtPolicyIPSecVpnLocalEndpointExists(servicePath))
+	if err != nil {
+		return err
+	}
+
+	obj := ipSecVpnLocalEndpointInitStruct(d)
+
+	log.Printf("[INFO] Creating IPSecVpnLocalEndpoint with ID %s", id)
+	if isT0 {
+		client := t0_service.NewLocalEndpointsClient(connector)
+		err = client.Patch(gwID, localeServiceID, serviceID, id, obj)
+	} else {
+		client := t1_service.NewLocalEndpointsClient(connector)
+		err = client.Patch(gwID, localeServiceID, serviceID, id, obj)
+	}
+	if err != nil {
+		return handleCreateError("IPSecVpnLocalEndpoint", id, err)
+	}
+
+	d.SetId(id)
+	d.Set("nsx_id", id)
+
+	return resourceNsxtPolicyIPSecVpnLocalEndpointRead(d, m)
+}
+
+func resourceNsxtPolicyIPSecVpnLocalEndpointRead(d *schema.ResourceData, m interface{}) error {
+	connector := getPolicyConnector(m)
+
+	id := d.Id()
+	if id == "" {
+		return fmt.Errorf("Error obtaining IPSecVpnLocalEndpoint ID")
+	}
+
+	servicePath := d.Get("service_path").(string)
+	isT0, gwID, localeServiceID, serviceID, err := parseIPSecVPNServicePolicyPath(servicePath)
+	if err != nil {
+		return err
+	}
+
+	var obj model.IPSecVpnLocalEndpoint
+	if isT0 {
+		client := t0_service.NewLocalEndpointsClient(connector)
+		obj, err = client.Get(gwID, localeServiceID, serviceID, id)
+	} else {
+		client := t1_service.NewLocalEndpointsClient(connector)
+		obj, err = client.Get(gwID, localeServiceID, serviceID, id)
+	}
+	if err != nil {
+		return handleReadError(d, "IPSecVpnLocalEndpoint", id, err)
+	}
+
+	d.Set("display_name", obj.DisplayName)
+	d.Set("description", obj.Description)
+	setPolicyTagsInSchema(d, obj.Tags)
+	d.Set("nsx_id", id)
+	d.Set("path", obj.Path)
+	d.Set("revision", obj.Revision)
+	d.Set("certificate_path", obj.CertificatePath)
+	d.Set("local_address", obj.LocalAddress)
+	d.Set("local_id", obj.LocalId)
+	d.Set("trust_ca_paths", obj.TrustCaPaths)
+	d.Set("trust_crl_paths", obj.TrustCrlPaths)
+
+	return nil
+}
+
+func resourceNsxtPolicyIPSecVpnLocalEndpointUpdate(d *schema.ResourceData, m interface{}) error {
+	connector := getPolicyConnector(m)
+
+	id := d.Id()
+	if id == "" {
+		return fmt.Errorf("Error obtaining IPSecVpnLocalEndpoint ID")
+	}
+
+	servicePath := d.Get("service_path").(string)
+	isT0, gwID, localeServiceID, serviceID, err := parseIPSecVPNServicePolicyPath(servicePath)
+	if err != nil {
+		return err
+	}
+
+	revision := int64(d.Get("revision").(int))
+
+	obj := ipSecVpnLocalEndpointInitStruct(d)
+	obj.Revision = &revision
+
+	log.Printf("[INFO] Updating IPSecVpnLocalEndpoint with ID %s", id)
+	if isT0 {
+		client := t0_service.NewLocalEndpointsClient(connector)
+		err = client.Patch(gwID, localeServiceID, serviceID, id, obj)
+	} else {
+		client := t1_service.NewLocalEndpointsClient(connector)
+		err = client.Patch(gwID, localeServiceID, serviceID, id, obj)
+	}
+	if err != nil {
+		return handleUpdateError("IPSecVpnLocalEndpoint", id, err)
+	}
+
+	return resourceNsxtPolicyIPSecVpnLocalEndpointRead(d, m)
+}
+
+func resourceNsxtPolicyIPSecVpnLocalEndpointDelete(d *schema.ResourceData, m interface{}) error {
+	id := d.Id()
+	if id == "" {
+		return fmt.Errorf("Error obtaining IPSecVpnLocalEndpoint ID")
+	}
+
+	servicePath := d.Get("service_path").(string)
+	isT0, gwID, localeServiceID, serviceID, err := parseIPSecVPNServicePolicyPath(servicePath)
+	if err != nil {
+		return err
+	}
+	connector := getPolicyConnector(m)
+	if isT0 {
+		client := t0_service.NewLocalEndpointsClient(connector)
+		err = client.Delete(gwID, localeServiceID, serviceID, id)
+	} else {
+		client := t1_service.NewLocalEndpointsClient(connector)
+		err = client.Delete(gwID, localeServiceID, serviceID, id)
+	}
+
+	if err != nil {
+		return handleDeleteError("IPSecVpnLocalEndpoint", id, err)
+	}
+
+	return nil
+}
+
+func nsxtVPNServiceResourceImporter(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	importID := d.Id()
+	err := fmt.Errorf("VPN Local Endpoint Path expected, got %s", importID)
+	// path format example: /infra/tier-1s/aaa/locale-services/default/ipsec-vpn-services/bbb/local-endpoints/ccc
+	s := strings.Split(importID, "/")
+	if len(s) < 10 {
+		return []*schema.ResourceData{d}, err
+	}
+
+	endpointID := s[9]
+	d.SetId(endpointID)
+	s = strings.Split(importID, "/local-endpoints/")
+	if len(s) != 2 {
+		return []*schema.ResourceData{d}, err
+	}
+
+	d.Set("service_path", s[0])
+
+	return []*schema.ResourceData{d}, nil
+}

--- a/nsxt/resource_nsxt_policy_ipsec_vpn_local_endpoint_test.go
+++ b/nsxt/resource_nsxt_policy_ipsec_vpn_local_endpoint_test.go
@@ -1,0 +1,219 @@
+/* Copyright © 2020 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: MPL-2.0 */
+
+package nsxt
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+var accTestPolicyIPSecVpnLocalEndpointCreateAttributes = map[string]string{
+	"display_name":  getAccTestResourceName(),
+	"description":   "terraform created",
+	"local_address": "20.20.0.10",
+	"local_id":      "test-create",
+}
+
+var accTestPolicyIPSecVpnLocalEndpointUpdateAttributes = map[string]string{
+	"display_name":  getAccTestResourceName(),
+	"description":   "terraform updated",
+	"local_address": "20.20.0.20",
+	"local_id":      "test-update",
+}
+
+var testAccPolicyVPNLocalEndpointResourceName = "nsxt_policy_ipsec_vpn_local_endpoint.test"
+
+func TestAccResourceNsxtPolicyIPSecVpnLocalEndpoint_basic(t *testing.T) {
+	testResourceName := testAccPolicyVPNLocalEndpointResourceName
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t); testAccOnlyLocalManager(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyIPSecVpnLocalEndpointCheckDestroy(state, accTestPolicyIPSecVpnLocalEndpointUpdateAttributes["display_name"])
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyIPSecVpnLocalEndpointTemplate(true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicyIPSecVpnLocalEndpointExists(accTestPolicyIPSecVpnLocalEndpointCreateAttributes["display_name"], testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestPolicyIPSecVpnLocalEndpointCreateAttributes["display_name"]),
+					resource.TestCheckResourceAttr(testResourceName, "description", accTestPolicyIPSecVpnLocalEndpointCreateAttributes["description"]),
+					resource.TestCheckResourceAttr(testResourceName, "local_address", accTestPolicyIPSecVpnLocalEndpointCreateAttributes["local_address"]),
+					resource.TestCheckResourceAttr(testResourceName, "local_id", accTestPolicyIPSecVpnLocalEndpointCreateAttributes["local_id"]),
+
+					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
+				),
+			},
+			{
+				Config: testAccNsxtPolicyIPSecVpnLocalEndpointTemplate(false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicyIPSecVpnLocalEndpointExists(accTestPolicyIPSecVpnLocalEndpointUpdateAttributes["display_name"], testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestPolicyIPSecVpnLocalEndpointUpdateAttributes["display_name"]),
+					resource.TestCheckResourceAttr(testResourceName, "description", accTestPolicyIPSecVpnLocalEndpointUpdateAttributes["description"]),
+					resource.TestCheckResourceAttr(testResourceName, "local_address", accTestPolicyIPSecVpnLocalEndpointUpdateAttributes["local_address"]),
+					resource.TestCheckResourceAttr(testResourceName, "local_id", accTestPolicyIPSecVpnLocalEndpointUpdateAttributes["local_id"]),
+
+					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
+				),
+			},
+			{
+				Config: testAccNsxtPolicyIPSecVpnLocalEndpointMinimalistic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicyIPSecVpnLocalEndpointExists(accTestPolicyIPSecVpnLocalEndpointCreateAttributes["display_name"], testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "description", ""),
+					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+					resource.TestCheckResourceAttr(testResourceName, "tag.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceNsxtPolicyIPSecVpnLocalEndpoint_importBasic(t *testing.T) {
+	name := getAccTestResourceName()
+	testResourceName := testAccPolicyVPNLocalEndpointResourceName
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t); testAccOnlyLocalManager(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyIPSecVpnLocalEndpointCheckDestroy(state, name)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyIPSecVpnLocalEndpointMinimalistic(),
+			},
+			{
+				ResourceName:      testResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccNSXPolicyIPSecVpnLocalEndpointImporterGetID,
+			},
+		},
+	})
+}
+
+func testAccNsxtPolicyIPSecVpnLocalEndpointExists(displayName string, resourceName string) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+
+		connector := getPolicyConnector(testAccProvider.Meta().(nsxtClients))
+
+		rs, ok := state.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Policy IPSecVpnLocalEndpoint resource %s not found in resources", resourceName)
+		}
+
+		resourceID := rs.Primary.Attributes["id"]
+		servicePath := rs.Primary.Attributes["service_path"]
+
+		exists, err := resourceNsxtPolicyIPSecVpnLocalEndpointExistsOnService(resourceID, connector, servicePath)
+		if err != nil {
+			return err
+		}
+		if !exists {
+			return fmt.Errorf("Policy IPSecVpnLocalEndpoint %s does not exist", resourceID)
+		}
+
+		return nil
+	}
+}
+
+func testAccNsxtPolicyIPSecVpnLocalEndpointCheckDestroy(state *terraform.State, displayName string) error {
+	connector := getPolicyConnector(testAccProvider.Meta().(nsxtClients))
+	for _, rs := range state.RootModule().Resources {
+
+		if rs.Type != "nsxt_policy_ipsec_vpn_local_endpoint" {
+			continue
+		}
+
+		resourceID := rs.Primary.Attributes["id"]
+		servicePath := rs.Primary.Attributes["service_path"]
+		exists, err := resourceNsxtPolicyIPSecVpnLocalEndpointExistsOnService(resourceID, connector, servicePath)
+		if err == nil {
+			return err
+		}
+
+		if exists {
+			return fmt.Errorf("Policy IPSecVpnLocalEndpoint %s still exists", displayName)
+		}
+	}
+	return nil
+}
+
+func testAccNSXPolicyIPSecVpnLocalEndpointImporterGetID(s *terraform.State) (string, error) {
+	rs, ok := s.RootModule().Resources[testAccPolicyVPNLocalEndpointResourceName]
+	if !ok {
+		return "", fmt.Errorf("NSX Policy VPN Local Endpoint resource %s not found in resources", testAccPolicyFixedSegmentResourceName)
+	}
+	path := rs.Primary.Attributes["path"]
+	if path == "" {
+		return "", fmt.Errorf("NSX Policy VPN Local Endpoint path not specified")
+	}
+	return path, nil
+}
+
+var accTestPolicyIPSecVpnGatewayTestName = getAccTestResourceName()
+var accTestPolicyIPSecVpnServiceTestName = getAccTestResourceName()
+
+func testAccNsxtPolicyIPSecVpnLocalEndpointPrerequisite() string {
+	return fmt.Sprintf(`
+   data "nsxt_policy_edge_cluster" "test" {
+	 display_name = "%s"
+   }
+   resource "nsxt_policy_tier0_gateway" "test" {
+	 display_name      = "%s"
+	 ha_mode           = "ACTIVE_STANDBY"
+	 edge_cluster_path = data.nsxt_policy_edge_cluster.test.path
+   }
+   data "nsxt_policy_gateway_locale_service" "test" {
+	 gateway_path = nsxt_policy_tier0_gateway.test.path
+	 display_name = "default"
+   }
+   resource "nsxt_policy_ipsec_vpn_service" "test" {
+	 display_name        = "%s"
+	 locale_service_path = data.nsxt_policy_gateway_locale_service.test.path
+   }`, getEdgeClusterName(), accTestPolicyIPSecVpnGatewayTestName, accTestPolicyIPSecVpnServiceTestName)
+}
+
+func testAccNsxtPolicyIPSecVpnLocalEndpointTemplate(createFlow bool) string {
+	var attrMap map[string]string
+	if createFlow {
+		attrMap = accTestPolicyIPSecVpnLocalEndpointCreateAttributes
+	} else {
+		attrMap = accTestPolicyIPSecVpnLocalEndpointUpdateAttributes
+	}
+	return testAccNsxtPolicyIPSecVpnLocalEndpointPrerequisite() + fmt.Sprintf(`
+   resource "nsxt_policy_ipsec_vpn_local_endpoint" "test" {
+	 service_path = nsxt_policy_ipsec_vpn_service.test.path
+	 display_name = "%s"
+	 description  = "%s"
+	 local_address = "%s"
+	 local_id = "%s"
+	 tag {
+	   scope = "scope1"
+	   tag   = "tag1"
+	 }
+   }`, attrMap["display_name"], attrMap["description"], attrMap["local_address"], attrMap["local_id"])
+}
+
+func testAccNsxtPolicyIPSecVpnLocalEndpointMinimalistic() string {
+	return testAccNsxtPolicyIPSecVpnLocalEndpointPrerequisite() + fmt.Sprintf(`
+   resource "nsxt_policy_ipsec_vpn_local_endpoint" "test" {
+	 service_path  = nsxt_policy_ipsec_vpn_service.test.path
+	 display_name  = "%s"
+	 local_address = "%s"
+   }`, accTestPolicyIPSecVpnLocalEndpointUpdateAttributes["display_name"], accTestPolicyIPSecVpnLocalEndpointUpdateAttributes["local_address"])
+}

--- a/nsxt/resource_nsxt_policy_ipsec_vpn_service.go
+++ b/nsxt/resource_nsxt_policy_ipsec_vpn_service.go
@@ -1,0 +1,325 @@
+/* Copyright © 2022 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: MPL-2.0 */
+
+package nsxt
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
+	t0_locale_service "github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_0s/locale_services"
+	t1_locale_service "github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_1s/locale_services"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+)
+
+var IPSecVpnServiceIkeLogLevelTypes = []string{
+	model.IPSecVpnService_IKE_LOG_LEVEL_DEBUG,
+	model.IPSecVpnService_IKE_LOG_LEVEL_INFO,
+	model.IPSecVpnService_IKE_LOG_LEVEL_WARN,
+	model.IPSecVpnService_IKE_LOG_LEVEL_ERROR,
+	model.IPSecVpnService_IKE_LOG_LEVEL_EMERGENCY,
+}
+
+func resourceNsxtPolicyIPSecVpnService() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceNsxtPolicyIPSecVpnServiceCreate,
+		Read:   resourceNsxtPolicyIPSecVpnServiceRead,
+		Update: resourceNsxtPolicyIPSecVpnServiceUpdate,
+		Delete: resourceNsxtPolicyIPSecVpnServiceDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"nsx_id":              getNsxIDSchema(),
+			"path":                getPathSchema(),
+			"display_name":        getDisplayNameSchema(),
+			"description":         getDescriptionSchema(),
+			"revision":            getRevisionSchema(),
+			"tag":                 getTagsSchema(),
+			"locale_service_path": getPolicyPathSchema(true, false, "Polciy path for the locale service."),
+			"enabled": {
+				Type:        schema.TypeBool,
+				Description: "Enable/Disable IPSec VPN service.",
+				Optional:    true,
+				Default:     true,
+			},
+			"ha_sync": {
+				Type:        schema.TypeBool,
+				Description: "Enable/Disable IPSec VPN service HA state sync.",
+				Optional:    true,
+				Default:     true,
+			},
+			"ike_log_level": {
+				Type:         schema.TypeString,
+				Description:  "Log level for internet key exchange (IKE).",
+				ValidateFunc: validation.StringInSlice(IPSecVpnServiceIkeLogLevelTypes, false),
+				Optional:     true,
+				Default:      model.IPSecVpnService_IKE_LOG_LEVEL_INFO,
+			},
+			"bypass_rule": getIPSecVPNRulesSchema(),
+		},
+	}
+}
+
+func getNsxtPolicyIPSecVpnServiceByID(connector *client.RestConnector, gwID string, isT0 bool, localeServiceID string, serviceID string, isGlobalManager bool) (model.IPSecVpnService, error) {
+	if isT0 {
+		client := t0_locale_service.NewIpsecVpnServicesClient(connector)
+		return client.Get(gwID, localeServiceID, serviceID)
+	}
+	client := t1_locale_service.NewIpsecVpnServicesClient(connector)
+	return client.Get(gwID, localeServiceID, serviceID)
+}
+
+func patchNsxtPolicyIPSecVpnService(connector *client.RestConnector, gwID string, localeServiceID string, ipSecVpnService model.IPSecVpnService, isT0 bool) error {
+	id := *ipSecVpnService.Id
+	if isT0 {
+		client := t0_locale_service.NewIpsecVpnServicesClient(connector)
+		return client.Patch(gwID, localeServiceID, id, ipSecVpnService)
+	}
+	client := t1_locale_service.NewIpsecVpnServicesClient(connector)
+	return client.Patch(gwID, localeServiceID, id, ipSecVpnService)
+}
+
+func updateNsxtPolicyIPSecVpnService(connector *client.RestConnector, gwID string, localeServiceID string, ipSecVpnService model.IPSecVpnService, isT0 bool) error {
+	id := *ipSecVpnService.Id
+	if isT0 {
+		client := t0_locale_service.NewIpsecVpnServicesClient(connector)
+		_, err := client.Update(gwID, localeServiceID, id, ipSecVpnService)
+		return err
+	}
+	client := t1_locale_service.NewIpsecVpnServicesClient(connector)
+	_, err := client.Update(gwID, localeServiceID, id, ipSecVpnService)
+	return err
+}
+
+func deleteNsxtPolicyIPSecVpnService(connector *client.RestConnector, gwID string, localeServiceID string, isT0 bool, id string) error {
+	if isT0 {
+		client := t0_locale_service.NewIpsecVpnServicesClient(connector)
+		return client.Delete(gwID, localeServiceID, id)
+	}
+	client := t1_locale_service.NewIpsecVpnServicesClient(connector)
+	return client.Delete(gwID, localeServiceID, id)
+}
+
+func setBypassRuleInSchema(d *schema.ResourceData, bypassRules []model.IPSecVpnRule) {
+	var ruleList []map[string]interface{}
+	for _, rule := range bypassRules {
+		elem := make(map[string]interface{})
+		var srcList []string
+		for _, src := range rule.Sources {
+			srcList = append(srcList, *src.Subnet)
+		}
+		var destList []string
+		for _, dest := range rule.Destinations {
+			destList = append(destList, *dest.Subnet)
+		}
+		elem["sources"] = srcList
+		elem["destinations"] = destList
+		elem["action"] = rule.Action
+		ruleList = append(ruleList, elem)
+	}
+	err := d.Set("bypass_rule", ruleList)
+	if err != nil {
+		log.Printf("[WARNING] Failed to set bypass_rule in schema: %v", err)
+	}
+}
+
+func getIPSecVPNBypassRulesFromSchema(d *schema.ResourceData) []model.IPSecVpnRule {
+	rules := d.Get("bypass_rule")
+	if rules != nil {
+		rules := rules.([]interface{})
+		var ruleList []model.IPSecVpnRule
+		for _, rule := range rules {
+			data := rule.(map[string]interface{})
+			action := data["action"].(string)
+			sourceRanges := interface2StringList(data["sources"].(*schema.Set).List())
+			destinationRanges := interface2StringList(data["destinations"].(*schema.Set).List())
+			/// Source Subnets
+			sourceIPSecVpnSubnetList := make([]model.IPSecVpnSubnet, 0)
+			if len(sourceRanges) > 0 {
+				for _, element := range sourceRanges {
+					subnet := element
+					ipSecVpnSubnet := model.IPSecVpnSubnet{
+						Subnet: &subnet,
+					}
+					sourceIPSecVpnSubnetList = append(sourceIPSecVpnSubnetList, ipSecVpnSubnet)
+				}
+			}
+			/// Destination Subnets
+			destinationIPSecVpnSubnetList := make([]model.IPSecVpnSubnet, 0)
+			if len(destinationRanges) > 0 {
+				for _, element := range destinationRanges {
+					subnet := element
+					ipSecVpnSubnet := model.IPSecVpnSubnet{
+						Subnet: &subnet,
+					}
+					destinationIPSecVpnSubnetList = append(destinationIPSecVpnSubnetList, ipSecVpnSubnet)
+				}
+			}
+			ruleID := data["nsx_id"].(string)
+			if ruleID == "" {
+				ruleID = newUUID()
+			}
+			elem := model.IPSecVpnRule{
+				Action:       &action,
+				Sources:      sourceIPSecVpnSubnetList,
+				Destinations: destinationIPSecVpnSubnetList,
+				UniqueId:     &ruleID,
+				Id:           &ruleID,
+			}
+			ruleList = append(ruleList, elem)
+		}
+		return ruleList
+	}
+	return nil
+}
+
+func resourceNsxtPolicyIPSecVpnServiceRead(d *schema.ResourceData, m interface{}) error {
+	connector := getPolicyConnector(m)
+
+	id := d.Id()
+	if id == "" {
+		return fmt.Errorf("Error obtaining IPSecVpnService ID")
+	}
+	localeServicePath := d.Get("locale_service_path").(string)
+	isT0, gwID, localeServiceID, err := parseLocaleServicePolicyPath(localeServicePath)
+	if err != nil {
+		return err
+	}
+	obj, err := getNsxtPolicyIPSecVpnServiceByID(connector, gwID, isT0, localeServiceID, id, isPolicyGlobalManager(m))
+	if err != nil {
+		return handleReadError(d, "IPSecVpnService", id, err)
+	}
+	d.Set("display_name", obj.DisplayName)
+	d.Set("description", obj.Description)
+	setPolicyTagsInSchema(d, obj.Tags)
+	d.Set("nsx_id", id)
+	d.Set("path", obj.Path)
+	d.Set("revision", obj.Revision)
+	d.Set("enabled", obj.Enabled)
+	d.Set("ha_sync", obj.HaSync)
+	setBypassRuleInSchema(d, obj.BypassRules)
+	if obj.IkeLogLevel != nil {
+		d.Set("ike_log_level", obj.IkeLogLevel)
+	}
+	return nil
+}
+
+func resourceNsxtPolicyIPSecVpnServiceCreate(d *schema.ResourceData, m interface{}) error {
+	connector := getPolicyConnector(m)
+	localeServicePath := d.Get("locale_service_path").(string)
+	isT0, gwID, localeServiceID, err := parseLocaleServicePolicyPath(localeServicePath)
+	if err != nil {
+		return err
+	}
+	isGlobalManager := isPolicyGlobalManager(m)
+	id := d.Get("nsx_id").(string)
+	if id == "" {
+		id = newUUID()
+	} else {
+		_, err := getNsxtPolicyIPSecVpnServiceByID(connector, gwID, isT0, localeServiceID, id, isGlobalManager)
+		if err == nil {
+			return fmt.Errorf("IPSecVpnService with nsx_id '%s' already exists", id)
+		} else if !isNotFoundError(err) {
+			return err
+		}
+	}
+
+	displayName := d.Get("display_name").(string)
+	description := d.Get("description").(string)
+	enabled := d.Get("enabled").(bool)
+	haSync := d.Get("ha_sync").(bool)
+	rules := getIPSecVPNBypassRulesFromSchema(d)
+	tags := getPolicyTagsFromSchema(d)
+
+	ipSecVpnService := model.IPSecVpnService{
+		Id:          &id,
+		DisplayName: &displayName,
+		Description: &description,
+		Tags:        tags,
+		Enabled:     &enabled,
+		HaSync:      &haSync,
+		BypassRules: rules,
+	}
+
+	ikeLogLevel := d.Get("ike_log_level").(string)
+	if ikeLogLevel != "" {
+		ipSecVpnService.IkeLogLevel = &ikeLogLevel
+	}
+
+	err = patchNsxtPolicyIPSecVpnService(connector, gwID, localeServiceID, ipSecVpnService, isT0)
+	if err != nil {
+		return handleCreateError("IPSecVpnService", id, err)
+	}
+	d.SetId(id)
+	d.Set("nsx_id", id)
+	return resourceNsxtPolicyIPSecVpnServiceRead(d, m)
+}
+
+func resourceNsxtPolicyIPSecVpnServiceUpdate(d *schema.ResourceData, m interface{}) error {
+	connector := getPolicyConnector(m)
+
+	id := d.Id()
+	if id == "" {
+		return fmt.Errorf("Error obtaining IPSec VPN Service ID")
+	}
+	localeServicePath := d.Get("locale_service_path").(string)
+	isT0, gwID, localeServiceID, err := parseLocaleServicePolicyPath(localeServicePath)
+	if err != nil {
+		return err
+	}
+
+	displayName := d.Get("display_name").(string)
+	description := d.Get("description").(string)
+	enabled := d.Get("enabled").(bool)
+	haSync := d.Get("ha_sync").(bool)
+	rules := getIPSecVPNBypassRulesFromSchema(d)
+	tags := getPolicyTagsFromSchema(d)
+	revision := int64(d.Get("revision").(int))
+	ipSecVpnService := model.IPSecVpnService{
+		Id:          &id,
+		DisplayName: &displayName,
+		Description: &description,
+		Tags:        tags,
+		Enabled:     &enabled,
+		HaSync:      &haSync,
+		BypassRules: rules,
+		Revision:    &revision,
+	}
+
+	ikeLogLevel := d.Get("ike_log_level").(string)
+	if ikeLogLevel != "" {
+		ipSecVpnService.IkeLogLevel = &ikeLogLevel
+	}
+
+	log.Printf("[INFO] Updating IPSecVpnService with ID %s", id)
+	err = updateNsxtPolicyIPSecVpnService(connector, gwID, localeServiceID, ipSecVpnService, isT0)
+	if err != nil {
+		return handleUpdateError("IPSecVpnService", id, err)
+	}
+	d.Set("nsx_id", id)
+	return resourceNsxtPolicyIPSecVpnServiceRead(d, m)
+}
+
+func resourceNsxtPolicyIPSecVpnServiceDelete(d *schema.ResourceData, m interface{}) error {
+	id := d.Id()
+	if id == "" {
+		return fmt.Errorf("Error obtaining IPSec VPN Service ID")
+	}
+
+	localeServicePath := d.Get("locale_service_path").(string)
+	isT0, gwID, localeServiceID, err := parseLocaleServicePolicyPath(localeServicePath)
+	if err != nil {
+		return err
+	}
+
+	err = deleteNsxtPolicyIPSecVpnService(getPolicyConnector(m), gwID, localeServiceID, isT0, id)
+	if err != nil {
+		return handleDeleteError("IPSecVpnService", id, err)
+	}
+	return nil
+}

--- a/nsxt/resource_nsxt_policy_ipsec_vpn_service_test.go
+++ b/nsxt/resource_nsxt_policy_ipsec_vpn_service_test.go
@@ -1,0 +1,193 @@
+/* Copyright © 2022 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: MPL-2.0 */
+
+package nsxt
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+var accTestPolicyIPSecVpnServiceCreateAttributes = map[string]string{
+	"display_name":  getAccTestResourceName(),
+	"description":   "terraform created",
+	"enabled":       "true",
+	"ha_sync":       "true",
+	"ike_log_level": "INFO",
+	"sources":       "192.168.10.0/24",
+	"destinations":  "192.169.10.0/24",
+	"action":        "BYPASS",
+}
+
+var accTestPolicyIPSecVpnServiceUpdateAttributes = map[string]string{
+	"display_name":  getAccTestResourceName(),
+	"description":   "terraform updated",
+	"enabled":       "false",
+	"ha_sync":       "true",
+	"ike_log_level": "DEBUG",
+	"sources":       "192.170.10.0/24",
+	"destinations":  "192.171.10.0/24",
+	"action":        "BYPASS",
+}
+
+func TestAccResourceNsxtPolicyIPSecVpnService_basic(t *testing.T) {
+	testResourceName := "nsxt_policy_ipsec_vpn_service.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t); testAccOnlyLocalManager(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyIPSecVpnServiceCheckDestroy(state, accTestPolicyIPSecVpnServiceUpdateAttributes["display_name"])
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyIPSecVpnServiceTemplate(true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicyIPSecVpnServiceExists(accTestPolicyIPSecVpnServiceCreateAttributes["display_name"], testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestPolicyIPSecVpnServiceCreateAttributes["display_name"]),
+					resource.TestCheckResourceAttr(testResourceName, "description", accTestPolicyIPSecVpnServiceCreateAttributes["description"]),
+					resource.TestCheckResourceAttrSet(testResourceName, "locale_service_path"),
+					resource.TestCheckResourceAttr(testResourceName, "enabled", accTestPolicyIPSecVpnServiceCreateAttributes["enabled"]),
+					resource.TestCheckResourceAttr(testResourceName, "ha_sync", accTestPolicyIPSecVpnServiceCreateAttributes["ha_sync"]),
+					resource.TestCheckResourceAttr(testResourceName, "ike_log_level", accTestPolicyIPSecVpnServiceCreateAttributes["ike_log_level"]),
+					resource.TestCheckResourceAttr(testResourceName, "bypass_rule.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "bypass_rule.0.sources.0", accTestPolicyIPSecVpnServiceCreateAttributes["sources"]),
+					resource.TestCheckResourceAttr(testResourceName, "bypass_rule.0.destinations.0", accTestPolicyIPSecVpnServiceCreateAttributes["destinations"]),
+					resource.TestCheckResourceAttr(testResourceName, "bypass_rule.0.action", accTestPolicyIPSecVpnServiceCreateAttributes["action"]),
+					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
+				),
+			},
+			{
+				Config: testAccNsxtPolicyIPSecVpnServiceTemplate(false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicyIPSecVpnServiceExists(accTestPolicyIPSecVpnServiceUpdateAttributes["display_name"], testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestPolicyIPSecVpnServiceUpdateAttributes["display_name"]),
+					resource.TestCheckResourceAttr(testResourceName, "description", accTestPolicyIPSecVpnServiceUpdateAttributes["description"]),
+					resource.TestCheckResourceAttrSet(testResourceName, "locale_service_path"),
+					resource.TestCheckResourceAttr(testResourceName, "enabled", accTestPolicyIPSecVpnServiceUpdateAttributes["enabled"]),
+					resource.TestCheckResourceAttr(testResourceName, "ha_sync", accTestPolicyIPSecVpnServiceUpdateAttributes["ha_sync"]),
+					resource.TestCheckResourceAttr(testResourceName, "ike_log_level", accTestPolicyIPSecVpnServiceUpdateAttributes["ike_log_level"]),
+					resource.TestCheckResourceAttr(testResourceName, "bypass_rule.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "bypass_rule.0.sources.0", accTestPolicyIPSecVpnServiceUpdateAttributes["sources"]),
+					resource.TestCheckResourceAttr(testResourceName, "bypass_rule.0.destinations.0", accTestPolicyIPSecVpnServiceUpdateAttributes["destinations"]),
+					resource.TestCheckResourceAttr(testResourceName, "bypass_rule.0.action", accTestPolicyIPSecVpnServiceUpdateAttributes["action"]),
+					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
+				),
+			},
+			{
+				Config: testAccNsxtPolicyIPSecVpnServiceMinimalistic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicyIPSecVpnServiceExists(accTestPolicyIPSecVpnServiceCreateAttributes["display_name"], testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "description", ""),
+					resource.TestCheckResourceAttrSet(testResourceName, "locale_service_path"),
+					resource.TestCheckResourceAttr(testResourceName, "bypass_rule.#", "0"),
+					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+					resource.TestCheckResourceAttr(testResourceName, "tag.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccNsxtPolicyIPSecVpnServiceExists(displayName string, resourceName string) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+
+		connector := getPolicyConnector(testAccProvider.Meta().(nsxtClients))
+
+		rs, ok := state.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Policy IPSecVpnService resource %s not found in resources", resourceName)
+		}
+
+		resourceID := rs.Primary.ID
+		if resourceID == "" {
+			return fmt.Errorf("Policy IPSecVpnService resource ID not set in resources")
+		}
+
+		localeServicePath := rs.Primary.Attributes["locale_service_path"]
+		isT0, gwID, localeServiceID, err := parseLocaleServicePolicyPath(localeServicePath)
+
+		if err != nil {
+			return nil
+		}
+		_, err1 := getNsxtPolicyIPSecVpnServiceByID(connector, gwID, isT0, localeServiceID, resourceID, testAccIsGlobalManager())
+		if err1 != nil {
+			return fmt.Errorf("Policy IPSecVpnService %s does not exist", displayName)
+		}
+
+		return nil
+	}
+}
+
+func testAccNsxtPolicyIPSecVpnServiceCheckDestroy(state *terraform.State, displayName string) error {
+	connector := getPolicyConnector(testAccProvider.Meta().(nsxtClients))
+	for _, rs := range state.RootModule().Resources {
+
+		if rs.Type != "nsxt_policy_ipsec_vpn_service" {
+			continue
+		}
+
+		resourceID := rs.Primary.Attributes["id"]
+		localeServicePath := rs.Primary.Attributes["locale_service_path"]
+		isT0, gwID, localeServiceID, err := parseLocaleServicePolicyPath(localeServicePath)
+
+		if err != nil {
+			return nil
+		}
+
+		_, err1 := getNsxtPolicyIPSecVpnServiceByID(connector, gwID, isT0, localeServiceID, resourceID, testAccIsGlobalManager())
+		if err1 == nil {
+			return fmt.Errorf("Policy IPSecVpnService %s still exists", displayName)
+		}
+	}
+	return nil
+}
+
+func testAccNsxtPolicyIPSecVpnServiceTemplate(createFlow bool) string {
+	var attrMap map[string]string
+	if createFlow {
+		attrMap = accTestPolicyIPSecVpnServiceCreateAttributes
+	} else {
+		attrMap = accTestPolicyIPSecVpnServiceUpdateAttributes
+	}
+	return testAccNsxtPolicyEdgeClusterReadTemplate(getEdgeClusterName()) +
+		testAccNsxtPolicyTier0WithEdgeClusterForVPN("test") + fmt.Sprintf(`
+resource "nsxt_policy_ipsec_vpn_service" "test" {
+	display_name                   = "%s"
+	description                    = "%s"
+	locale_service_path   		   = one(nsxt_policy_tier0_gateway.test.locale_service).path
+	enabled                        = "%s"
+	ha_sync                        = "%s"
+	ike_log_level                  = "%s"
+	bypass_rule {
+		sources                    = ["%s"]
+		destinations               = ["%s"]
+		action                     = "%s"
+	}
+
+	tag {
+	scope = "scope1"
+	tag   = "tag1"
+	}
+   }`, attrMap["display_name"], attrMap["description"], attrMap["enabled"], attrMap["ha_sync"], attrMap["ike_log_level"], attrMap["sources"], attrMap["destinations"], attrMap["action"])
+}
+
+func testAccNsxtPolicyIPSecVpnServiceMinimalistic() string {
+	return testAccNsxtPolicyEdgeClusterReadTemplate(getEdgeClusterName()) +
+		testAccNsxtPolicyTier0WithEdgeClusterForVPN("test") + fmt.Sprintf(`
+   resource "nsxt_policy_ipsec_vpn_service" "test" {
+	 display_name          = "%s"
+	 locale_service_path   = one(nsxt_policy_tier0_gateway.test.locale_service).path
+   }`, accTestPolicyIPSecVpnServiceUpdateAttributes["display_name"])
+}

--- a/nsxt/resource_nsxt_policy_ipsec_vpn_session.go
+++ b/nsxt/resource_nsxt_policy_ipsec_vpn_session.go
@@ -1,0 +1,664 @@
+/* Copyright © 2022 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: MPL-2.0 */
+
+package nsxt
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/bindings"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/data"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
+
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_0s/locale_services/ipsec_vpn_services"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+)
+
+const policyBasedIPSecVpnSession string = "PolicyBased"
+const routeBasedIPSecVpnSession string = "RouteBased"
+
+var IPSecVpnSessionResourceType = []string{
+	policyBasedIPSecVpnSession,
+	routeBasedIPSecVpnSession,
+}
+
+var IPSecVpnSessionAuthenticationMode = []string{
+	model.IPSecVpnSession_AUTHENTICATION_MODE_PSK,
+	model.IPSecVpnSession_AUTHENTICATION_MODE_CERTIFICATE,
+}
+
+var IPSecVpnSessionConnectionInitiationMode = []string{
+	model.IPSecVpnSession_CONNECTION_INITIATION_MODE_INITIATOR,
+	model.IPSecVpnSession_CONNECTION_INITIATION_MODE_RESPOND_ONLY,
+	model.IPSecVpnSession_CONNECTION_INITIATION_MODE_ON_DEMAND,
+}
+var IPSecVpnSessionComplianceSuite = []string{
+	model.IPSecVpnSession_COMPLIANCE_SUITE_CNSA,
+	model.IPSecVpnSession_COMPLIANCE_SUITE_SUITE_B_GCM_128,
+	model.IPSecVpnSession_COMPLIANCE_SUITE_SUITE_B_GCM_256,
+	model.IPSecVpnSession_COMPLIANCE_SUITE_PRIME,
+	model.IPSecVpnSession_COMPLIANCE_SUITE_FOUNDATION,
+	model.IPSecVpnSession_COMPLIANCE_SUITE_FIPS,
+	model.IPSecVpnSession_COMPLIANCE_SUITE_NONE,
+}
+
+var IPSecRulesActionValues = []string{
+	model.IPSecVpnRule_ACTION_PROTECT,
+	model.IPSecVpnRule_ACTION_BYPASS,
+}
+
+func resourceNsxtPolicyIPSecVpnSession() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceNsxtPolicyIPSecVpnSessionCreate,
+		Read:   resourceNsxtPolicyIPSecVpnSessionRead,
+		Update: resourceNsxtPolicyIPSecVpnSessionUpdate,
+		Delete: resourceNsxtPolicyIPSecVpnSessionDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"nsx_id":              getNsxIDSchema(),
+			"path":                getPathSchema(),
+			"display_name":        getDisplayNameSchema(),
+			"description":         getDescriptionSchema(),
+			"revision":            getRevisionSchema(),
+			"tag":                 getTagsSchema(),
+			"tunnel_profile_path": getPolicyPathSchema(true, false, "Policy path referencing Tunnel profile to be used."),
+			"local_endpoint_path": getPolicyPathSchema(true, false, "Policy path referencing Local endpoint."),
+			"ike_profile_path":    getPolicyPathSchema(false, false, "Policy path referencing Ike profile."),
+			"dpd_profile_path":    getPolicyPathSchema(false, false, "Policy path referencing dpd profile."),
+			"vpn_type": {
+				Type:         schema.TypeString,
+				Description:  "A Policy Based VPN requires to define protect rules that match local and peer subnets. IPSec security associations is negotiated for each pair of local and peer subnet. A Route Based VPN is more flexible, more powerful and recommended over policy based VPN. IP Tunnel port is created and all traffic routed via tunnel port is protected. Routes can be configured statically or can be learned through BGP. A route based VPN is must for establishing redundant VPN session to remote site.",
+				ValidateFunc: validation.StringInSlice(IPSecVpnSessionResourceType, false),
+				Required:     true,
+			},
+			"compliance_suite": {
+				Type:         schema.TypeString,
+				Description:  "Compliance suite.",
+				ValidateFunc: validation.StringInSlice(IPSecVpnSessionComplianceSuite, false),
+				Optional:     true,
+				Default:      model.IPSecVpnSession_COMPLIANCE_SUITE_NONE,
+			},
+			"connection_initiation_mode": {
+				Type:         schema.TypeString,
+				Description:  "Connection initiation mode used by local endpoint to establish ike connection with peer site. INITIATOR - In this mode local endpoint initiates tunnel setup and will also respond to incoming tunnel setup requests from peer gateway. RESPOND_ONLY - In this mode, local endpoint shall only respond to incoming tunnel setup requests. It shall not initiate the tunnel setup. ON_DEMAND - In this mode local endpoint will initiate tunnel creation once first packet matching the policy rule is received and will also respond to incoming initiation request.",
+				ValidateFunc: validation.StringInSlice(IPSecVpnSessionConnectionInitiationMode, false),
+				Optional:     true,
+				Default:      model.IPSecVpnSession_CONNECTION_INITIATION_MODE_INITIATOR,
+			},
+			"authentication_mode": {
+				Type:         schema.TypeString,
+				Description:  "Peer authentication mode. PSK - In this mode a secret key shared between local and peer sites is to be used for authentication. The secret key can be a string with a maximum length of 128 characters. CERTIFICATE - In this mode a certificate defined at the global level is to be used for authentication.",
+				ValidateFunc: validation.StringInSlice(IPSecVpnSessionAuthenticationMode, false),
+				Optional:     true,
+				Default:      model.IPSecVpnSession_AUTHENTICATION_MODE_PSK,
+			},
+			"enabled": {
+				Type:        schema.TypeBool,
+				Description: "Enable/Disable IPSec VPN session.",
+				Optional:    true,
+				Default:     true,
+			},
+			"psk": {
+				Type:        schema.TypeString,
+				Description: "IPSec Pre-shared key. Maximum length of this field is 128 characters.",
+				Optional:    true,
+				Sensitive:   true,
+			},
+			"peer_id": {
+				Type:         schema.TypeString,
+				Description:  "Peer ID to uniquely identify the peer site. The peer ID is the public IP address of the remote device terminating the VPN tunnel. When NAT is configured for the peer, enter the private IP address of the peer.",
+				Required:     true,
+				ValidateFunc: validation.IsIPv4Address,
+			},
+			"peer_address": {
+				Type:         schema.TypeString,
+				Description:  "Public IPV4 address of the remote device terminating the VPN connection.",
+				Required:     true,
+				ValidateFunc: validation.IsIPv4Address,
+			},
+			"service_path": getPolicyPathSchema(true, true, "Policy path for IPSec VPN service"),
+			"ip_addresses": {
+				Type:        schema.TypeList,
+				Description: "IP Tunnel interface (commonly referred as VTI) ip addresses.",
+				Optional:    true,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validateSingleIP(),
+				},
+			},
+			"rule": getIPSecVPNRulesSchema(),
+			"prefix_length": {
+				Type:         schema.TypeInt,
+				Description:  "Subnet Prefix Length.",
+				Optional:     true,
+				ValidateFunc: validation.IntBetween(1, 255),
+			},
+			"direction": {
+				Type:         schema.TypeString,
+				Description:  "The traffic direction apply to the MSS clamping",
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice(L2VpnSessionTCPSegmentClampingDirection, false),
+			},
+			"max_segment_size": {
+				Type:         schema.TypeInt,
+				Description:  "Maximum amount of data the host will accept in a Tcp segment.",
+				Optional:     true,
+				ValidateFunc: validation.IntBetween(108, 8860),
+			},
+		},
+	}
+}
+
+func getIPSecVPNSessionFromSchema(d *schema.ResourceData) (*data.StructValue, error) {
+	converter := bindings.NewTypeConverter()
+	converter.SetMode(bindings.REST)
+
+	psk := d.Get("psk").(string)
+	peerID := d.Get("peer_id").(string)
+	peerAddress := d.Get("peer_address").(string)
+	displayName := d.Get("display_name").(string)
+	description := d.Get("description").(string)
+	ikeProfilePath := d.Get("ike_profile_path").(string)
+	resourceType := d.Get("vpn_type").(string)
+	localEndpointPath := d.Get("local_endpoint_path").(string)
+	dpdProfilePath := d.Get("dpd_profile_path").(string)
+	tunnelProfilePath := d.Get("tunnel_profile_path").(string)
+	connectionInitiationMode := d.Get("connection_initiation_mode").(string)
+	authenticationMode := d.Get("authentication_mode").(string)
+	complianceSuite := d.Get("compliance_suite").(string)
+	prefixLengh := int64(d.Get("prefix_length").(int))
+	enabled := d.Get("enabled").(bool)
+	direction := d.Get("direction").(string)
+	mss := int64(d.Get("max_segment_size").(int))
+	tags := getPolicyTagsFromSchema(d)
+
+	if resourceType == routeBasedIPSecVpnSession {
+		tunnelInterface := interfaceListToStringList(d.Get("ip_addresses").([]interface{}))
+		var ipSubnets []model.TunnelInterfaceIPSubnet
+		ipSubnet := model.TunnelInterfaceIPSubnet{
+			IpAddresses:  tunnelInterface,
+			PrefixLength: &prefixLengh,
+		}
+		ipSubnets = append(ipSubnets, ipSubnet)
+		var vtiList []model.IPSecVpnTunnelInterface
+
+		vti := model.IPSecVpnTunnelInterface{
+			IpSubnets:   ipSubnets,
+			DisplayName: &displayName,
+		}
+
+		vtiList = append(vtiList, vti)
+		rsType := model.IPSecVpnSession_RESOURCE_TYPE_ROUTEBASEDIPSECVPNSESSION
+		routeObj := model.RouteBasedIPSecVpnSession{
+			DisplayName:              &displayName,
+			Description:              &description,
+			ConnectionInitiationMode: &connectionInitiationMode,
+			ComplianceSuite:          &complianceSuite,
+			AuthenticationMode:       &authenticationMode,
+			ResourceType:             rsType,
+			Enabled:                  &enabled,
+			TunnelInterfaces:         vtiList,
+			PeerAddress:              &peerAddress,
+			PeerId:                   &peerID,
+			Psk:                      &psk,
+			Tags:                     tags,
+		}
+		if nsxVersionHigherOrEqual("3.2.0") {
+			if direction != "" {
+				tcpMSSClamping := model.TcpMaximumSegmentSizeClamping{
+					Direction:      &direction,
+					MaxSegmentSize: &mss,
+				}
+				routeObj.TcpMssClamping = &tcpMSSClamping
+			}
+		}
+		if len(ikeProfilePath) > 0 {
+			routeObj.IkeProfilePath = &ikeProfilePath
+		}
+		if len(localEndpointPath) > 0 {
+			routeObj.LocalEndpointPath = &localEndpointPath
+		}
+		if len(tunnelProfilePath) > 0 {
+			routeObj.TunnelProfilePath = &tunnelProfilePath
+		}
+		if len(dpdProfilePath) > 0 {
+			routeObj.DpdProfilePath = &dpdProfilePath
+		}
+
+		dataValue, err := converter.ConvertToVapi(routeObj, model.RouteBasedIPSecVpnSessionBindingType())
+		if err != nil {
+			return nil, err[0]
+		}
+		return dataValue.(*data.StructValue), nil
+	}
+
+	if resourceType == policyBasedIPSecVpnSession {
+		rsType := model.IPSecVpnSession_RESOURCE_TYPE_POLICYBASEDIPSECVPNSESSION
+		ipSecVpnRules := getIPSecVPNRulesFromSchema(d)
+		policyObj := model.PolicyBasedIPSecVpnSession{
+			DisplayName:              &displayName,
+			Description:              &description,
+			ConnectionInitiationMode: &connectionInitiationMode,
+			ComplianceSuite:          &complianceSuite,
+			AuthenticationMode:       &authenticationMode,
+			ResourceType:             rsType,
+			Enabled:                  &enabled,
+			Rules:                    ipSecVpnRules,
+			PeerAddress:              &peerAddress,
+			PeerId:                   &peerID,
+			Psk:                      &psk,
+			Tags:                     tags,
+		}
+		if nsxVersionHigherOrEqual("3.2.0") {
+			if direction != "" {
+				tcpMSSClamping := model.TcpMaximumSegmentSizeClamping{
+					Direction:      &direction,
+					MaxSegmentSize: &mss,
+				}
+				policyObj.TcpMssClamping = &tcpMSSClamping
+			}
+		}
+		if len(ikeProfilePath) > 0 {
+			policyObj.IkeProfilePath = &ikeProfilePath
+		}
+		if len(localEndpointPath) > 0 {
+			policyObj.LocalEndpointPath = &localEndpointPath
+		}
+		if len(tunnelProfilePath) > 0 {
+			policyObj.TunnelProfilePath = &tunnelProfilePath
+		}
+		if len(dpdProfilePath) > 0 {
+			policyObj.DpdProfilePath = &dpdProfilePath
+		}
+		dataValue, err := converter.ConvertToVapi(policyObj, model.PolicyBasedIPSecVpnSessionBindingType())
+		if err != nil {
+			return nil, err[0]
+		}
+		return dataValue.(*data.StructValue), nil
+
+	}
+
+	return nil, fmt.Errorf("Failed to get IPSecVPNSession from Schema")
+}
+
+func getIPSecVPNRulesSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeList,
+		Description: "For policy-based IPsec VPNs, a security policy specifies as its action the VPN tunnel to be used for transit traffic that meets the policy’s match criteria.",
+		Optional:    true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"nsx_id": getNsxIDSchema(),
+				"sources": {
+					Type:        schema.TypeSet,
+					Description: "List of local subnets. Specifying no value is interpreted as 0.0.0.0/0.",
+					Elem: &schema.Schema{
+						Type:         schema.TypeString,
+						ValidateFunc: validateCidr(),
+					},
+					Required: true,
+				},
+				"destinations": {
+					Type:        schema.TypeSet,
+					Description: "List of remote subnets used in policy-based L3Vpn.",
+					Elem: &schema.Schema{
+						Type:         schema.TypeString,
+						ValidateFunc: validateCidr(),
+					},
+					Required: true,
+				},
+				"action": {
+					Type:         schema.TypeString,
+					Description:  "PROTECT - Protect rules are defined per policy based IPSec VPN session. BYPASS - Bypass rules are defined per IPSec VPN service and affects all policy based IPSec VPN sessions. Bypass rules are prioritized over protect rules.",
+					Default:      model.IPSecVpnRule_ACTION_PROTECT,
+					Optional:     true,
+					ValidateFunc: validation.StringInSlice(IPSecRulesActionValues, false),
+				},
+			},
+		},
+	}
+}
+
+func parseIPSecVPNServicePolicyPath(path string) (bool, string, string, string, error) {
+	segs := strings.Split(path, "/")
+	// Path should be like /infra/tier-1s/aaa/locale-services/default/ipsec-vpn-services/ccc
+	segCount := len(segs)
+	if (segCount < 8) || (segs[segCount-2] != "ipsec-vpn-services") {
+		// error - this is not a segment path
+		return false, "", "", "", fmt.Errorf("Invalid IPSec VPN service path %s", path)
+	}
+
+	serviceID := segs[segCount-1]
+	localeServiceID := segs[5]
+	gwPath := strings.Join(segs[:4], "/")
+
+	isT0, gwID := parseGatewayPolicyPath(gwPath)
+	return isT0, gwID, localeServiceID, serviceID, nil
+}
+
+func setRuleInSchema(d *schema.ResourceData, bypassRules []model.IPSecVpnRule) {
+	var ruleList []map[string]interface{}
+	for _, rule := range bypassRules {
+		elem := make(map[string]interface{})
+		var srcList []string
+		for _, src := range rule.Sources {
+			srcList = append(srcList, *src.Subnet)
+		}
+		var destList []string
+		for _, dest := range rule.Destinations {
+			destList = append(destList, *dest.Subnet)
+		}
+		nsxID := rule.Id
+		elem["nsx_id"] = nsxID
+		elem["sources"] = srcList
+		elem["destinations"] = destList
+		elem["action"] = rule.Action
+		ruleList = append(ruleList, elem)
+	}
+	err := d.Set("rule", ruleList)
+	if err != nil {
+		log.Printf("[WARNING] Failed to set bypass_rules in schema: %v", err)
+	}
+}
+
+func getIPSecVPNRulesFromSchema(d *schema.ResourceData) []model.IPSecVpnRule {
+	rules := d.Get("rule")
+	if rules != nil {
+		rules := rules.([]interface{})
+		var ruleList []model.IPSecVpnRule
+		for _, rule := range rules {
+			data := rule.(map[string]interface{})
+			action := data["action"].(string)
+			sourceRanges := interface2StringList(data["sources"].(*schema.Set).List())
+			destinationRanges := interface2StringList(data["destinations"].(*schema.Set).List())
+
+			/// Source Subnets
+
+			SourceIPSecVpnSubnetList := make([]model.IPSecVpnSubnet, 0)
+			if len(sourceRanges) > 0 {
+				for _, element := range sourceRanges {
+					subnet := element
+					IPSecVpnSubnet := model.IPSecVpnSubnet{
+						Subnet: &subnet,
+					}
+					SourceIPSecVpnSubnetList = append(SourceIPSecVpnSubnetList, IPSecVpnSubnet)
+				}
+			}
+
+			/// Destination Subnets
+			DestinationIPSecVpnSubnetList := make([]model.IPSecVpnSubnet, 0)
+			if len(destinationRanges) > 0 {
+				for _, element := range destinationRanges {
+					subnet := element
+					IPSecVpnSubnet := model.IPSecVpnSubnet{
+						Subnet: &subnet,
+					}
+					DestinationIPSecVpnSubnetList = append(DestinationIPSecVpnSubnetList, IPSecVpnSubnet)
+				}
+			}
+			ruleID := data["nsx_id"].(string)
+			if ruleID == "" {
+				ruleID = newUUID()
+			}
+			elem := model.IPSecVpnRule{
+				Action:       &action,
+				Sources:      SourceIPSecVpnSubnetList,
+				Destinations: DestinationIPSecVpnSubnetList,
+				UniqueId:     &ruleID,
+				Id:           &ruleID,
+			}
+			ruleList = append(ruleList, elem)
+		}
+		return ruleList
+	}
+	return nil
+}
+
+func resourceNsxtPolicyIPSecVpnSessionCreate(d *schema.ResourceData, m interface{}) error {
+
+	servicePath := d.Get("service_path").(string)
+	isT0, gwID, localeServiceID, serviceID, err := parseIPSecVPNServicePolicyPath(servicePath)
+	if err != nil {
+		return err
+	}
+	if !isT0 {
+		return fmt.Errorf("VPN is supported only on Tier-0 with ACTIVE-STANDBY HA mode")
+	}
+	id := d.Get("nsx_id").(string)
+	if id == "" {
+		id = newUUID()
+	}
+
+	connector := getPolicyConnector(m)
+
+	_, err1 := resourceNsxtPolicyIPSecVpnSessionExists(gwID, localeServiceID, serviceID, id, connector)
+	if err1 == nil {
+		return fmt.Errorf("IPSecVpnSession with nsx_id '%s' already exists under IPSecVpnService '%s' of localeService '%s'", id, serviceID, localeServiceID)
+	} else if !isNotFoundError(err1) {
+		return err1
+	}
+
+	obj, err2 := getIPSecVPNSessionFromSchema(d)
+	if err2 != nil {
+		return err2
+	}
+
+	client := ipsec_vpn_services.NewSessionsClient(connector)
+
+	err3 := client.Patch(gwID, localeServiceID, serviceID, id, obj)
+
+	if err3 != nil {
+		return handleCreateError("IPSecVpnSession", id, err3)
+	}
+
+	d.SetId(id)
+	d.Set("nsx_id", id)
+
+	return resourceNsxtPolicyIPSecVpnSessionRead(d, m)
+}
+
+func resourceNsxtPolicyIPSecVpnSessionExists(tier0ID string, localeServiceID string, serviceID string, sessionID string, connector *client.RestConnector) (bool, error) {
+	client := ipsec_vpn_services.NewSessionsClient(connector)
+	_, err := client.Get(tier0ID, localeServiceID, serviceID, sessionID)
+	if err == nil {
+		return true, nil
+	}
+
+	if isNotFoundError(err) {
+		return false, err
+	}
+
+	return false, logAPIError("Error retrieving resource", err)
+}
+
+func resourceNsxtPolicyIPSecVpnSessionRead(d *schema.ResourceData, m interface{}) error {
+	connector := getPolicyConnector(m)
+	converter := bindings.NewTypeConverter()
+	converter.SetMode(bindings.REST)
+
+	id := d.Id()
+	resourceType := d.Get("vpn_type").(string)
+	if id == "" {
+		return fmt.Errorf("Error obtaining IPSecVpnSession ID")
+	}
+
+	servicePath := d.Get("service_path").(string)
+	isT0, gwID, localeServiceID, serviceID, err := parseIPSecVPNServicePolicyPath(servicePath)
+	if err != nil {
+		return err
+	}
+	if !isT0 {
+		return fmt.Errorf("VPN is supported only on Tier-0 with ACTIVE-STANDBY HA mode")
+	}
+
+	client := ipsec_vpn_services.NewSessionsClient(connector)
+
+	obj, err1 := client.Get(gwID, localeServiceID, serviceID, id)
+
+	if err1 != nil {
+		if isNotFoundError(err1) {
+			d.SetId("")
+			return nil
+		}
+		return handleReadError(d, "VPN Session", id, err1)
+	}
+
+	if resourceType == routeBasedIPSecVpnSession {
+		interfaceVpn, errs := converter.ConvertToGolang(obj, model.RouteBasedIPSecVpnSessionBindingType())
+		if len(errs) > 0 {
+			return fmt.Errorf("Error converting VPN Session %s", errs[0])
+		}
+		blockVPN := interfaceVpn.(model.RouteBasedIPSecVpnSession)
+
+		d.Set("display_name", blockVPN.DisplayName)
+		d.Set("description", blockVPN.Description)
+		setPolicyTagsInSchema(d, blockVPN.Tags)
+		d.Set("nsx_id", blockVPN.Id)
+		d.Set("path", blockVPN.Path)
+		d.Set("revision", blockVPN.Revision)
+		d.Set("vpn_type", routeBasedIPSecVpnSession)
+		d.Set("authentication_mode", blockVPN.AuthenticationMode)
+		d.Set("compliance_suite", blockVPN.ComplianceSuite)
+		d.Set("connection_initiation_mode", blockVPN.ConnectionInitiationMode)
+		d.Set("enabled", blockVPN.Enabled)
+		d.Set("ike_profile_path", blockVPN.IkeProfilePath)
+		d.Set("local_endpoint_path", blockVPN.LocalEndpointPath)
+		d.Set("dpd_profile_path", blockVPN.DpdProfilePath)
+		d.Set("tunnel_profile_path", blockVPN.TunnelProfilePath)
+		d.Set("peer_address", blockVPN.PeerAddress)
+		d.Set("peer_id", blockVPN.PeerId)
+		if nsxVersionHigherOrEqual("3.2.0") {
+			if blockVPN.TcpMssClamping != nil {
+				direction := blockVPN.TcpMssClamping.Direction
+				mss := blockVPN.TcpMssClamping.MaxSegmentSize
+				d.Set("direction", direction)
+				d.Set("max_segment_size", mss)
+			}
+		}
+		var subnets []string
+		var prefixLength int64
+		if blockVPN.TunnelInterfaces != nil && len(blockVPN.TunnelInterfaces) > 0 {
+			for _, tunnelInterface := range blockVPN.TunnelInterfaces {
+				ipSubnets := tunnelInterface.IpSubnets
+				for _, ipSubnet := range ipSubnets {
+					ipAddresses := ipSubnet.IpAddresses
+					if len(ipAddresses) > 0 {
+						subnets = append(subnets, ipAddresses...)
+					}
+					if prefixLength == 0 {
+						prefixLength = *ipSubnet.PrefixLength
+					}
+				}
+			}
+		}
+		d.Set("prefix_length", prefixLength)
+		if len(subnets) > 0 {
+			d.Set("ip_addresses", subnets)
+		}
+
+	} else {
+		// Policy based ipsec vpn session
+		interfaceVpn, errs := converter.ConvertToGolang(obj, model.PolicyBasedIPSecVpnSessionBindingType())
+		if len(errs) > 0 {
+			return fmt.Errorf("Error converting VPN Session %s", errs[0])
+		}
+		blockVPN := interfaceVpn.(model.PolicyBasedIPSecVpnSession)
+
+		d.Set("display_name", blockVPN.DisplayName)
+		d.Set("description", blockVPN.Description)
+		setPolicyTagsInSchema(d, blockVPN.Tags)
+		d.Set("nsx_id", blockVPN.Id)
+		d.Set("path", blockVPN.Path)
+		d.Set("revision", blockVPN.Revision)
+		d.Set("vpn_type", policyBasedIPSecVpnSession)
+		d.Set("authentication_mode", blockVPN.AuthenticationMode)
+		d.Set("compliance_suite", blockVPN.ComplianceSuite)
+		d.Set("connection_initiation_mode", blockVPN.ConnectionInitiationMode)
+		d.Set("enabled", blockVPN.Enabled)
+		d.Set("ike_profile_path", blockVPN.IkeProfilePath)
+		d.Set("local_endpoint_path", blockVPN.LocalEndpointPath)
+		d.Set("dpd_profile_path", blockVPN.DpdProfilePath)
+		d.Set("tunnel_profile_path", blockVPN.TunnelProfilePath)
+		if blockVPN.Rules != nil {
+			setRuleInSchema(d, blockVPN.Rules)
+		}
+		if nsxVersionHigherOrEqual("3.2.0") {
+			if blockVPN.TcpMssClamping != nil {
+				direction := blockVPN.TcpMssClamping.Direction
+				mss := blockVPN.TcpMssClamping.MaxSegmentSize
+				d.Set("direction", direction)
+				d.Set("max_segment_size", mss)
+			}
+		}
+	}
+	return nil
+}
+
+func resourceNsxtPolicyIPSecVpnSessionUpdate(d *schema.ResourceData, m interface{}) error {
+	connector := getPolicyConnector(m)
+
+	id := d.Id()
+	if id == "" {
+		return fmt.Errorf("Error obtaining IPSecVpnSession ID")
+	}
+
+	servicePath := d.Get("service_path").(string)
+	isT0, gwID, localeServiceID, serviceID, err := parseIPSecVPNServicePolicyPath(servicePath)
+	if err != nil {
+		return err
+	}
+	if !isT0 {
+		return fmt.Errorf("VPN is supported only on Tier-0 with ACTIVE-STANDBY HA mode")
+	}
+	obj, err := getIPSecVPNSessionFromSchema(d)
+	if err != nil {
+		return err
+	}
+
+	client := ipsec_vpn_services.NewSessionsClient(connector)
+
+	err = client.Patch(gwID, localeServiceID, serviceID, id, obj)
+
+	if err != nil {
+		return handleUpdateError("IPSecVpnSession", id, err)
+	}
+	d.SetId(id)
+	d.Set("nsx_id", id)
+	return resourceNsxtPolicyIPSecVpnSessionRead(d, m)
+
+}
+
+func resourceNsxtPolicyIPSecVpnSessionDelete(d *schema.ResourceData, m interface{}) error {
+
+	id := d.Id()
+	if id == "" {
+		return fmt.Errorf("Error obtaining IPSecVpnSession ID")
+	}
+	servicePath := d.Get("service_path").(string)
+	isT0, gwID, localeServiceID, serviceID, err := parseIPSecVPNServicePolicyPath(servicePath)
+	if err != nil {
+		return err
+	}
+	if !isT0 {
+		return fmt.Errorf("VPN is supported only on Tier-0 with ACTIVE-STANDBY HA mode")
+	}
+
+	connector := getPolicyConnector(m)
+
+	var err1 error
+	client := ipsec_vpn_services.NewSessionsClient(connector)
+	err1 = client.Delete(gwID, localeServiceID, serviceID, id)
+
+	if err1 != nil {
+		return handleDeleteError("IPSecVpnSession", id, err1)
+	}
+
+	return nil
+}

--- a/nsxt/resource_nsxt_policy_ipsec_vpn_session_test.go
+++ b/nsxt/resource_nsxt_policy_ipsec_vpn_session_test.go
@@ -1,0 +1,404 @@
+/* Copyright © 2022 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: MPL-2.0 */
+
+package nsxt
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+var accTestPolicyIPSecVpnSessionRouteBasedCreateAttributes = map[string]string{
+	"display_name":               getAccTestResourceName(),
+	"description":                "Terraform-provisioned IPsec Route-Based VPN",
+	"enabled":                    "true",
+	"vpn_type":                   "RouteBased",
+	"authentication_mode":        "PSK",
+	"compliance_suite":           "NONE",
+	"ip_addresses":               "169.254.152.25",
+	"prefix_length":              "24",
+	"peer_address":               "18.18.18.22",
+	"peer_id":                    "18.18.18.22",
+	"psk":                        "VMware123!",
+	"connection_initiation_mode": "INITIATOR",
+}
+
+var accTestPolicyIPSecVpnSessionRouteBasedUpdateAttributes = map[string]string{
+	"display_name":               getAccTestResourceName(),
+	"description":                "Terraform-provisioned IPsec Route-Based VPN",
+	"enabled":                    "true",
+	"vpn_type":                   "RouteBased",
+	"authentication_mode":        "PSK",
+	"compliance_suite":           "NONE",
+	"ip_addresses":               "169.254.152.26",
+	"prefix_length":              "24",
+	"peer_address":               "18.18.18.21",
+	"peer_id":                    "18.18.18.21",
+	"psk":                        "VMware123!",
+	"connection_initiation_mode": "INITIATOR",
+}
+
+var accTestPolicyIPSecVpnSessionPolicyBasedCreateAttributes = map[string]string{
+	"display_name":               getAccTestResourceName(),
+	"description":                "Terraform-provisioned IPsec Route-Based VPN",
+	"enabled":                    "true",
+	"vpn_type":                   "PolicyBased",
+	"authentication_mode":        "PSK",
+	"compliance_suite":           "NONE",
+	"peer_address":               "18.18.18.21",
+	"peer_id":                    "18.18.18.21",
+	"psk":                        "VMware123!",
+	"connection_initiation_mode": "RESPOND_ONLY",
+	"sources":                    "192.170.10.0/24",
+	"destinations":               "192.171.10.0/24",
+	"action":                     "PROTECT",
+}
+
+var accTestPolicyIPSecVpnSessionPolicyBasedUpdateAttributes = map[string]string{
+	"display_name":               getAccTestResourceName(),
+	"description":                "Terraform-provisioned IPsec Route-Based VPN",
+	"enabled":                    "true",
+	"vpn_type":                   "PolicyBased",
+	"authentication_mode":        "PSK",
+	"compliance_suite":           "NONE",
+	"peer_address":               "18.18.18.22",
+	"peer_id":                    "18.18.18.22",
+	"psk":                        "VMware123!",
+	"connection_initiation_mode": "RESPOND_ONLY",
+	"sources":                    "192.172.10.0/24",
+	"destinations":               "192.173.10.0/24",
+	"action":                     "PROTECT",
+}
+
+func TestAccResourceNsxtPolicyIPSecVpnSessionRouteBased_basic(t *testing.T) {
+	testResourceName := "nsxt_policy_ipsec_vpn_session.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t); testAccOnlyLocalManager(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyIPSecVpnSessionCheckDestroy(state, accTestPolicyIPSecVpnSessionRouteBasedCreateAttributes["display_name"])
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyIPSecVpnSessionRouteBasedTemplate(true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicyIPSecVpnSessionExists(accTestPolicyIPSecVpnSessionRouteBasedCreateAttributes["display_name"], testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestPolicyIPSecVpnSessionRouteBasedCreateAttributes["display_name"]),
+					resource.TestCheckResourceAttr(testResourceName, "description", accTestPolicyIPSecVpnSessionRouteBasedCreateAttributes["description"]),
+					resource.TestCheckResourceAttrSet(testResourceName, "ike_profile_path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "tunnel_profile_path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "dpd_profile_path"),
+					resource.TestCheckResourceAttr(testResourceName, "enabled", accTestPolicyIPSecVpnSessionRouteBasedCreateAttributes["enabled"]),
+					resource.TestCheckResourceAttrSet(testResourceName, "service_path"),
+					resource.TestCheckResourceAttr(testResourceName, "vpn_type", accTestPolicyIPSecVpnSessionRouteBasedCreateAttributes["vpn_type"]),
+					resource.TestCheckResourceAttr(testResourceName, "authentication_mode", accTestPolicyIPSecVpnSessionRouteBasedCreateAttributes["authentication_mode"]),
+					resource.TestCheckResourceAttr(testResourceName, "compliance_suite", accTestPolicyIPSecVpnSessionRouteBasedCreateAttributes["compliance_suite"]),
+					resource.TestCheckResourceAttr(testResourceName, "ip_addresses.0", accTestPolicyIPSecVpnSessionRouteBasedCreateAttributes["ip_addresses"]),
+					resource.TestCheckResourceAttr(testResourceName, "prefix_length", accTestPolicyIPSecVpnSessionRouteBasedCreateAttributes["prefix_length"]),
+					resource.TestCheckResourceAttr(testResourceName, "peer_address", accTestPolicyIPSecVpnSessionRouteBasedCreateAttributes["peer_address"]),
+					resource.TestCheckResourceAttr(testResourceName, "peer_id", accTestPolicyIPSecVpnSessionRouteBasedCreateAttributes["peer_id"]),
+					resource.TestCheckResourceAttr(testResourceName, "psk", accTestPolicyIPSecVpnSessionRouteBasedCreateAttributes["psk"]),
+					resource.TestCheckResourceAttr(testResourceName, "connection_initiation_mode", accTestPolicyIPSecVpnSessionRouteBasedCreateAttributes["connection_initiation_mode"]),
+
+					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
+				),
+			},
+			{
+				Config: testAccNsxtPolicyIPSecVpnSessionRouteBasedTemplate(false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicyIPSecVpnSessionExists(accTestPolicyIPSecVpnSessionRouteBasedUpdateAttributes["display_name"], testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestPolicyIPSecVpnSessionRouteBasedUpdateAttributes["display_name"]),
+					resource.TestCheckResourceAttr(testResourceName, "description", accTestPolicyIPSecVpnSessionRouteBasedUpdateAttributes["description"]),
+					resource.TestCheckResourceAttrSet(testResourceName, "ike_profile_path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "tunnel_profile_path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "dpd_profile_path"),
+					resource.TestCheckResourceAttr(testResourceName, "enabled", accTestPolicyIPSecVpnSessionRouteBasedUpdateAttributes["enabled"]),
+					resource.TestCheckResourceAttrSet(testResourceName, "service_path"),
+					resource.TestCheckResourceAttr(testResourceName, "vpn_type", accTestPolicyIPSecVpnSessionRouteBasedUpdateAttributes["vpn_type"]),
+					resource.TestCheckResourceAttr(testResourceName, "authentication_mode", accTestPolicyIPSecVpnSessionRouteBasedUpdateAttributes["authentication_mode"]),
+					resource.TestCheckResourceAttr(testResourceName, "compliance_suite", accTestPolicyIPSecVpnSessionRouteBasedUpdateAttributes["compliance_suite"]),
+					resource.TestCheckResourceAttr(testResourceName, "ip_addresses.0", accTestPolicyIPSecVpnSessionRouteBasedUpdateAttributes["ip_addresses"]),
+					resource.TestCheckResourceAttr(testResourceName, "prefix_length", accTestPolicyIPSecVpnSessionRouteBasedUpdateAttributes["prefix_length"]),
+					resource.TestCheckResourceAttr(testResourceName, "peer_address", accTestPolicyIPSecVpnSessionRouteBasedUpdateAttributes["peer_address"]),
+					resource.TestCheckResourceAttr(testResourceName, "peer_id", accTestPolicyIPSecVpnSessionRouteBasedUpdateAttributes["peer_id"]),
+					resource.TestCheckResourceAttr(testResourceName, "psk", accTestPolicyIPSecVpnSessionRouteBasedUpdateAttributes["psk"]),
+					resource.TestCheckResourceAttr(testResourceName, "connection_initiation_mode", accTestPolicyIPSecVpnSessionRouteBasedUpdateAttributes["connection_initiation_mode"]),
+
+					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceNsxtPolicyIPSecVpnSessionPolicyBased_basic(t *testing.T) {
+	testResourceName := "nsxt_policy_ipsec_vpn_session.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t); testAccOnlyLocalManager(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyIPSecVpnSessionCheckDestroy(state, accTestPolicyIPSecVpnSessionPolicyBasedCreateAttributes["display_name"])
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyIPSecVpnSessionPolicyBasedTemplate(true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicyIPSecVpnSessionExists(accTestPolicyIPSecVpnSessionPolicyBasedCreateAttributes["display_name"], testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestPolicyIPSecVpnSessionPolicyBasedCreateAttributes["display_name"]),
+					resource.TestCheckResourceAttr(testResourceName, "description", accTestPolicyIPSecVpnSessionPolicyBasedCreateAttributes["description"]),
+					resource.TestCheckResourceAttrSet(testResourceName, "ike_profile_path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "tunnel_profile_path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "dpd_profile_path"),
+					resource.TestCheckResourceAttr(testResourceName, "enabled", accTestPolicyIPSecVpnSessionPolicyBasedCreateAttributes["enabled"]),
+					resource.TestCheckResourceAttrSet(testResourceName, "service_path"),
+					resource.TestCheckResourceAttr(testResourceName, "vpn_type", accTestPolicyIPSecVpnSessionPolicyBasedCreateAttributes["vpn_type"]),
+					resource.TestCheckResourceAttr(testResourceName, "authentication_mode", accTestPolicyIPSecVpnSessionPolicyBasedCreateAttributes["authentication_mode"]),
+					resource.TestCheckResourceAttr(testResourceName, "compliance_suite", accTestPolicyIPSecVpnSessionPolicyBasedCreateAttributes["compliance_suite"]),
+					resource.TestCheckResourceAttr(testResourceName, "peer_address", accTestPolicyIPSecVpnSessionPolicyBasedCreateAttributes["peer_address"]),
+					resource.TestCheckResourceAttr(testResourceName, "peer_id", accTestPolicyIPSecVpnSessionPolicyBasedCreateAttributes["peer_id"]),
+					resource.TestCheckResourceAttr(testResourceName, "psk", accTestPolicyIPSecVpnSessionPolicyBasedCreateAttributes["psk"]),
+					resource.TestCheckResourceAttr(testResourceName, "connection_initiation_mode", accTestPolicyIPSecVpnSessionPolicyBasedCreateAttributes["connection_initiation_mode"]),
+					resource.TestCheckResourceAttr(testResourceName, "rule.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.0.sources.0", accTestPolicyIPSecVpnSessionPolicyBasedCreateAttributes["sources"]),
+					resource.TestCheckResourceAttr(testResourceName, "rule.0.destinations.0", accTestPolicyIPSecVpnSessionPolicyBasedCreateAttributes["destinations"]),
+					resource.TestCheckResourceAttr(testResourceName, "rule.0.action", accTestPolicyIPSecVpnSessionPolicyBasedCreateAttributes["action"]),
+
+					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
+				),
+			},
+			{
+				Config: testAccNsxtPolicyIPSecVpnSessionPolicyBasedTemplate(false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicyIPSecVpnSessionExists(accTestPolicyIPSecVpnSessionPolicyBasedUpdateAttributes["display_name"], testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestPolicyIPSecVpnSessionPolicyBasedUpdateAttributes["display_name"]),
+					resource.TestCheckResourceAttr(testResourceName, "description", accTestPolicyIPSecVpnSessionPolicyBasedUpdateAttributes["description"]),
+					resource.TestCheckResourceAttrSet(testResourceName, "ike_profile_path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "tunnel_profile_path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "dpd_profile_path"),
+					resource.TestCheckResourceAttr(testResourceName, "enabled", accTestPolicyIPSecVpnSessionPolicyBasedUpdateAttributes["enabled"]),
+					resource.TestCheckResourceAttrSet(testResourceName, "service_path"),
+					resource.TestCheckResourceAttr(testResourceName, "vpn_type", accTestPolicyIPSecVpnSessionPolicyBasedUpdateAttributes["vpn_type"]),
+					resource.TestCheckResourceAttr(testResourceName, "authentication_mode", accTestPolicyIPSecVpnSessionPolicyBasedUpdateAttributes["authentication_mode"]),
+					resource.TestCheckResourceAttr(testResourceName, "compliance_suite", accTestPolicyIPSecVpnSessionPolicyBasedUpdateAttributes["compliance_suite"]),
+					resource.TestCheckResourceAttr(testResourceName, "peer_address", accTestPolicyIPSecVpnSessionPolicyBasedUpdateAttributes["peer_address"]),
+					resource.TestCheckResourceAttr(testResourceName, "peer_id", accTestPolicyIPSecVpnSessionPolicyBasedUpdateAttributes["peer_id"]),
+					resource.TestCheckResourceAttr(testResourceName, "psk", accTestPolicyIPSecVpnSessionPolicyBasedUpdateAttributes["psk"]),
+					resource.TestCheckResourceAttr(testResourceName, "connection_initiation_mode", accTestPolicyIPSecVpnSessionPolicyBasedUpdateAttributes["connection_initiation_mode"]),
+					resource.TestCheckResourceAttr(testResourceName, "rule.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.0.sources.0", accTestPolicyIPSecVpnSessionPolicyBasedUpdateAttributes["sources"]),
+					resource.TestCheckResourceAttr(testResourceName, "rule.0.destinations.0", accTestPolicyIPSecVpnSessionPolicyBasedUpdateAttributes["destinations"]),
+					resource.TestCheckResourceAttr(testResourceName, "rule.0.action", accTestPolicyIPSecVpnSessionPolicyBasedUpdateAttributes["action"]),
+
+					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func testAccNsxtPolicyIPSecVpnSessionExists(displayName string, resourceName string) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+
+		connector := getPolicyConnector(testAccProvider.Meta().(nsxtClients))
+
+		rs, ok := state.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Policy IPSecVpnSession resource %s not found in resources", displayName)
+		}
+
+		resourceID := rs.Primary.Attributes["id"]
+		servicePath := rs.Primary.Attributes["service_path"]
+		isT0, gwID, localeServiceID, serviceID, err := parseIPSecVPNServicePolicyPath(servicePath)
+		if err != nil {
+			return err
+		}
+		if !isT0 {
+			return fmt.Errorf("VPN is supported only on Tier-0 with ACTIVE-STANDBY HA mode")
+		}
+		if resourceID == "" {
+			return fmt.Errorf("Policy IPSecVpnSession resource ID not set in resources")
+		}
+
+		exists, err := resourceNsxtPolicyIPSecVpnSessionExists(gwID, localeServiceID, serviceID, resourceID, connector)
+		if err != nil {
+			return err
+		}
+		if !exists {
+			return fmt.Errorf("Policy IPSecVpnSession %s does not exist", displayName)
+		}
+
+		return nil
+	}
+}
+
+func testAccNsxtPolicyIPSecVpnSessionCheckDestroy(state *terraform.State, displayName string) error {
+	connector := getPolicyConnector(testAccProvider.Meta().(nsxtClients))
+	for _, rs := range state.RootModule().Resources {
+
+		if rs.Type != "nsxt_policy_ipsec_vpn_session" {
+			continue
+		}
+
+		resourceID := rs.Primary.Attributes["id"]
+		servicePath := rs.Primary.Attributes["service_path"]
+		isT0, gwID, localeServiceID, serviceID, err := parseIPSecVPNServicePolicyPath(servicePath)
+		if err != nil {
+			return err
+		}
+		if !isT0 {
+			return fmt.Errorf("VPN is supported only on Tier-0 with ACTIVE-STANDBY HA mode")
+		}
+
+		exists, err := resourceNsxtPolicyIPSecVpnSessionExists(gwID, localeServiceID, serviceID, resourceID, connector)
+		if err == nil {
+			return err
+		}
+
+		if exists {
+			return fmt.Errorf("Policy IPSecVpnSession %s still exists", displayName)
+		}
+	}
+	return nil
+}
+
+func testAccNsxtPolicyIPSecVpnSessionPreConditionTemplate() string {
+	return fmt.Sprintf(`
+resource "nsxt_policy_ipsec_vpn_ike_profile" "test" {
+	display_name          = "%s"
+	description           = "Ike profile for ipsec vpn session"
+	encryption_algorithms = ["AES_128"]
+	digest_algorithms     = ["SHA2_256"]
+	dh_groups             = ["GROUP14"]
+	ike_version           = "IKE_V2"
+}
+
+resource "nsxt_policy_ipsec_vpn_tunnel_profile" "test" {
+	display_name          = "%s"
+	description           = "Terraform provisioned IPSec VPN Ike Profile"
+	df_policy             = "COPY"
+	encryption_algorithms = ["AES_128"]
+	digest_algorithms     = ["SHA2_256"]
+	dh_groups             = ["GROUP14"]
+	sa_life_time          = 7200
+}
+
+resource "nsxt_policy_ipsec_vpn_dpd_profile" "test" {
+	display_name       = "%s"
+	description        = "Terraform provisioned IPSec VPN DPD Profile"
+	dpd_probe_mode     = "ON_DEMAND"
+	dpd_probe_interval = 1
+	enabled            = true
+	retry_count        = 8
+  }
+
+resource "nsxt_policy_ipsec_vpn_service" "test" {
+	display_name          = "%s"
+	locale_service_path   = one(nsxt_policy_tier0_gateway.test.locale_service).path
+  }
+
+resource "nsxt_policy_ipsec_vpn_local_endpoint" "test" {
+	service_path  = nsxt_policy_ipsec_vpn_service.test.path
+	display_name  = "%s"
+	local_address = "20.20.0.25"
+  }
+`, getAccTestResourceName(), getAccTestResourceName(), getAccTestResourceName(), getAccTestResourceName(), getAccTestResourceName())
+}
+
+func testAccNsxtPolicyIPSecVpnSessionRouteBasedTemplate(createFlow bool) string {
+	var attrMap map[string]string
+	if createFlow {
+		attrMap = accTestPolicyIPSecVpnSessionRouteBasedCreateAttributes
+	} else {
+		attrMap = accTestPolicyIPSecVpnSessionRouteBasedUpdateAttributes
+	}
+	return testAccNsxtPolicyEdgeClusterReadTemplate(getEdgeClusterName()) +
+		testAccNsxtPolicyTier0WithEdgeClusterForVPN("test") +
+		testAccNsxtPolicyIPSecVpnSessionPreConditionTemplate() +
+		fmt.Sprintf(`
+resource "nsxt_policy_ipsec_vpn_session" "test" {
+	display_name               = "%s"
+	description                = "%s"
+	ike_profile_path           = nsxt_policy_ipsec_vpn_ike_profile.test.path
+	tunnel_profile_path        = nsxt_policy_ipsec_vpn_tunnel_profile.test.path
+	dpd_profile_path		   = nsxt_policy_ipsec_vpn_dpd_profile.test.path
+	local_endpoint_path		   = nsxt_policy_ipsec_vpn_local_endpoint.test.path
+	enabled                    = "%s"
+	service_path               = nsxt_policy_ipsec_vpn_service.test.path
+	vpn_type                   = "%s"
+	authentication_mode        = "%s"
+	compliance_suite           = "%s"
+	ip_addresses               = ["%s"]
+	prefix_length              = "%s"
+	peer_address               = "%s"
+	peer_id                    = "%s"
+	psk                        = "%s"
+	connection_initiation_mode = "%s"
+
+	tag {
+	scope = "scope1"
+	tag   = "tag1"
+	  }
+}`, attrMap["display_name"], attrMap["description"], attrMap["enabled"], attrMap["vpn_type"],
+			attrMap["authentication_mode"], attrMap["compliance_suite"], attrMap["ip_addresses"], attrMap["prefix_length"], attrMap["peer_address"], attrMap["peer_id"],
+			attrMap["psk"], attrMap["connection_initiation_mode"])
+}
+
+func testAccNsxtPolicyIPSecVpnSessionPolicyBasedTemplate(createFlow bool) string {
+	var attrMap map[string]string
+	if createFlow {
+		attrMap = accTestPolicyIPSecVpnSessionPolicyBasedCreateAttributes
+	} else {
+		attrMap = accTestPolicyIPSecVpnSessionPolicyBasedUpdateAttributes
+	}
+	return testAccNsxtPolicyEdgeClusterReadTemplate(getEdgeClusterName()) +
+		testAccNsxtPolicyTier0WithEdgeClusterForVPN("test") +
+		testAccNsxtPolicyIPSecVpnSessionPreConditionTemplate() +
+		fmt.Sprintf(`
+resource "nsxt_policy_ipsec_vpn_session" "test" {
+	display_name               = "%s"
+	description                = "%s"
+	ike_profile_path           = nsxt_policy_ipsec_vpn_ike_profile.test.path
+	tunnel_profile_path        = nsxt_policy_ipsec_vpn_tunnel_profile.test.path
+	dpd_profile_path		   = nsxt_policy_ipsec_vpn_dpd_profile.test.path
+	local_endpoint_path		   = nsxt_policy_ipsec_vpn_local_endpoint.test.path
+	enabled                    = "%s"
+	service_path               = nsxt_policy_ipsec_vpn_service.test.path
+	vpn_type                   = "%s"
+	authentication_mode        = "%s"
+	compliance_suite           = "%s"
+	peer_address               = "%s"
+	peer_id                    = "%s"
+	psk                        = "%s"
+	connection_initiation_mode = "%s"
+
+	rule {
+		sources             = ["%s"]
+		destinations        = ["%s"]
+		action              = "%s"
+	  }
+
+	tag {
+	scope = "scope1"
+	tag   = "tag1"
+	  }
+}`, attrMap["display_name"], attrMap["description"], attrMap["enabled"], attrMap["vpn_type"],
+			attrMap["authentication_mode"], attrMap["compliance_suite"], attrMap["peer_address"], attrMap["peer_id"],
+			attrMap["psk"], attrMap["connection_initiation_mode"], attrMap["sources"], attrMap["destinations"], attrMap["action"])
+}

--- a/nsxt/resource_nsxt_policy_l2_vpn_service.go
+++ b/nsxt/resource_nsxt_policy_l2_vpn_service.go
@@ -1,0 +1,245 @@
+/* Copyright © 2022 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: MPL-2.0 */
+
+package nsxt
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
+	t0_locale_service "github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_0s/locale_services"
+	t1_locale_service "github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_1s/locale_services"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+)
+
+var L2VpnServiceModes = []string{
+	model.L2VPNService_MODE_SERVER,
+	model.L2VPNService_MODE_CLIENT,
+}
+
+func resourceNsxtPolicyL2VpnService() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceNsxtPolicyL2VpnServiceCreate,
+		Read:   resourceNsxtPolicyL2VpnServiceRead,
+		Update: resourceNsxtPolicyL2VpnServiceUpdate,
+		Delete: resourceNsxtPolicyL2VpnServiceDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"nsx_id":              getNsxIDSchema(),
+			"path":                getPathSchema(),
+			"display_name":        getDisplayNameSchema(),
+			"description":         getDescriptionSchema(),
+			"revision":            getRevisionSchema(),
+			"tag":                 getTagsSchema(),
+			"locale_service_path": getPolicyPathSchema(true, false, "Polciy path for the locale service."),
+			"enable_hub": {
+				Type:        schema.TypeBool,
+				Description: "This property applies only in SERVER mode. If set to true, traffic from any client will be replicated to all other clients. If set to false, traffic received from clients is only replicated to the local VPN endpoint.",
+				Optional:    true,
+				Default:     true,
+			},
+			"encap_ip_pool": {
+				Type:        schema.TypeList,
+				Description: "IP Pool to allocate local and peer endpoint IPs.",
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validateIPCidr(),
+				},
+				Optional: true,
+			},
+			"mode": {
+				Type:         schema.TypeString,
+				Description:  "Specify an L2VPN service mode as SERVER or CLIENT.",
+				ValidateFunc: validation.StringInSlice(L2VpnServiceModes, false),
+				Optional:     true,
+				Default:      model.L2VPNService_MODE_SERVER,
+			},
+		},
+	}
+}
+
+func getNsxtPolicyL2VpnServiceByID(connector *client.RestConnector, gwID string, isT0 bool, localeServiceID string, serviceID string, isGlobalManager bool) (model.L2VPNService, error) {
+	if isT0 {
+		client := t0_locale_service.NewL2vpnServicesClient(connector)
+		return client.Get(gwID, localeServiceID, serviceID)
+	}
+	client := t1_locale_service.NewL2vpnServicesClient(connector)
+	return client.Get(gwID, localeServiceID, serviceID)
+}
+
+func patchNsxtPolicyL2VpnService(connector *client.RestConnector, gwID string, localeServiceID string, l2VpnService model.L2VPNService, isT0 bool) error {
+	id := *l2VpnService.Id
+	if isT0 {
+		client := t0_locale_service.NewL2vpnServicesClient(connector)
+		return client.Patch(gwID, localeServiceID, id, l2VpnService)
+	}
+	client := t1_locale_service.NewL2vpnServicesClient(connector)
+	return client.Patch(gwID, localeServiceID, id, l2VpnService)
+}
+
+func deleteNsxtPolicyL2VpnService(connector *client.RestConnector, gwID string, localeServiceID string, isT0 bool, id string) error {
+	if isT0 {
+		client := t0_locale_service.NewL2vpnServicesClient(connector)
+		return client.Delete(gwID, localeServiceID, id)
+	}
+	client := t1_locale_service.NewL2vpnServicesClient(connector)
+	return client.Delete(gwID, localeServiceID, id)
+}
+
+func resourceNsxtPolicyL2VpnServiceRead(d *schema.ResourceData, m interface{}) error {
+	connector := getPolicyConnector(m)
+
+	id := d.Id()
+	if id == "" {
+		return fmt.Errorf("Error obtaining L2VpnService ID")
+	}
+	localeServicePath := d.Get("locale_service_path").(string)
+	isT0, gwID, localeServiceID, err := parseLocaleServicePolicyPath(localeServicePath)
+	if err != nil {
+		return err
+	}
+	obj, err := getNsxtPolicyL2VpnServiceByID(connector, gwID, isT0, localeServiceID, id, isPolicyGlobalManager(m))
+	if err != nil {
+		return handleReadError(d, "L2VpnService", id, err)
+	}
+	d.Set("display_name", obj.DisplayName)
+	d.Set("description", obj.Description)
+	setPolicyTagsInSchema(d, obj.Tags)
+	d.Set("nsx_id", id)
+	d.Set("path", obj.Path)
+	d.Set("revision", obj.Revision)
+	d.Set("enable_hub", obj.EnableHub)
+	d.Set("mode", obj.Mode)
+
+	if obj.EncapIpPool != nil {
+		d.Set("encap_ip_pool", obj.EncapIpPool)
+	}
+	return nil
+}
+
+func resourceNsxtPolicyL2VpnServiceCreate(d *schema.ResourceData, m interface{}) error {
+	connector := getPolicyConnector(m)
+	localeServicePath := d.Get("locale_service_path").(string)
+	isT0, gwID, localeServiceID, err := parseLocaleServicePolicyPath(localeServicePath)
+	if err != nil {
+		return err
+	}
+	isGlobalManager := isPolicyGlobalManager(m)
+	id := d.Get("nsx_id").(string)
+	if id == "" {
+		id = newUUID()
+	} else {
+		_, err := getNsxtPolicyL2VpnServiceByID(connector, gwID, isT0, localeServiceID, id, isGlobalManager)
+		if err == nil {
+			return fmt.Errorf("L2VpnService with nsx_id '%s' already exists", id)
+		} else if !isNotFoundError(err) {
+			return err
+		}
+	}
+
+	displayName := d.Get("display_name").(string)
+	description := d.Get("description").(string)
+	enableHub := d.Get("enable_hub").(bool)
+	mode := d.Get("mode").(string)
+	tags := getPolicyTagsFromSchema(d)
+
+	l2VpnService := model.L2VPNService{
+		Id:          &id,
+		DisplayName: &displayName,
+		Description: &description,
+		Tags:        tags,
+		EnableHub:   &enableHub,
+		Mode:        &mode,
+	}
+
+	ipPool := d.Get("encap_ip_pool").([]interface{})
+	encapIPPool := make([]string, 0, len(ipPool))
+	for _, s := range ipPool {
+		encapIPPool = append(encapIPPool, s.(string))
+	}
+	if len(encapIPPool) != 0 {
+		l2VpnService.EncapIpPool = encapIPPool
+	}
+
+	err = patchNsxtPolicyL2VpnService(connector, gwID, localeServiceID, l2VpnService, isT0)
+	if err != nil {
+		return handleCreateError("L2VpnService", id, err)
+	}
+	d.SetId(id)
+	d.Set("nsx_id", id)
+	return resourceNsxtPolicyL2VpnServiceRead(d, m)
+}
+
+func resourceNsxtPolicyL2VpnServiceUpdate(d *schema.ResourceData, m interface{}) error {
+	connector := getPolicyConnector(m)
+
+	id := d.Id()
+	if id == "" {
+		return fmt.Errorf("Error obtaining L2 VPN Service ID")
+	}
+	localeServicePath := d.Get("locale_service_path").(string)
+	isT0, gwID, localeServiceID, err := parseLocaleServicePolicyPath(localeServicePath)
+	if err != nil {
+		return err
+	}
+
+	displayName := d.Get("display_name").(string)
+	description := d.Get("description").(string)
+	enableHub := d.Get("enable_hub").(bool)
+	revision := int64(d.Get("revision").(int))
+	mode := d.Get("mode").(string)
+	tags := getPolicyTagsFromSchema(d)
+
+	l2VpnService := model.L2VPNService{
+		Id:          &id,
+		DisplayName: &displayName,
+		Description: &description,
+		Tags:        tags,
+		EnableHub:   &enableHub,
+		Mode:        &mode,
+		Revision:    &revision,
+	}
+
+	ipPool := d.Get("encap_ip_pool").([]interface{})
+	encapIPPool := make([]string, 0, len(ipPool))
+	for _, s := range ipPool {
+		encapIPPool = append(encapIPPool, s.(string))
+	}
+	if len(encapIPPool) != 0 {
+		l2VpnService.EncapIpPool = encapIPPool
+	}
+
+	log.Printf("[INFO] Updating L2VpnService with ID %s", id)
+	err = patchNsxtPolicyL2VpnService(connector, gwID, localeServiceID, l2VpnService, isT0)
+	if err != nil {
+		return handleUpdateError("L2VpnService", id, err)
+	}
+	d.SetId(id)
+	d.Set("nsx_id", id)
+	return resourceNsxtPolicyL2VpnServiceRead(d, m)
+}
+
+func resourceNsxtPolicyL2VpnServiceDelete(d *schema.ResourceData, m interface{}) error {
+	id := d.Id()
+	if id == "" {
+		return fmt.Errorf("Error obtaining L2 VPN Service ID")
+	}
+
+	localeServicePath := d.Get("locale_service_path").(string)
+	isT0, gwID, localeServiceID, err := parseLocaleServicePolicyPath(localeServicePath)
+	if err != nil {
+		return err
+	}
+
+	err = deleteNsxtPolicyL2VpnService(getPolicyConnector(m), gwID, localeServiceID, isT0, id)
+	if err != nil {
+		return handleDeleteError("L2VpnService", id, err)
+	}
+	return nil
+}

--- a/nsxt/resource_nsxt_policy_l2_vpn_service_test.go
+++ b/nsxt/resource_nsxt_policy_l2_vpn_service_test.go
@@ -1,0 +1,217 @@
+/* Copyright © 2022 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: MPL-2.0 */
+
+package nsxt
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+var accTestPolicyL2VpnServiceCreateAttributes = map[string]string{
+	"display_name":  getAccTestResourceName(),
+	"description":   "terraform created",
+	"enable_hub":    "true",
+	"mode":          "SERVER",
+	"encap_ip_pool": "192.168.12.0/24",
+}
+
+var accTestPolicyL2VpnServiceUpdateAttributes = map[string]string{
+	"display_name":  getAccTestResourceName(),
+	"description":   "terraform created",
+	"enable_hub":    "false",
+	"mode":          "SERVER",
+	"encap_ip_pool": "192.168.13.0/24",
+}
+
+var accTestPolicyL2VpnServiceCreateClientModeAttributes = map[string]string{
+	"display_name":  getAccTestResourceName(),
+	"description":   "terraform created",
+	"enable_hub":    "false",
+	"mode":          "CLIENT",
+	"encap_ip_pool": "192.168.12.0/24",
+}
+
+func TestAccResourceNsxtPolicyL2VpnService_basic(t *testing.T) {
+	testResourceName := "nsxt_policy_l2_vpn_service.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t); testAccOnlyLocalManager(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyL2VpnServiceCheckDestroy(state, accTestPolicyL2VpnServiceUpdateAttributes["display_name"])
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyL2VpnServiceMinimalistic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicyL2VpnServiceExists(accTestPolicyL2VpnServiceCreateAttributes["display_name"], testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "description", ""),
+					resource.TestCheckResourceAttrSet(testResourceName, "locale_service_path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+					resource.TestCheckResourceAttr(testResourceName, "tag.#", "0"),
+				),
+			},
+			{
+				Config: testAccNsxtPolicyL2VpnServiceTemplate(true, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicyL2VpnServiceExists(accTestPolicyL2VpnServiceCreateAttributes["display_name"], testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestPolicyL2VpnServiceCreateAttributes["display_name"]),
+					resource.TestCheckResourceAttr(testResourceName, "description", accTestPolicyL2VpnServiceCreateAttributes["description"]),
+					resource.TestCheckResourceAttrSet(testResourceName, "locale_service_path"),
+					resource.TestCheckResourceAttr(testResourceName, "enable_hub", accTestPolicyL2VpnServiceCreateAttributes["enable_hub"]),
+					resource.TestCheckResourceAttr(testResourceName, "mode", accTestPolicyL2VpnServiceCreateAttributes["mode"]),
+					resource.TestCheckResourceAttr(testResourceName, "encap_ip_pool.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "encap_ip_pool.0", accTestPolicyL2VpnServiceCreateAttributes["encap_ip_pool"]),
+					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
+				),
+			},
+			{
+				Config: testAccNsxtPolicyL2VpnServiceTemplate(false, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicyL2VpnServiceExists(accTestPolicyL2VpnServiceUpdateAttributes["display_name"], testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestPolicyL2VpnServiceUpdateAttributes["display_name"]),
+					resource.TestCheckResourceAttr(testResourceName, "description", accTestPolicyL2VpnServiceUpdateAttributes["description"]),
+					resource.TestCheckResourceAttrSet(testResourceName, "locale_service_path"),
+					resource.TestCheckResourceAttr(testResourceName, "enable_hub", accTestPolicyL2VpnServiceUpdateAttributes["enable_hub"]),
+					resource.TestCheckResourceAttr(testResourceName, "mode", accTestPolicyL2VpnServiceUpdateAttributes["mode"]),
+					resource.TestCheckResourceAttr(testResourceName, "encap_ip_pool.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "encap_ip_pool.0", accTestPolicyL2VpnServiceUpdateAttributes["encap_ip_pool"]),
+					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceNsxtPolicyL2VpnService_ClientMode(t *testing.T) {
+	testResourceName := "nsxt_policy_l2_vpn_service.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t); testAccOnlyLocalManager(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyL2VpnServiceCheckDestroy(state, accTestPolicyL2VpnServiceCreateClientModeAttributes["display_name"])
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyL2VpnServiceTemplate(false, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicyL2VpnServiceExists(accTestPolicyL2VpnServiceCreateClientModeAttributes["display_name"], testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestPolicyL2VpnServiceCreateClientModeAttributes["display_name"]),
+					resource.TestCheckResourceAttr(testResourceName, "description", accTestPolicyL2VpnServiceCreateClientModeAttributes["description"]),
+					resource.TestCheckResourceAttrSet(testResourceName, "locale_service_path"),
+					resource.TestCheckResourceAttr(testResourceName, "enable_hub", accTestPolicyL2VpnServiceCreateClientModeAttributes["enable_hub"]),
+					resource.TestCheckResourceAttr(testResourceName, "mode", accTestPolicyL2VpnServiceCreateClientModeAttributes["mode"]),
+					resource.TestCheckResourceAttr(testResourceName, "encap_ip_pool.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "encap_ip_pool.0", accTestPolicyL2VpnServiceCreateClientModeAttributes["encap_ip_pool"]),
+					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func testAccNsxtPolicyL2VpnServiceExists(displayName string, resourceName string) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+
+		connector := getPolicyConnector(testAccProvider.Meta().(nsxtClients))
+
+		rs, ok := state.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Policy L2VpnService resource %s not found in resources", resourceName)
+		}
+
+		resourceID := rs.Primary.ID
+		if resourceID == "" {
+			return fmt.Errorf("Policy L2VpnService resource ID not set in resources")
+		}
+
+		localeServicePath := rs.Primary.Attributes["locale_service_path"]
+		isT0, gwID, localeServiceID, err := parseLocaleServicePolicyPath(localeServicePath)
+
+		if err != nil {
+			return nil
+		}
+		_, err1 := getNsxtPolicyL2VpnServiceByID(connector, gwID, isT0, localeServiceID, resourceID, testAccIsGlobalManager())
+		if err1 != nil {
+			return fmt.Errorf("Policy L2VpnService %s does not exist", displayName)
+		}
+
+		return nil
+	}
+}
+
+func testAccNsxtPolicyL2VpnServiceCheckDestroy(state *terraform.State, displayName string) error {
+	connector := getPolicyConnector(testAccProvider.Meta().(nsxtClients))
+	for _, rs := range state.RootModule().Resources {
+
+		if rs.Type != "nsxt_policy_l2_vpn_service" {
+			continue
+		}
+
+		resourceID := rs.Primary.Attributes["id"]
+		localeServicePath := rs.Primary.Attributes["locale_service_path"]
+		isT0, gwID, localeServiceID, err := parseLocaleServicePolicyPath(localeServicePath)
+
+		if err != nil {
+			return nil
+		}
+
+		_, err1 := getNsxtPolicyL2VpnServiceByID(connector, gwID, isT0, localeServiceID, resourceID, testAccIsGlobalManager())
+		if err1 == nil {
+			return fmt.Errorf("Policy L2VpnService %s still exists", displayName)
+		}
+	}
+	return nil
+}
+
+func testAccNsxtPolicyL2VpnServiceTemplate(createFlow bool, clientMode bool) string {
+	var attrMap map[string]string
+	if clientMode {
+		attrMap = accTestPolicyL2VpnServiceCreateClientModeAttributes
+	} else {
+		if createFlow {
+			attrMap = accTestPolicyL2VpnServiceCreateAttributes
+		} else {
+			attrMap = accTestPolicyL2VpnServiceUpdateAttributes
+		}
+	}
+	return testAccNsxtPolicyEdgeClusterReadTemplate(getEdgeClusterName()) +
+		testAccNsxtPolicyTier0WithEdgeClusterForVPN("test") + fmt.Sprintf(`
+	  resource "nsxt_policy_l2_vpn_service" "test" {
+		display_name                   = "%s"
+		description                    = "%s"
+		locale_service_path   		   = one(nsxt_policy_tier0_gateway.test.locale_service).path
+		enable_hub                     = "%s"
+		mode               			   = "%s"
+		encap_ip_pool 				   = ["%s"]
+		tag {
+		  scope = "scope1"
+		  tag   = "tag1"
+		}
+	  }`, attrMap["display_name"], attrMap["description"], attrMap["enable_hub"], attrMap["mode"], attrMap["encap_ip_pool"])
+}
+
+func testAccNsxtPolicyL2VpnServiceMinimalistic() string {
+	return testAccNsxtPolicyEdgeClusterReadTemplate(getEdgeClusterName()) +
+		testAccNsxtPolicyTier0WithEdgeClusterForVPN("test") + fmt.Sprintf(`
+	  resource "nsxt_policy_l2_vpn_service" "test" {
+		display_name          = "%s"
+		locale_service_path   = one(nsxt_policy_tier0_gateway.test.locale_service).path
+	  }`, accTestPolicyL2VpnServiceUpdateAttributes["display_name"])
+}

--- a/nsxt/resource_nsxt_policy_l2_vpn_session.go
+++ b/nsxt/resource_nsxt_policy_l2_vpn_session.go
@@ -1,0 +1,340 @@
+/* Copyright © 2022 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: MPL-2.0 */
+
+package nsxt
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_0s/locale_services/l2vpn_services"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+)
+
+var L2VpnSessionTCPSegmentClampingDirection = []string{
+	model.L2TcpMaxSegmentSizeClamping_DIRECTION_NONE,
+	model.L2TcpMaxSegmentSizeClamping_DIRECTION_BOTH,
+}
+
+var L2VpnTunnelEncapsulationProtocal = []string{
+	model.L2VPNTunnelEncapsulation_PROTOCOL_GRE,
+}
+
+func resourceNsxtPolicyL2VPNSession() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceNsxtPolicyL2VPNSessionCreate,
+		Read:   resourceNsxtPolicyL2VPNSessionRead,
+		Update: resourceNsxtPolicyL2VPNSessionUpdate,
+		Delete: resourceNsxtPolicyL2VPNSessionDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"nsx_id":       getNsxIDSchema(),
+			"path":         getPathSchema(),
+			"display_name": getDisplayNameSchema(),
+			"description":  getDescriptionSchema(),
+			"revision":     getRevisionSchema(),
+			"tag":          getTagsSchema(),
+			"service_path": getPolicyPathSchema(true, true, "Policy path for L2 VPN service"),
+			"enabled": {
+				Type:        schema.TypeBool,
+				Description: "Enable/Disable IPSec VPN session.",
+				Optional:    true,
+				Default:     true,
+			},
+			"transport_tunnels": {
+				Type:        schema.TypeList,
+				Description: "List of transport tunnels(vpn sessions path) for redundancy",
+				Required:    true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"direction": {
+				Type:         schema.TypeString,
+				Description:  "The traffic direction apply to the MSS clamping",
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice(L2VpnSessionTCPSegmentClampingDirection, false),
+			},
+			"max_segment_size": {
+				Type:         schema.TypeInt,
+				Description:  "Maximum amount of data the host will accept in a Tcp segment.",
+				Optional:     true,
+				ValidateFunc: validation.IntBetween(108, 8860),
+			},
+			"local_address": {
+				Type:         schema.TypeString,
+				Description:  "IP Address of the local tunnel port. This property only applies in CLIENT mode",
+				Optional:     true,
+				ValidateFunc: validation.IsIPv4Address,
+			},
+			"peer_address": {
+				Type:         schema.TypeString,
+				Description:  "IP Address of the peer tunnel port. This property only applies in CLIENT mode",
+				Optional:     true,
+				ValidateFunc: validation.IsIPv4Address,
+			},
+			"protocol": {
+				Type:         schema.TypeString,
+				Description:  "Encapsulation protocol used by the tunnel.",
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice(L2VpnTunnelEncapsulationProtocal, false),
+			},
+		},
+	}
+}
+
+func resourceNsxtPolicyL2VPNSessionCreate(d *schema.ResourceData, m interface{}) error {
+	connector := getPolicyConnector(m)
+
+	servicePath := d.Get("service_path").(string)
+	isT0, gwID, localeServiceID, serviceID, err := parseL2VPNServicePolicyPath(servicePath)
+	if err != nil {
+		return err
+	}
+	if !isT0 {
+		return fmt.Errorf("VPN is supported only on Tier-0 with ACTIVE-STANDBY HA mode")
+	}
+	transportTunnel := getStringListFromSchemaList(d, "transport_tunnels")
+	id := d.Get("nsx_id").(string)
+	if id == "" {
+		id = newUUID()
+	}
+	_, err = resourceNsxtPolicyL2VpnSessionExists(gwID, localeServiceID, serviceID, id, connector)
+	if err == nil {
+		return fmt.Errorf("L2VpnSession with nsx_id '%s' already exists.'", id)
+	} else if !isNotFoundError(err) {
+		return err
+	}
+	displayName := d.Get("display_name").(string)
+	description := d.Get("description").(string)
+	enabled := d.Get("enabled").(bool)
+	tags := getPolicyTagsFromSchema(d)
+
+	obj := model.L2VPNSession{
+		DisplayName:      &displayName,
+		Description:      &description,
+		Enabled:          &enabled,
+		Tags:             tags,
+		TransportTunnels: transportTunnel,
+	}
+
+	if nsxVersionHigherOrEqual("3.2.0") {
+		direction := d.Get("direction").(string)
+		maxSegmentSize := int64(d.Get("max_segment_size").(int))
+		if direction != "" {
+			l2TcpMSSClamping := model.L2TcpMaxSegmentSizeClamping{
+				Direction:      &direction,
+				MaxSegmentSize: &maxSegmentSize,
+			}
+			obj.TcpMssClamping = &l2TcpMSSClamping
+		}
+		localAddress := d.Get("local_address").(string)
+		peerAddress := d.Get("peer_address").(string)
+		protocol := d.Get("protocol").(string)
+		if localAddress != "" && peerAddress != "" {
+			l2VpnTunnelEncapsulation := model.L2VPNTunnelEncapsulation{
+				LocalEndpointAddress: &localAddress,
+				PeerEndpointAddress:  &peerAddress,
+				Protocol:             &protocol,
+			}
+			obj.TunnelEncapsulation = &l2VpnTunnelEncapsulation
+		}
+	}
+
+	client := l2vpn_services.NewSessionsClient(connector)
+	err = client.Patch(gwID, localeServiceID, serviceID, id, obj)
+
+	if err != nil {
+		return handleCreateError("L2VPNSession", id, err)
+	}
+
+	d.SetId(id)
+	d.Set("nsx_id", id)
+
+	return resourceNsxtPolicyL2VPNSessionRead(d, m)
+}
+
+func parseL2VPNServicePolicyPath(path string) (bool, string, string, string, error) {
+	segs := strings.Split(path, "/")
+	// Path should be like /infra/tier-1s/aaa/l2vpn-services/default/ipsec-vpn-services/ccc
+	segCount := len(segs)
+	if (segCount < 8) || (segs[segCount-2] != "l2vpn-services") {
+		// error - this is not a segment path
+		return false, "", "", "", fmt.Errorf("Invalid L2 VPN service path %s", path)
+	}
+
+	serviceID := segs[segCount-1]
+	localeServiceID := segs[5]
+	gwPath := strings.Join(segs[:4], "/")
+
+	isT0, gwID := parseGatewayPolicyPath(gwPath)
+	return isT0, gwID, localeServiceID, serviceID, nil
+}
+
+func resourceNsxtPolicyL2VPNSessionRead(d *schema.ResourceData, m interface{}) error {
+	connector := getPolicyConnector(m)
+	servicePath := d.Get("service_path").(string)
+	isT0, gwID, localeServiceID, serviceID, err := parseL2VPNServicePolicyPath(servicePath)
+	if err != nil {
+		return err
+	}
+	if !isT0 {
+		return fmt.Errorf("VPN is supported only on Tier-0 with ACTIVE-STANDBY HA mode")
+	}
+	id := d.Id()
+	if id == "" {
+		return fmt.Errorf("Error obtaining L2VPNSession ID")
+	}
+
+	var obj model.L2VPNSession
+
+	client := l2vpn_services.NewSessionsClient(connector)
+	obj, err = client.Get(gwID, localeServiceID, serviceID, id)
+	if err != nil {
+		return handleReadError(d, "L2VPNSession", id, err)
+	}
+
+	d.Set("display_name", obj.DisplayName)
+	d.Set("description", obj.Description)
+	setPolicyTagsInSchema(d, obj.Tags)
+	d.Set("nsx_id", id)
+	d.Set("path", obj.Path)
+	d.Set("revision", obj.Revision)
+	d.Set("enabled", obj.Enabled)
+
+	if len(obj.TransportTunnels) > 0 {
+		d.Set("transport_tunnels", obj.TransportTunnels)
+	}
+	if nsxVersionHigherOrEqual("3.2.0") {
+		if obj.TcpMssClamping != nil {
+			direction := obj.TcpMssClamping.Direction
+			mss := obj.TcpMssClamping.MaxSegmentSize
+			d.Set("direction", direction)
+			d.Set("max_segment_size", mss)
+		}
+		if obj.TunnelEncapsulation != nil {
+			localAddress := obj.TunnelEncapsulation.LocalEndpointAddress
+			peerAddress := obj.TunnelEncapsulation.PeerEndpointAddress
+			protocol := obj.TunnelEncapsulation.Protocol
+			d.Set("local_address", localAddress)
+			d.Set("peer_address", peerAddress)
+			d.Set("protocol", protocol)
+		}
+	}
+	d.SetId(id)
+
+	return nil
+}
+
+func resourceNsxtPolicyL2VpnSessionExists(tier0ID string, localeServiceID string, serviceID string, sessionID string, connector *client.RestConnector) (bool, error) {
+	client := l2vpn_services.NewSessionsClient(connector)
+	_, err := client.Get(tier0ID, localeServiceID, serviceID, sessionID)
+	if err == nil {
+		return true, nil
+	}
+
+	if isNotFoundError(err) {
+		return false, err
+	}
+
+	return false, logAPIError("Error retrieving resource", err)
+}
+
+func resourceNsxtPolicyL2VPNSessionUpdate(d *schema.ResourceData, m interface{}) error {
+	connector := getPolicyConnector(m)
+	servicePath := d.Get("service_path").(string)
+	isT0, gwID, localeServiceID, serviceID, err := parseL2VPNServicePolicyPath(servicePath)
+	if err != nil {
+		return err
+	}
+	if !isT0 {
+		return fmt.Errorf("VPN is supported only on Tier-0 with ACTIVE-STANDBY HA mode")
+	}
+	transportTunnel := getStringListFromSchemaList(d, "transport_tunnels")
+
+	id := d.Id()
+	if id == "" {
+		return fmt.Errorf("Error obtaining L2VPNSession ID")
+	}
+
+	// Read the rest of the configured parameters
+	description := d.Get("description").(string)
+	displayName := d.Get("display_name").(string)
+	revision := int64(d.Get("revision").(int))
+	enabled := d.Get("enabled").(bool)
+	tags := getPolicyTagsFromSchema(d)
+	obj := model.L2VPNSession{
+		DisplayName:      &displayName,
+		Description:      &description,
+		Tags:             tags,
+		TransportTunnels: transportTunnel,
+		Revision:         &revision,
+		Enabled:          &enabled,
+	}
+	if nsxVersionHigherOrEqual("3.2.0") {
+		direction := d.Get("direction").(string)
+		maxSegmentSize := int64(d.Get("max_segment_size").(int))
+		if direction != "" {
+			l2TcpMSSClamping := model.L2TcpMaxSegmentSizeClamping{
+				Direction:      &direction,
+				MaxSegmentSize: &maxSegmentSize,
+			}
+			obj.TcpMssClamping = &l2TcpMSSClamping
+		}
+		localAddress := d.Get("local_address").(string)
+		peerAddress := d.Get("peer_address").(string)
+		protocol := d.Get("protocol").(string)
+		if localAddress != "" && peerAddress != "" {
+			l2VpnTunnelEncapsulation := model.L2VPNTunnelEncapsulation{
+				LocalEndpointAddress: &localAddress,
+				PeerEndpointAddress:  &peerAddress,
+				Protocol:             &protocol,
+			}
+			obj.TunnelEncapsulation = &l2VpnTunnelEncapsulation
+		}
+	}
+
+	client := l2vpn_services.NewSessionsClient(connector)
+	err = client.Patch(gwID, localeServiceID, serviceID, id, obj)
+
+	if err != nil {
+		return handleUpdateError("L2VPNSession", id, err)
+	}
+
+	return resourceNsxtPolicyL2VPNSessionRead(d, m)
+
+}
+
+func resourceNsxtPolicyL2VPNSessionDelete(d *schema.ResourceData, m interface{}) error {
+
+	servicePath := d.Get("service_path").(string)
+	isT0, gwID, localeServiceID, serviceID, err := parseL2VPNServicePolicyPath(servicePath)
+	if err != nil {
+		return err
+	}
+	if !isT0 {
+		return fmt.Errorf("VPN is supported only on Tier-0 with ACTIVE-STANDBY HA mode")
+	}
+
+	id := d.Id()
+	if id == "" {
+		return fmt.Errorf("Error obtaining L2VPNSession ID")
+	}
+
+	connector := getPolicyConnector(m)
+
+	client := l2vpn_services.NewSessionsClient(connector)
+	err = client.Delete(gwID, localeServiceID, serviceID, id)
+
+	if err != nil {
+		return handleDeleteError("L2VPNSession", id, err)
+	}
+
+	return nil
+}

--- a/nsxt/resource_nsxt_policy_l2_vpn_session_test.go
+++ b/nsxt/resource_nsxt_policy_l2_vpn_session_test.go
@@ -1,0 +1,252 @@
+/* Copyright © 2022 VMware, Inc. All Rights Reserved.
+SPDX-License-Identifier: MPL-2.0 */
+
+package nsxt
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+var accTestPolicyL2VpnSessionCreateAttributes = map[string]string{
+	"display_name":     getAccTestResourceName(),
+	"description":      "Terraform-provisioned L2 VPN Session.",
+	"direction":        "NONE",
+	"max_segment_size": "109",
+	"local_address":    "10.12.23.45",
+	"peer_address":     "10.12.34.56",
+	"protocol":         "GRE",
+}
+
+var accTestPolicyL2VpnSessionUpdateAttributes = map[string]string{
+	"display_name":     getAccTestResourceName(),
+	"description":      "Terraform-provisioned L2 VPN Session (updated).",
+	"direction":        "BOTH",
+	"max_segment_size": "128",
+	"local_address":    "10.23.32.42",
+	"peer_address":     "10.11.33.32",
+	"protocol":         "GRE",
+}
+
+func TestAccResourceNsxtPolicyL2VpnSession_basic(t *testing.T) {
+	testResourceName := "nsxt_policy_l2_vpn_session.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t); testAccOnlyLocalManager(t); testAccNSXVersionLessThan(t, "3.2.0") },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyL2VpnSessionCheckDestroy(state, accTestPolicyL2VpnSessionCreateAttributes["display_name"])
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyL2VpnSessionTestTemplate(true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicyL2VpnSessionExists(accTestPolicyL2VpnSessionCreateAttributes["display_name"], testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestPolicyL2VpnSessionCreateAttributes["display_name"]),
+					resource.TestCheckResourceAttr(testResourceName, "description", accTestPolicyL2VpnSessionCreateAttributes["description"]),
+					resource.TestCheckResourceAttrSet(testResourceName, "service_path"),
+					resource.TestCheckResourceAttr(testResourceName, "transport_tunnels.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "direction", accTestPolicyL2VpnSessionCreateAttributes["direction"]),
+					resource.TestCheckResourceAttr(testResourceName, "max_segment_size", accTestPolicyL2VpnSessionCreateAttributes["max_segment_size"]),
+					resource.TestCheckResourceAttr(testResourceName, "local_address", accTestPolicyL2VpnSessionCreateAttributes["local_address"]),
+					resource.TestCheckResourceAttr(testResourceName, "peer_address", accTestPolicyL2VpnSessionCreateAttributes["peer_address"]),
+					resource.TestCheckResourceAttr(testResourceName, "protocol", accTestPolicyL2VpnSessionCreateAttributes["protocol"]),
+
+					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
+				),
+			},
+			{
+				Config: testAccNsxtPolicyL2VpnSessionTestTemplate(false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicyL2VpnSessionExists(accTestPolicyL2VpnSessionUpdateAttributes["display_name"], testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestPolicyL2VpnSessionUpdateAttributes["display_name"]),
+					resource.TestCheckResourceAttr(testResourceName, "description", accTestPolicyL2VpnSessionUpdateAttributes["description"]),
+					resource.TestCheckResourceAttrSet(testResourceName, "service_path"),
+					resource.TestCheckResourceAttr(testResourceName, "transport_tunnels.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "direction", accTestPolicyL2VpnSessionUpdateAttributes["direction"]),
+					resource.TestCheckResourceAttr(testResourceName, "max_segment_size", accTestPolicyL2VpnSessionUpdateAttributes["max_segment_size"]),
+					resource.TestCheckResourceAttr(testResourceName, "local_address", accTestPolicyL2VpnSessionUpdateAttributes["local_address"]),
+					resource.TestCheckResourceAttr(testResourceName, "peer_address", accTestPolicyL2VpnSessionUpdateAttributes["peer_address"]),
+					resource.TestCheckResourceAttr(testResourceName, "protocol", accTestPolicyL2VpnSessionUpdateAttributes["protocol"]),
+
+					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func testAccNsxtPolicyL2VpnSessionExists(displayName string, resourceName string) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+
+		connector := getPolicyConnector(testAccProvider.Meta().(nsxtClients))
+
+		rs, ok := state.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Policy L2VpnSession resource %s not found in resources", resourceName)
+		}
+
+		resourceID := rs.Primary.Attributes["id"]
+		servicePath := rs.Primary.Attributes["service_path"]
+		isT0, gwID, localeServiceID, serviceID, err := parseL2VPNServicePolicyPath(servicePath)
+		if err != nil {
+			return err
+		}
+		if !isT0 {
+			return fmt.Errorf("VPN is supported only on Tier-0 with ACTIVE-STANDBY HA mode")
+		}
+		if resourceID == "" {
+			return fmt.Errorf("Policy L2VpnSession resource ID not set in resources")
+		}
+
+		exists, err := resourceNsxtPolicyL2VpnSessionExists(gwID, localeServiceID, serviceID, resourceID, connector)
+		if err != nil {
+			return err
+		}
+		if !exists {
+			return fmt.Errorf("Policy L2VpnSession %s does not exist", resourceID)
+		}
+
+		return nil
+	}
+}
+
+func testAccNsxtPolicyL2VpnSessionCheckDestroy(state *terraform.State, displayName string) error {
+	connector := getPolicyConnector(testAccProvider.Meta().(nsxtClients))
+	for _, rs := range state.RootModule().Resources {
+
+		if rs.Type != "nsxt_policy_l2_vpn_session" {
+			continue
+		}
+
+		resourceID := rs.Primary.Attributes["id"]
+		servicePath := rs.Primary.Attributes["service_path"]
+		isT0, gwID, localeServiceID, serviceID, err := parseL2VPNServicePolicyPath(servicePath)
+		if err != nil {
+			return err
+		}
+		if !isT0 {
+			return fmt.Errorf("VPN is supported only on Tier-0 with ACTIVE-STANDBY HA mode")
+		}
+
+		exists, err := resourceNsxtPolicyL2VpnSessionExists(gwID, localeServiceID, serviceID, resourceID, connector)
+		if err == nil {
+			return err
+		}
+
+		if exists {
+			return fmt.Errorf("Policy L2VpnSession %s still exists", displayName)
+		}
+	}
+	return nil
+}
+
+func testAccNsxtPolicyL2VpnSessionPreConditionTemplate() string {
+	return fmt.Sprintf(`
+resource "nsxt_policy_ipsec_vpn_service" "test" {
+	display_name          = "%s"
+	locale_service_path   = one(nsxt_policy_tier0_gateway.test.locale_service).path
+	}
+
+resource "nsxt_policy_ipsec_vpn_ike_profile" "test" {
+	display_name          = "%s"
+	description           = "Ike profile for ipsec vpn session"
+	encryption_algorithms = ["AES_128"]
+	digest_algorithms     = ["SHA2_256"]
+	dh_groups             = ["GROUP14"]
+	ike_version           = "IKE_V2"
+}
+
+resource "nsxt_policy_l2_vpn_service" "test" {
+	display_name          = "%s"
+	description           = "Terraform provisioned L2 VPN service"
+	locale_service_path   = one(nsxt_policy_tier0_gateway.test.locale_service).path
+	enable_hub            = true
+	mode                  = "SERVER"
+	encap_ip_pool         = ["192.168.10.0/24"]
+	}
+resource "nsxt_policy_ipsec_vpn_dpd_profile" "test" {
+	display_name       = "%s"
+	description        = "Terraform provisioned IPSec VPN DPD Profile"
+	dpd_probe_mode     = "ON_DEMAND"
+	dpd_probe_interval = 1
+	enabled            = true
+	retry_count        = 8
+	}
+
+resource "nsxt_policy_ipsec_vpn_local_endpoint" "test" {
+	service_path  = nsxt_policy_ipsec_vpn_service.test.path
+	display_name  = "%s"
+	local_address = "20.20.0.20"
+}
+
+resource "nsxt_policy_ipsec_vpn_tunnel_profile" "test" {
+	display_name          = "%s"
+	description           = "Terraform provisioned IPSec VPN Ike Profile"
+	df_policy             = "COPY"
+	encryption_algorithms = ["AES_GCM_128"]
+	dh_groups             = ["GROUP14"]
+	sa_life_time          = 7200
+}
+
+resource "nsxt_policy_ipsec_vpn_session" "test" {
+	display_name               = "%s"
+	tunnel_profile_path        = nsxt_policy_ipsec_vpn_tunnel_profile.test.path
+	local_endpoint_path		   = nsxt_policy_ipsec_vpn_local_endpoint.test.path
+	dpd_profile_path		   = nsxt_policy_ipsec_vpn_dpd_profile.test.path
+	ike_profile_path		   = nsxt_policy_ipsec_vpn_ike_profile.test.path
+	service_path               = nsxt_policy_ipsec_vpn_service.test.path
+	vpn_type                   = "RouteBased"
+	authentication_mode        = "PSK"
+	peer_address               = "18.18.18.19"
+	peer_id                    = "18.18.18.19"
+	psk                        = "VMware123!"
+	ip_addresses               = ["169.254.152.2"]
+	prefix_length              = 24
+}
+`, getAccTestResourceName(), getAccTestResourceName(), getAccTestResourceName(), getAccTestResourceName(), getAccTestResourceName(), getAccTestResourceName(), getAccTestResourceName())
+}
+
+func testAccNsxtPolicyL2VpnSessionTestTemplate(createFlow bool) string {
+	return testAccNsxtPolicyEdgeClusterReadTemplate(getEdgeClusterName()) +
+		testAccNsxtPolicyTier0WithEdgeClusterForVPN("test") +
+		testAccNsxtPolicyL2VpnSessionPreConditionTemplate() +
+		testAccNsxtPolicyL2VpnSessionTemplate(createFlow)
+}
+
+func testAccNsxtPolicyL2VpnSessionTemplate(createFlow bool) string {
+	var attrMap map[string]string
+	if createFlow {
+		attrMap = accTestPolicyL2VpnSessionCreateAttributes
+	} else {
+		attrMap = accTestPolicyL2VpnSessionUpdateAttributes
+	}
+	return fmt.Sprintf(`
+resource "nsxt_policy_l2_vpn_session" "test" {
+	display_name      = "%s"
+	description       = "%s"
+	service_path      = nsxt_policy_l2_vpn_service.test.path
+	transport_tunnels = [nsxt_policy_ipsec_vpn_session.test.path]
+	direction         = "%s"
+  	max_segment_size  = "%s"
+	local_address     = "%s"
+	peer_address      = "%s"
+	protocol          = "%s"
+
+	tag {
+		scope = "scope1"
+		tag   = "tag1"
+		}
+}
+
+`, attrMap["display_name"], attrMap["description"], attrMap["direction"], attrMap["max_segment_size"], attrMap["local_address"], attrMap["peer_address"], attrMap["protocol"])
+}

--- a/nsxt/resource_nsxt_policy_security_policy_test.go
+++ b/nsxt/resource_nsxt_policy_security_policy_test.go
@@ -704,7 +704,7 @@ resource "nsxt_policy_service" "tcp778" {
 }`
 }
 
-//TODO: add profiles when available
+// TODO: add profiles when available
 func testAccNsxtPolicySecurityPolicyWithDepsCreate(name string) string {
 	return testAccNsxtPolicySecurityPolicyDeps() + fmt.Sprintf(`
 resource "nsxt_policy_security_policy" "test" {

--- a/nsxt/utils_test.go
+++ b/nsxt/utils_test.go
@@ -446,6 +446,19 @@ resource "nsxt_policy_tier%s_gateway" "test" {
 }`, tier, tier, edgeClusterName, haMode)
 }
 
+func testAccNsxtPolicyTier0WithEdgeClusterForVPN(edgeClusterName string) string {
+	// VPN is supported only on Tier-0 with ACTIVE-STANDBY HA mode
+	return fmt.Sprintf(`
+resource "nsxt_policy_tier0_gateway" "test" {
+  display_name = "%s"
+  description  = "Acceptance Test"
+  locale_service {
+    edge_cluster_path = data.nsxt_policy_edge_cluster.%s.path
+  }
+  ha_mode = "ACTIVE_STANDBY"
+}`, getAccTestResourceName(), edgeClusterName)
+}
+
 func testAccNsxtPolicyResourceExists(resourceName string, presenceChecker func(string, *client.RestConnector, bool) (bool, error)) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
 

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_0s/locale_services/ipsec_vpn_services/IpsecVpnServicesPackageTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_0s/locale_services/ipsec_vpn_services/IpsecVpnServicesPackageTypes.go
@@ -1,0 +1,11 @@
+// Copyright © 2019-2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+
+// Auto generated code. DO NOT EDIT.
+
+// Data type definitions file for package: com.vmware.nsx_policy.infra.tier_0s.locale_services.ipsec_vpn_services.
+// Includes binding types of a top level structures and enumerations.
+// Shared by client-side stubs and server-side skeletons to ensure type
+// compatibility.
+
+package ipsec_vpn_services

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_0s/locale_services/ipsec_vpn_services/LocalEndpointsClient.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_0s/locale_services/ipsec_vpn_services/LocalEndpointsClient.go
@@ -1,0 +1,292 @@
+// Copyright © 2019-2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+
+// Auto generated code. DO NOT EDIT.
+
+// Interface file for service: LocalEndpoints
+// Used by client-side stubs.
+
+package ipsec_vpn_services
+
+import (
+	"github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/bindings"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/core"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/lib"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+)
+
+const _ = core.SupportedByRuntimeVersion1
+
+type LocalEndpointsClient interface {
+
+	// Delete IPSec VPN local endpoint for a given locale service under Tier-0. This API is deprecated. Please use DELETE /infra/tier-0s/<tier-0-id>/ipsec-vpn-services/<service-id>/local-endpoints/<local-endpoint-id> instead. Note: Please note that request is validated and any error messages returned from validation may include the new VPN path instead of the deprecated path. Both new path and old path refer to same resource. Also VPN path returned in the Alarm, GPRR payload may include the new VPN path
+	//
+	// @param tier0IdParam (required)
+	// @param localeServiceIdParam (required)
+	// @param serviceIdParam (required)
+	// @param localEndpointIdParam (required)
+	// @throws InvalidRequest  Bad Request, Precondition Failed
+	// @throws Unauthorized  Forbidden
+	// @throws ServiceUnavailable  Service Unavailable
+	// @throws InternalServerError  Internal Server Error
+	// @throws NotFound  Not Found
+	Delete(tier0IdParam string, localeServiceIdParam string, serviceIdParam string, localEndpointIdParam string) error
+
+	// Get IPSec VPN local endpoint for a given locale service under Tier-0. This API is deprecated. Please use GET /infra/tier-0s/<tier-0-id>/ipsec-vpn-services/<service-id>/local-endpoints/<local-endpoint-id> instead. Note: Please note that request is validated and any error messages returned from validation may include the new VPN path instead of the deprecated path. Both new path and old path refer to same resource.
+	//
+	// @param tier0IdParam (required)
+	// @param localeServiceIdParam (required)
+	// @param serviceIdParam (required)
+	// @param localEndpointIdParam (required)
+	// @return com.vmware.nsx_policy.model.IPSecVpnLocalEndpoint
+	// @throws InvalidRequest  Bad Request, Precondition Failed
+	// @throws Unauthorized  Forbidden
+	// @throws ServiceUnavailable  Service Unavailable
+	// @throws InternalServerError  Internal Server Error
+	// @throws NotFound  Not Found
+	Get(tier0IdParam string, localeServiceIdParam string, serviceIdParam string, localEndpointIdParam string) (model.IPSecVpnLocalEndpoint, error)
+
+	// Get paginated list of all IPSec VPN local endpoints for a given locale service under Tier-0. This API is deprecated. Please use GET /infra/tier-0s/<tier-0-id>/ipsec-vpn-services/<service-id>/local-endpoints instead. Note: Please note that request is validated and any error messages returned from validation may include the new VPN path instead of the deprecated path. Both new path and old path refer to same resource.
+	//
+	// @param tier0IdParam (required)
+	// @param localeServiceIdParam (required)
+	// @param serviceIdParam (required)
+	// @param cursorParam Opaque cursor to be used for getting next page of records (supplied by current result page) (optional)
+	// @param includeMarkForDeleteObjectsParam Include objects that are marked for deletion in results (optional, default to false)
+	// @param includedFieldsParam Comma separated list of fields that should be included in query result (optional)
+	// @param pageSizeParam Maximum number of results to return in this page (server may return fewer) (optional, default to 1000)
+	// @param sortAscendingParam (optional)
+	// @param sortByParam Field by which records are sorted (optional)
+	// @return com.vmware.nsx_policy.model.IPSecVpnLocalEndpointListResult
+	// @throws InvalidRequest  Bad Request, Precondition Failed
+	// @throws Unauthorized  Forbidden
+	// @throws ServiceUnavailable  Service Unavailable
+	// @throws InternalServerError  Internal Server Error
+	// @throws NotFound  Not Found
+	List(tier0IdParam string, localeServiceIdParam string, serviceIdParam string, cursorParam *string, includeMarkForDeleteObjectsParam *bool, includedFieldsParam *string, pageSizeParam *int64, sortAscendingParam *bool, sortByParam *string) (model.IPSecVpnLocalEndpointListResult, error)
+
+	// Create or patch a custom IPSec VPN local endpoint for a given locale service under Tier-0. This API is deprecated. Please use PATCH /infra/tier-0s/<tier-0-id>/ipsec-vpn-services/<service-id>/local-endpoints/<local-endpoint-id> instead. Note: Please note that request is validated and any error messages returned from validation may include the new VPN path instead of the deprecated path. Both new path and old path refer to same resource. Also VPN path returned in the Alarm, GPRR payload may include the new VPN path
+	//
+	// @param tier0IdParam (required)
+	// @param localeServiceIdParam (required)
+	// @param serviceIdParam (required)
+	// @param localEndpointIdParam (required)
+	// @param ipSecVpnLocalEndpointParam (required)
+	// @throws InvalidRequest  Bad Request, Precondition Failed
+	// @throws Unauthorized  Forbidden
+	// @throws ServiceUnavailable  Service Unavailable
+	// @throws InternalServerError  Internal Server Error
+	// @throws NotFound  Not Found
+	Patch(tier0IdParam string, localeServiceIdParam string, serviceIdParam string, localEndpointIdParam string, ipSecVpnLocalEndpointParam model.IPSecVpnLocalEndpoint) error
+
+	// Create or fully replace IPSec VPN local endpoint for a given locale service under Tier-0. Revision is optional for creation and required for update. This API is deprecated. Please use PUT /infra/tier-0s/<tier-0-id>/ipsec-vpn-services/<service-id>/local-endpoints/<local-endpoint-id> instead. Note: Please note that request is validated and any error messages returned from validation may include the new VPN path instead of the deprecated path. Both new path and old path refer to same resource. Also VPN path returned in the Alarm, GPRR payload may include the new VPN path
+	//
+	// @param tier0IdParam (required)
+	// @param localeServiceIdParam (required)
+	// @param serviceIdParam (required)
+	// @param localEndpointIdParam (required)
+	// @param ipSecVpnLocalEndpointParam (required)
+	// @return com.vmware.nsx_policy.model.IPSecVpnLocalEndpoint
+	// @throws InvalidRequest  Bad Request, Precondition Failed
+	// @throws Unauthorized  Forbidden
+	// @throws ServiceUnavailable  Service Unavailable
+	// @throws InternalServerError  Internal Server Error
+	// @throws NotFound  Not Found
+	Update(tier0IdParam string, localeServiceIdParam string, serviceIdParam string, localEndpointIdParam string, ipSecVpnLocalEndpointParam model.IPSecVpnLocalEndpoint) (model.IPSecVpnLocalEndpoint, error)
+}
+
+type localEndpointsClient struct {
+	connector           client.Connector
+	interfaceDefinition core.InterfaceDefinition
+	errorsBindingMap    map[string]bindings.BindingType
+}
+
+func NewLocalEndpointsClient(connector client.Connector) *localEndpointsClient {
+	interfaceIdentifier := core.NewInterfaceIdentifier("com.vmware.nsx_policy.infra.tier_0s.locale_services.ipsec_vpn_services.local_endpoints")
+	methodIdentifiers := map[string]core.MethodIdentifier{
+		"delete": core.NewMethodIdentifier(interfaceIdentifier, "delete"),
+		"get":    core.NewMethodIdentifier(interfaceIdentifier, "get"),
+		"list":   core.NewMethodIdentifier(interfaceIdentifier, "list"),
+		"patch":  core.NewMethodIdentifier(interfaceIdentifier, "patch"),
+		"update": core.NewMethodIdentifier(interfaceIdentifier, "update"),
+	}
+	interfaceDefinition := core.NewInterfaceDefinition(interfaceIdentifier, methodIdentifiers)
+	errorsBindingMap := make(map[string]bindings.BindingType)
+
+	lIface := localEndpointsClient{interfaceDefinition: interfaceDefinition, errorsBindingMap: errorsBindingMap, connector: connector}
+	return &lIface
+}
+
+func (lIface *localEndpointsClient) GetErrorBindingType(errorName string) bindings.BindingType {
+	if entry, ok := lIface.errorsBindingMap[errorName]; ok {
+		return entry
+	}
+	return errors.ERROR_BINDINGS_MAP[errorName]
+}
+
+func (lIface *localEndpointsClient) Delete(tier0IdParam string, localeServiceIdParam string, serviceIdParam string, localEndpointIdParam string) error {
+	typeConverter := lIface.connector.TypeConverter()
+	executionContext := lIface.connector.NewExecutionContext()
+	sv := bindings.NewStructValueBuilder(localEndpointsDeleteInputType(), typeConverter)
+	sv.AddStructField("Tier0Id", tier0IdParam)
+	sv.AddStructField("LocaleServiceId", localeServiceIdParam)
+	sv.AddStructField("ServiceId", serviceIdParam)
+	sv.AddStructField("LocalEndpointId", localEndpointIdParam)
+	inputDataValue, inputError := sv.GetStructValue()
+	if inputError != nil {
+		return bindings.VAPIerrorsToError(inputError)
+	}
+	operationRestMetaData := localEndpointsDeleteRestMetadata()
+	connectionMetadata := map[string]interface{}{lib.REST_METADATA: operationRestMetaData}
+	connectionMetadata["isStreamingResponse"] = false
+	lIface.connector.SetConnectionMetadata(connectionMetadata)
+	methodResult := lIface.connector.GetApiProvider().Invoke("com.vmware.nsx_policy.infra.tier_0s.locale_services.ipsec_vpn_services.local_endpoints", "delete", inputDataValue, executionContext)
+	if methodResult.IsSuccess() {
+		return nil
+	} else {
+		methodError, errorInError := typeConverter.ConvertToGolang(methodResult.Error(), lIface.GetErrorBindingType(methodResult.Error().Name()))
+		if errorInError != nil {
+			return bindings.VAPIerrorsToError(errorInError)
+		}
+		return methodError.(error)
+	}
+}
+
+func (lIface *localEndpointsClient) Get(tier0IdParam string, localeServiceIdParam string, serviceIdParam string, localEndpointIdParam string) (model.IPSecVpnLocalEndpoint, error) {
+	typeConverter := lIface.connector.TypeConverter()
+	executionContext := lIface.connector.NewExecutionContext()
+	sv := bindings.NewStructValueBuilder(localEndpointsGetInputType(), typeConverter)
+	sv.AddStructField("Tier0Id", tier0IdParam)
+	sv.AddStructField("LocaleServiceId", localeServiceIdParam)
+	sv.AddStructField("ServiceId", serviceIdParam)
+	sv.AddStructField("LocalEndpointId", localEndpointIdParam)
+	inputDataValue, inputError := sv.GetStructValue()
+	if inputError != nil {
+		var emptyOutput model.IPSecVpnLocalEndpoint
+		return emptyOutput, bindings.VAPIerrorsToError(inputError)
+	}
+	operationRestMetaData := localEndpointsGetRestMetadata()
+	connectionMetadata := map[string]interface{}{lib.REST_METADATA: operationRestMetaData}
+	connectionMetadata["isStreamingResponse"] = false
+	lIface.connector.SetConnectionMetadata(connectionMetadata)
+	methodResult := lIface.connector.GetApiProvider().Invoke("com.vmware.nsx_policy.infra.tier_0s.locale_services.ipsec_vpn_services.local_endpoints", "get", inputDataValue, executionContext)
+	var emptyOutput model.IPSecVpnLocalEndpoint
+	if methodResult.IsSuccess() {
+		output, errorInOutput := typeConverter.ConvertToGolang(methodResult.Output(), localEndpointsGetOutputType())
+		if errorInOutput != nil {
+			return emptyOutput, bindings.VAPIerrorsToError(errorInOutput)
+		}
+		return output.(model.IPSecVpnLocalEndpoint), nil
+	} else {
+		methodError, errorInError := typeConverter.ConvertToGolang(methodResult.Error(), lIface.GetErrorBindingType(methodResult.Error().Name()))
+		if errorInError != nil {
+			return emptyOutput, bindings.VAPIerrorsToError(errorInError)
+		}
+		return emptyOutput, methodError.(error)
+	}
+}
+
+func (lIface *localEndpointsClient) List(tier0IdParam string, localeServiceIdParam string, serviceIdParam string, cursorParam *string, includeMarkForDeleteObjectsParam *bool, includedFieldsParam *string, pageSizeParam *int64, sortAscendingParam *bool, sortByParam *string) (model.IPSecVpnLocalEndpointListResult, error) {
+	typeConverter := lIface.connector.TypeConverter()
+	executionContext := lIface.connector.NewExecutionContext()
+	sv := bindings.NewStructValueBuilder(localEndpointsListInputType(), typeConverter)
+	sv.AddStructField("Tier0Id", tier0IdParam)
+	sv.AddStructField("LocaleServiceId", localeServiceIdParam)
+	sv.AddStructField("ServiceId", serviceIdParam)
+	sv.AddStructField("Cursor", cursorParam)
+	sv.AddStructField("IncludeMarkForDeleteObjects", includeMarkForDeleteObjectsParam)
+	sv.AddStructField("IncludedFields", includedFieldsParam)
+	sv.AddStructField("PageSize", pageSizeParam)
+	sv.AddStructField("SortAscending", sortAscendingParam)
+	sv.AddStructField("SortBy", sortByParam)
+	inputDataValue, inputError := sv.GetStructValue()
+	if inputError != nil {
+		var emptyOutput model.IPSecVpnLocalEndpointListResult
+		return emptyOutput, bindings.VAPIerrorsToError(inputError)
+	}
+	operationRestMetaData := localEndpointsListRestMetadata()
+	connectionMetadata := map[string]interface{}{lib.REST_METADATA: operationRestMetaData}
+	connectionMetadata["isStreamingResponse"] = false
+	lIface.connector.SetConnectionMetadata(connectionMetadata)
+	methodResult := lIface.connector.GetApiProvider().Invoke("com.vmware.nsx_policy.infra.tier_0s.locale_services.ipsec_vpn_services.local_endpoints", "list", inputDataValue, executionContext)
+	var emptyOutput model.IPSecVpnLocalEndpointListResult
+	if methodResult.IsSuccess() {
+		output, errorInOutput := typeConverter.ConvertToGolang(methodResult.Output(), localEndpointsListOutputType())
+		if errorInOutput != nil {
+			return emptyOutput, bindings.VAPIerrorsToError(errorInOutput)
+		}
+		return output.(model.IPSecVpnLocalEndpointListResult), nil
+	} else {
+		methodError, errorInError := typeConverter.ConvertToGolang(methodResult.Error(), lIface.GetErrorBindingType(methodResult.Error().Name()))
+		if errorInError != nil {
+			return emptyOutput, bindings.VAPIerrorsToError(errorInError)
+		}
+		return emptyOutput, methodError.(error)
+	}
+}
+
+func (lIface *localEndpointsClient) Patch(tier0IdParam string, localeServiceIdParam string, serviceIdParam string, localEndpointIdParam string, ipSecVpnLocalEndpointParam model.IPSecVpnLocalEndpoint) error {
+	typeConverter := lIface.connector.TypeConverter()
+	executionContext := lIface.connector.NewExecutionContext()
+	sv := bindings.NewStructValueBuilder(localEndpointsPatchInputType(), typeConverter)
+	sv.AddStructField("Tier0Id", tier0IdParam)
+	sv.AddStructField("LocaleServiceId", localeServiceIdParam)
+	sv.AddStructField("ServiceId", serviceIdParam)
+	sv.AddStructField("LocalEndpointId", localEndpointIdParam)
+	sv.AddStructField("IpSecVpnLocalEndpoint", ipSecVpnLocalEndpointParam)
+	inputDataValue, inputError := sv.GetStructValue()
+	if inputError != nil {
+		return bindings.VAPIerrorsToError(inputError)
+	}
+	operationRestMetaData := localEndpointsPatchRestMetadata()
+	connectionMetadata := map[string]interface{}{lib.REST_METADATA: operationRestMetaData}
+	connectionMetadata["isStreamingResponse"] = false
+	lIface.connector.SetConnectionMetadata(connectionMetadata)
+	methodResult := lIface.connector.GetApiProvider().Invoke("com.vmware.nsx_policy.infra.tier_0s.locale_services.ipsec_vpn_services.local_endpoints", "patch", inputDataValue, executionContext)
+	if methodResult.IsSuccess() {
+		return nil
+	} else {
+		methodError, errorInError := typeConverter.ConvertToGolang(methodResult.Error(), lIface.GetErrorBindingType(methodResult.Error().Name()))
+		if errorInError != nil {
+			return bindings.VAPIerrorsToError(errorInError)
+		}
+		return methodError.(error)
+	}
+}
+
+func (lIface *localEndpointsClient) Update(tier0IdParam string, localeServiceIdParam string, serviceIdParam string, localEndpointIdParam string, ipSecVpnLocalEndpointParam model.IPSecVpnLocalEndpoint) (model.IPSecVpnLocalEndpoint, error) {
+	typeConverter := lIface.connector.TypeConverter()
+	executionContext := lIface.connector.NewExecutionContext()
+	sv := bindings.NewStructValueBuilder(localEndpointsUpdateInputType(), typeConverter)
+	sv.AddStructField("Tier0Id", tier0IdParam)
+	sv.AddStructField("LocaleServiceId", localeServiceIdParam)
+	sv.AddStructField("ServiceId", serviceIdParam)
+	sv.AddStructField("LocalEndpointId", localEndpointIdParam)
+	sv.AddStructField("IpSecVpnLocalEndpoint", ipSecVpnLocalEndpointParam)
+	inputDataValue, inputError := sv.GetStructValue()
+	if inputError != nil {
+		var emptyOutput model.IPSecVpnLocalEndpoint
+		return emptyOutput, bindings.VAPIerrorsToError(inputError)
+	}
+	operationRestMetaData := localEndpointsUpdateRestMetadata()
+	connectionMetadata := map[string]interface{}{lib.REST_METADATA: operationRestMetaData}
+	connectionMetadata["isStreamingResponse"] = false
+	lIface.connector.SetConnectionMetadata(connectionMetadata)
+	methodResult := lIface.connector.GetApiProvider().Invoke("com.vmware.nsx_policy.infra.tier_0s.locale_services.ipsec_vpn_services.local_endpoints", "update", inputDataValue, executionContext)
+	var emptyOutput model.IPSecVpnLocalEndpoint
+	if methodResult.IsSuccess() {
+		output, errorInOutput := typeConverter.ConvertToGolang(methodResult.Output(), localEndpointsUpdateOutputType())
+		if errorInOutput != nil {
+			return emptyOutput, bindings.VAPIerrorsToError(errorInOutput)
+		}
+		return output.(model.IPSecVpnLocalEndpoint), nil
+	} else {
+		methodError, errorInError := typeConverter.ConvertToGolang(methodResult.Error(), lIface.GetErrorBindingType(methodResult.Error().Name()))
+		if errorInError != nil {
+			return emptyOutput, bindings.VAPIerrorsToError(errorInError)
+		}
+		return emptyOutput, methodError.(error)
+	}
+}

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_0s/locale_services/ipsec_vpn_services/LocalEndpointsTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_0s/locale_services/ipsec_vpn_services/LocalEndpointsTypes.go
@@ -1,0 +1,413 @@
+// Copyright © 2019-2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+
+// Auto generated code. DO NOT EDIT.
+
+// Data type definitions file for service: LocalEndpoints.
+// Includes binding types of a structures and enumerations defined in the service.
+// Shared by client-side stubs and server-side skeletons to ensure type
+// compatibility.
+
+package ipsec_vpn_services
+
+import (
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/bindings"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/data"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+	"reflect"
+)
+
+func localEndpointsDeleteInputType() bindings.StructType {
+	fields := make(map[string]bindings.BindingType)
+	fieldNameMap := make(map[string]string)
+	fields["tier0_id"] = bindings.NewStringType()
+	fields["locale_service_id"] = bindings.NewStringType()
+	fields["service_id"] = bindings.NewStringType()
+	fields["local_endpoint_id"] = bindings.NewStringType()
+	fieldNameMap["tier0_id"] = "Tier0Id"
+	fieldNameMap["locale_service_id"] = "LocaleServiceId"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["local_endpoint_id"] = "LocalEndpointId"
+	var validators = []bindings.Validator{}
+	return bindings.NewStructType("operation-input", fields, reflect.TypeOf(data.StructValue{}), fieldNameMap, validators)
+}
+
+func localEndpointsDeleteOutputType() bindings.BindingType {
+	return bindings.NewVoidType()
+}
+
+func localEndpointsDeleteRestMetadata() protocol.OperationRestMetadata {
+	fields := map[string]bindings.BindingType{}
+	fieldNameMap := map[string]string{}
+	paramsTypeMap := map[string]bindings.BindingType{}
+	pathParams := map[string]string{}
+	queryParams := map[string]string{}
+	headerParams := map[string]string{}
+	dispatchHeaderParams := map[string]string{}
+	bodyFieldsMap := map[string]string{}
+	fields["tier0_id"] = bindings.NewStringType()
+	fields["locale_service_id"] = bindings.NewStringType()
+	fields["service_id"] = bindings.NewStringType()
+	fields["local_endpoint_id"] = bindings.NewStringType()
+	fieldNameMap["tier0_id"] = "Tier0Id"
+	fieldNameMap["locale_service_id"] = "LocaleServiceId"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["local_endpoint_id"] = "LocalEndpointId"
+	paramsTypeMap["tier0_id"] = bindings.NewStringType()
+	paramsTypeMap["locale_service_id"] = bindings.NewStringType()
+	paramsTypeMap["service_id"] = bindings.NewStringType()
+	paramsTypeMap["local_endpoint_id"] = bindings.NewStringType()
+	paramsTypeMap["tier0Id"] = bindings.NewStringType()
+	paramsTypeMap["localeServiceId"] = bindings.NewStringType()
+	paramsTypeMap["serviceId"] = bindings.NewStringType()
+	paramsTypeMap["localEndpointId"] = bindings.NewStringType()
+	pathParams["local_endpoint_id"] = "localEndpointId"
+	pathParams["tier0_id"] = "tier0Id"
+	pathParams["locale_service_id"] = "localeServiceId"
+	pathParams["service_id"] = "serviceId"
+	resultHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
+	return protocol.NewOperationRestMetadata(
+		fields,
+		fieldNameMap,
+		paramsTypeMap,
+		pathParams,
+		queryParams,
+		headerParams,
+		dispatchHeaderParams,
+		bodyFieldsMap,
+		"",
+		"",
+		"DELETE",
+		"/policy/api/v1/infra/tier-0s/{tier0Id}/locale-services/{localeServiceId}/ipsec-vpn-services/{serviceId}/local-endpoints/{localEndpointId}",
+		"",
+		resultHeaders,
+		204,
+		"",
+		errorHeaders,
+		map[string]int{"com.vmware.vapi.std.errors.invalid_request": 400, "com.vmware.vapi.std.errors.unauthorized": 403, "com.vmware.vapi.std.errors.service_unavailable": 503, "com.vmware.vapi.std.errors.internal_server_error": 500, "com.vmware.vapi.std.errors.not_found": 404})
+}
+
+func localEndpointsGetInputType() bindings.StructType {
+	fields := make(map[string]bindings.BindingType)
+	fieldNameMap := make(map[string]string)
+	fields["tier0_id"] = bindings.NewStringType()
+	fields["locale_service_id"] = bindings.NewStringType()
+	fields["service_id"] = bindings.NewStringType()
+	fields["local_endpoint_id"] = bindings.NewStringType()
+	fieldNameMap["tier0_id"] = "Tier0Id"
+	fieldNameMap["locale_service_id"] = "LocaleServiceId"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["local_endpoint_id"] = "LocalEndpointId"
+	var validators = []bindings.Validator{}
+	return bindings.NewStructType("operation-input", fields, reflect.TypeOf(data.StructValue{}), fieldNameMap, validators)
+}
+
+func localEndpointsGetOutputType() bindings.BindingType {
+	return bindings.NewReferenceType(model.IPSecVpnLocalEndpointBindingType)
+}
+
+func localEndpointsGetRestMetadata() protocol.OperationRestMetadata {
+	fields := map[string]bindings.BindingType{}
+	fieldNameMap := map[string]string{}
+	paramsTypeMap := map[string]bindings.BindingType{}
+	pathParams := map[string]string{}
+	queryParams := map[string]string{}
+	headerParams := map[string]string{}
+	dispatchHeaderParams := map[string]string{}
+	bodyFieldsMap := map[string]string{}
+	fields["tier0_id"] = bindings.NewStringType()
+	fields["locale_service_id"] = bindings.NewStringType()
+	fields["service_id"] = bindings.NewStringType()
+	fields["local_endpoint_id"] = bindings.NewStringType()
+	fieldNameMap["tier0_id"] = "Tier0Id"
+	fieldNameMap["locale_service_id"] = "LocaleServiceId"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["local_endpoint_id"] = "LocalEndpointId"
+	paramsTypeMap["tier0_id"] = bindings.NewStringType()
+	paramsTypeMap["locale_service_id"] = bindings.NewStringType()
+	paramsTypeMap["service_id"] = bindings.NewStringType()
+	paramsTypeMap["local_endpoint_id"] = bindings.NewStringType()
+	paramsTypeMap["tier0Id"] = bindings.NewStringType()
+	paramsTypeMap["localeServiceId"] = bindings.NewStringType()
+	paramsTypeMap["serviceId"] = bindings.NewStringType()
+	paramsTypeMap["localEndpointId"] = bindings.NewStringType()
+	pathParams["local_endpoint_id"] = "localEndpointId"
+	pathParams["tier0_id"] = "tier0Id"
+	pathParams["locale_service_id"] = "localeServiceId"
+	pathParams["service_id"] = "serviceId"
+	resultHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
+	return protocol.NewOperationRestMetadata(
+		fields,
+		fieldNameMap,
+		paramsTypeMap,
+		pathParams,
+		queryParams,
+		headerParams,
+		dispatchHeaderParams,
+		bodyFieldsMap,
+		"",
+		"",
+		"GET",
+		"/policy/api/v1/infra/tier-0s/{tier0Id}/locale-services/{localeServiceId}/ipsec-vpn-services/{serviceId}/local-endpoints/{localEndpointId}",
+		"",
+		resultHeaders,
+		200,
+		"",
+		errorHeaders,
+		map[string]int{"com.vmware.vapi.std.errors.invalid_request": 400, "com.vmware.vapi.std.errors.unauthorized": 403, "com.vmware.vapi.std.errors.service_unavailable": 503, "com.vmware.vapi.std.errors.internal_server_error": 500, "com.vmware.vapi.std.errors.not_found": 404})
+}
+
+func localEndpointsListInputType() bindings.StructType {
+	fields := make(map[string]bindings.BindingType)
+	fieldNameMap := make(map[string]string)
+	fields["tier0_id"] = bindings.NewStringType()
+	fields["locale_service_id"] = bindings.NewStringType()
+	fields["service_id"] = bindings.NewStringType()
+	fields["cursor"] = bindings.NewOptionalType(bindings.NewStringType())
+	fields["include_mark_for_delete_objects"] = bindings.NewOptionalType(bindings.NewBooleanType())
+	fields["included_fields"] = bindings.NewOptionalType(bindings.NewStringType())
+	fields["page_size"] = bindings.NewOptionalType(bindings.NewIntegerType())
+	fields["sort_ascending"] = bindings.NewOptionalType(bindings.NewBooleanType())
+	fields["sort_by"] = bindings.NewOptionalType(bindings.NewStringType())
+	fieldNameMap["tier0_id"] = "Tier0Id"
+	fieldNameMap["locale_service_id"] = "LocaleServiceId"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["cursor"] = "Cursor"
+	fieldNameMap["include_mark_for_delete_objects"] = "IncludeMarkForDeleteObjects"
+	fieldNameMap["included_fields"] = "IncludedFields"
+	fieldNameMap["page_size"] = "PageSize"
+	fieldNameMap["sort_ascending"] = "SortAscending"
+	fieldNameMap["sort_by"] = "SortBy"
+	var validators = []bindings.Validator{}
+	return bindings.NewStructType("operation-input", fields, reflect.TypeOf(data.StructValue{}), fieldNameMap, validators)
+}
+
+func localEndpointsListOutputType() bindings.BindingType {
+	return bindings.NewReferenceType(model.IPSecVpnLocalEndpointListResultBindingType)
+}
+
+func localEndpointsListRestMetadata() protocol.OperationRestMetadata {
+	fields := map[string]bindings.BindingType{}
+	fieldNameMap := map[string]string{}
+	paramsTypeMap := map[string]bindings.BindingType{}
+	pathParams := map[string]string{}
+	queryParams := map[string]string{}
+	headerParams := map[string]string{}
+	dispatchHeaderParams := map[string]string{}
+	bodyFieldsMap := map[string]string{}
+	fields["tier0_id"] = bindings.NewStringType()
+	fields["locale_service_id"] = bindings.NewStringType()
+	fields["service_id"] = bindings.NewStringType()
+	fields["cursor"] = bindings.NewOptionalType(bindings.NewStringType())
+	fields["include_mark_for_delete_objects"] = bindings.NewOptionalType(bindings.NewBooleanType())
+	fields["included_fields"] = bindings.NewOptionalType(bindings.NewStringType())
+	fields["page_size"] = bindings.NewOptionalType(bindings.NewIntegerType())
+	fields["sort_ascending"] = bindings.NewOptionalType(bindings.NewBooleanType())
+	fields["sort_by"] = bindings.NewOptionalType(bindings.NewStringType())
+	fieldNameMap["tier0_id"] = "Tier0Id"
+	fieldNameMap["locale_service_id"] = "LocaleServiceId"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["cursor"] = "Cursor"
+	fieldNameMap["include_mark_for_delete_objects"] = "IncludeMarkForDeleteObjects"
+	fieldNameMap["included_fields"] = "IncludedFields"
+	fieldNameMap["page_size"] = "PageSize"
+	fieldNameMap["sort_ascending"] = "SortAscending"
+	fieldNameMap["sort_by"] = "SortBy"
+	paramsTypeMap["tier0_id"] = bindings.NewStringType()
+	paramsTypeMap["locale_service_id"] = bindings.NewStringType()
+	paramsTypeMap["service_id"] = bindings.NewStringType()
+	paramsTypeMap["included_fields"] = bindings.NewOptionalType(bindings.NewStringType())
+	paramsTypeMap["page_size"] = bindings.NewOptionalType(bindings.NewIntegerType())
+	paramsTypeMap["include_mark_for_delete_objects"] = bindings.NewOptionalType(bindings.NewBooleanType())
+	paramsTypeMap["cursor"] = bindings.NewOptionalType(bindings.NewStringType())
+	paramsTypeMap["sort_by"] = bindings.NewOptionalType(bindings.NewStringType())
+	paramsTypeMap["sort_ascending"] = bindings.NewOptionalType(bindings.NewBooleanType())
+	paramsTypeMap["tier0Id"] = bindings.NewStringType()
+	paramsTypeMap["localeServiceId"] = bindings.NewStringType()
+	paramsTypeMap["serviceId"] = bindings.NewStringType()
+	pathParams["tier0_id"] = "tier0Id"
+	pathParams["locale_service_id"] = "localeServiceId"
+	pathParams["service_id"] = "serviceId"
+	queryParams["cursor"] = "cursor"
+	queryParams["sort_ascending"] = "sort_ascending"
+	queryParams["included_fields"] = "included_fields"
+	queryParams["sort_by"] = "sort_by"
+	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
+	queryParams["page_size"] = "page_size"
+	resultHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
+	return protocol.NewOperationRestMetadata(
+		fields,
+		fieldNameMap,
+		paramsTypeMap,
+		pathParams,
+		queryParams,
+		headerParams,
+		dispatchHeaderParams,
+		bodyFieldsMap,
+		"",
+		"",
+		"GET",
+		"/policy/api/v1/infra/tier-0s/{tier0Id}/locale-services/{localeServiceId}/ipsec-vpn-services/{serviceId}/local-endpoints",
+		"",
+		resultHeaders,
+		200,
+		"",
+		errorHeaders,
+		map[string]int{"com.vmware.vapi.std.errors.invalid_request": 400, "com.vmware.vapi.std.errors.unauthorized": 403, "com.vmware.vapi.std.errors.service_unavailable": 503, "com.vmware.vapi.std.errors.internal_server_error": 500, "com.vmware.vapi.std.errors.not_found": 404})
+}
+
+func localEndpointsPatchInputType() bindings.StructType {
+	fields := make(map[string]bindings.BindingType)
+	fieldNameMap := make(map[string]string)
+	fields["tier0_id"] = bindings.NewStringType()
+	fields["locale_service_id"] = bindings.NewStringType()
+	fields["service_id"] = bindings.NewStringType()
+	fields["local_endpoint_id"] = bindings.NewStringType()
+	fields["ip_sec_vpn_local_endpoint"] = bindings.NewReferenceType(model.IPSecVpnLocalEndpointBindingType)
+	fieldNameMap["tier0_id"] = "Tier0Id"
+	fieldNameMap["locale_service_id"] = "LocaleServiceId"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["local_endpoint_id"] = "LocalEndpointId"
+	fieldNameMap["ip_sec_vpn_local_endpoint"] = "IpSecVpnLocalEndpoint"
+	var validators = []bindings.Validator{}
+	return bindings.NewStructType("operation-input", fields, reflect.TypeOf(data.StructValue{}), fieldNameMap, validators)
+}
+
+func localEndpointsPatchOutputType() bindings.BindingType {
+	return bindings.NewVoidType()
+}
+
+func localEndpointsPatchRestMetadata() protocol.OperationRestMetadata {
+	fields := map[string]bindings.BindingType{}
+	fieldNameMap := map[string]string{}
+	paramsTypeMap := map[string]bindings.BindingType{}
+	pathParams := map[string]string{}
+	queryParams := map[string]string{}
+	headerParams := map[string]string{}
+	dispatchHeaderParams := map[string]string{}
+	bodyFieldsMap := map[string]string{}
+	fields["tier0_id"] = bindings.NewStringType()
+	fields["locale_service_id"] = bindings.NewStringType()
+	fields["service_id"] = bindings.NewStringType()
+	fields["local_endpoint_id"] = bindings.NewStringType()
+	fields["ip_sec_vpn_local_endpoint"] = bindings.NewReferenceType(model.IPSecVpnLocalEndpointBindingType)
+	fieldNameMap["tier0_id"] = "Tier0Id"
+	fieldNameMap["locale_service_id"] = "LocaleServiceId"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["local_endpoint_id"] = "LocalEndpointId"
+	fieldNameMap["ip_sec_vpn_local_endpoint"] = "IpSecVpnLocalEndpoint"
+	paramsTypeMap["tier0_id"] = bindings.NewStringType()
+	paramsTypeMap["ip_sec_vpn_local_endpoint"] = bindings.NewReferenceType(model.IPSecVpnLocalEndpointBindingType)
+	paramsTypeMap["locale_service_id"] = bindings.NewStringType()
+	paramsTypeMap["service_id"] = bindings.NewStringType()
+	paramsTypeMap["local_endpoint_id"] = bindings.NewStringType()
+	paramsTypeMap["tier0Id"] = bindings.NewStringType()
+	paramsTypeMap["localeServiceId"] = bindings.NewStringType()
+	paramsTypeMap["serviceId"] = bindings.NewStringType()
+	paramsTypeMap["localEndpointId"] = bindings.NewStringType()
+	pathParams["local_endpoint_id"] = "localEndpointId"
+	pathParams["tier0_id"] = "tier0Id"
+	pathParams["locale_service_id"] = "localeServiceId"
+	pathParams["service_id"] = "serviceId"
+	resultHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
+	return protocol.NewOperationRestMetadata(
+		fields,
+		fieldNameMap,
+		paramsTypeMap,
+		pathParams,
+		queryParams,
+		headerParams,
+		dispatchHeaderParams,
+		bodyFieldsMap,
+		"",
+		"ip_sec_vpn_local_endpoint",
+		"PATCH",
+		"/policy/api/v1/infra/tier-0s/{tier0Id}/locale-services/{localeServiceId}/ipsec-vpn-services/{serviceId}/local-endpoints/{localEndpointId}",
+		"",
+		resultHeaders,
+		204,
+		"",
+		errorHeaders,
+		map[string]int{"com.vmware.vapi.std.errors.invalid_request": 400, "com.vmware.vapi.std.errors.unauthorized": 403, "com.vmware.vapi.std.errors.service_unavailable": 503, "com.vmware.vapi.std.errors.internal_server_error": 500, "com.vmware.vapi.std.errors.not_found": 404})
+}
+
+func localEndpointsUpdateInputType() bindings.StructType {
+	fields := make(map[string]bindings.BindingType)
+	fieldNameMap := make(map[string]string)
+	fields["tier0_id"] = bindings.NewStringType()
+	fields["locale_service_id"] = bindings.NewStringType()
+	fields["service_id"] = bindings.NewStringType()
+	fields["local_endpoint_id"] = bindings.NewStringType()
+	fields["ip_sec_vpn_local_endpoint"] = bindings.NewReferenceType(model.IPSecVpnLocalEndpointBindingType)
+	fieldNameMap["tier0_id"] = "Tier0Id"
+	fieldNameMap["locale_service_id"] = "LocaleServiceId"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["local_endpoint_id"] = "LocalEndpointId"
+	fieldNameMap["ip_sec_vpn_local_endpoint"] = "IpSecVpnLocalEndpoint"
+	var validators = []bindings.Validator{}
+	return bindings.NewStructType("operation-input", fields, reflect.TypeOf(data.StructValue{}), fieldNameMap, validators)
+}
+
+func localEndpointsUpdateOutputType() bindings.BindingType {
+	return bindings.NewReferenceType(model.IPSecVpnLocalEndpointBindingType)
+}
+
+func localEndpointsUpdateRestMetadata() protocol.OperationRestMetadata {
+	fields := map[string]bindings.BindingType{}
+	fieldNameMap := map[string]string{}
+	paramsTypeMap := map[string]bindings.BindingType{}
+	pathParams := map[string]string{}
+	queryParams := map[string]string{}
+	headerParams := map[string]string{}
+	dispatchHeaderParams := map[string]string{}
+	bodyFieldsMap := map[string]string{}
+	fields["tier0_id"] = bindings.NewStringType()
+	fields["locale_service_id"] = bindings.NewStringType()
+	fields["service_id"] = bindings.NewStringType()
+	fields["local_endpoint_id"] = bindings.NewStringType()
+	fields["ip_sec_vpn_local_endpoint"] = bindings.NewReferenceType(model.IPSecVpnLocalEndpointBindingType)
+	fieldNameMap["tier0_id"] = "Tier0Id"
+	fieldNameMap["locale_service_id"] = "LocaleServiceId"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["local_endpoint_id"] = "LocalEndpointId"
+	fieldNameMap["ip_sec_vpn_local_endpoint"] = "IpSecVpnLocalEndpoint"
+	paramsTypeMap["tier0_id"] = bindings.NewStringType()
+	paramsTypeMap["ip_sec_vpn_local_endpoint"] = bindings.NewReferenceType(model.IPSecVpnLocalEndpointBindingType)
+	paramsTypeMap["locale_service_id"] = bindings.NewStringType()
+	paramsTypeMap["service_id"] = bindings.NewStringType()
+	paramsTypeMap["local_endpoint_id"] = bindings.NewStringType()
+	paramsTypeMap["tier0Id"] = bindings.NewStringType()
+	paramsTypeMap["localeServiceId"] = bindings.NewStringType()
+	paramsTypeMap["serviceId"] = bindings.NewStringType()
+	paramsTypeMap["localEndpointId"] = bindings.NewStringType()
+	pathParams["local_endpoint_id"] = "localEndpointId"
+	pathParams["tier0_id"] = "tier0Id"
+	pathParams["locale_service_id"] = "localeServiceId"
+	pathParams["service_id"] = "serviceId"
+	resultHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
+	return protocol.NewOperationRestMetadata(
+		fields,
+		fieldNameMap,
+		paramsTypeMap,
+		pathParams,
+		queryParams,
+		headerParams,
+		dispatchHeaderParams,
+		bodyFieldsMap,
+		"",
+		"ip_sec_vpn_local_endpoint",
+		"PUT",
+		"/policy/api/v1/infra/tier-0s/{tier0Id}/locale-services/{localeServiceId}/ipsec-vpn-services/{serviceId}/local-endpoints/{localEndpointId}",
+		"",
+		resultHeaders,
+		200,
+		"",
+		errorHeaders,
+		map[string]int{"com.vmware.vapi.std.errors.invalid_request": 400, "com.vmware.vapi.std.errors.unauthorized": 403, "com.vmware.vapi.std.errors.service_unavailable": 503, "com.vmware.vapi.std.errors.internal_server_error": 500, "com.vmware.vapi.std.errors.not_found": 404})
+}

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_0s/locale_services/ipsec_vpn_services/SessionsClient.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_0s/locale_services/ipsec_vpn_services/SessionsClient.go
@@ -1,0 +1,347 @@
+// Copyright © 2019-2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+
+// Auto generated code. DO NOT EDIT.
+
+// Interface file for service: Sessions
+// Used by client-side stubs.
+
+package ipsec_vpn_services
+
+import (
+	"github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/bindings"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/core"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/data"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/lib"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+)
+
+const _ = core.SupportedByRuntimeVersion1
+
+type SessionsClient interface {
+
+	// Delete IPSec VPN session for a given locale service under Tier-0. This API is deprecated. Please use DELETE /infra/tier-0s/<tier-0-id>/ipsec-vpn-services/<service-id>/sessions/<session-id> instead. Note: Please note that request is validated and any error messages returned from validation may include the new VPN path instead of the deprecated path. Both new path and old path refer to same resource. Also VPN path returned in the Alarm, GPRR payload may include the new VPN path
+	//
+	// @param tier0IdParam (required)
+	// @param localeServiceIdParam (required)
+	// @param serviceIdParam (required)
+	// @param sessionIdParam (required)
+	// @throws InvalidRequest  Bad Request, Precondition Failed
+	// @throws Unauthorized  Forbidden
+	// @throws ServiceUnavailable  Service Unavailable
+	// @throws InternalServerError  Internal Server Error
+	// @throws NotFound  Not Found
+	Delete(tier0IdParam string, localeServiceIdParam string, serviceIdParam string, sessionIdParam string) error
+
+	// Get IPSec VPN session without sensitive data for a given locale service under Tier-0. This API is deprecated. Please use GET /infra/tier-0s/<tier-0-id>/ipsec-vpn-services/<service-id>/sessions/<session-id> instead. Note: Please note that request is validated and any error messages returned from validation may include the new VPN path instead of the deprecated path. Both new path and old path refer to same resource.
+	//
+	// @param tier0IdParam (required)
+	// @param localeServiceIdParam (required)
+	// @param serviceIdParam (required)
+	// @param sessionIdParam (required)
+	// @return com.vmware.nsx_policy.model.IPSecVpnSession
+	// The return value will contain all the properties defined in model.IPSecVpnSession.
+	// @throws InvalidRequest  Bad Request, Precondition Failed
+	// @throws Unauthorized  Forbidden
+	// @throws ServiceUnavailable  Service Unavailable
+	// @throws InternalServerError  Internal Server Error
+	// @throws NotFound  Not Found
+	Get(tier0IdParam string, localeServiceIdParam string, serviceIdParam string, sessionIdParam string) (*data.StructValue, error)
+
+	// Get paginated list of all IPSec VPN sessions for a given locale service under Tier-0. This API is deprecated. Please use GET /infra/tier-0s/<tier-0-id>/ipsec-vpn-services/<service-id>/sessions instead. Note: Please note that request is validated and any error messages returned from validation may include the new VPN path instead of the deprecated path. Both new path and old path refer to same resource.
+	//
+	// @param tier0IdParam (required)
+	// @param localeServiceIdParam (required)
+	// @param serviceIdParam (required)
+	// @param cursorParam Opaque cursor to be used for getting next page of records (supplied by current result page) (optional)
+	// @param includeMarkForDeleteObjectsParam Include objects that are marked for deletion in results (optional, default to false)
+	// @param includedFieldsParam Comma separated list of fields that should be included in query result (optional)
+	// @param pageSizeParam Maximum number of results to return in this page (server may return fewer) (optional, default to 1000)
+	// @param sortAscendingParam (optional)
+	// @param sortByParam Field by which records are sorted (optional)
+	// @return com.vmware.nsx_policy.model.IPSecVpnSessionListResult
+	// @throws InvalidRequest  Bad Request, Precondition Failed
+	// @throws Unauthorized  Forbidden
+	// @throws ServiceUnavailable  Service Unavailable
+	// @throws InternalServerError  Internal Server Error
+	// @throws NotFound  Not Found
+	List(tier0IdParam string, localeServiceIdParam string, serviceIdParam string, cursorParam *string, includeMarkForDeleteObjectsParam *bool, includedFieldsParam *string, pageSizeParam *int64, sortAscendingParam *bool, sortByParam *string) (model.IPSecVpnSessionListResult, error)
+
+	// Create or patch an IPSec VPN session for a given locale service under Tier-0. This API is deprecated. Please use PATCH /infra/tier-0s/<tier-0-id>/ipsec-vpn-services/<service-id>/sessions/<session-id> instead. Note: Please note that request is validated and any error messages returned from validation may include the new VPN path instead of the deprecated path. Both new path and old path refer to same resource. Also VPN path returned in the Alarm, GPRR payload may include the new VPN path
+	//
+	// @param tier0IdParam (required)
+	// @param localeServiceIdParam (required)
+	// @param serviceIdParam (required)
+	// @param sessionIdParam (required)
+	// @param ipSecVpnSessionParam (required)
+	// The parameter must contain all the properties defined in model.IPSecVpnSession.
+	// @throws InvalidRequest  Bad Request, Precondition Failed
+	// @throws Unauthorized  Forbidden
+	// @throws ServiceUnavailable  Service Unavailable
+	// @throws InternalServerError  Internal Server Error
+	// @throws NotFound  Not Found
+	Patch(tier0IdParam string, localeServiceIdParam string, serviceIdParam string, sessionIdParam string, ipSecVpnSessionParam *data.StructValue) error
+
+	// Get IPSec VPN session with senstive data for a given locale service under Tier-0. This API is deprecated. Please use GET /infra/tier-0s/<tier-0-id>/ipsec-vpn-services/<service-id>/sessions/<session-id>?action=show_sensitive_data instead. Note: Please note that request is validated and any error messages returned from validation may include the new VPN path instead of the deprecated path. Both new path and old path refer to same resource.
+	//
+	// @param tier0IdParam (required)
+	// @param localeServiceIdParam (required)
+	// @param serviceIdParam (required)
+	// @param sessionIdParam (required)
+	// @return com.vmware.nsx_policy.model.IPSecVpnSession
+	// The return value will contain all the properties defined in model.IPSecVpnSession.
+	// @throws InvalidRequest  Bad Request, Precondition Failed
+	// @throws Unauthorized  Forbidden
+	// @throws ServiceUnavailable  Service Unavailable
+	// @throws InternalServerError  Internal Server Error
+	// @throws NotFound  Not Found
+	Showsensitivedata(tier0IdParam string, localeServiceIdParam string, serviceIdParam string, sessionIdParam string) (*data.StructValue, error)
+
+	// Create or fully replace IPSec VPN session for a given locale service under Tier-0. Revision is optional for creation and required for update. This API is deprecated. Please use PUT /infra/tier-0s/<tier-0-id>/ipsec-vpn-services/<service-id>/sessions/<session-id> instead. Note: Please note that request is validated and any error messages returned from validation may include the new VPN path instead of the deprecated path. Both new path and old path refer to same resource. Also VPN path returned in the Alarm, GPRR payload may include the new VPN path
+	//
+	// @param tier0IdParam (required)
+	// @param localeServiceIdParam (required)
+	// @param serviceIdParam (required)
+	// @param sessionIdParam (required)
+	// @param ipSecVpnSessionParam (required)
+	// The parameter must contain all the properties defined in model.IPSecVpnSession.
+	// @return com.vmware.nsx_policy.model.IPSecVpnSession
+	// The return value will contain all the properties defined in model.IPSecVpnSession.
+	// @throws InvalidRequest  Bad Request, Precondition Failed
+	// @throws Unauthorized  Forbidden
+	// @throws ServiceUnavailable  Service Unavailable
+	// @throws InternalServerError  Internal Server Error
+	// @throws NotFound  Not Found
+	Update(tier0IdParam string, localeServiceIdParam string, serviceIdParam string, sessionIdParam string, ipSecVpnSessionParam *data.StructValue) (*data.StructValue, error)
+}
+
+type sessionsClient struct {
+	connector           client.Connector
+	interfaceDefinition core.InterfaceDefinition
+	errorsBindingMap    map[string]bindings.BindingType
+}
+
+func NewSessionsClient(connector client.Connector) *sessionsClient {
+	interfaceIdentifier := core.NewInterfaceIdentifier("com.vmware.nsx_policy.infra.tier_0s.locale_services.ipsec_vpn_services.sessions")
+	methodIdentifiers := map[string]core.MethodIdentifier{
+		"delete":            core.NewMethodIdentifier(interfaceIdentifier, "delete"),
+		"get":               core.NewMethodIdentifier(interfaceIdentifier, "get"),
+		"list":              core.NewMethodIdentifier(interfaceIdentifier, "list"),
+		"patch":             core.NewMethodIdentifier(interfaceIdentifier, "patch"),
+		"showsensitivedata": core.NewMethodIdentifier(interfaceIdentifier, "showsensitivedata"),
+		"update":            core.NewMethodIdentifier(interfaceIdentifier, "update"),
+	}
+	interfaceDefinition := core.NewInterfaceDefinition(interfaceIdentifier, methodIdentifiers)
+	errorsBindingMap := make(map[string]bindings.BindingType)
+
+	sIface := sessionsClient{interfaceDefinition: interfaceDefinition, errorsBindingMap: errorsBindingMap, connector: connector}
+	return &sIface
+}
+
+func (sIface *sessionsClient) GetErrorBindingType(errorName string) bindings.BindingType {
+	if entry, ok := sIface.errorsBindingMap[errorName]; ok {
+		return entry
+	}
+	return errors.ERROR_BINDINGS_MAP[errorName]
+}
+
+func (sIface *sessionsClient) Delete(tier0IdParam string, localeServiceIdParam string, serviceIdParam string, sessionIdParam string) error {
+	typeConverter := sIface.connector.TypeConverter()
+	executionContext := sIface.connector.NewExecutionContext()
+	sv := bindings.NewStructValueBuilder(sessionsDeleteInputType(), typeConverter)
+	sv.AddStructField("Tier0Id", tier0IdParam)
+	sv.AddStructField("LocaleServiceId", localeServiceIdParam)
+	sv.AddStructField("ServiceId", serviceIdParam)
+	sv.AddStructField("SessionId", sessionIdParam)
+	inputDataValue, inputError := sv.GetStructValue()
+	if inputError != nil {
+		return bindings.VAPIerrorsToError(inputError)
+	}
+	operationRestMetaData := sessionsDeleteRestMetadata()
+	connectionMetadata := map[string]interface{}{lib.REST_METADATA: operationRestMetaData}
+	connectionMetadata["isStreamingResponse"] = false
+	sIface.connector.SetConnectionMetadata(connectionMetadata)
+	methodResult := sIface.connector.GetApiProvider().Invoke("com.vmware.nsx_policy.infra.tier_0s.locale_services.ipsec_vpn_services.sessions", "delete", inputDataValue, executionContext)
+	if methodResult.IsSuccess() {
+		return nil
+	} else {
+		methodError, errorInError := typeConverter.ConvertToGolang(methodResult.Error(), sIface.GetErrorBindingType(methodResult.Error().Name()))
+		if errorInError != nil {
+			return bindings.VAPIerrorsToError(errorInError)
+		}
+		return methodError.(error)
+	}
+}
+
+func (sIface *sessionsClient) Get(tier0IdParam string, localeServiceIdParam string, serviceIdParam string, sessionIdParam string) (*data.StructValue, error) {
+	typeConverter := sIface.connector.TypeConverter()
+	executionContext := sIface.connector.NewExecutionContext()
+	sv := bindings.NewStructValueBuilder(sessionsGetInputType(), typeConverter)
+	sv.AddStructField("Tier0Id", tier0IdParam)
+	sv.AddStructField("LocaleServiceId", localeServiceIdParam)
+	sv.AddStructField("ServiceId", serviceIdParam)
+	sv.AddStructField("SessionId", sessionIdParam)
+	inputDataValue, inputError := sv.GetStructValue()
+	if inputError != nil {
+		var emptyOutput *data.StructValue
+		return emptyOutput, bindings.VAPIerrorsToError(inputError)
+	}
+	operationRestMetaData := sessionsGetRestMetadata()
+	connectionMetadata := map[string]interface{}{lib.REST_METADATA: operationRestMetaData}
+	connectionMetadata["isStreamingResponse"] = false
+	sIface.connector.SetConnectionMetadata(connectionMetadata)
+	methodResult := sIface.connector.GetApiProvider().Invoke("com.vmware.nsx_policy.infra.tier_0s.locale_services.ipsec_vpn_services.sessions", "get", inputDataValue, executionContext)
+	var emptyOutput *data.StructValue
+	if methodResult.IsSuccess() {
+		output, errorInOutput := typeConverter.ConvertToGolang(methodResult.Output(), sessionsGetOutputType())
+		if errorInOutput != nil {
+			return emptyOutput, bindings.VAPIerrorsToError(errorInOutput)
+		}
+		return output.(*data.StructValue), nil
+	} else {
+		methodError, errorInError := typeConverter.ConvertToGolang(methodResult.Error(), sIface.GetErrorBindingType(methodResult.Error().Name()))
+		if errorInError != nil {
+			return emptyOutput, bindings.VAPIerrorsToError(errorInError)
+		}
+		return emptyOutput, methodError.(error)
+	}
+}
+
+func (sIface *sessionsClient) List(tier0IdParam string, localeServiceIdParam string, serviceIdParam string, cursorParam *string, includeMarkForDeleteObjectsParam *bool, includedFieldsParam *string, pageSizeParam *int64, sortAscendingParam *bool, sortByParam *string) (model.IPSecVpnSessionListResult, error) {
+	typeConverter := sIface.connector.TypeConverter()
+	executionContext := sIface.connector.NewExecutionContext()
+	sv := bindings.NewStructValueBuilder(sessionsListInputType(), typeConverter)
+	sv.AddStructField("Tier0Id", tier0IdParam)
+	sv.AddStructField("LocaleServiceId", localeServiceIdParam)
+	sv.AddStructField("ServiceId", serviceIdParam)
+	sv.AddStructField("Cursor", cursorParam)
+	sv.AddStructField("IncludeMarkForDeleteObjects", includeMarkForDeleteObjectsParam)
+	sv.AddStructField("IncludedFields", includedFieldsParam)
+	sv.AddStructField("PageSize", pageSizeParam)
+	sv.AddStructField("SortAscending", sortAscendingParam)
+	sv.AddStructField("SortBy", sortByParam)
+	inputDataValue, inputError := sv.GetStructValue()
+	if inputError != nil {
+		var emptyOutput model.IPSecVpnSessionListResult
+		return emptyOutput, bindings.VAPIerrorsToError(inputError)
+	}
+	operationRestMetaData := sessionsListRestMetadata()
+	connectionMetadata := map[string]interface{}{lib.REST_METADATA: operationRestMetaData}
+	connectionMetadata["isStreamingResponse"] = false
+	sIface.connector.SetConnectionMetadata(connectionMetadata)
+	methodResult := sIface.connector.GetApiProvider().Invoke("com.vmware.nsx_policy.infra.tier_0s.locale_services.ipsec_vpn_services.sessions", "list", inputDataValue, executionContext)
+	var emptyOutput model.IPSecVpnSessionListResult
+	if methodResult.IsSuccess() {
+		output, errorInOutput := typeConverter.ConvertToGolang(methodResult.Output(), sessionsListOutputType())
+		if errorInOutput != nil {
+			return emptyOutput, bindings.VAPIerrorsToError(errorInOutput)
+		}
+		return output.(model.IPSecVpnSessionListResult), nil
+	} else {
+		methodError, errorInError := typeConverter.ConvertToGolang(methodResult.Error(), sIface.GetErrorBindingType(methodResult.Error().Name()))
+		if errorInError != nil {
+			return emptyOutput, bindings.VAPIerrorsToError(errorInError)
+		}
+		return emptyOutput, methodError.(error)
+	}
+}
+
+func (sIface *sessionsClient) Patch(tier0IdParam string, localeServiceIdParam string, serviceIdParam string, sessionIdParam string, ipSecVpnSessionParam *data.StructValue) error {
+	typeConverter := sIface.connector.TypeConverter()
+	executionContext := sIface.connector.NewExecutionContext()
+	sv := bindings.NewStructValueBuilder(sessionsPatchInputType(), typeConverter)
+	sv.AddStructField("Tier0Id", tier0IdParam)
+	sv.AddStructField("LocaleServiceId", localeServiceIdParam)
+	sv.AddStructField("ServiceId", serviceIdParam)
+	sv.AddStructField("SessionId", sessionIdParam)
+	sv.AddStructField("IpSecVpnSession", ipSecVpnSessionParam)
+	inputDataValue, inputError := sv.GetStructValue()
+	if inputError != nil {
+		return bindings.VAPIerrorsToError(inputError)
+	}
+	operationRestMetaData := sessionsPatchRestMetadata()
+	connectionMetadata := map[string]interface{}{lib.REST_METADATA: operationRestMetaData}
+	connectionMetadata["isStreamingResponse"] = false
+	sIface.connector.SetConnectionMetadata(connectionMetadata)
+	methodResult := sIface.connector.GetApiProvider().Invoke("com.vmware.nsx_policy.infra.tier_0s.locale_services.ipsec_vpn_services.sessions", "patch", inputDataValue, executionContext)
+	if methodResult.IsSuccess() {
+		return nil
+	} else {
+		methodError, errorInError := typeConverter.ConvertToGolang(methodResult.Error(), sIface.GetErrorBindingType(methodResult.Error().Name()))
+		if errorInError != nil {
+			return bindings.VAPIerrorsToError(errorInError)
+		}
+		return methodError.(error)
+	}
+}
+
+func (sIface *sessionsClient) Showsensitivedata(tier0IdParam string, localeServiceIdParam string, serviceIdParam string, sessionIdParam string) (*data.StructValue, error) {
+	typeConverter := sIface.connector.TypeConverter()
+	executionContext := sIface.connector.NewExecutionContext()
+	sv := bindings.NewStructValueBuilder(sessionsShowsensitivedataInputType(), typeConverter)
+	sv.AddStructField("Tier0Id", tier0IdParam)
+	sv.AddStructField("LocaleServiceId", localeServiceIdParam)
+	sv.AddStructField("ServiceId", serviceIdParam)
+	sv.AddStructField("SessionId", sessionIdParam)
+	inputDataValue, inputError := sv.GetStructValue()
+	if inputError != nil {
+		var emptyOutput *data.StructValue
+		return emptyOutput, bindings.VAPIerrorsToError(inputError)
+	}
+	operationRestMetaData := sessionsShowsensitivedataRestMetadata()
+	connectionMetadata := map[string]interface{}{lib.REST_METADATA: operationRestMetaData}
+	connectionMetadata["isStreamingResponse"] = false
+	sIface.connector.SetConnectionMetadata(connectionMetadata)
+	methodResult := sIface.connector.GetApiProvider().Invoke("com.vmware.nsx_policy.infra.tier_0s.locale_services.ipsec_vpn_services.sessions", "showsensitivedata", inputDataValue, executionContext)
+	var emptyOutput *data.StructValue
+	if methodResult.IsSuccess() {
+		output, errorInOutput := typeConverter.ConvertToGolang(methodResult.Output(), sessionsShowsensitivedataOutputType())
+		if errorInOutput != nil {
+			return emptyOutput, bindings.VAPIerrorsToError(errorInOutput)
+		}
+		return output.(*data.StructValue), nil
+	} else {
+		methodError, errorInError := typeConverter.ConvertToGolang(methodResult.Error(), sIface.GetErrorBindingType(methodResult.Error().Name()))
+		if errorInError != nil {
+			return emptyOutput, bindings.VAPIerrorsToError(errorInError)
+		}
+		return emptyOutput, methodError.(error)
+	}
+}
+
+func (sIface *sessionsClient) Update(tier0IdParam string, localeServiceIdParam string, serviceIdParam string, sessionIdParam string, ipSecVpnSessionParam *data.StructValue) (*data.StructValue, error) {
+	typeConverter := sIface.connector.TypeConverter()
+	executionContext := sIface.connector.NewExecutionContext()
+	sv := bindings.NewStructValueBuilder(sessionsUpdateInputType(), typeConverter)
+	sv.AddStructField("Tier0Id", tier0IdParam)
+	sv.AddStructField("LocaleServiceId", localeServiceIdParam)
+	sv.AddStructField("ServiceId", serviceIdParam)
+	sv.AddStructField("SessionId", sessionIdParam)
+	sv.AddStructField("IpSecVpnSession", ipSecVpnSessionParam)
+	inputDataValue, inputError := sv.GetStructValue()
+	if inputError != nil {
+		var emptyOutput *data.StructValue
+		return emptyOutput, bindings.VAPIerrorsToError(inputError)
+	}
+	operationRestMetaData := sessionsUpdateRestMetadata()
+	connectionMetadata := map[string]interface{}{lib.REST_METADATA: operationRestMetaData}
+	connectionMetadata["isStreamingResponse"] = false
+	sIface.connector.SetConnectionMetadata(connectionMetadata)
+	methodResult := sIface.connector.GetApiProvider().Invoke("com.vmware.nsx_policy.infra.tier_0s.locale_services.ipsec_vpn_services.sessions", "update", inputDataValue, executionContext)
+	var emptyOutput *data.StructValue
+	if methodResult.IsSuccess() {
+		output, errorInOutput := typeConverter.ConvertToGolang(methodResult.Output(), sessionsUpdateOutputType())
+		if errorInOutput != nil {
+			return emptyOutput, bindings.VAPIerrorsToError(errorInOutput)
+		}
+		return output.(*data.StructValue), nil
+	} else {
+		methodError, errorInError := typeConverter.ConvertToGolang(methodResult.Error(), sIface.GetErrorBindingType(methodResult.Error().Name()))
+		if errorInError != nil {
+			return emptyOutput, bindings.VAPIerrorsToError(errorInError)
+		}
+		return emptyOutput, methodError.(error)
+	}
+}

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_0s/locale_services/ipsec_vpn_services/SessionsTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_0s/locale_services/ipsec_vpn_services/SessionsTypes.go
@@ -1,0 +1,484 @@
+// Copyright © 2019-2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+
+// Auto generated code. DO NOT EDIT.
+
+// Data type definitions file for service: Sessions.
+// Includes binding types of a structures and enumerations defined in the service.
+// Shared by client-side stubs and server-side skeletons to ensure type
+// compatibility.
+
+package ipsec_vpn_services
+
+import (
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/bindings"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/data"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+	"reflect"
+)
+
+func sessionsDeleteInputType() bindings.StructType {
+	fields := make(map[string]bindings.BindingType)
+	fieldNameMap := make(map[string]string)
+	fields["tier0_id"] = bindings.NewStringType()
+	fields["locale_service_id"] = bindings.NewStringType()
+	fields["service_id"] = bindings.NewStringType()
+	fields["session_id"] = bindings.NewStringType()
+	fieldNameMap["tier0_id"] = "Tier0Id"
+	fieldNameMap["locale_service_id"] = "LocaleServiceId"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["session_id"] = "SessionId"
+	var validators = []bindings.Validator{}
+	return bindings.NewStructType("operation-input", fields, reflect.TypeOf(data.StructValue{}), fieldNameMap, validators)
+}
+
+func sessionsDeleteOutputType() bindings.BindingType {
+	return bindings.NewVoidType()
+}
+
+func sessionsDeleteRestMetadata() protocol.OperationRestMetadata {
+	fields := map[string]bindings.BindingType{}
+	fieldNameMap := map[string]string{}
+	paramsTypeMap := map[string]bindings.BindingType{}
+	pathParams := map[string]string{}
+	queryParams := map[string]string{}
+	headerParams := map[string]string{}
+	dispatchHeaderParams := map[string]string{}
+	bodyFieldsMap := map[string]string{}
+	fields["tier0_id"] = bindings.NewStringType()
+	fields["locale_service_id"] = bindings.NewStringType()
+	fields["service_id"] = bindings.NewStringType()
+	fields["session_id"] = bindings.NewStringType()
+	fieldNameMap["tier0_id"] = "Tier0Id"
+	fieldNameMap["locale_service_id"] = "LocaleServiceId"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["session_id"] = "SessionId"
+	paramsTypeMap["tier0_id"] = bindings.NewStringType()
+	paramsTypeMap["locale_service_id"] = bindings.NewStringType()
+	paramsTypeMap["service_id"] = bindings.NewStringType()
+	paramsTypeMap["session_id"] = bindings.NewStringType()
+	paramsTypeMap["tier0Id"] = bindings.NewStringType()
+	paramsTypeMap["localeServiceId"] = bindings.NewStringType()
+	paramsTypeMap["serviceId"] = bindings.NewStringType()
+	paramsTypeMap["sessionId"] = bindings.NewStringType()
+	pathParams["tier0_id"] = "tier0Id"
+	pathParams["session_id"] = "sessionId"
+	pathParams["locale_service_id"] = "localeServiceId"
+	pathParams["service_id"] = "serviceId"
+	resultHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
+	return protocol.NewOperationRestMetadata(
+		fields,
+		fieldNameMap,
+		paramsTypeMap,
+		pathParams,
+		queryParams,
+		headerParams,
+		dispatchHeaderParams,
+		bodyFieldsMap,
+		"",
+		"",
+		"DELETE",
+		"/policy/api/v1/infra/tier-0s/{tier0Id}/locale-services/{localeServiceId}/ipsec-vpn-services/{serviceId}/sessions/{sessionId}",
+		"",
+		resultHeaders,
+		204,
+		"",
+		errorHeaders,
+		map[string]int{"com.vmware.vapi.std.errors.invalid_request": 400, "com.vmware.vapi.std.errors.unauthorized": 403, "com.vmware.vapi.std.errors.service_unavailable": 503, "com.vmware.vapi.std.errors.internal_server_error": 500, "com.vmware.vapi.std.errors.not_found": 404})
+}
+
+func sessionsGetInputType() bindings.StructType {
+	fields := make(map[string]bindings.BindingType)
+	fieldNameMap := make(map[string]string)
+	fields["tier0_id"] = bindings.NewStringType()
+	fields["locale_service_id"] = bindings.NewStringType()
+	fields["service_id"] = bindings.NewStringType()
+	fields["session_id"] = bindings.NewStringType()
+	fieldNameMap["tier0_id"] = "Tier0Id"
+	fieldNameMap["locale_service_id"] = "LocaleServiceId"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["session_id"] = "SessionId"
+	var validators = []bindings.Validator{}
+	return bindings.NewStructType("operation-input", fields, reflect.TypeOf(data.StructValue{}), fieldNameMap, validators)
+}
+
+func sessionsGetOutputType() bindings.BindingType {
+	return bindings.NewDynamicStructType([]bindings.ReferenceType{bindings.NewReferenceType(model.IPSecVpnSessionBindingType)}, bindings.REST)
+}
+
+func sessionsGetRestMetadata() protocol.OperationRestMetadata {
+	fields := map[string]bindings.BindingType{}
+	fieldNameMap := map[string]string{}
+	paramsTypeMap := map[string]bindings.BindingType{}
+	pathParams := map[string]string{}
+	queryParams := map[string]string{}
+	headerParams := map[string]string{}
+	dispatchHeaderParams := map[string]string{}
+	bodyFieldsMap := map[string]string{}
+	fields["tier0_id"] = bindings.NewStringType()
+	fields["locale_service_id"] = bindings.NewStringType()
+	fields["service_id"] = bindings.NewStringType()
+	fields["session_id"] = bindings.NewStringType()
+	fieldNameMap["tier0_id"] = "Tier0Id"
+	fieldNameMap["locale_service_id"] = "LocaleServiceId"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["session_id"] = "SessionId"
+	paramsTypeMap["tier0_id"] = bindings.NewStringType()
+	paramsTypeMap["locale_service_id"] = bindings.NewStringType()
+	paramsTypeMap["service_id"] = bindings.NewStringType()
+	paramsTypeMap["session_id"] = bindings.NewStringType()
+	paramsTypeMap["tier0Id"] = bindings.NewStringType()
+	paramsTypeMap["localeServiceId"] = bindings.NewStringType()
+	paramsTypeMap["serviceId"] = bindings.NewStringType()
+	paramsTypeMap["sessionId"] = bindings.NewStringType()
+	pathParams["tier0_id"] = "tier0Id"
+	pathParams["session_id"] = "sessionId"
+	pathParams["locale_service_id"] = "localeServiceId"
+	pathParams["service_id"] = "serviceId"
+	resultHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
+	return protocol.NewOperationRestMetadata(
+		fields,
+		fieldNameMap,
+		paramsTypeMap,
+		pathParams,
+		queryParams,
+		headerParams,
+		dispatchHeaderParams,
+		bodyFieldsMap,
+		"",
+		"",
+		"GET",
+		"/policy/api/v1/infra/tier-0s/{tier0Id}/locale-services/{localeServiceId}/ipsec-vpn-services/{serviceId}/sessions/{sessionId}",
+		"",
+		resultHeaders,
+		200,
+		"",
+		errorHeaders,
+		map[string]int{"com.vmware.vapi.std.errors.invalid_request": 400, "com.vmware.vapi.std.errors.unauthorized": 403, "com.vmware.vapi.std.errors.service_unavailable": 503, "com.vmware.vapi.std.errors.internal_server_error": 500, "com.vmware.vapi.std.errors.not_found": 404})
+}
+
+func sessionsListInputType() bindings.StructType {
+	fields := make(map[string]bindings.BindingType)
+	fieldNameMap := make(map[string]string)
+	fields["tier0_id"] = bindings.NewStringType()
+	fields["locale_service_id"] = bindings.NewStringType()
+	fields["service_id"] = bindings.NewStringType()
+	fields["cursor"] = bindings.NewOptionalType(bindings.NewStringType())
+	fields["include_mark_for_delete_objects"] = bindings.NewOptionalType(bindings.NewBooleanType())
+	fields["included_fields"] = bindings.NewOptionalType(bindings.NewStringType())
+	fields["page_size"] = bindings.NewOptionalType(bindings.NewIntegerType())
+	fields["sort_ascending"] = bindings.NewOptionalType(bindings.NewBooleanType())
+	fields["sort_by"] = bindings.NewOptionalType(bindings.NewStringType())
+	fieldNameMap["tier0_id"] = "Tier0Id"
+	fieldNameMap["locale_service_id"] = "LocaleServiceId"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["cursor"] = "Cursor"
+	fieldNameMap["include_mark_for_delete_objects"] = "IncludeMarkForDeleteObjects"
+	fieldNameMap["included_fields"] = "IncludedFields"
+	fieldNameMap["page_size"] = "PageSize"
+	fieldNameMap["sort_ascending"] = "SortAscending"
+	fieldNameMap["sort_by"] = "SortBy"
+	var validators = []bindings.Validator{}
+	return bindings.NewStructType("operation-input", fields, reflect.TypeOf(data.StructValue{}), fieldNameMap, validators)
+}
+
+func sessionsListOutputType() bindings.BindingType {
+	return bindings.NewReferenceType(model.IPSecVpnSessionListResultBindingType)
+}
+
+func sessionsListRestMetadata() protocol.OperationRestMetadata {
+	fields := map[string]bindings.BindingType{}
+	fieldNameMap := map[string]string{}
+	paramsTypeMap := map[string]bindings.BindingType{}
+	pathParams := map[string]string{}
+	queryParams := map[string]string{}
+	headerParams := map[string]string{}
+	dispatchHeaderParams := map[string]string{}
+	bodyFieldsMap := map[string]string{}
+	fields["tier0_id"] = bindings.NewStringType()
+	fields["locale_service_id"] = bindings.NewStringType()
+	fields["service_id"] = bindings.NewStringType()
+	fields["cursor"] = bindings.NewOptionalType(bindings.NewStringType())
+	fields["include_mark_for_delete_objects"] = bindings.NewOptionalType(bindings.NewBooleanType())
+	fields["included_fields"] = bindings.NewOptionalType(bindings.NewStringType())
+	fields["page_size"] = bindings.NewOptionalType(bindings.NewIntegerType())
+	fields["sort_ascending"] = bindings.NewOptionalType(bindings.NewBooleanType())
+	fields["sort_by"] = bindings.NewOptionalType(bindings.NewStringType())
+	fieldNameMap["tier0_id"] = "Tier0Id"
+	fieldNameMap["locale_service_id"] = "LocaleServiceId"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["cursor"] = "Cursor"
+	fieldNameMap["include_mark_for_delete_objects"] = "IncludeMarkForDeleteObjects"
+	fieldNameMap["included_fields"] = "IncludedFields"
+	fieldNameMap["page_size"] = "PageSize"
+	fieldNameMap["sort_ascending"] = "SortAscending"
+	fieldNameMap["sort_by"] = "SortBy"
+	paramsTypeMap["tier0_id"] = bindings.NewStringType()
+	paramsTypeMap["locale_service_id"] = bindings.NewStringType()
+	paramsTypeMap["service_id"] = bindings.NewStringType()
+	paramsTypeMap["included_fields"] = bindings.NewOptionalType(bindings.NewStringType())
+	paramsTypeMap["page_size"] = bindings.NewOptionalType(bindings.NewIntegerType())
+	paramsTypeMap["include_mark_for_delete_objects"] = bindings.NewOptionalType(bindings.NewBooleanType())
+	paramsTypeMap["cursor"] = bindings.NewOptionalType(bindings.NewStringType())
+	paramsTypeMap["sort_by"] = bindings.NewOptionalType(bindings.NewStringType())
+	paramsTypeMap["sort_ascending"] = bindings.NewOptionalType(bindings.NewBooleanType())
+	paramsTypeMap["tier0Id"] = bindings.NewStringType()
+	paramsTypeMap["localeServiceId"] = bindings.NewStringType()
+	paramsTypeMap["serviceId"] = bindings.NewStringType()
+	pathParams["tier0_id"] = "tier0Id"
+	pathParams["locale_service_id"] = "localeServiceId"
+	pathParams["service_id"] = "serviceId"
+	queryParams["cursor"] = "cursor"
+	queryParams["sort_ascending"] = "sort_ascending"
+	queryParams["included_fields"] = "included_fields"
+	queryParams["sort_by"] = "sort_by"
+	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
+	queryParams["page_size"] = "page_size"
+	resultHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
+	return protocol.NewOperationRestMetadata(
+		fields,
+		fieldNameMap,
+		paramsTypeMap,
+		pathParams,
+		queryParams,
+		headerParams,
+		dispatchHeaderParams,
+		bodyFieldsMap,
+		"",
+		"",
+		"GET",
+		"/policy/api/v1/infra/tier-0s/{tier0Id}/locale-services/{localeServiceId}/ipsec-vpn-services/{serviceId}/sessions",
+		"",
+		resultHeaders,
+		200,
+		"",
+		errorHeaders,
+		map[string]int{"com.vmware.vapi.std.errors.invalid_request": 400, "com.vmware.vapi.std.errors.unauthorized": 403, "com.vmware.vapi.std.errors.service_unavailable": 503, "com.vmware.vapi.std.errors.internal_server_error": 500, "com.vmware.vapi.std.errors.not_found": 404})
+}
+
+func sessionsPatchInputType() bindings.StructType {
+	fields := make(map[string]bindings.BindingType)
+	fieldNameMap := make(map[string]string)
+	fields["tier0_id"] = bindings.NewStringType()
+	fields["locale_service_id"] = bindings.NewStringType()
+	fields["service_id"] = bindings.NewStringType()
+	fields["session_id"] = bindings.NewStringType()
+	fields["ip_sec_vpn_session"] = bindings.NewDynamicStructType([]bindings.ReferenceType{bindings.NewReferenceType(model.IPSecVpnSessionBindingType)}, bindings.REST)
+	fieldNameMap["tier0_id"] = "Tier0Id"
+	fieldNameMap["locale_service_id"] = "LocaleServiceId"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["session_id"] = "SessionId"
+	fieldNameMap["ip_sec_vpn_session"] = "IpSecVpnSession"
+	var validators = []bindings.Validator{}
+	return bindings.NewStructType("operation-input", fields, reflect.TypeOf(data.StructValue{}), fieldNameMap, validators)
+}
+
+func sessionsPatchOutputType() bindings.BindingType {
+	return bindings.NewVoidType()
+}
+
+func sessionsPatchRestMetadata() protocol.OperationRestMetadata {
+	fields := map[string]bindings.BindingType{}
+	fieldNameMap := map[string]string{}
+	paramsTypeMap := map[string]bindings.BindingType{}
+	pathParams := map[string]string{}
+	queryParams := map[string]string{}
+	headerParams := map[string]string{}
+	dispatchHeaderParams := map[string]string{}
+	bodyFieldsMap := map[string]string{}
+	fields["tier0_id"] = bindings.NewStringType()
+	fields["locale_service_id"] = bindings.NewStringType()
+	fields["service_id"] = bindings.NewStringType()
+	fields["session_id"] = bindings.NewStringType()
+	fields["ip_sec_vpn_session"] = bindings.NewDynamicStructType([]bindings.ReferenceType{bindings.NewReferenceType(model.IPSecVpnSessionBindingType)}, bindings.REST)
+	fieldNameMap["tier0_id"] = "Tier0Id"
+	fieldNameMap["locale_service_id"] = "LocaleServiceId"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["session_id"] = "SessionId"
+	fieldNameMap["ip_sec_vpn_session"] = "IpSecVpnSession"
+	paramsTypeMap["tier0_id"] = bindings.NewStringType()
+	paramsTypeMap["locale_service_id"] = bindings.NewStringType()
+	paramsTypeMap["service_id"] = bindings.NewStringType()
+	paramsTypeMap["session_id"] = bindings.NewStringType()
+	paramsTypeMap["ip_sec_vpn_session"] = bindings.NewDynamicStructType([]bindings.ReferenceType{bindings.NewReferenceType(model.IPSecVpnSessionBindingType)}, bindings.REST)
+	paramsTypeMap["tier0Id"] = bindings.NewStringType()
+	paramsTypeMap["localeServiceId"] = bindings.NewStringType()
+	paramsTypeMap["serviceId"] = bindings.NewStringType()
+	paramsTypeMap["sessionId"] = bindings.NewStringType()
+	pathParams["tier0_id"] = "tier0Id"
+	pathParams["session_id"] = "sessionId"
+	pathParams["locale_service_id"] = "localeServiceId"
+	pathParams["service_id"] = "serviceId"
+	resultHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
+	return protocol.NewOperationRestMetadata(
+		fields,
+		fieldNameMap,
+		paramsTypeMap,
+		pathParams,
+		queryParams,
+		headerParams,
+		dispatchHeaderParams,
+		bodyFieldsMap,
+		"",
+		"ip_sec_vpn_session",
+		"PATCH",
+		"/policy/api/v1/infra/tier-0s/{tier0Id}/locale-services/{localeServiceId}/ipsec-vpn-services/{serviceId}/sessions/{sessionId}",
+		"",
+		resultHeaders,
+		204,
+		"",
+		errorHeaders,
+		map[string]int{"com.vmware.vapi.std.errors.invalid_request": 400, "com.vmware.vapi.std.errors.unauthorized": 403, "com.vmware.vapi.std.errors.service_unavailable": 503, "com.vmware.vapi.std.errors.internal_server_error": 500, "com.vmware.vapi.std.errors.not_found": 404})
+}
+
+func sessionsShowsensitivedataInputType() bindings.StructType {
+	fields := make(map[string]bindings.BindingType)
+	fieldNameMap := make(map[string]string)
+	fields["tier0_id"] = bindings.NewStringType()
+	fields["locale_service_id"] = bindings.NewStringType()
+	fields["service_id"] = bindings.NewStringType()
+	fields["session_id"] = bindings.NewStringType()
+	fieldNameMap["tier0_id"] = "Tier0Id"
+	fieldNameMap["locale_service_id"] = "LocaleServiceId"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["session_id"] = "SessionId"
+	var validators = []bindings.Validator{}
+	return bindings.NewStructType("operation-input", fields, reflect.TypeOf(data.StructValue{}), fieldNameMap, validators)
+}
+
+func sessionsShowsensitivedataOutputType() bindings.BindingType {
+	return bindings.NewDynamicStructType([]bindings.ReferenceType{bindings.NewReferenceType(model.IPSecVpnSessionBindingType)}, bindings.REST)
+}
+
+func sessionsShowsensitivedataRestMetadata() protocol.OperationRestMetadata {
+	fields := map[string]bindings.BindingType{}
+	fieldNameMap := map[string]string{}
+	paramsTypeMap := map[string]bindings.BindingType{}
+	pathParams := map[string]string{}
+	queryParams := map[string]string{}
+	headerParams := map[string]string{}
+	dispatchHeaderParams := map[string]string{}
+	bodyFieldsMap := map[string]string{}
+	fields["tier0_id"] = bindings.NewStringType()
+	fields["locale_service_id"] = bindings.NewStringType()
+	fields["service_id"] = bindings.NewStringType()
+	fields["session_id"] = bindings.NewStringType()
+	fieldNameMap["tier0_id"] = "Tier0Id"
+	fieldNameMap["locale_service_id"] = "LocaleServiceId"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["session_id"] = "SessionId"
+	paramsTypeMap["tier0_id"] = bindings.NewStringType()
+	paramsTypeMap["locale_service_id"] = bindings.NewStringType()
+	paramsTypeMap["service_id"] = bindings.NewStringType()
+	paramsTypeMap["session_id"] = bindings.NewStringType()
+	paramsTypeMap["tier0Id"] = bindings.NewStringType()
+	paramsTypeMap["localeServiceId"] = bindings.NewStringType()
+	paramsTypeMap["serviceId"] = bindings.NewStringType()
+	paramsTypeMap["sessionId"] = bindings.NewStringType()
+	pathParams["tier0_id"] = "tier0Id"
+	pathParams["session_id"] = "sessionId"
+	pathParams["locale_service_id"] = "localeServiceId"
+	pathParams["service_id"] = "serviceId"
+	resultHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
+	return protocol.NewOperationRestMetadata(
+		fields,
+		fieldNameMap,
+		paramsTypeMap,
+		pathParams,
+		queryParams,
+		headerParams,
+		dispatchHeaderParams,
+		bodyFieldsMap,
+		"action=show_sensitive_data",
+		"",
+		"GET",
+		"/policy/api/v1/infra/tier-0s/{tier0Id}/locale-services/{localeServiceId}/ipsec-vpn-services/{serviceId}/sessions/{sessionId}",
+		"",
+		resultHeaders,
+		200,
+		"",
+		errorHeaders,
+		map[string]int{"com.vmware.vapi.std.errors.invalid_request": 400, "com.vmware.vapi.std.errors.unauthorized": 403, "com.vmware.vapi.std.errors.service_unavailable": 503, "com.vmware.vapi.std.errors.internal_server_error": 500, "com.vmware.vapi.std.errors.not_found": 404})
+}
+
+func sessionsUpdateInputType() bindings.StructType {
+	fields := make(map[string]bindings.BindingType)
+	fieldNameMap := make(map[string]string)
+	fields["tier0_id"] = bindings.NewStringType()
+	fields["locale_service_id"] = bindings.NewStringType()
+	fields["service_id"] = bindings.NewStringType()
+	fields["session_id"] = bindings.NewStringType()
+	fields["ip_sec_vpn_session"] = bindings.NewDynamicStructType([]bindings.ReferenceType{bindings.NewReferenceType(model.IPSecVpnSessionBindingType)}, bindings.REST)
+	fieldNameMap["tier0_id"] = "Tier0Id"
+	fieldNameMap["locale_service_id"] = "LocaleServiceId"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["session_id"] = "SessionId"
+	fieldNameMap["ip_sec_vpn_session"] = "IpSecVpnSession"
+	var validators = []bindings.Validator{}
+	return bindings.NewStructType("operation-input", fields, reflect.TypeOf(data.StructValue{}), fieldNameMap, validators)
+}
+
+func sessionsUpdateOutputType() bindings.BindingType {
+	return bindings.NewDynamicStructType([]bindings.ReferenceType{bindings.NewReferenceType(model.IPSecVpnSessionBindingType)}, bindings.REST)
+}
+
+func sessionsUpdateRestMetadata() protocol.OperationRestMetadata {
+	fields := map[string]bindings.BindingType{}
+	fieldNameMap := map[string]string{}
+	paramsTypeMap := map[string]bindings.BindingType{}
+	pathParams := map[string]string{}
+	queryParams := map[string]string{}
+	headerParams := map[string]string{}
+	dispatchHeaderParams := map[string]string{}
+	bodyFieldsMap := map[string]string{}
+	fields["tier0_id"] = bindings.NewStringType()
+	fields["locale_service_id"] = bindings.NewStringType()
+	fields["service_id"] = bindings.NewStringType()
+	fields["session_id"] = bindings.NewStringType()
+	fields["ip_sec_vpn_session"] = bindings.NewDynamicStructType([]bindings.ReferenceType{bindings.NewReferenceType(model.IPSecVpnSessionBindingType)}, bindings.REST)
+	fieldNameMap["tier0_id"] = "Tier0Id"
+	fieldNameMap["locale_service_id"] = "LocaleServiceId"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["session_id"] = "SessionId"
+	fieldNameMap["ip_sec_vpn_session"] = "IpSecVpnSession"
+	paramsTypeMap["tier0_id"] = bindings.NewStringType()
+	paramsTypeMap["locale_service_id"] = bindings.NewStringType()
+	paramsTypeMap["service_id"] = bindings.NewStringType()
+	paramsTypeMap["session_id"] = bindings.NewStringType()
+	paramsTypeMap["ip_sec_vpn_session"] = bindings.NewDynamicStructType([]bindings.ReferenceType{bindings.NewReferenceType(model.IPSecVpnSessionBindingType)}, bindings.REST)
+	paramsTypeMap["tier0Id"] = bindings.NewStringType()
+	paramsTypeMap["localeServiceId"] = bindings.NewStringType()
+	paramsTypeMap["serviceId"] = bindings.NewStringType()
+	paramsTypeMap["sessionId"] = bindings.NewStringType()
+	pathParams["tier0_id"] = "tier0Id"
+	pathParams["session_id"] = "sessionId"
+	pathParams["locale_service_id"] = "localeServiceId"
+	pathParams["service_id"] = "serviceId"
+	resultHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
+	return protocol.NewOperationRestMetadata(
+		fields,
+		fieldNameMap,
+		paramsTypeMap,
+		pathParams,
+		queryParams,
+		headerParams,
+		dispatchHeaderParams,
+		bodyFieldsMap,
+		"",
+		"ip_sec_vpn_session",
+		"PUT",
+		"/policy/api/v1/infra/tier-0s/{tier0Id}/locale-services/{localeServiceId}/ipsec-vpn-services/{serviceId}/sessions/{sessionId}",
+		"",
+		resultHeaders,
+		200,
+		"",
+		errorHeaders,
+		map[string]int{"com.vmware.vapi.std.errors.invalid_request": 400, "com.vmware.vapi.std.errors.unauthorized": 403, "com.vmware.vapi.std.errors.service_unavailable": 503, "com.vmware.vapi.std.errors.internal_server_error": 500, "com.vmware.vapi.std.errors.not_found": 404})
+}

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_0s/locale_services/ipsec_vpn_services/SummaryClient.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_0s/locale_services/ipsec_vpn_services/SummaryClient.go
@@ -1,0 +1,98 @@
+// Copyright © 2019-2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+
+// Auto generated code. DO NOT EDIT.
+
+// Interface file for service: Summary
+// Used by client-side stubs.
+
+package ipsec_vpn_services
+
+import (
+	"github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/bindings"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/core"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/lib"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+)
+
+const _ = core.SupportedByRuntimeVersion1
+
+type SummaryClient interface {
+
+	// Summarized view of all tier-0 IPSec VPN sessions for a specified service. This API is deprecated. Please use GET /infra/tier-0s/<tier-0-id>/ipsec-vpn-services/<service-id>/summary instead.
+	//
+	// @param tier0IdParam (required)
+	// @param localeServiceIdParam (required)
+	// @param serviceIdParam (required)
+	// @param enforcementPointPathParam String Path of the enforcement point (optional)
+	// @param sourceParam Data source type. (optional)
+	// @return com.vmware.nsx_policy.model.PolicyIpsecVpnIkeServiceSummary
+	// @throws InvalidRequest  Bad Request, Precondition Failed
+	// @throws Unauthorized  Forbidden
+	// @throws ServiceUnavailable  Service Unavailable
+	// @throws InternalServerError  Internal Server Error
+	// @throws NotFound  Not Found
+	Get(tier0IdParam string, localeServiceIdParam string, serviceIdParam string, enforcementPointPathParam *string, sourceParam *string) (model.PolicyIpsecVpnIkeServiceSummary, error)
+}
+
+type summaryClient struct {
+	connector           client.Connector
+	interfaceDefinition core.InterfaceDefinition
+	errorsBindingMap    map[string]bindings.BindingType
+}
+
+func NewSummaryClient(connector client.Connector) *summaryClient {
+	interfaceIdentifier := core.NewInterfaceIdentifier("com.vmware.nsx_policy.infra.tier_0s.locale_services.ipsec_vpn_services.summary")
+	methodIdentifiers := map[string]core.MethodIdentifier{
+		"get": core.NewMethodIdentifier(interfaceIdentifier, "get"),
+	}
+	interfaceDefinition := core.NewInterfaceDefinition(interfaceIdentifier, methodIdentifiers)
+	errorsBindingMap := make(map[string]bindings.BindingType)
+
+	sIface := summaryClient{interfaceDefinition: interfaceDefinition, errorsBindingMap: errorsBindingMap, connector: connector}
+	return &sIface
+}
+
+func (sIface *summaryClient) GetErrorBindingType(errorName string) bindings.BindingType {
+	if entry, ok := sIface.errorsBindingMap[errorName]; ok {
+		return entry
+	}
+	return errors.ERROR_BINDINGS_MAP[errorName]
+}
+
+func (sIface *summaryClient) Get(tier0IdParam string, localeServiceIdParam string, serviceIdParam string, enforcementPointPathParam *string, sourceParam *string) (model.PolicyIpsecVpnIkeServiceSummary, error) {
+	typeConverter := sIface.connector.TypeConverter()
+	executionContext := sIface.connector.NewExecutionContext()
+	sv := bindings.NewStructValueBuilder(summaryGetInputType(), typeConverter)
+	sv.AddStructField("Tier0Id", tier0IdParam)
+	sv.AddStructField("LocaleServiceId", localeServiceIdParam)
+	sv.AddStructField("ServiceId", serviceIdParam)
+	sv.AddStructField("EnforcementPointPath", enforcementPointPathParam)
+	sv.AddStructField("Source", sourceParam)
+	inputDataValue, inputError := sv.GetStructValue()
+	if inputError != nil {
+		var emptyOutput model.PolicyIpsecVpnIkeServiceSummary
+		return emptyOutput, bindings.VAPIerrorsToError(inputError)
+	}
+	operationRestMetaData := summaryGetRestMetadata()
+	connectionMetadata := map[string]interface{}{lib.REST_METADATA: operationRestMetaData}
+	connectionMetadata["isStreamingResponse"] = false
+	sIface.connector.SetConnectionMetadata(connectionMetadata)
+	methodResult := sIface.connector.GetApiProvider().Invoke("com.vmware.nsx_policy.infra.tier_0s.locale_services.ipsec_vpn_services.summary", "get", inputDataValue, executionContext)
+	var emptyOutput model.PolicyIpsecVpnIkeServiceSummary
+	if methodResult.IsSuccess() {
+		output, errorInOutput := typeConverter.ConvertToGolang(methodResult.Output(), summaryGetOutputType())
+		if errorInOutput != nil {
+			return emptyOutput, bindings.VAPIerrorsToError(errorInOutput)
+		}
+		return output.(model.PolicyIpsecVpnIkeServiceSummary), nil
+	} else {
+		methodError, errorInError := typeConverter.ConvertToGolang(methodResult.Error(), sIface.GetErrorBindingType(methodResult.Error().Name()))
+		if errorInError != nil {
+			return emptyOutput, bindings.VAPIerrorsToError(errorInError)
+		}
+		return emptyOutput, methodError.(error)
+	}
+}

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_0s/locale_services/ipsec_vpn_services/SummaryTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_0s/locale_services/ipsec_vpn_services/SummaryTypes.go
@@ -1,0 +1,101 @@
+// Copyright © 2019-2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+
+// Auto generated code. DO NOT EDIT.
+
+// Data type definitions file for service: Summary.
+// Includes binding types of a structures and enumerations defined in the service.
+// Shared by client-side stubs and server-side skeletons to ensure type
+// compatibility.
+
+package ipsec_vpn_services
+
+import (
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/bindings"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/data"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+	"reflect"
+)
+
+// Possible value for ``source`` of method Summary#get.
+const Summary_GET_SOURCE_REALTIME = "realtime"
+
+// Possible value for ``source`` of method Summary#get.
+const Summary_GET_SOURCE_CACHED = "cached"
+
+func summaryGetInputType() bindings.StructType {
+	fields := make(map[string]bindings.BindingType)
+	fieldNameMap := make(map[string]string)
+	fields["tier0_id"] = bindings.NewStringType()
+	fields["locale_service_id"] = bindings.NewStringType()
+	fields["service_id"] = bindings.NewStringType()
+	fields["enforcement_point_path"] = bindings.NewOptionalType(bindings.NewStringType())
+	fields["source"] = bindings.NewOptionalType(bindings.NewStringType())
+	fieldNameMap["tier0_id"] = "Tier0Id"
+	fieldNameMap["locale_service_id"] = "LocaleServiceId"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["enforcement_point_path"] = "EnforcementPointPath"
+	fieldNameMap["source"] = "Source"
+	var validators = []bindings.Validator{}
+	return bindings.NewStructType("operation-input", fields, reflect.TypeOf(data.StructValue{}), fieldNameMap, validators)
+}
+
+func summaryGetOutputType() bindings.BindingType {
+	return bindings.NewReferenceType(model.PolicyIpsecVpnIkeServiceSummaryBindingType)
+}
+
+func summaryGetRestMetadata() protocol.OperationRestMetadata {
+	fields := map[string]bindings.BindingType{}
+	fieldNameMap := map[string]string{}
+	paramsTypeMap := map[string]bindings.BindingType{}
+	pathParams := map[string]string{}
+	queryParams := map[string]string{}
+	headerParams := map[string]string{}
+	dispatchHeaderParams := map[string]string{}
+	bodyFieldsMap := map[string]string{}
+	fields["tier0_id"] = bindings.NewStringType()
+	fields["locale_service_id"] = bindings.NewStringType()
+	fields["service_id"] = bindings.NewStringType()
+	fields["enforcement_point_path"] = bindings.NewOptionalType(bindings.NewStringType())
+	fields["source"] = bindings.NewOptionalType(bindings.NewStringType())
+	fieldNameMap["tier0_id"] = "Tier0Id"
+	fieldNameMap["locale_service_id"] = "LocaleServiceId"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["enforcement_point_path"] = "EnforcementPointPath"
+	fieldNameMap["source"] = "Source"
+	paramsTypeMap["source"] = bindings.NewOptionalType(bindings.NewStringType())
+	paramsTypeMap["tier0_id"] = bindings.NewStringType()
+	paramsTypeMap["enforcement_point_path"] = bindings.NewOptionalType(bindings.NewStringType())
+	paramsTypeMap["locale_service_id"] = bindings.NewStringType()
+	paramsTypeMap["service_id"] = bindings.NewStringType()
+	paramsTypeMap["tier0Id"] = bindings.NewStringType()
+	paramsTypeMap["localeServiceId"] = bindings.NewStringType()
+	paramsTypeMap["serviceId"] = bindings.NewStringType()
+	pathParams["tier0_id"] = "tier0Id"
+	pathParams["locale_service_id"] = "localeServiceId"
+	pathParams["service_id"] = "serviceId"
+	queryParams["enforcement_point_path"] = "enforcement_point_path"
+	queryParams["source"] = "source"
+	resultHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
+	return protocol.NewOperationRestMetadata(
+		fields,
+		fieldNameMap,
+		paramsTypeMap,
+		pathParams,
+		queryParams,
+		headerParams,
+		dispatchHeaderParams,
+		bodyFieldsMap,
+		"",
+		"",
+		"GET",
+		"/policy/api/v1/infra/tier-0s/{tier0Id}/locale-services/{localeServiceId}/ipsec-vpn-services/{serviceId}/summary",
+		"",
+		resultHeaders,
+		200,
+		"",
+		errorHeaders,
+		map[string]int{"com.vmware.vapi.std.errors.invalid_request": 400, "com.vmware.vapi.std.errors.unauthorized": 403, "com.vmware.vapi.std.errors.service_unavailable": 503, "com.vmware.vapi.std.errors.internal_server_error": 500, "com.vmware.vapi.std.errors.not_found": 404})
+}

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_0s/locale_services/l2vpn_services/L2vpnServicesPackageTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_0s/locale_services/l2vpn_services/L2vpnServicesPackageTypes.go
@@ -1,0 +1,11 @@
+// Copyright © 2019-2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+
+// Auto generated code. DO NOT EDIT.
+
+// Data type definitions file for package: com.vmware.nsx_policy.infra.tier_0s.locale_services.l2vpn_services.
+// Includes binding types of a top level structures and enumerations.
+// Shared by client-side stubs and server-side skeletons to ensure type
+// compatibility.
+
+package l2vpn_services

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_0s/locale_services/l2vpn_services/SessionsClient.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_0s/locale_services/l2vpn_services/SessionsClient.go
@@ -1,0 +1,336 @@
+// Copyright © 2019-2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+
+// Auto generated code. DO NOT EDIT.
+
+// Interface file for service: Sessions
+// Used by client-side stubs.
+
+package l2vpn_services
+
+import (
+	"github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/bindings"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/core"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/lib"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+)
+
+const _ = core.SupportedByRuntimeVersion1
+
+type SessionsClient interface {
+
+	// Create or patch an L2VPN session under Tier-0 from Peer Codes. In addition to the L2VPN Session, the IPSec VPN Session, along with the IKE, Tunnel, and DPD Profiles are created and owned by the system. IPSec VPN Service and Local Endpoint are created only when required, i.e., an IPSec VPN Service does not already exist, or an IPSec VPN Local Endpoint with same local address does not already exist. Updating the L2VPN Session can be performed only through this API by specifying new peer codes. Use of specific APIs to update the L2VPN Session and the different resources associated with it is not allowed, except for IPSec VPN Service and Local Endpoint, resources that are not system owned. API supported only when L2VPN Service is in Client Mode. This API is deprecated. Please use POST /infra/tier-0s/<tier-0-id>/l2vpn-services/<service-id>/ sessions/<session-id>?action=create_with_peer_code instead. Note: Please note that request is validated and any error messages returned from validation may include the new VPN path instead of the deprecated path. Both new path and old path refer to same resource. Also VPN path returned in the Alarm, GPRR payload may include the new VPN path.
+	//
+	// @param tier0IdParam (required)
+	// @param localeServiceIdParam (required)
+	// @param serviceIdParam (required)
+	// @param sessionIdParam (required)
+	// @param l2VPNSessionDataParam (required)
+	// @throws InvalidRequest  Bad Request, Precondition Failed
+	// @throws Unauthorized  Forbidden
+	// @throws ServiceUnavailable  Service Unavailable
+	// @throws InternalServerError  Internal Server Error
+	// @throws NotFound  Not Found
+	Createwithpeercode(tier0IdParam string, localeServiceIdParam string, serviceIdParam string, sessionIdParam string, l2VPNSessionDataParam model.L2VPNSessionData) error
+
+	// Delete L2VPN session under Tier-0. When L2VPN Service is in CLIENT Mode, the L2VPN Session is deleted along with its transpot tunnels and related resources. This API is deprecated. Please use DELETE /infra/tier-0s/<tier-0-id>/ l2vpn-services/<service-id>/sessions/<session-id> instead. Note: Please note that request is validated and any error messages returned from validation may include the new VPN path instead of the deprecated path. Both new path and old path refer to same resource. Also VPN path returned in the Alarm, GPRR payload may include the new VPN path.
+	//
+	// @param tier0IdParam (required)
+	// @param localeServiceIdParam (required)
+	// @param serviceIdParam (required)
+	// @param sessionIdParam (required)
+	// @throws InvalidRequest  Bad Request, Precondition Failed
+	// @throws Unauthorized  Forbidden
+	// @throws ServiceUnavailable  Service Unavailable
+	// @throws InternalServerError  Internal Server Error
+	// @throws NotFound  Not Found
+	Delete(tier0IdParam string, localeServiceIdParam string, serviceIdParam string, sessionIdParam string) error
+
+	// Get L2VPN session under Tier-0. This API is deprecated. Please use GET /infra/tier-0s/<tier-0-id>/ l2vpn-services/<service-id>/sessions/<session-id> instead. Note: The API will return a new VPN path for \"transport_tunnels\" in the response payload instead of the deprecated API path Both paths refer to the same object. Please note that request is validated and any error messages returned from validation may include the new VPN path instead of the deprecated path. Both new path and old path refer to same resource.
+	//
+	// @param tier0IdParam (required)
+	// @param localeServiceIdParam (required)
+	// @param serviceIdParam (required)
+	// @param sessionIdParam (required)
+	// @return com.vmware.nsx_policy.model.L2VPNSession
+	// @throws InvalidRequest  Bad Request, Precondition Failed
+	// @throws Unauthorized  Forbidden
+	// @throws ServiceUnavailable  Service Unavailable
+	// @throws InternalServerError  Internal Server Error
+	// @throws NotFound  Not Found
+	Get(tier0IdParam string, localeServiceIdParam string, serviceIdParam string, sessionIdParam string) (model.L2VPNSession, error)
+
+	// Get paginated list of all L2VPN sessions under Tier-0. This API is deprecated. Please use GET /infra/tier-0s/<tier-0-id>/ l2vpn-services/<service-id>/sessions instead. Note: The API will return a new VPN path for \"transport_tunnels\" in the response payload instead of the deprecated API path Both paths refer to the same object. Please note that request is validated and any error messages returned from validation may include the new VPN path instead of the deprecated path. Both new path and old path refer to same resource.
+	//
+	// @param tier0IdParam (required)
+	// @param localeServiceIdParam (required)
+	// @param serviceIdParam (required)
+	// @param cursorParam Opaque cursor to be used for getting next page of records (supplied by current result page) (optional)
+	// @param includeMarkForDeleteObjectsParam Include objects that are marked for deletion in results (optional, default to false)
+	// @param includedFieldsParam Comma separated list of fields that should be included in query result (optional)
+	// @param pageSizeParam Maximum number of results to return in this page (server may return fewer) (optional, default to 1000)
+	// @param sortAscendingParam (optional)
+	// @param sortByParam Field by which records are sorted (optional)
+	// @return com.vmware.nsx_policy.model.L2VPNSessionListResult
+	// @throws InvalidRequest  Bad Request, Precondition Failed
+	// @throws Unauthorized  Forbidden
+	// @throws ServiceUnavailable  Service Unavailable
+	// @throws InternalServerError  Internal Server Error
+	// @throws NotFound  Not Found
+	List(tier0IdParam string, localeServiceIdParam string, serviceIdParam string, cursorParam *string, includeMarkForDeleteObjectsParam *bool, includedFieldsParam *string, pageSizeParam *int64, sortAscendingParam *bool, sortByParam *string) (model.L2VPNSessionListResult, error)
+
+	// Create or patch an L2VPN session under Tier-0. API supported only when L2VPN Service is in Server Mode. This API is deprecated. Please use PATCH /infra/tier-0s/<tier-0-id>/ l2vpn-services/<service-id>/sessions/<session-id> instead. Note: Please note that request is validated and any error messages returned from validation may include the new VPN path instead of the deprecated path. Both new path and old path refer to same resource. Also VPN path returned in the Alarm, GPRR payload may include the new VPN path.
+	//
+	// @param tier0IdParam (required)
+	// @param localeServiceIdParam (required)
+	// @param serviceIdParam (required)
+	// @param sessionIdParam (required)
+	// @param l2VPNSessionParam (required)
+	// @throws InvalidRequest  Bad Request, Precondition Failed
+	// @throws Unauthorized  Forbidden
+	// @throws ServiceUnavailable  Service Unavailable
+	// @throws InternalServerError  Internal Server Error
+	// @throws NotFound  Not Found
+	Patch(tier0IdParam string, localeServiceIdParam string, serviceIdParam string, sessionIdParam string, l2VPNSessionParam model.L2VPNSession) error
+
+	// Create or fully replace L2VPN session under Tier-0. API supported only when L2VPN Service is in Server Mode. Revision is optional for creation and required for update. This API is deprecated. Please use PUT /infra/tier-0s/<tier-0-id>/ l2vpn-services/<service-id>/sessions/<session-id> instead. Note: The API will return a new VPN path for \"transport_tunnels\" in the response payload instead of the deprecated API path Both paths refer to the same object. Please note that request is validated and any error messages returned from validation may include the new VPN path instead of the deprecated path. Both new path and old path refer to same resource. Also VPN path returned in the Alarm, GPRR payload may include the new VPN path.
+	//
+	// @param tier0IdParam (required)
+	// @param localeServiceIdParam (required)
+	// @param serviceIdParam (required)
+	// @param sessionIdParam (required)
+	// @param l2VPNSessionParam (required)
+	// @return com.vmware.nsx_policy.model.L2VPNSession
+	// @throws InvalidRequest  Bad Request, Precondition Failed
+	// @throws Unauthorized  Forbidden
+	// @throws ServiceUnavailable  Service Unavailable
+	// @throws InternalServerError  Internal Server Error
+	// @throws NotFound  Not Found
+	Update(tier0IdParam string, localeServiceIdParam string, serviceIdParam string, sessionIdParam string, l2VPNSessionParam model.L2VPNSession) (model.L2VPNSession, error)
+}
+
+type sessionsClient struct {
+	connector           client.Connector
+	interfaceDefinition core.InterfaceDefinition
+	errorsBindingMap    map[string]bindings.BindingType
+}
+
+func NewSessionsClient(connector client.Connector) *sessionsClient {
+	interfaceIdentifier := core.NewInterfaceIdentifier("com.vmware.nsx_policy.infra.tier_0s.locale_services.l2vpn_services.sessions")
+	methodIdentifiers := map[string]core.MethodIdentifier{
+		"createwithpeercode": core.NewMethodIdentifier(interfaceIdentifier, "createwithpeercode"),
+		"delete":             core.NewMethodIdentifier(interfaceIdentifier, "delete"),
+		"get":                core.NewMethodIdentifier(interfaceIdentifier, "get"),
+		"list":               core.NewMethodIdentifier(interfaceIdentifier, "list"),
+		"patch":              core.NewMethodIdentifier(interfaceIdentifier, "patch"),
+		"update":             core.NewMethodIdentifier(interfaceIdentifier, "update"),
+	}
+	interfaceDefinition := core.NewInterfaceDefinition(interfaceIdentifier, methodIdentifiers)
+	errorsBindingMap := make(map[string]bindings.BindingType)
+
+	sIface := sessionsClient{interfaceDefinition: interfaceDefinition, errorsBindingMap: errorsBindingMap, connector: connector}
+	return &sIface
+}
+
+func (sIface *sessionsClient) GetErrorBindingType(errorName string) bindings.BindingType {
+	if entry, ok := sIface.errorsBindingMap[errorName]; ok {
+		return entry
+	}
+	return errors.ERROR_BINDINGS_MAP[errorName]
+}
+
+func (sIface *sessionsClient) Createwithpeercode(tier0IdParam string, localeServiceIdParam string, serviceIdParam string, sessionIdParam string, l2VPNSessionDataParam model.L2VPNSessionData) error {
+	typeConverter := sIface.connector.TypeConverter()
+	executionContext := sIface.connector.NewExecutionContext()
+	sv := bindings.NewStructValueBuilder(sessionsCreatewithpeercodeInputType(), typeConverter)
+	sv.AddStructField("Tier0Id", tier0IdParam)
+	sv.AddStructField("LocaleServiceId", localeServiceIdParam)
+	sv.AddStructField("ServiceId", serviceIdParam)
+	sv.AddStructField("SessionId", sessionIdParam)
+	sv.AddStructField("L2VPNSessionData", l2VPNSessionDataParam)
+	inputDataValue, inputError := sv.GetStructValue()
+	if inputError != nil {
+		return bindings.VAPIerrorsToError(inputError)
+	}
+	operationRestMetaData := sessionsCreatewithpeercodeRestMetadata()
+	connectionMetadata := map[string]interface{}{lib.REST_METADATA: operationRestMetaData}
+	connectionMetadata["isStreamingResponse"] = false
+	sIface.connector.SetConnectionMetadata(connectionMetadata)
+	methodResult := sIface.connector.GetApiProvider().Invoke("com.vmware.nsx_policy.infra.tier_0s.locale_services.l2vpn_services.sessions", "createwithpeercode", inputDataValue, executionContext)
+	if methodResult.IsSuccess() {
+		return nil
+	} else {
+		methodError, errorInError := typeConverter.ConvertToGolang(methodResult.Error(), sIface.GetErrorBindingType(methodResult.Error().Name()))
+		if errorInError != nil {
+			return bindings.VAPIerrorsToError(errorInError)
+		}
+		return methodError.(error)
+	}
+}
+
+func (sIface *sessionsClient) Delete(tier0IdParam string, localeServiceIdParam string, serviceIdParam string, sessionIdParam string) error {
+	typeConverter := sIface.connector.TypeConverter()
+	executionContext := sIface.connector.NewExecutionContext()
+	sv := bindings.NewStructValueBuilder(sessionsDeleteInputType(), typeConverter)
+	sv.AddStructField("Tier0Id", tier0IdParam)
+	sv.AddStructField("LocaleServiceId", localeServiceIdParam)
+	sv.AddStructField("ServiceId", serviceIdParam)
+	sv.AddStructField("SessionId", sessionIdParam)
+	inputDataValue, inputError := sv.GetStructValue()
+	if inputError != nil {
+		return bindings.VAPIerrorsToError(inputError)
+	}
+	operationRestMetaData := sessionsDeleteRestMetadata()
+	connectionMetadata := map[string]interface{}{lib.REST_METADATA: operationRestMetaData}
+	connectionMetadata["isStreamingResponse"] = false
+	sIface.connector.SetConnectionMetadata(connectionMetadata)
+	methodResult := sIface.connector.GetApiProvider().Invoke("com.vmware.nsx_policy.infra.tier_0s.locale_services.l2vpn_services.sessions", "delete", inputDataValue, executionContext)
+	if methodResult.IsSuccess() {
+		return nil
+	} else {
+		methodError, errorInError := typeConverter.ConvertToGolang(methodResult.Error(), sIface.GetErrorBindingType(methodResult.Error().Name()))
+		if errorInError != nil {
+			return bindings.VAPIerrorsToError(errorInError)
+		}
+		return methodError.(error)
+	}
+}
+
+func (sIface *sessionsClient) Get(tier0IdParam string, localeServiceIdParam string, serviceIdParam string, sessionIdParam string) (model.L2VPNSession, error) {
+	typeConverter := sIface.connector.TypeConverter()
+	executionContext := sIface.connector.NewExecutionContext()
+	sv := bindings.NewStructValueBuilder(sessionsGetInputType(), typeConverter)
+	sv.AddStructField("Tier0Id", tier0IdParam)
+	sv.AddStructField("LocaleServiceId", localeServiceIdParam)
+	sv.AddStructField("ServiceId", serviceIdParam)
+	sv.AddStructField("SessionId", sessionIdParam)
+	inputDataValue, inputError := sv.GetStructValue()
+	if inputError != nil {
+		var emptyOutput model.L2VPNSession
+		return emptyOutput, bindings.VAPIerrorsToError(inputError)
+	}
+	operationRestMetaData := sessionsGetRestMetadata()
+	connectionMetadata := map[string]interface{}{lib.REST_METADATA: operationRestMetaData}
+	connectionMetadata["isStreamingResponse"] = false
+	sIface.connector.SetConnectionMetadata(connectionMetadata)
+	methodResult := sIface.connector.GetApiProvider().Invoke("com.vmware.nsx_policy.infra.tier_0s.locale_services.l2vpn_services.sessions", "get", inputDataValue, executionContext)
+	var emptyOutput model.L2VPNSession
+	if methodResult.IsSuccess() {
+		output, errorInOutput := typeConverter.ConvertToGolang(methodResult.Output(), sessionsGetOutputType())
+		if errorInOutput != nil {
+			return emptyOutput, bindings.VAPIerrorsToError(errorInOutput)
+		}
+		return output.(model.L2VPNSession), nil
+	} else {
+		methodError, errorInError := typeConverter.ConvertToGolang(methodResult.Error(), sIface.GetErrorBindingType(methodResult.Error().Name()))
+		if errorInError != nil {
+			return emptyOutput, bindings.VAPIerrorsToError(errorInError)
+		}
+		return emptyOutput, methodError.(error)
+	}
+}
+
+func (sIface *sessionsClient) List(tier0IdParam string, localeServiceIdParam string, serviceIdParam string, cursorParam *string, includeMarkForDeleteObjectsParam *bool, includedFieldsParam *string, pageSizeParam *int64, sortAscendingParam *bool, sortByParam *string) (model.L2VPNSessionListResult, error) {
+	typeConverter := sIface.connector.TypeConverter()
+	executionContext := sIface.connector.NewExecutionContext()
+	sv := bindings.NewStructValueBuilder(sessionsListInputType(), typeConverter)
+	sv.AddStructField("Tier0Id", tier0IdParam)
+	sv.AddStructField("LocaleServiceId", localeServiceIdParam)
+	sv.AddStructField("ServiceId", serviceIdParam)
+	sv.AddStructField("Cursor", cursorParam)
+	sv.AddStructField("IncludeMarkForDeleteObjects", includeMarkForDeleteObjectsParam)
+	sv.AddStructField("IncludedFields", includedFieldsParam)
+	sv.AddStructField("PageSize", pageSizeParam)
+	sv.AddStructField("SortAscending", sortAscendingParam)
+	sv.AddStructField("SortBy", sortByParam)
+	inputDataValue, inputError := sv.GetStructValue()
+	if inputError != nil {
+		var emptyOutput model.L2VPNSessionListResult
+		return emptyOutput, bindings.VAPIerrorsToError(inputError)
+	}
+	operationRestMetaData := sessionsListRestMetadata()
+	connectionMetadata := map[string]interface{}{lib.REST_METADATA: operationRestMetaData}
+	connectionMetadata["isStreamingResponse"] = false
+	sIface.connector.SetConnectionMetadata(connectionMetadata)
+	methodResult := sIface.connector.GetApiProvider().Invoke("com.vmware.nsx_policy.infra.tier_0s.locale_services.l2vpn_services.sessions", "list", inputDataValue, executionContext)
+	var emptyOutput model.L2VPNSessionListResult
+	if methodResult.IsSuccess() {
+		output, errorInOutput := typeConverter.ConvertToGolang(methodResult.Output(), sessionsListOutputType())
+		if errorInOutput != nil {
+			return emptyOutput, bindings.VAPIerrorsToError(errorInOutput)
+		}
+		return output.(model.L2VPNSessionListResult), nil
+	} else {
+		methodError, errorInError := typeConverter.ConvertToGolang(methodResult.Error(), sIface.GetErrorBindingType(methodResult.Error().Name()))
+		if errorInError != nil {
+			return emptyOutput, bindings.VAPIerrorsToError(errorInError)
+		}
+		return emptyOutput, methodError.(error)
+	}
+}
+
+func (sIface *sessionsClient) Patch(tier0IdParam string, localeServiceIdParam string, serviceIdParam string, sessionIdParam string, l2VPNSessionParam model.L2VPNSession) error {
+	typeConverter := sIface.connector.TypeConverter()
+	executionContext := sIface.connector.NewExecutionContext()
+	sv := bindings.NewStructValueBuilder(sessionsPatchInputType(), typeConverter)
+	sv.AddStructField("Tier0Id", tier0IdParam)
+	sv.AddStructField("LocaleServiceId", localeServiceIdParam)
+	sv.AddStructField("ServiceId", serviceIdParam)
+	sv.AddStructField("SessionId", sessionIdParam)
+	sv.AddStructField("L2VPNSession", l2VPNSessionParam)
+	inputDataValue, inputError := sv.GetStructValue()
+	if inputError != nil {
+		return bindings.VAPIerrorsToError(inputError)
+	}
+	operationRestMetaData := sessionsPatchRestMetadata()
+	connectionMetadata := map[string]interface{}{lib.REST_METADATA: operationRestMetaData}
+	connectionMetadata["isStreamingResponse"] = false
+	sIface.connector.SetConnectionMetadata(connectionMetadata)
+	methodResult := sIface.connector.GetApiProvider().Invoke("com.vmware.nsx_policy.infra.tier_0s.locale_services.l2vpn_services.sessions", "patch", inputDataValue, executionContext)
+	if methodResult.IsSuccess() {
+		return nil
+	} else {
+		methodError, errorInError := typeConverter.ConvertToGolang(methodResult.Error(), sIface.GetErrorBindingType(methodResult.Error().Name()))
+		if errorInError != nil {
+			return bindings.VAPIerrorsToError(errorInError)
+		}
+		return methodError.(error)
+	}
+}
+
+func (sIface *sessionsClient) Update(tier0IdParam string, localeServiceIdParam string, serviceIdParam string, sessionIdParam string, l2VPNSessionParam model.L2VPNSession) (model.L2VPNSession, error) {
+	typeConverter := sIface.connector.TypeConverter()
+	executionContext := sIface.connector.NewExecutionContext()
+	sv := bindings.NewStructValueBuilder(sessionsUpdateInputType(), typeConverter)
+	sv.AddStructField("Tier0Id", tier0IdParam)
+	sv.AddStructField("LocaleServiceId", localeServiceIdParam)
+	sv.AddStructField("ServiceId", serviceIdParam)
+	sv.AddStructField("SessionId", sessionIdParam)
+	sv.AddStructField("L2VPNSession", l2VPNSessionParam)
+	inputDataValue, inputError := sv.GetStructValue()
+	if inputError != nil {
+		var emptyOutput model.L2VPNSession
+		return emptyOutput, bindings.VAPIerrorsToError(inputError)
+	}
+	operationRestMetaData := sessionsUpdateRestMetadata()
+	connectionMetadata := map[string]interface{}{lib.REST_METADATA: operationRestMetaData}
+	connectionMetadata["isStreamingResponse"] = false
+	sIface.connector.SetConnectionMetadata(connectionMetadata)
+	methodResult := sIface.connector.GetApiProvider().Invoke("com.vmware.nsx_policy.infra.tier_0s.locale_services.l2vpn_services.sessions", "update", inputDataValue, executionContext)
+	var emptyOutput model.L2VPNSession
+	if methodResult.IsSuccess() {
+		output, errorInOutput := typeConverter.ConvertToGolang(methodResult.Output(), sessionsUpdateOutputType())
+		if errorInOutput != nil {
+			return emptyOutput, bindings.VAPIerrorsToError(errorInOutput)
+		}
+		return output.(model.L2VPNSession), nil
+	} else {
+		methodError, errorInError := typeConverter.ConvertToGolang(methodResult.Error(), sIface.GetErrorBindingType(methodResult.Error().Name()))
+		if errorInError != nil {
+			return emptyOutput, bindings.VAPIerrorsToError(errorInError)
+		}
+		return emptyOutput, methodError.(error)
+	}
+}

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_0s/locale_services/l2vpn_services/SessionsTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_0s/locale_services/l2vpn_services/SessionsTypes.go
@@ -1,0 +1,489 @@
+// Copyright © 2019-2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+
+// Auto generated code. DO NOT EDIT.
+
+// Data type definitions file for service: Sessions.
+// Includes binding types of a structures and enumerations defined in the service.
+// Shared by client-side stubs and server-side skeletons to ensure type
+// compatibility.
+
+package l2vpn_services
+
+import (
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/bindings"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/data"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+	"reflect"
+)
+
+func sessionsCreatewithpeercodeInputType() bindings.StructType {
+	fields := make(map[string]bindings.BindingType)
+	fieldNameMap := make(map[string]string)
+	fields["tier0_id"] = bindings.NewStringType()
+	fields["locale_service_id"] = bindings.NewStringType()
+	fields["service_id"] = bindings.NewStringType()
+	fields["session_id"] = bindings.NewStringType()
+	fields["l2_VPN_session_data"] = bindings.NewReferenceType(model.L2VPNSessionDataBindingType)
+	fieldNameMap["tier0_id"] = "Tier0Id"
+	fieldNameMap["locale_service_id"] = "LocaleServiceId"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["session_id"] = "SessionId"
+	fieldNameMap["l2_VPN_session_data"] = "L2VPNSessionData"
+	var validators = []bindings.Validator{}
+	return bindings.NewStructType("operation-input", fields, reflect.TypeOf(data.StructValue{}), fieldNameMap, validators)
+}
+
+func sessionsCreatewithpeercodeOutputType() bindings.BindingType {
+	return bindings.NewVoidType()
+}
+
+func sessionsCreatewithpeercodeRestMetadata() protocol.OperationRestMetadata {
+	fields := map[string]bindings.BindingType{}
+	fieldNameMap := map[string]string{}
+	paramsTypeMap := map[string]bindings.BindingType{}
+	pathParams := map[string]string{}
+	queryParams := map[string]string{}
+	headerParams := map[string]string{}
+	dispatchHeaderParams := map[string]string{}
+	bodyFieldsMap := map[string]string{}
+	fields["tier0_id"] = bindings.NewStringType()
+	fields["locale_service_id"] = bindings.NewStringType()
+	fields["service_id"] = bindings.NewStringType()
+	fields["session_id"] = bindings.NewStringType()
+	fields["l2_VPN_session_data"] = bindings.NewReferenceType(model.L2VPNSessionDataBindingType)
+	fieldNameMap["tier0_id"] = "Tier0Id"
+	fieldNameMap["locale_service_id"] = "LocaleServiceId"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["session_id"] = "SessionId"
+	fieldNameMap["l2_VPN_session_data"] = "L2VPNSessionData"
+	paramsTypeMap["tier0_id"] = bindings.NewStringType()
+	paramsTypeMap["l2_VPN_session_data"] = bindings.NewReferenceType(model.L2VPNSessionDataBindingType)
+	paramsTypeMap["locale_service_id"] = bindings.NewStringType()
+	paramsTypeMap["service_id"] = bindings.NewStringType()
+	paramsTypeMap["session_id"] = bindings.NewStringType()
+	paramsTypeMap["tier0Id"] = bindings.NewStringType()
+	paramsTypeMap["localeServiceId"] = bindings.NewStringType()
+	paramsTypeMap["serviceId"] = bindings.NewStringType()
+	paramsTypeMap["sessionId"] = bindings.NewStringType()
+	pathParams["tier0_id"] = "tier0Id"
+	pathParams["session_id"] = "sessionId"
+	pathParams["locale_service_id"] = "localeServiceId"
+	pathParams["service_id"] = "serviceId"
+	resultHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
+	return protocol.NewOperationRestMetadata(
+		fields,
+		fieldNameMap,
+		paramsTypeMap,
+		pathParams,
+		queryParams,
+		headerParams,
+		dispatchHeaderParams,
+		bodyFieldsMap,
+		"action=create_with_peer_code",
+		"l2_VPN_session_data",
+		"POST",
+		"/policy/api/v1/infra/tier-0s/{tier0Id}/locale-services/{localeServiceId}/l2vpn-services/{serviceId}/sessions/{sessionId}",
+		"",
+		resultHeaders,
+		204,
+		"",
+		errorHeaders,
+		map[string]int{"com.vmware.vapi.std.errors.invalid_request": 400, "com.vmware.vapi.std.errors.unauthorized": 403, "com.vmware.vapi.std.errors.service_unavailable": 503, "com.vmware.vapi.std.errors.internal_server_error": 500, "com.vmware.vapi.std.errors.not_found": 404})
+}
+
+func sessionsDeleteInputType() bindings.StructType {
+	fields := make(map[string]bindings.BindingType)
+	fieldNameMap := make(map[string]string)
+	fields["tier0_id"] = bindings.NewStringType()
+	fields["locale_service_id"] = bindings.NewStringType()
+	fields["service_id"] = bindings.NewStringType()
+	fields["session_id"] = bindings.NewStringType()
+	fieldNameMap["tier0_id"] = "Tier0Id"
+	fieldNameMap["locale_service_id"] = "LocaleServiceId"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["session_id"] = "SessionId"
+	var validators = []bindings.Validator{}
+	return bindings.NewStructType("operation-input", fields, reflect.TypeOf(data.StructValue{}), fieldNameMap, validators)
+}
+
+func sessionsDeleteOutputType() bindings.BindingType {
+	return bindings.NewVoidType()
+}
+
+func sessionsDeleteRestMetadata() protocol.OperationRestMetadata {
+	fields := map[string]bindings.BindingType{}
+	fieldNameMap := map[string]string{}
+	paramsTypeMap := map[string]bindings.BindingType{}
+	pathParams := map[string]string{}
+	queryParams := map[string]string{}
+	headerParams := map[string]string{}
+	dispatchHeaderParams := map[string]string{}
+	bodyFieldsMap := map[string]string{}
+	fields["tier0_id"] = bindings.NewStringType()
+	fields["locale_service_id"] = bindings.NewStringType()
+	fields["service_id"] = bindings.NewStringType()
+	fields["session_id"] = bindings.NewStringType()
+	fieldNameMap["tier0_id"] = "Tier0Id"
+	fieldNameMap["locale_service_id"] = "LocaleServiceId"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["session_id"] = "SessionId"
+	paramsTypeMap["tier0_id"] = bindings.NewStringType()
+	paramsTypeMap["locale_service_id"] = bindings.NewStringType()
+	paramsTypeMap["service_id"] = bindings.NewStringType()
+	paramsTypeMap["session_id"] = bindings.NewStringType()
+	paramsTypeMap["tier0Id"] = bindings.NewStringType()
+	paramsTypeMap["localeServiceId"] = bindings.NewStringType()
+	paramsTypeMap["serviceId"] = bindings.NewStringType()
+	paramsTypeMap["sessionId"] = bindings.NewStringType()
+	pathParams["tier0_id"] = "tier0Id"
+	pathParams["session_id"] = "sessionId"
+	pathParams["locale_service_id"] = "localeServiceId"
+	pathParams["service_id"] = "serviceId"
+	resultHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
+	return protocol.NewOperationRestMetadata(
+		fields,
+		fieldNameMap,
+		paramsTypeMap,
+		pathParams,
+		queryParams,
+		headerParams,
+		dispatchHeaderParams,
+		bodyFieldsMap,
+		"",
+		"",
+		"DELETE",
+		"/policy/api/v1/infra/tier-0s/{tier0Id}/locale-services/{localeServiceId}/l2vpn-services/{serviceId}/sessions/{sessionId}",
+		"",
+		resultHeaders,
+		204,
+		"",
+		errorHeaders,
+		map[string]int{"com.vmware.vapi.std.errors.invalid_request": 400, "com.vmware.vapi.std.errors.unauthorized": 403, "com.vmware.vapi.std.errors.service_unavailable": 503, "com.vmware.vapi.std.errors.internal_server_error": 500, "com.vmware.vapi.std.errors.not_found": 404})
+}
+
+func sessionsGetInputType() bindings.StructType {
+	fields := make(map[string]bindings.BindingType)
+	fieldNameMap := make(map[string]string)
+	fields["tier0_id"] = bindings.NewStringType()
+	fields["locale_service_id"] = bindings.NewStringType()
+	fields["service_id"] = bindings.NewStringType()
+	fields["session_id"] = bindings.NewStringType()
+	fieldNameMap["tier0_id"] = "Tier0Id"
+	fieldNameMap["locale_service_id"] = "LocaleServiceId"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["session_id"] = "SessionId"
+	var validators = []bindings.Validator{}
+	return bindings.NewStructType("operation-input", fields, reflect.TypeOf(data.StructValue{}), fieldNameMap, validators)
+}
+
+func sessionsGetOutputType() bindings.BindingType {
+	return bindings.NewReferenceType(model.L2VPNSessionBindingType)
+}
+
+func sessionsGetRestMetadata() protocol.OperationRestMetadata {
+	fields := map[string]bindings.BindingType{}
+	fieldNameMap := map[string]string{}
+	paramsTypeMap := map[string]bindings.BindingType{}
+	pathParams := map[string]string{}
+	queryParams := map[string]string{}
+	headerParams := map[string]string{}
+	dispatchHeaderParams := map[string]string{}
+	bodyFieldsMap := map[string]string{}
+	fields["tier0_id"] = bindings.NewStringType()
+	fields["locale_service_id"] = bindings.NewStringType()
+	fields["service_id"] = bindings.NewStringType()
+	fields["session_id"] = bindings.NewStringType()
+	fieldNameMap["tier0_id"] = "Tier0Id"
+	fieldNameMap["locale_service_id"] = "LocaleServiceId"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["session_id"] = "SessionId"
+	paramsTypeMap["tier0_id"] = bindings.NewStringType()
+	paramsTypeMap["locale_service_id"] = bindings.NewStringType()
+	paramsTypeMap["service_id"] = bindings.NewStringType()
+	paramsTypeMap["session_id"] = bindings.NewStringType()
+	paramsTypeMap["tier0Id"] = bindings.NewStringType()
+	paramsTypeMap["localeServiceId"] = bindings.NewStringType()
+	paramsTypeMap["serviceId"] = bindings.NewStringType()
+	paramsTypeMap["sessionId"] = bindings.NewStringType()
+	pathParams["tier0_id"] = "tier0Id"
+	pathParams["session_id"] = "sessionId"
+	pathParams["locale_service_id"] = "localeServiceId"
+	pathParams["service_id"] = "serviceId"
+	resultHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
+	return protocol.NewOperationRestMetadata(
+		fields,
+		fieldNameMap,
+		paramsTypeMap,
+		pathParams,
+		queryParams,
+		headerParams,
+		dispatchHeaderParams,
+		bodyFieldsMap,
+		"",
+		"",
+		"GET",
+		"/policy/api/v1/infra/tier-0s/{tier0Id}/locale-services/{localeServiceId}/l2vpn-services/{serviceId}/sessions/{sessionId}",
+		"",
+		resultHeaders,
+		200,
+		"",
+		errorHeaders,
+		map[string]int{"com.vmware.vapi.std.errors.invalid_request": 400, "com.vmware.vapi.std.errors.unauthorized": 403, "com.vmware.vapi.std.errors.service_unavailable": 503, "com.vmware.vapi.std.errors.internal_server_error": 500, "com.vmware.vapi.std.errors.not_found": 404})
+}
+
+func sessionsListInputType() bindings.StructType {
+	fields := make(map[string]bindings.BindingType)
+	fieldNameMap := make(map[string]string)
+	fields["tier0_id"] = bindings.NewStringType()
+	fields["locale_service_id"] = bindings.NewStringType()
+	fields["service_id"] = bindings.NewStringType()
+	fields["cursor"] = bindings.NewOptionalType(bindings.NewStringType())
+	fields["include_mark_for_delete_objects"] = bindings.NewOptionalType(bindings.NewBooleanType())
+	fields["included_fields"] = bindings.NewOptionalType(bindings.NewStringType())
+	fields["page_size"] = bindings.NewOptionalType(bindings.NewIntegerType())
+	fields["sort_ascending"] = bindings.NewOptionalType(bindings.NewBooleanType())
+	fields["sort_by"] = bindings.NewOptionalType(bindings.NewStringType())
+	fieldNameMap["tier0_id"] = "Tier0Id"
+	fieldNameMap["locale_service_id"] = "LocaleServiceId"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["cursor"] = "Cursor"
+	fieldNameMap["include_mark_for_delete_objects"] = "IncludeMarkForDeleteObjects"
+	fieldNameMap["included_fields"] = "IncludedFields"
+	fieldNameMap["page_size"] = "PageSize"
+	fieldNameMap["sort_ascending"] = "SortAscending"
+	fieldNameMap["sort_by"] = "SortBy"
+	var validators = []bindings.Validator{}
+	return bindings.NewStructType("operation-input", fields, reflect.TypeOf(data.StructValue{}), fieldNameMap, validators)
+}
+
+func sessionsListOutputType() bindings.BindingType {
+	return bindings.NewReferenceType(model.L2VPNSessionListResultBindingType)
+}
+
+func sessionsListRestMetadata() protocol.OperationRestMetadata {
+	fields := map[string]bindings.BindingType{}
+	fieldNameMap := map[string]string{}
+	paramsTypeMap := map[string]bindings.BindingType{}
+	pathParams := map[string]string{}
+	queryParams := map[string]string{}
+	headerParams := map[string]string{}
+	dispatchHeaderParams := map[string]string{}
+	bodyFieldsMap := map[string]string{}
+	fields["tier0_id"] = bindings.NewStringType()
+	fields["locale_service_id"] = bindings.NewStringType()
+	fields["service_id"] = bindings.NewStringType()
+	fields["cursor"] = bindings.NewOptionalType(bindings.NewStringType())
+	fields["include_mark_for_delete_objects"] = bindings.NewOptionalType(bindings.NewBooleanType())
+	fields["included_fields"] = bindings.NewOptionalType(bindings.NewStringType())
+	fields["page_size"] = bindings.NewOptionalType(bindings.NewIntegerType())
+	fields["sort_ascending"] = bindings.NewOptionalType(bindings.NewBooleanType())
+	fields["sort_by"] = bindings.NewOptionalType(bindings.NewStringType())
+	fieldNameMap["tier0_id"] = "Tier0Id"
+	fieldNameMap["locale_service_id"] = "LocaleServiceId"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["cursor"] = "Cursor"
+	fieldNameMap["include_mark_for_delete_objects"] = "IncludeMarkForDeleteObjects"
+	fieldNameMap["included_fields"] = "IncludedFields"
+	fieldNameMap["page_size"] = "PageSize"
+	fieldNameMap["sort_ascending"] = "SortAscending"
+	fieldNameMap["sort_by"] = "SortBy"
+	paramsTypeMap["tier0_id"] = bindings.NewStringType()
+	paramsTypeMap["locale_service_id"] = bindings.NewStringType()
+	paramsTypeMap["service_id"] = bindings.NewStringType()
+	paramsTypeMap["included_fields"] = bindings.NewOptionalType(bindings.NewStringType())
+	paramsTypeMap["page_size"] = bindings.NewOptionalType(bindings.NewIntegerType())
+	paramsTypeMap["include_mark_for_delete_objects"] = bindings.NewOptionalType(bindings.NewBooleanType())
+	paramsTypeMap["cursor"] = bindings.NewOptionalType(bindings.NewStringType())
+	paramsTypeMap["sort_by"] = bindings.NewOptionalType(bindings.NewStringType())
+	paramsTypeMap["sort_ascending"] = bindings.NewOptionalType(bindings.NewBooleanType())
+	paramsTypeMap["tier0Id"] = bindings.NewStringType()
+	paramsTypeMap["localeServiceId"] = bindings.NewStringType()
+	paramsTypeMap["serviceId"] = bindings.NewStringType()
+	pathParams["tier0_id"] = "tier0Id"
+	pathParams["locale_service_id"] = "localeServiceId"
+	pathParams["service_id"] = "serviceId"
+	queryParams["cursor"] = "cursor"
+	queryParams["sort_ascending"] = "sort_ascending"
+	queryParams["included_fields"] = "included_fields"
+	queryParams["sort_by"] = "sort_by"
+	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
+	queryParams["page_size"] = "page_size"
+	resultHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
+	return protocol.NewOperationRestMetadata(
+		fields,
+		fieldNameMap,
+		paramsTypeMap,
+		pathParams,
+		queryParams,
+		headerParams,
+		dispatchHeaderParams,
+		bodyFieldsMap,
+		"",
+		"",
+		"GET",
+		"/policy/api/v1/infra/tier-0s/{tier0Id}/locale-services/{localeServiceId}/l2vpn-services/{serviceId}/sessions",
+		"",
+		resultHeaders,
+		200,
+		"",
+		errorHeaders,
+		map[string]int{"com.vmware.vapi.std.errors.invalid_request": 400, "com.vmware.vapi.std.errors.unauthorized": 403, "com.vmware.vapi.std.errors.service_unavailable": 503, "com.vmware.vapi.std.errors.internal_server_error": 500, "com.vmware.vapi.std.errors.not_found": 404})
+}
+
+func sessionsPatchInputType() bindings.StructType {
+	fields := make(map[string]bindings.BindingType)
+	fieldNameMap := make(map[string]string)
+	fields["tier0_id"] = bindings.NewStringType()
+	fields["locale_service_id"] = bindings.NewStringType()
+	fields["service_id"] = bindings.NewStringType()
+	fields["session_id"] = bindings.NewStringType()
+	fields["l2_VPN_session"] = bindings.NewReferenceType(model.L2VPNSessionBindingType)
+	fieldNameMap["tier0_id"] = "Tier0Id"
+	fieldNameMap["locale_service_id"] = "LocaleServiceId"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["session_id"] = "SessionId"
+	fieldNameMap["l2_VPN_session"] = "L2VPNSession"
+	var validators = []bindings.Validator{}
+	return bindings.NewStructType("operation-input", fields, reflect.TypeOf(data.StructValue{}), fieldNameMap, validators)
+}
+
+func sessionsPatchOutputType() bindings.BindingType {
+	return bindings.NewVoidType()
+}
+
+func sessionsPatchRestMetadata() protocol.OperationRestMetadata {
+	fields := map[string]bindings.BindingType{}
+	fieldNameMap := map[string]string{}
+	paramsTypeMap := map[string]bindings.BindingType{}
+	pathParams := map[string]string{}
+	queryParams := map[string]string{}
+	headerParams := map[string]string{}
+	dispatchHeaderParams := map[string]string{}
+	bodyFieldsMap := map[string]string{}
+	fields["tier0_id"] = bindings.NewStringType()
+	fields["locale_service_id"] = bindings.NewStringType()
+	fields["service_id"] = bindings.NewStringType()
+	fields["session_id"] = bindings.NewStringType()
+	fields["l2_VPN_session"] = bindings.NewReferenceType(model.L2VPNSessionBindingType)
+	fieldNameMap["tier0_id"] = "Tier0Id"
+	fieldNameMap["locale_service_id"] = "LocaleServiceId"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["session_id"] = "SessionId"
+	fieldNameMap["l2_VPN_session"] = "L2VPNSession"
+	paramsTypeMap["tier0_id"] = bindings.NewStringType()
+	paramsTypeMap["l2_VPN_session"] = bindings.NewReferenceType(model.L2VPNSessionBindingType)
+	paramsTypeMap["locale_service_id"] = bindings.NewStringType()
+	paramsTypeMap["service_id"] = bindings.NewStringType()
+	paramsTypeMap["session_id"] = bindings.NewStringType()
+	paramsTypeMap["tier0Id"] = bindings.NewStringType()
+	paramsTypeMap["localeServiceId"] = bindings.NewStringType()
+	paramsTypeMap["serviceId"] = bindings.NewStringType()
+	paramsTypeMap["sessionId"] = bindings.NewStringType()
+	pathParams["tier0_id"] = "tier0Id"
+	pathParams["session_id"] = "sessionId"
+	pathParams["locale_service_id"] = "localeServiceId"
+	pathParams["service_id"] = "serviceId"
+	resultHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
+	return protocol.NewOperationRestMetadata(
+		fields,
+		fieldNameMap,
+		paramsTypeMap,
+		pathParams,
+		queryParams,
+		headerParams,
+		dispatchHeaderParams,
+		bodyFieldsMap,
+		"",
+		"l2_VPN_session",
+		"PATCH",
+		"/policy/api/v1/infra/tier-0s/{tier0Id}/locale-services/{localeServiceId}/l2vpn-services/{serviceId}/sessions/{sessionId}",
+		"",
+		resultHeaders,
+		204,
+		"",
+		errorHeaders,
+		map[string]int{"com.vmware.vapi.std.errors.invalid_request": 400, "com.vmware.vapi.std.errors.unauthorized": 403, "com.vmware.vapi.std.errors.service_unavailable": 503, "com.vmware.vapi.std.errors.internal_server_error": 500, "com.vmware.vapi.std.errors.not_found": 404})
+}
+
+func sessionsUpdateInputType() bindings.StructType {
+	fields := make(map[string]bindings.BindingType)
+	fieldNameMap := make(map[string]string)
+	fields["tier0_id"] = bindings.NewStringType()
+	fields["locale_service_id"] = bindings.NewStringType()
+	fields["service_id"] = bindings.NewStringType()
+	fields["session_id"] = bindings.NewStringType()
+	fields["l2_VPN_session"] = bindings.NewReferenceType(model.L2VPNSessionBindingType)
+	fieldNameMap["tier0_id"] = "Tier0Id"
+	fieldNameMap["locale_service_id"] = "LocaleServiceId"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["session_id"] = "SessionId"
+	fieldNameMap["l2_VPN_session"] = "L2VPNSession"
+	var validators = []bindings.Validator{}
+	return bindings.NewStructType("operation-input", fields, reflect.TypeOf(data.StructValue{}), fieldNameMap, validators)
+}
+
+func sessionsUpdateOutputType() bindings.BindingType {
+	return bindings.NewReferenceType(model.L2VPNSessionBindingType)
+}
+
+func sessionsUpdateRestMetadata() protocol.OperationRestMetadata {
+	fields := map[string]bindings.BindingType{}
+	fieldNameMap := map[string]string{}
+	paramsTypeMap := map[string]bindings.BindingType{}
+	pathParams := map[string]string{}
+	queryParams := map[string]string{}
+	headerParams := map[string]string{}
+	dispatchHeaderParams := map[string]string{}
+	bodyFieldsMap := map[string]string{}
+	fields["tier0_id"] = bindings.NewStringType()
+	fields["locale_service_id"] = bindings.NewStringType()
+	fields["service_id"] = bindings.NewStringType()
+	fields["session_id"] = bindings.NewStringType()
+	fields["l2_VPN_session"] = bindings.NewReferenceType(model.L2VPNSessionBindingType)
+	fieldNameMap["tier0_id"] = "Tier0Id"
+	fieldNameMap["locale_service_id"] = "LocaleServiceId"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["session_id"] = "SessionId"
+	fieldNameMap["l2_VPN_session"] = "L2VPNSession"
+	paramsTypeMap["tier0_id"] = bindings.NewStringType()
+	paramsTypeMap["l2_VPN_session"] = bindings.NewReferenceType(model.L2VPNSessionBindingType)
+	paramsTypeMap["locale_service_id"] = bindings.NewStringType()
+	paramsTypeMap["service_id"] = bindings.NewStringType()
+	paramsTypeMap["session_id"] = bindings.NewStringType()
+	paramsTypeMap["tier0Id"] = bindings.NewStringType()
+	paramsTypeMap["localeServiceId"] = bindings.NewStringType()
+	paramsTypeMap["serviceId"] = bindings.NewStringType()
+	paramsTypeMap["sessionId"] = bindings.NewStringType()
+	pathParams["tier0_id"] = "tier0Id"
+	pathParams["session_id"] = "sessionId"
+	pathParams["locale_service_id"] = "localeServiceId"
+	pathParams["service_id"] = "serviceId"
+	resultHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
+	return protocol.NewOperationRestMetadata(
+		fields,
+		fieldNameMap,
+		paramsTypeMap,
+		pathParams,
+		queryParams,
+		headerParams,
+		dispatchHeaderParams,
+		bodyFieldsMap,
+		"",
+		"l2_VPN_session",
+		"PUT",
+		"/policy/api/v1/infra/tier-0s/{tier0Id}/locale-services/{localeServiceId}/l2vpn-services/{serviceId}/sessions/{sessionId}",
+		"",
+		resultHeaders,
+		200,
+		"",
+		errorHeaders,
+		map[string]int{"com.vmware.vapi.std.errors.invalid_request": 400, "com.vmware.vapi.std.errors.unauthorized": 403, "com.vmware.vapi.std.errors.service_unavailable": 503, "com.vmware.vapi.std.errors.internal_server_error": 500, "com.vmware.vapi.std.errors.not_found": 404})
+}

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_1s/locale_services/ipsec_vpn_services/IpsecVpnServicesPackageTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_1s/locale_services/ipsec_vpn_services/IpsecVpnServicesPackageTypes.go
@@ -1,0 +1,11 @@
+// Copyright © 2019-2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+
+// Auto generated code. DO NOT EDIT.
+
+// Data type definitions file for package: com.vmware.nsx_policy.infra.tier_1s.locale_services.ipsec_vpn_services.
+// Includes binding types of a top level structures and enumerations.
+// Shared by client-side stubs and server-side skeletons to ensure type
+// compatibility.
+
+package ipsec_vpn_services

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_1s/locale_services/ipsec_vpn_services/LocalEndpointsClient.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_1s/locale_services/ipsec_vpn_services/LocalEndpointsClient.go
@@ -1,0 +1,292 @@
+// Copyright © 2019-2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+
+// Auto generated code. DO NOT EDIT.
+
+// Interface file for service: LocalEndpoints
+// Used by client-side stubs.
+
+package ipsec_vpn_services
+
+import (
+	"github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/bindings"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/core"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/lib"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+)
+
+const _ = core.SupportedByRuntimeVersion1
+
+type LocalEndpointsClient interface {
+
+	// Delete IPSec VPN local endpoint for a given locale service under Tier-1. This API is deprecated. Please use DELETE /infra/tier-1s/<tier-1-id>/ipsec-vpn-services/<service-id>/ local-endpoints/<local-endpoint-id> instead. Note: Please note that request is validated and any error messages returned from validation may include the new VPN path instead of the deprecated path. Both new path and old path refer to same resource. Also VPN path returned in the Alarm, GPRR payload may include the new VPN path
+	//
+	// @param tier1IdParam (required)
+	// @param localeServiceIdParam (required)
+	// @param serviceIdParam (required)
+	// @param localEndpointIdParam (required)
+	// @throws InvalidRequest  Bad Request, Precondition Failed
+	// @throws Unauthorized  Forbidden
+	// @throws ServiceUnavailable  Service Unavailable
+	// @throws InternalServerError  Internal Server Error
+	// @throws NotFound  Not Found
+	Delete(tier1IdParam string, localeServiceIdParam string, serviceIdParam string, localEndpointIdParam string) error
+
+	// Get IPSec VPN local endpoint for a given locale service under Tier-1. This API is deprecated. Please use GET /infra/tier-1s/<tier-1-id>/ipsec-vpn-services/<service-id>/ local-endpoints/<local-endpoint-id> instead. Note: Please note that request is validated and any error messages returned from validation may include the new VPN path instead of the deprecated path. Both new path and old path refer to same resource.
+	//
+	// @param tier1IdParam (required)
+	// @param localeServiceIdParam (required)
+	// @param serviceIdParam (required)
+	// @param localEndpointIdParam (required)
+	// @return com.vmware.nsx_policy.model.IPSecVpnLocalEndpoint
+	// @throws InvalidRequest  Bad Request, Precondition Failed
+	// @throws Unauthorized  Forbidden
+	// @throws ServiceUnavailable  Service Unavailable
+	// @throws InternalServerError  Internal Server Error
+	// @throws NotFound  Not Found
+	Get(tier1IdParam string, localeServiceIdParam string, serviceIdParam string, localEndpointIdParam string) (model.IPSecVpnLocalEndpoint, error)
+
+	// Get paginated list of all IPSec VPN local endpoints for a given locale service under Tier-1. This API is deprecated. Please use GET /infra/tier-1s/<tier-1-id>/ipsec-vpn-services/<service-id>/local-endpoints instead. Note: Please note that request is validated and any error messages returned from validation may include the new VPN path instead of the deprecated path. Both new path and old path refer to same resource.
+	//
+	// @param tier1IdParam (required)
+	// @param localeServiceIdParam (required)
+	// @param serviceIdParam (required)
+	// @param cursorParam Opaque cursor to be used for getting next page of records (supplied by current result page) (optional)
+	// @param includeMarkForDeleteObjectsParam Include objects that are marked for deletion in results (optional, default to false)
+	// @param includedFieldsParam Comma separated list of fields that should be included in query result (optional)
+	// @param pageSizeParam Maximum number of results to return in this page (server may return fewer) (optional, default to 1000)
+	// @param sortAscendingParam (optional)
+	// @param sortByParam Field by which records are sorted (optional)
+	// @return com.vmware.nsx_policy.model.IPSecVpnLocalEndpointListResult
+	// @throws InvalidRequest  Bad Request, Precondition Failed
+	// @throws Unauthorized  Forbidden
+	// @throws ServiceUnavailable  Service Unavailable
+	// @throws InternalServerError  Internal Server Error
+	// @throws NotFound  Not Found
+	List(tier1IdParam string, localeServiceIdParam string, serviceIdParam string, cursorParam *string, includeMarkForDeleteObjectsParam *bool, includedFieldsParam *string, pageSizeParam *int64, sortAscendingParam *bool, sortByParam *string) (model.IPSecVpnLocalEndpointListResult, error)
+
+	// Create or patch a custom IPSec VPN local endpoint for a given locale service under Tier-1. This API is deprecated. Please use PATCH /infra/tier-1s/<tier-1-id>/ipsec-vpn-services/<service-id>/ local-endpoints/<local-endpoint-id> instead. Note: Please note that request is validated and any error messages returned from validation may include the new VPN path instead of the deprecated path. Both new path and old path refer to same resource. Also VPN path returned in the Alarm, GPRR payload may include the new VPN path
+	//
+	// @param tier1IdParam (required)
+	// @param localeServiceIdParam (required)
+	// @param serviceIdParam (required)
+	// @param localEndpointIdParam (required)
+	// @param ipSecVpnLocalEndpointParam (required)
+	// @throws InvalidRequest  Bad Request, Precondition Failed
+	// @throws Unauthorized  Forbidden
+	// @throws ServiceUnavailable  Service Unavailable
+	// @throws InternalServerError  Internal Server Error
+	// @throws NotFound  Not Found
+	Patch(tier1IdParam string, localeServiceIdParam string, serviceIdParam string, localEndpointIdParam string, ipSecVpnLocalEndpointParam model.IPSecVpnLocalEndpoint) error
+
+	// Create or fully replace IPSec VPN local endpoint for a given locale service under Tier-1. Revision is optional for creation and required for update. This API is deprecated. Please use PUT /infra/tier-1s/<tier-1-id>/ipsec-vpn-services/<service-id>/ local-endpoints/<local-endpoint-id> instead. Note: Please note that request is validated and any error messages returned from validation may include the new VPN path instead of the deprecated path. Both new path and old path refer to same resource. Also VPN path returned in the Alarm, GPRR payload may include the new VPN path
+	//
+	// @param tier1IdParam (required)
+	// @param localeServiceIdParam (required)
+	// @param serviceIdParam (required)
+	// @param localEndpointIdParam (required)
+	// @param ipSecVpnLocalEndpointParam (required)
+	// @return com.vmware.nsx_policy.model.IPSecVpnLocalEndpoint
+	// @throws InvalidRequest  Bad Request, Precondition Failed
+	// @throws Unauthorized  Forbidden
+	// @throws ServiceUnavailable  Service Unavailable
+	// @throws InternalServerError  Internal Server Error
+	// @throws NotFound  Not Found
+	Update(tier1IdParam string, localeServiceIdParam string, serviceIdParam string, localEndpointIdParam string, ipSecVpnLocalEndpointParam model.IPSecVpnLocalEndpoint) (model.IPSecVpnLocalEndpoint, error)
+}
+
+type localEndpointsClient struct {
+	connector           client.Connector
+	interfaceDefinition core.InterfaceDefinition
+	errorsBindingMap    map[string]bindings.BindingType
+}
+
+func NewLocalEndpointsClient(connector client.Connector) *localEndpointsClient {
+	interfaceIdentifier := core.NewInterfaceIdentifier("com.vmware.nsx_policy.infra.tier_1s.locale_services.ipsec_vpn_services.local_endpoints")
+	methodIdentifiers := map[string]core.MethodIdentifier{
+		"delete": core.NewMethodIdentifier(interfaceIdentifier, "delete"),
+		"get":    core.NewMethodIdentifier(interfaceIdentifier, "get"),
+		"list":   core.NewMethodIdentifier(interfaceIdentifier, "list"),
+		"patch":  core.NewMethodIdentifier(interfaceIdentifier, "patch"),
+		"update": core.NewMethodIdentifier(interfaceIdentifier, "update"),
+	}
+	interfaceDefinition := core.NewInterfaceDefinition(interfaceIdentifier, methodIdentifiers)
+	errorsBindingMap := make(map[string]bindings.BindingType)
+
+	lIface := localEndpointsClient{interfaceDefinition: interfaceDefinition, errorsBindingMap: errorsBindingMap, connector: connector}
+	return &lIface
+}
+
+func (lIface *localEndpointsClient) GetErrorBindingType(errorName string) bindings.BindingType {
+	if entry, ok := lIface.errorsBindingMap[errorName]; ok {
+		return entry
+	}
+	return errors.ERROR_BINDINGS_MAP[errorName]
+}
+
+func (lIface *localEndpointsClient) Delete(tier1IdParam string, localeServiceIdParam string, serviceIdParam string, localEndpointIdParam string) error {
+	typeConverter := lIface.connector.TypeConverter()
+	executionContext := lIface.connector.NewExecutionContext()
+	sv := bindings.NewStructValueBuilder(localEndpointsDeleteInputType(), typeConverter)
+	sv.AddStructField("Tier1Id", tier1IdParam)
+	sv.AddStructField("LocaleServiceId", localeServiceIdParam)
+	sv.AddStructField("ServiceId", serviceIdParam)
+	sv.AddStructField("LocalEndpointId", localEndpointIdParam)
+	inputDataValue, inputError := sv.GetStructValue()
+	if inputError != nil {
+		return bindings.VAPIerrorsToError(inputError)
+	}
+	operationRestMetaData := localEndpointsDeleteRestMetadata()
+	connectionMetadata := map[string]interface{}{lib.REST_METADATA: operationRestMetaData}
+	connectionMetadata["isStreamingResponse"] = false
+	lIface.connector.SetConnectionMetadata(connectionMetadata)
+	methodResult := lIface.connector.GetApiProvider().Invoke("com.vmware.nsx_policy.infra.tier_1s.locale_services.ipsec_vpn_services.local_endpoints", "delete", inputDataValue, executionContext)
+	if methodResult.IsSuccess() {
+		return nil
+	} else {
+		methodError, errorInError := typeConverter.ConvertToGolang(methodResult.Error(), lIface.GetErrorBindingType(methodResult.Error().Name()))
+		if errorInError != nil {
+			return bindings.VAPIerrorsToError(errorInError)
+		}
+		return methodError.(error)
+	}
+}
+
+func (lIface *localEndpointsClient) Get(tier1IdParam string, localeServiceIdParam string, serviceIdParam string, localEndpointIdParam string) (model.IPSecVpnLocalEndpoint, error) {
+	typeConverter := lIface.connector.TypeConverter()
+	executionContext := lIface.connector.NewExecutionContext()
+	sv := bindings.NewStructValueBuilder(localEndpointsGetInputType(), typeConverter)
+	sv.AddStructField("Tier1Id", tier1IdParam)
+	sv.AddStructField("LocaleServiceId", localeServiceIdParam)
+	sv.AddStructField("ServiceId", serviceIdParam)
+	sv.AddStructField("LocalEndpointId", localEndpointIdParam)
+	inputDataValue, inputError := sv.GetStructValue()
+	if inputError != nil {
+		var emptyOutput model.IPSecVpnLocalEndpoint
+		return emptyOutput, bindings.VAPIerrorsToError(inputError)
+	}
+	operationRestMetaData := localEndpointsGetRestMetadata()
+	connectionMetadata := map[string]interface{}{lib.REST_METADATA: operationRestMetaData}
+	connectionMetadata["isStreamingResponse"] = false
+	lIface.connector.SetConnectionMetadata(connectionMetadata)
+	methodResult := lIface.connector.GetApiProvider().Invoke("com.vmware.nsx_policy.infra.tier_1s.locale_services.ipsec_vpn_services.local_endpoints", "get", inputDataValue, executionContext)
+	var emptyOutput model.IPSecVpnLocalEndpoint
+	if methodResult.IsSuccess() {
+		output, errorInOutput := typeConverter.ConvertToGolang(methodResult.Output(), localEndpointsGetOutputType())
+		if errorInOutput != nil {
+			return emptyOutput, bindings.VAPIerrorsToError(errorInOutput)
+		}
+		return output.(model.IPSecVpnLocalEndpoint), nil
+	} else {
+		methodError, errorInError := typeConverter.ConvertToGolang(methodResult.Error(), lIface.GetErrorBindingType(methodResult.Error().Name()))
+		if errorInError != nil {
+			return emptyOutput, bindings.VAPIerrorsToError(errorInError)
+		}
+		return emptyOutput, methodError.(error)
+	}
+}
+
+func (lIface *localEndpointsClient) List(tier1IdParam string, localeServiceIdParam string, serviceIdParam string, cursorParam *string, includeMarkForDeleteObjectsParam *bool, includedFieldsParam *string, pageSizeParam *int64, sortAscendingParam *bool, sortByParam *string) (model.IPSecVpnLocalEndpointListResult, error) {
+	typeConverter := lIface.connector.TypeConverter()
+	executionContext := lIface.connector.NewExecutionContext()
+	sv := bindings.NewStructValueBuilder(localEndpointsListInputType(), typeConverter)
+	sv.AddStructField("Tier1Id", tier1IdParam)
+	sv.AddStructField("LocaleServiceId", localeServiceIdParam)
+	sv.AddStructField("ServiceId", serviceIdParam)
+	sv.AddStructField("Cursor", cursorParam)
+	sv.AddStructField("IncludeMarkForDeleteObjects", includeMarkForDeleteObjectsParam)
+	sv.AddStructField("IncludedFields", includedFieldsParam)
+	sv.AddStructField("PageSize", pageSizeParam)
+	sv.AddStructField("SortAscending", sortAscendingParam)
+	sv.AddStructField("SortBy", sortByParam)
+	inputDataValue, inputError := sv.GetStructValue()
+	if inputError != nil {
+		var emptyOutput model.IPSecVpnLocalEndpointListResult
+		return emptyOutput, bindings.VAPIerrorsToError(inputError)
+	}
+	operationRestMetaData := localEndpointsListRestMetadata()
+	connectionMetadata := map[string]interface{}{lib.REST_METADATA: operationRestMetaData}
+	connectionMetadata["isStreamingResponse"] = false
+	lIface.connector.SetConnectionMetadata(connectionMetadata)
+	methodResult := lIface.connector.GetApiProvider().Invoke("com.vmware.nsx_policy.infra.tier_1s.locale_services.ipsec_vpn_services.local_endpoints", "list", inputDataValue, executionContext)
+	var emptyOutput model.IPSecVpnLocalEndpointListResult
+	if methodResult.IsSuccess() {
+		output, errorInOutput := typeConverter.ConvertToGolang(methodResult.Output(), localEndpointsListOutputType())
+		if errorInOutput != nil {
+			return emptyOutput, bindings.VAPIerrorsToError(errorInOutput)
+		}
+		return output.(model.IPSecVpnLocalEndpointListResult), nil
+	} else {
+		methodError, errorInError := typeConverter.ConvertToGolang(methodResult.Error(), lIface.GetErrorBindingType(methodResult.Error().Name()))
+		if errorInError != nil {
+			return emptyOutput, bindings.VAPIerrorsToError(errorInError)
+		}
+		return emptyOutput, methodError.(error)
+	}
+}
+
+func (lIface *localEndpointsClient) Patch(tier1IdParam string, localeServiceIdParam string, serviceIdParam string, localEndpointIdParam string, ipSecVpnLocalEndpointParam model.IPSecVpnLocalEndpoint) error {
+	typeConverter := lIface.connector.TypeConverter()
+	executionContext := lIface.connector.NewExecutionContext()
+	sv := bindings.NewStructValueBuilder(localEndpointsPatchInputType(), typeConverter)
+	sv.AddStructField("Tier1Id", tier1IdParam)
+	sv.AddStructField("LocaleServiceId", localeServiceIdParam)
+	sv.AddStructField("ServiceId", serviceIdParam)
+	sv.AddStructField("LocalEndpointId", localEndpointIdParam)
+	sv.AddStructField("IpSecVpnLocalEndpoint", ipSecVpnLocalEndpointParam)
+	inputDataValue, inputError := sv.GetStructValue()
+	if inputError != nil {
+		return bindings.VAPIerrorsToError(inputError)
+	}
+	operationRestMetaData := localEndpointsPatchRestMetadata()
+	connectionMetadata := map[string]interface{}{lib.REST_METADATA: operationRestMetaData}
+	connectionMetadata["isStreamingResponse"] = false
+	lIface.connector.SetConnectionMetadata(connectionMetadata)
+	methodResult := lIface.connector.GetApiProvider().Invoke("com.vmware.nsx_policy.infra.tier_1s.locale_services.ipsec_vpn_services.local_endpoints", "patch", inputDataValue, executionContext)
+	if methodResult.IsSuccess() {
+		return nil
+	} else {
+		methodError, errorInError := typeConverter.ConvertToGolang(methodResult.Error(), lIface.GetErrorBindingType(methodResult.Error().Name()))
+		if errorInError != nil {
+			return bindings.VAPIerrorsToError(errorInError)
+		}
+		return methodError.(error)
+	}
+}
+
+func (lIface *localEndpointsClient) Update(tier1IdParam string, localeServiceIdParam string, serviceIdParam string, localEndpointIdParam string, ipSecVpnLocalEndpointParam model.IPSecVpnLocalEndpoint) (model.IPSecVpnLocalEndpoint, error) {
+	typeConverter := lIface.connector.TypeConverter()
+	executionContext := lIface.connector.NewExecutionContext()
+	sv := bindings.NewStructValueBuilder(localEndpointsUpdateInputType(), typeConverter)
+	sv.AddStructField("Tier1Id", tier1IdParam)
+	sv.AddStructField("LocaleServiceId", localeServiceIdParam)
+	sv.AddStructField("ServiceId", serviceIdParam)
+	sv.AddStructField("LocalEndpointId", localEndpointIdParam)
+	sv.AddStructField("IpSecVpnLocalEndpoint", ipSecVpnLocalEndpointParam)
+	inputDataValue, inputError := sv.GetStructValue()
+	if inputError != nil {
+		var emptyOutput model.IPSecVpnLocalEndpoint
+		return emptyOutput, bindings.VAPIerrorsToError(inputError)
+	}
+	operationRestMetaData := localEndpointsUpdateRestMetadata()
+	connectionMetadata := map[string]interface{}{lib.REST_METADATA: operationRestMetaData}
+	connectionMetadata["isStreamingResponse"] = false
+	lIface.connector.SetConnectionMetadata(connectionMetadata)
+	methodResult := lIface.connector.GetApiProvider().Invoke("com.vmware.nsx_policy.infra.tier_1s.locale_services.ipsec_vpn_services.local_endpoints", "update", inputDataValue, executionContext)
+	var emptyOutput model.IPSecVpnLocalEndpoint
+	if methodResult.IsSuccess() {
+		output, errorInOutput := typeConverter.ConvertToGolang(methodResult.Output(), localEndpointsUpdateOutputType())
+		if errorInOutput != nil {
+			return emptyOutput, bindings.VAPIerrorsToError(errorInOutput)
+		}
+		return output.(model.IPSecVpnLocalEndpoint), nil
+	} else {
+		methodError, errorInError := typeConverter.ConvertToGolang(methodResult.Error(), lIface.GetErrorBindingType(methodResult.Error().Name()))
+		if errorInError != nil {
+			return emptyOutput, bindings.VAPIerrorsToError(errorInError)
+		}
+		return emptyOutput, methodError.(error)
+	}
+}

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_1s/locale_services/ipsec_vpn_services/LocalEndpointsTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_1s/locale_services/ipsec_vpn_services/LocalEndpointsTypes.go
@@ -1,0 +1,413 @@
+// Copyright © 2019-2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+
+// Auto generated code. DO NOT EDIT.
+
+// Data type definitions file for service: LocalEndpoints.
+// Includes binding types of a structures and enumerations defined in the service.
+// Shared by client-side stubs and server-side skeletons to ensure type
+// compatibility.
+
+package ipsec_vpn_services
+
+import (
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/bindings"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/data"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+	"reflect"
+)
+
+func localEndpointsDeleteInputType() bindings.StructType {
+	fields := make(map[string]bindings.BindingType)
+	fieldNameMap := make(map[string]string)
+	fields["tier1_id"] = bindings.NewStringType()
+	fields["locale_service_id"] = bindings.NewStringType()
+	fields["service_id"] = bindings.NewStringType()
+	fields["local_endpoint_id"] = bindings.NewStringType()
+	fieldNameMap["tier1_id"] = "Tier1Id"
+	fieldNameMap["locale_service_id"] = "LocaleServiceId"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["local_endpoint_id"] = "LocalEndpointId"
+	var validators = []bindings.Validator{}
+	return bindings.NewStructType("operation-input", fields, reflect.TypeOf(data.StructValue{}), fieldNameMap, validators)
+}
+
+func localEndpointsDeleteOutputType() bindings.BindingType {
+	return bindings.NewVoidType()
+}
+
+func localEndpointsDeleteRestMetadata() protocol.OperationRestMetadata {
+	fields := map[string]bindings.BindingType{}
+	fieldNameMap := map[string]string{}
+	paramsTypeMap := map[string]bindings.BindingType{}
+	pathParams := map[string]string{}
+	queryParams := map[string]string{}
+	headerParams := map[string]string{}
+	dispatchHeaderParams := map[string]string{}
+	bodyFieldsMap := map[string]string{}
+	fields["tier1_id"] = bindings.NewStringType()
+	fields["locale_service_id"] = bindings.NewStringType()
+	fields["service_id"] = bindings.NewStringType()
+	fields["local_endpoint_id"] = bindings.NewStringType()
+	fieldNameMap["tier1_id"] = "Tier1Id"
+	fieldNameMap["locale_service_id"] = "LocaleServiceId"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["local_endpoint_id"] = "LocalEndpointId"
+	paramsTypeMap["locale_service_id"] = bindings.NewStringType()
+	paramsTypeMap["tier1_id"] = bindings.NewStringType()
+	paramsTypeMap["service_id"] = bindings.NewStringType()
+	paramsTypeMap["local_endpoint_id"] = bindings.NewStringType()
+	paramsTypeMap["tier1Id"] = bindings.NewStringType()
+	paramsTypeMap["localeServiceId"] = bindings.NewStringType()
+	paramsTypeMap["serviceId"] = bindings.NewStringType()
+	paramsTypeMap["localEndpointId"] = bindings.NewStringType()
+	pathParams["local_endpoint_id"] = "localEndpointId"
+	pathParams["tier1_id"] = "tier1Id"
+	pathParams["locale_service_id"] = "localeServiceId"
+	pathParams["service_id"] = "serviceId"
+	resultHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
+	return protocol.NewOperationRestMetadata(
+		fields,
+		fieldNameMap,
+		paramsTypeMap,
+		pathParams,
+		queryParams,
+		headerParams,
+		dispatchHeaderParams,
+		bodyFieldsMap,
+		"",
+		"",
+		"DELETE",
+		"/policy/api/v1/infra/tier-1s/{tier1Id}/locale-services/{localeServiceId}/ipsec-vpn-services/{serviceId}/local-endpoints/{localEndpointId}",
+		"",
+		resultHeaders,
+		204,
+		"",
+		errorHeaders,
+		map[string]int{"com.vmware.vapi.std.errors.invalid_request": 400, "com.vmware.vapi.std.errors.unauthorized": 403, "com.vmware.vapi.std.errors.service_unavailable": 503, "com.vmware.vapi.std.errors.internal_server_error": 500, "com.vmware.vapi.std.errors.not_found": 404})
+}
+
+func localEndpointsGetInputType() bindings.StructType {
+	fields := make(map[string]bindings.BindingType)
+	fieldNameMap := make(map[string]string)
+	fields["tier1_id"] = bindings.NewStringType()
+	fields["locale_service_id"] = bindings.NewStringType()
+	fields["service_id"] = bindings.NewStringType()
+	fields["local_endpoint_id"] = bindings.NewStringType()
+	fieldNameMap["tier1_id"] = "Tier1Id"
+	fieldNameMap["locale_service_id"] = "LocaleServiceId"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["local_endpoint_id"] = "LocalEndpointId"
+	var validators = []bindings.Validator{}
+	return bindings.NewStructType("operation-input", fields, reflect.TypeOf(data.StructValue{}), fieldNameMap, validators)
+}
+
+func localEndpointsGetOutputType() bindings.BindingType {
+	return bindings.NewReferenceType(model.IPSecVpnLocalEndpointBindingType)
+}
+
+func localEndpointsGetRestMetadata() protocol.OperationRestMetadata {
+	fields := map[string]bindings.BindingType{}
+	fieldNameMap := map[string]string{}
+	paramsTypeMap := map[string]bindings.BindingType{}
+	pathParams := map[string]string{}
+	queryParams := map[string]string{}
+	headerParams := map[string]string{}
+	dispatchHeaderParams := map[string]string{}
+	bodyFieldsMap := map[string]string{}
+	fields["tier1_id"] = bindings.NewStringType()
+	fields["locale_service_id"] = bindings.NewStringType()
+	fields["service_id"] = bindings.NewStringType()
+	fields["local_endpoint_id"] = bindings.NewStringType()
+	fieldNameMap["tier1_id"] = "Tier1Id"
+	fieldNameMap["locale_service_id"] = "LocaleServiceId"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["local_endpoint_id"] = "LocalEndpointId"
+	paramsTypeMap["locale_service_id"] = bindings.NewStringType()
+	paramsTypeMap["tier1_id"] = bindings.NewStringType()
+	paramsTypeMap["service_id"] = bindings.NewStringType()
+	paramsTypeMap["local_endpoint_id"] = bindings.NewStringType()
+	paramsTypeMap["tier1Id"] = bindings.NewStringType()
+	paramsTypeMap["localeServiceId"] = bindings.NewStringType()
+	paramsTypeMap["serviceId"] = bindings.NewStringType()
+	paramsTypeMap["localEndpointId"] = bindings.NewStringType()
+	pathParams["local_endpoint_id"] = "localEndpointId"
+	pathParams["tier1_id"] = "tier1Id"
+	pathParams["locale_service_id"] = "localeServiceId"
+	pathParams["service_id"] = "serviceId"
+	resultHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
+	return protocol.NewOperationRestMetadata(
+		fields,
+		fieldNameMap,
+		paramsTypeMap,
+		pathParams,
+		queryParams,
+		headerParams,
+		dispatchHeaderParams,
+		bodyFieldsMap,
+		"",
+		"",
+		"GET",
+		"/policy/api/v1/infra/tier-1s/{tier1Id}/locale-services/{localeServiceId}/ipsec-vpn-services/{serviceId}/local-endpoints/{localEndpointId}",
+		"",
+		resultHeaders,
+		200,
+		"",
+		errorHeaders,
+		map[string]int{"com.vmware.vapi.std.errors.invalid_request": 400, "com.vmware.vapi.std.errors.unauthorized": 403, "com.vmware.vapi.std.errors.service_unavailable": 503, "com.vmware.vapi.std.errors.internal_server_error": 500, "com.vmware.vapi.std.errors.not_found": 404})
+}
+
+func localEndpointsListInputType() bindings.StructType {
+	fields := make(map[string]bindings.BindingType)
+	fieldNameMap := make(map[string]string)
+	fields["tier1_id"] = bindings.NewStringType()
+	fields["locale_service_id"] = bindings.NewStringType()
+	fields["service_id"] = bindings.NewStringType()
+	fields["cursor"] = bindings.NewOptionalType(bindings.NewStringType())
+	fields["include_mark_for_delete_objects"] = bindings.NewOptionalType(bindings.NewBooleanType())
+	fields["included_fields"] = bindings.NewOptionalType(bindings.NewStringType())
+	fields["page_size"] = bindings.NewOptionalType(bindings.NewIntegerType())
+	fields["sort_ascending"] = bindings.NewOptionalType(bindings.NewBooleanType())
+	fields["sort_by"] = bindings.NewOptionalType(bindings.NewStringType())
+	fieldNameMap["tier1_id"] = "Tier1Id"
+	fieldNameMap["locale_service_id"] = "LocaleServiceId"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["cursor"] = "Cursor"
+	fieldNameMap["include_mark_for_delete_objects"] = "IncludeMarkForDeleteObjects"
+	fieldNameMap["included_fields"] = "IncludedFields"
+	fieldNameMap["page_size"] = "PageSize"
+	fieldNameMap["sort_ascending"] = "SortAscending"
+	fieldNameMap["sort_by"] = "SortBy"
+	var validators = []bindings.Validator{}
+	return bindings.NewStructType("operation-input", fields, reflect.TypeOf(data.StructValue{}), fieldNameMap, validators)
+}
+
+func localEndpointsListOutputType() bindings.BindingType {
+	return bindings.NewReferenceType(model.IPSecVpnLocalEndpointListResultBindingType)
+}
+
+func localEndpointsListRestMetadata() protocol.OperationRestMetadata {
+	fields := map[string]bindings.BindingType{}
+	fieldNameMap := map[string]string{}
+	paramsTypeMap := map[string]bindings.BindingType{}
+	pathParams := map[string]string{}
+	queryParams := map[string]string{}
+	headerParams := map[string]string{}
+	dispatchHeaderParams := map[string]string{}
+	bodyFieldsMap := map[string]string{}
+	fields["tier1_id"] = bindings.NewStringType()
+	fields["locale_service_id"] = bindings.NewStringType()
+	fields["service_id"] = bindings.NewStringType()
+	fields["cursor"] = bindings.NewOptionalType(bindings.NewStringType())
+	fields["include_mark_for_delete_objects"] = bindings.NewOptionalType(bindings.NewBooleanType())
+	fields["included_fields"] = bindings.NewOptionalType(bindings.NewStringType())
+	fields["page_size"] = bindings.NewOptionalType(bindings.NewIntegerType())
+	fields["sort_ascending"] = bindings.NewOptionalType(bindings.NewBooleanType())
+	fields["sort_by"] = bindings.NewOptionalType(bindings.NewStringType())
+	fieldNameMap["tier1_id"] = "Tier1Id"
+	fieldNameMap["locale_service_id"] = "LocaleServiceId"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["cursor"] = "Cursor"
+	fieldNameMap["include_mark_for_delete_objects"] = "IncludeMarkForDeleteObjects"
+	fieldNameMap["included_fields"] = "IncludedFields"
+	fieldNameMap["page_size"] = "PageSize"
+	fieldNameMap["sort_ascending"] = "SortAscending"
+	fieldNameMap["sort_by"] = "SortBy"
+	paramsTypeMap["locale_service_id"] = bindings.NewStringType()
+	paramsTypeMap["tier1_id"] = bindings.NewStringType()
+	paramsTypeMap["service_id"] = bindings.NewStringType()
+	paramsTypeMap["included_fields"] = bindings.NewOptionalType(bindings.NewStringType())
+	paramsTypeMap["page_size"] = bindings.NewOptionalType(bindings.NewIntegerType())
+	paramsTypeMap["include_mark_for_delete_objects"] = bindings.NewOptionalType(bindings.NewBooleanType())
+	paramsTypeMap["cursor"] = bindings.NewOptionalType(bindings.NewStringType())
+	paramsTypeMap["sort_by"] = bindings.NewOptionalType(bindings.NewStringType())
+	paramsTypeMap["sort_ascending"] = bindings.NewOptionalType(bindings.NewBooleanType())
+	paramsTypeMap["tier1Id"] = bindings.NewStringType()
+	paramsTypeMap["localeServiceId"] = bindings.NewStringType()
+	paramsTypeMap["serviceId"] = bindings.NewStringType()
+	pathParams["tier1_id"] = "tier1Id"
+	pathParams["locale_service_id"] = "localeServiceId"
+	pathParams["service_id"] = "serviceId"
+	queryParams["cursor"] = "cursor"
+	queryParams["sort_ascending"] = "sort_ascending"
+	queryParams["included_fields"] = "included_fields"
+	queryParams["sort_by"] = "sort_by"
+	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
+	queryParams["page_size"] = "page_size"
+	resultHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
+	return protocol.NewOperationRestMetadata(
+		fields,
+		fieldNameMap,
+		paramsTypeMap,
+		pathParams,
+		queryParams,
+		headerParams,
+		dispatchHeaderParams,
+		bodyFieldsMap,
+		"",
+		"",
+		"GET",
+		"/policy/api/v1/infra/tier-1s/{tier1Id}/locale-services/{localeServiceId}/ipsec-vpn-services/{serviceId}/local-endpoints",
+		"",
+		resultHeaders,
+		200,
+		"",
+		errorHeaders,
+		map[string]int{"com.vmware.vapi.std.errors.invalid_request": 400, "com.vmware.vapi.std.errors.unauthorized": 403, "com.vmware.vapi.std.errors.service_unavailable": 503, "com.vmware.vapi.std.errors.internal_server_error": 500, "com.vmware.vapi.std.errors.not_found": 404})
+}
+
+func localEndpointsPatchInputType() bindings.StructType {
+	fields := make(map[string]bindings.BindingType)
+	fieldNameMap := make(map[string]string)
+	fields["tier1_id"] = bindings.NewStringType()
+	fields["locale_service_id"] = bindings.NewStringType()
+	fields["service_id"] = bindings.NewStringType()
+	fields["local_endpoint_id"] = bindings.NewStringType()
+	fields["ip_sec_vpn_local_endpoint"] = bindings.NewReferenceType(model.IPSecVpnLocalEndpointBindingType)
+	fieldNameMap["tier1_id"] = "Tier1Id"
+	fieldNameMap["locale_service_id"] = "LocaleServiceId"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["local_endpoint_id"] = "LocalEndpointId"
+	fieldNameMap["ip_sec_vpn_local_endpoint"] = "IpSecVpnLocalEndpoint"
+	var validators = []bindings.Validator{}
+	return bindings.NewStructType("operation-input", fields, reflect.TypeOf(data.StructValue{}), fieldNameMap, validators)
+}
+
+func localEndpointsPatchOutputType() bindings.BindingType {
+	return bindings.NewVoidType()
+}
+
+func localEndpointsPatchRestMetadata() protocol.OperationRestMetadata {
+	fields := map[string]bindings.BindingType{}
+	fieldNameMap := map[string]string{}
+	paramsTypeMap := map[string]bindings.BindingType{}
+	pathParams := map[string]string{}
+	queryParams := map[string]string{}
+	headerParams := map[string]string{}
+	dispatchHeaderParams := map[string]string{}
+	bodyFieldsMap := map[string]string{}
+	fields["tier1_id"] = bindings.NewStringType()
+	fields["locale_service_id"] = bindings.NewStringType()
+	fields["service_id"] = bindings.NewStringType()
+	fields["local_endpoint_id"] = bindings.NewStringType()
+	fields["ip_sec_vpn_local_endpoint"] = bindings.NewReferenceType(model.IPSecVpnLocalEndpointBindingType)
+	fieldNameMap["tier1_id"] = "Tier1Id"
+	fieldNameMap["locale_service_id"] = "LocaleServiceId"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["local_endpoint_id"] = "LocalEndpointId"
+	fieldNameMap["ip_sec_vpn_local_endpoint"] = "IpSecVpnLocalEndpoint"
+	paramsTypeMap["ip_sec_vpn_local_endpoint"] = bindings.NewReferenceType(model.IPSecVpnLocalEndpointBindingType)
+	paramsTypeMap["locale_service_id"] = bindings.NewStringType()
+	paramsTypeMap["tier1_id"] = bindings.NewStringType()
+	paramsTypeMap["service_id"] = bindings.NewStringType()
+	paramsTypeMap["local_endpoint_id"] = bindings.NewStringType()
+	paramsTypeMap["tier1Id"] = bindings.NewStringType()
+	paramsTypeMap["localeServiceId"] = bindings.NewStringType()
+	paramsTypeMap["serviceId"] = bindings.NewStringType()
+	paramsTypeMap["localEndpointId"] = bindings.NewStringType()
+	pathParams["local_endpoint_id"] = "localEndpointId"
+	pathParams["tier1_id"] = "tier1Id"
+	pathParams["locale_service_id"] = "localeServiceId"
+	pathParams["service_id"] = "serviceId"
+	resultHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
+	return protocol.NewOperationRestMetadata(
+		fields,
+		fieldNameMap,
+		paramsTypeMap,
+		pathParams,
+		queryParams,
+		headerParams,
+		dispatchHeaderParams,
+		bodyFieldsMap,
+		"",
+		"ip_sec_vpn_local_endpoint",
+		"PATCH",
+		"/policy/api/v1/infra/tier-1s/{tier1Id}/locale-services/{localeServiceId}/ipsec-vpn-services/{serviceId}/local-endpoints/{localEndpointId}",
+		"",
+		resultHeaders,
+		204,
+		"",
+		errorHeaders,
+		map[string]int{"com.vmware.vapi.std.errors.invalid_request": 400, "com.vmware.vapi.std.errors.unauthorized": 403, "com.vmware.vapi.std.errors.service_unavailable": 503, "com.vmware.vapi.std.errors.internal_server_error": 500, "com.vmware.vapi.std.errors.not_found": 404})
+}
+
+func localEndpointsUpdateInputType() bindings.StructType {
+	fields := make(map[string]bindings.BindingType)
+	fieldNameMap := make(map[string]string)
+	fields["tier1_id"] = bindings.NewStringType()
+	fields["locale_service_id"] = bindings.NewStringType()
+	fields["service_id"] = bindings.NewStringType()
+	fields["local_endpoint_id"] = bindings.NewStringType()
+	fields["ip_sec_vpn_local_endpoint"] = bindings.NewReferenceType(model.IPSecVpnLocalEndpointBindingType)
+	fieldNameMap["tier1_id"] = "Tier1Id"
+	fieldNameMap["locale_service_id"] = "LocaleServiceId"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["local_endpoint_id"] = "LocalEndpointId"
+	fieldNameMap["ip_sec_vpn_local_endpoint"] = "IpSecVpnLocalEndpoint"
+	var validators = []bindings.Validator{}
+	return bindings.NewStructType("operation-input", fields, reflect.TypeOf(data.StructValue{}), fieldNameMap, validators)
+}
+
+func localEndpointsUpdateOutputType() bindings.BindingType {
+	return bindings.NewReferenceType(model.IPSecVpnLocalEndpointBindingType)
+}
+
+func localEndpointsUpdateRestMetadata() protocol.OperationRestMetadata {
+	fields := map[string]bindings.BindingType{}
+	fieldNameMap := map[string]string{}
+	paramsTypeMap := map[string]bindings.BindingType{}
+	pathParams := map[string]string{}
+	queryParams := map[string]string{}
+	headerParams := map[string]string{}
+	dispatchHeaderParams := map[string]string{}
+	bodyFieldsMap := map[string]string{}
+	fields["tier1_id"] = bindings.NewStringType()
+	fields["locale_service_id"] = bindings.NewStringType()
+	fields["service_id"] = bindings.NewStringType()
+	fields["local_endpoint_id"] = bindings.NewStringType()
+	fields["ip_sec_vpn_local_endpoint"] = bindings.NewReferenceType(model.IPSecVpnLocalEndpointBindingType)
+	fieldNameMap["tier1_id"] = "Tier1Id"
+	fieldNameMap["locale_service_id"] = "LocaleServiceId"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["local_endpoint_id"] = "LocalEndpointId"
+	fieldNameMap["ip_sec_vpn_local_endpoint"] = "IpSecVpnLocalEndpoint"
+	paramsTypeMap["ip_sec_vpn_local_endpoint"] = bindings.NewReferenceType(model.IPSecVpnLocalEndpointBindingType)
+	paramsTypeMap["locale_service_id"] = bindings.NewStringType()
+	paramsTypeMap["tier1_id"] = bindings.NewStringType()
+	paramsTypeMap["service_id"] = bindings.NewStringType()
+	paramsTypeMap["local_endpoint_id"] = bindings.NewStringType()
+	paramsTypeMap["tier1Id"] = bindings.NewStringType()
+	paramsTypeMap["localeServiceId"] = bindings.NewStringType()
+	paramsTypeMap["serviceId"] = bindings.NewStringType()
+	paramsTypeMap["localEndpointId"] = bindings.NewStringType()
+	pathParams["local_endpoint_id"] = "localEndpointId"
+	pathParams["tier1_id"] = "tier1Id"
+	pathParams["locale_service_id"] = "localeServiceId"
+	pathParams["service_id"] = "serviceId"
+	resultHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
+	return protocol.NewOperationRestMetadata(
+		fields,
+		fieldNameMap,
+		paramsTypeMap,
+		pathParams,
+		queryParams,
+		headerParams,
+		dispatchHeaderParams,
+		bodyFieldsMap,
+		"",
+		"ip_sec_vpn_local_endpoint",
+		"PUT",
+		"/policy/api/v1/infra/tier-1s/{tier1Id}/locale-services/{localeServiceId}/ipsec-vpn-services/{serviceId}/local-endpoints/{localEndpointId}",
+		"",
+		resultHeaders,
+		200,
+		"",
+		errorHeaders,
+		map[string]int{"com.vmware.vapi.std.errors.invalid_request": 400, "com.vmware.vapi.std.errors.unauthorized": 403, "com.vmware.vapi.std.errors.service_unavailable": 503, "com.vmware.vapi.std.errors.internal_server_error": 500, "com.vmware.vapi.std.errors.not_found": 404})
+}

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_1s/locale_services/ipsec_vpn_services/SessionsClient.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_1s/locale_services/ipsec_vpn_services/SessionsClient.go
@@ -1,0 +1,347 @@
+// Copyright © 2019-2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+
+// Auto generated code. DO NOT EDIT.
+
+// Interface file for service: Sessions
+// Used by client-side stubs.
+
+package ipsec_vpn_services
+
+import (
+	"github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/bindings"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/core"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/data"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/lib"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+)
+
+const _ = core.SupportedByRuntimeVersion1
+
+type SessionsClient interface {
+
+	// Delete IPSec VPN session for a given locale service under Tier-1. This API is deprecated. Please use DELETE /infra/tier-1s/<tier-1-id>/ipsec-vpn-services/<service-id>/ sessions/<session-id> instead. Note: Please note that request is validated and any error messages returned from validation may include the new VPN path instead of the deprecated path. Both new path and old path refer to same resource. Also VPN path returned in the Alarm, GPRR payload may include the new VPN path.
+	//
+	// @param tier1IdParam (required)
+	// @param localeServiceIdParam (required)
+	// @param serviceIdParam (required)
+	// @param sessionIdParam (required)
+	// @throws InvalidRequest  Bad Request, Precondition Failed
+	// @throws Unauthorized  Forbidden
+	// @throws ServiceUnavailable  Service Unavailable
+	// @throws InternalServerError  Internal Server Error
+	// @throws NotFound  Not Found
+	Delete(tier1IdParam string, localeServiceIdParam string, serviceIdParam string, sessionIdParam string) error
+
+	// Get IPSec VPN session without sensitive data for a given locale service under Tier-1. This API is deprecated. Please use GET /infra/tier-1s/<tier-1-id>/ipsec-vpn-services/<service-id>/sessions/<session-id> instead. Note: Please note that request is validated and any error messages returned from validation may include the new VPN path instead of the deprecated path. Both new path and old path refer to same resource.
+	//
+	// @param tier1IdParam (required)
+	// @param localeServiceIdParam (required)
+	// @param serviceIdParam (required)
+	// @param sessionIdParam (required)
+	// @return com.vmware.nsx_policy.model.IPSecVpnSession
+	// The return value will contain all the properties defined in model.IPSecVpnSession.
+	// @throws InvalidRequest  Bad Request, Precondition Failed
+	// @throws Unauthorized  Forbidden
+	// @throws ServiceUnavailable  Service Unavailable
+	// @throws InternalServerError  Internal Server Error
+	// @throws NotFound  Not Found
+	Get(tier1IdParam string, localeServiceIdParam string, serviceIdParam string, sessionIdParam string) (*data.StructValue, error)
+
+	// Get paginated list of all IPSec VPN sessions for a given locale service under Tier-1. This API is deprecated. Please use GET /infra/tier-1s/<tier-1-id>/ipsec-vpn-services/<service-id>/sessions instead. Note: Please note that request is validated and any error messages returned from validation may include the new VPN path instead of the deprecated path. Both new path and old path refer to same resource.
+	//
+	// @param tier1IdParam (required)
+	// @param localeServiceIdParam (required)
+	// @param serviceIdParam (required)
+	// @param cursorParam Opaque cursor to be used for getting next page of records (supplied by current result page) (optional)
+	// @param includeMarkForDeleteObjectsParam Include objects that are marked for deletion in results (optional, default to false)
+	// @param includedFieldsParam Comma separated list of fields that should be included in query result (optional)
+	// @param pageSizeParam Maximum number of results to return in this page (server may return fewer) (optional, default to 1000)
+	// @param sortAscendingParam (optional)
+	// @param sortByParam Field by which records are sorted (optional)
+	// @return com.vmware.nsx_policy.model.IPSecVpnSessionListResult
+	// @throws InvalidRequest  Bad Request, Precondition Failed
+	// @throws Unauthorized  Forbidden
+	// @throws ServiceUnavailable  Service Unavailable
+	// @throws InternalServerError  Internal Server Error
+	// @throws NotFound  Not Found
+	List(tier1IdParam string, localeServiceIdParam string, serviceIdParam string, cursorParam *string, includeMarkForDeleteObjectsParam *bool, includedFieldsParam *string, pageSizeParam *int64, sortAscendingParam *bool, sortByParam *string) (model.IPSecVpnSessionListResult, error)
+
+	// Create or patch an IPSec VPN session for a given locale service under Tier-1. This API is deprecated. Please use PATCH /infra/tier-1s/<tier-1-id>/ipsec-vpn-services/<service-id>/sessions/<session-id> instead. Note: Please note that request is validated and any error messages returned from validation may include the new VPN path instead of the deprecated path. Both new path and old path refer to same resource. Also VPN path returned in the Alarm, GPRR payload may include the new VPN path
+	//
+	// @param tier1IdParam (required)
+	// @param localeServiceIdParam (required)
+	// @param serviceIdParam (required)
+	// @param sessionIdParam (required)
+	// @param ipSecVpnSessionParam (required)
+	// The parameter must contain all the properties defined in model.IPSecVpnSession.
+	// @throws InvalidRequest  Bad Request, Precondition Failed
+	// @throws Unauthorized  Forbidden
+	// @throws ServiceUnavailable  Service Unavailable
+	// @throws InternalServerError  Internal Server Error
+	// @throws NotFound  Not Found
+	Patch(tier1IdParam string, localeServiceIdParam string, serviceIdParam string, sessionIdParam string, ipSecVpnSessionParam *data.StructValue) error
+
+	// Get IPSec VPN session with senstive data for a given locale service under Tier-1. This API is deprecated. Please use GET /infra/tier-1s/<tier-1-id>/ipsec-vpn-services/<service-id>/sessions/<session-id>?action=show_sensitive_data instead. Note: Please note that request is validated and any error messages returned from validation may include the new VPN path instead of the deprecated path. Both new path and old path refer to same resource.
+	//
+	// @param tier1IdParam (required)
+	// @param localeServiceIdParam (required)
+	// @param serviceIdParam (required)
+	// @param sessionIdParam (required)
+	// @return com.vmware.nsx_policy.model.IPSecVpnSession
+	// The return value will contain all the properties defined in model.IPSecVpnSession.
+	// @throws InvalidRequest  Bad Request, Precondition Failed
+	// @throws Unauthorized  Forbidden
+	// @throws ServiceUnavailable  Service Unavailable
+	// @throws InternalServerError  Internal Server Error
+	// @throws NotFound  Not Found
+	Showsensitivedata(tier1IdParam string, localeServiceIdParam string, serviceIdParam string, sessionIdParam string) (*data.StructValue, error)
+
+	// Create or fully replace IPSec VPN session for a given locale service under Tier-1. Revision is optional for creation and required for update. This API is deprecated. Please use PUT /infra/tier-1s/<tier-1-id>/ipsec-vpn-services/<service-id>/sessions/<session-id> instead. Note: Please note that request is validated and any error messages returned from validation may include the new VPN path instead of the deprecated path. Both new path and old path refer to same resource. Also VPN path returned in the Alarm, GPRR payload may include the new VPN path.
+	//
+	// @param tier1IdParam (required)
+	// @param localeServiceIdParam (required)
+	// @param serviceIdParam (required)
+	// @param sessionIdParam (required)
+	// @param ipSecVpnSessionParam (required)
+	// The parameter must contain all the properties defined in model.IPSecVpnSession.
+	// @return com.vmware.nsx_policy.model.IPSecVpnSession
+	// The return value will contain all the properties defined in model.IPSecVpnSession.
+	// @throws InvalidRequest  Bad Request, Precondition Failed
+	// @throws Unauthorized  Forbidden
+	// @throws ServiceUnavailable  Service Unavailable
+	// @throws InternalServerError  Internal Server Error
+	// @throws NotFound  Not Found
+	Update(tier1IdParam string, localeServiceIdParam string, serviceIdParam string, sessionIdParam string, ipSecVpnSessionParam *data.StructValue) (*data.StructValue, error)
+}
+
+type sessionsClient struct {
+	connector           client.Connector
+	interfaceDefinition core.InterfaceDefinition
+	errorsBindingMap    map[string]bindings.BindingType
+}
+
+func NewSessionsClient(connector client.Connector) *sessionsClient {
+	interfaceIdentifier := core.NewInterfaceIdentifier("com.vmware.nsx_policy.infra.tier_1s.locale_services.ipsec_vpn_services.sessions")
+	methodIdentifiers := map[string]core.MethodIdentifier{
+		"delete":            core.NewMethodIdentifier(interfaceIdentifier, "delete"),
+		"get":               core.NewMethodIdentifier(interfaceIdentifier, "get"),
+		"list":              core.NewMethodIdentifier(interfaceIdentifier, "list"),
+		"patch":             core.NewMethodIdentifier(interfaceIdentifier, "patch"),
+		"showsensitivedata": core.NewMethodIdentifier(interfaceIdentifier, "showsensitivedata"),
+		"update":            core.NewMethodIdentifier(interfaceIdentifier, "update"),
+	}
+	interfaceDefinition := core.NewInterfaceDefinition(interfaceIdentifier, methodIdentifiers)
+	errorsBindingMap := make(map[string]bindings.BindingType)
+
+	sIface := sessionsClient{interfaceDefinition: interfaceDefinition, errorsBindingMap: errorsBindingMap, connector: connector}
+	return &sIface
+}
+
+func (sIface *sessionsClient) GetErrorBindingType(errorName string) bindings.BindingType {
+	if entry, ok := sIface.errorsBindingMap[errorName]; ok {
+		return entry
+	}
+	return errors.ERROR_BINDINGS_MAP[errorName]
+}
+
+func (sIface *sessionsClient) Delete(tier1IdParam string, localeServiceIdParam string, serviceIdParam string, sessionIdParam string) error {
+	typeConverter := sIface.connector.TypeConverter()
+	executionContext := sIface.connector.NewExecutionContext()
+	sv := bindings.NewStructValueBuilder(sessionsDeleteInputType(), typeConverter)
+	sv.AddStructField("Tier1Id", tier1IdParam)
+	sv.AddStructField("LocaleServiceId", localeServiceIdParam)
+	sv.AddStructField("ServiceId", serviceIdParam)
+	sv.AddStructField("SessionId", sessionIdParam)
+	inputDataValue, inputError := sv.GetStructValue()
+	if inputError != nil {
+		return bindings.VAPIerrorsToError(inputError)
+	}
+	operationRestMetaData := sessionsDeleteRestMetadata()
+	connectionMetadata := map[string]interface{}{lib.REST_METADATA: operationRestMetaData}
+	connectionMetadata["isStreamingResponse"] = false
+	sIface.connector.SetConnectionMetadata(connectionMetadata)
+	methodResult := sIface.connector.GetApiProvider().Invoke("com.vmware.nsx_policy.infra.tier_1s.locale_services.ipsec_vpn_services.sessions", "delete", inputDataValue, executionContext)
+	if methodResult.IsSuccess() {
+		return nil
+	} else {
+		methodError, errorInError := typeConverter.ConvertToGolang(methodResult.Error(), sIface.GetErrorBindingType(methodResult.Error().Name()))
+		if errorInError != nil {
+			return bindings.VAPIerrorsToError(errorInError)
+		}
+		return methodError.(error)
+	}
+}
+
+func (sIface *sessionsClient) Get(tier1IdParam string, localeServiceIdParam string, serviceIdParam string, sessionIdParam string) (*data.StructValue, error) {
+	typeConverter := sIface.connector.TypeConverter()
+	executionContext := sIface.connector.NewExecutionContext()
+	sv := bindings.NewStructValueBuilder(sessionsGetInputType(), typeConverter)
+	sv.AddStructField("Tier1Id", tier1IdParam)
+	sv.AddStructField("LocaleServiceId", localeServiceIdParam)
+	sv.AddStructField("ServiceId", serviceIdParam)
+	sv.AddStructField("SessionId", sessionIdParam)
+	inputDataValue, inputError := sv.GetStructValue()
+	if inputError != nil {
+		var emptyOutput *data.StructValue
+		return emptyOutput, bindings.VAPIerrorsToError(inputError)
+	}
+	operationRestMetaData := sessionsGetRestMetadata()
+	connectionMetadata := map[string]interface{}{lib.REST_METADATA: operationRestMetaData}
+	connectionMetadata["isStreamingResponse"] = false
+	sIface.connector.SetConnectionMetadata(connectionMetadata)
+	methodResult := sIface.connector.GetApiProvider().Invoke("com.vmware.nsx_policy.infra.tier_1s.locale_services.ipsec_vpn_services.sessions", "get", inputDataValue, executionContext)
+	var emptyOutput *data.StructValue
+	if methodResult.IsSuccess() {
+		output, errorInOutput := typeConverter.ConvertToGolang(methodResult.Output(), sessionsGetOutputType())
+		if errorInOutput != nil {
+			return emptyOutput, bindings.VAPIerrorsToError(errorInOutput)
+		}
+		return output.(*data.StructValue), nil
+	} else {
+		methodError, errorInError := typeConverter.ConvertToGolang(methodResult.Error(), sIface.GetErrorBindingType(methodResult.Error().Name()))
+		if errorInError != nil {
+			return emptyOutput, bindings.VAPIerrorsToError(errorInError)
+		}
+		return emptyOutput, methodError.(error)
+	}
+}
+
+func (sIface *sessionsClient) List(tier1IdParam string, localeServiceIdParam string, serviceIdParam string, cursorParam *string, includeMarkForDeleteObjectsParam *bool, includedFieldsParam *string, pageSizeParam *int64, sortAscendingParam *bool, sortByParam *string) (model.IPSecVpnSessionListResult, error) {
+	typeConverter := sIface.connector.TypeConverter()
+	executionContext := sIface.connector.NewExecutionContext()
+	sv := bindings.NewStructValueBuilder(sessionsListInputType(), typeConverter)
+	sv.AddStructField("Tier1Id", tier1IdParam)
+	sv.AddStructField("LocaleServiceId", localeServiceIdParam)
+	sv.AddStructField("ServiceId", serviceIdParam)
+	sv.AddStructField("Cursor", cursorParam)
+	sv.AddStructField("IncludeMarkForDeleteObjects", includeMarkForDeleteObjectsParam)
+	sv.AddStructField("IncludedFields", includedFieldsParam)
+	sv.AddStructField("PageSize", pageSizeParam)
+	sv.AddStructField("SortAscending", sortAscendingParam)
+	sv.AddStructField("SortBy", sortByParam)
+	inputDataValue, inputError := sv.GetStructValue()
+	if inputError != nil {
+		var emptyOutput model.IPSecVpnSessionListResult
+		return emptyOutput, bindings.VAPIerrorsToError(inputError)
+	}
+	operationRestMetaData := sessionsListRestMetadata()
+	connectionMetadata := map[string]interface{}{lib.REST_METADATA: operationRestMetaData}
+	connectionMetadata["isStreamingResponse"] = false
+	sIface.connector.SetConnectionMetadata(connectionMetadata)
+	methodResult := sIface.connector.GetApiProvider().Invoke("com.vmware.nsx_policy.infra.tier_1s.locale_services.ipsec_vpn_services.sessions", "list", inputDataValue, executionContext)
+	var emptyOutput model.IPSecVpnSessionListResult
+	if methodResult.IsSuccess() {
+		output, errorInOutput := typeConverter.ConvertToGolang(methodResult.Output(), sessionsListOutputType())
+		if errorInOutput != nil {
+			return emptyOutput, bindings.VAPIerrorsToError(errorInOutput)
+		}
+		return output.(model.IPSecVpnSessionListResult), nil
+	} else {
+		methodError, errorInError := typeConverter.ConvertToGolang(methodResult.Error(), sIface.GetErrorBindingType(methodResult.Error().Name()))
+		if errorInError != nil {
+			return emptyOutput, bindings.VAPIerrorsToError(errorInError)
+		}
+		return emptyOutput, methodError.(error)
+	}
+}
+
+func (sIface *sessionsClient) Patch(tier1IdParam string, localeServiceIdParam string, serviceIdParam string, sessionIdParam string, ipSecVpnSessionParam *data.StructValue) error {
+	typeConverter := sIface.connector.TypeConverter()
+	executionContext := sIface.connector.NewExecutionContext()
+	sv := bindings.NewStructValueBuilder(sessionsPatchInputType(), typeConverter)
+	sv.AddStructField("Tier1Id", tier1IdParam)
+	sv.AddStructField("LocaleServiceId", localeServiceIdParam)
+	sv.AddStructField("ServiceId", serviceIdParam)
+	sv.AddStructField("SessionId", sessionIdParam)
+	sv.AddStructField("IpSecVpnSession", ipSecVpnSessionParam)
+	inputDataValue, inputError := sv.GetStructValue()
+	if inputError != nil {
+		return bindings.VAPIerrorsToError(inputError)
+	}
+	operationRestMetaData := sessionsPatchRestMetadata()
+	connectionMetadata := map[string]interface{}{lib.REST_METADATA: operationRestMetaData}
+	connectionMetadata["isStreamingResponse"] = false
+	sIface.connector.SetConnectionMetadata(connectionMetadata)
+	methodResult := sIface.connector.GetApiProvider().Invoke("com.vmware.nsx_policy.infra.tier_1s.locale_services.ipsec_vpn_services.sessions", "patch", inputDataValue, executionContext)
+	if methodResult.IsSuccess() {
+		return nil
+	} else {
+		methodError, errorInError := typeConverter.ConvertToGolang(methodResult.Error(), sIface.GetErrorBindingType(methodResult.Error().Name()))
+		if errorInError != nil {
+			return bindings.VAPIerrorsToError(errorInError)
+		}
+		return methodError.(error)
+	}
+}
+
+func (sIface *sessionsClient) Showsensitivedata(tier1IdParam string, localeServiceIdParam string, serviceIdParam string, sessionIdParam string) (*data.StructValue, error) {
+	typeConverter := sIface.connector.TypeConverter()
+	executionContext := sIface.connector.NewExecutionContext()
+	sv := bindings.NewStructValueBuilder(sessionsShowsensitivedataInputType(), typeConverter)
+	sv.AddStructField("Tier1Id", tier1IdParam)
+	sv.AddStructField("LocaleServiceId", localeServiceIdParam)
+	sv.AddStructField("ServiceId", serviceIdParam)
+	sv.AddStructField("SessionId", sessionIdParam)
+	inputDataValue, inputError := sv.GetStructValue()
+	if inputError != nil {
+		var emptyOutput *data.StructValue
+		return emptyOutput, bindings.VAPIerrorsToError(inputError)
+	}
+	operationRestMetaData := sessionsShowsensitivedataRestMetadata()
+	connectionMetadata := map[string]interface{}{lib.REST_METADATA: operationRestMetaData}
+	connectionMetadata["isStreamingResponse"] = false
+	sIface.connector.SetConnectionMetadata(connectionMetadata)
+	methodResult := sIface.connector.GetApiProvider().Invoke("com.vmware.nsx_policy.infra.tier_1s.locale_services.ipsec_vpn_services.sessions", "showsensitivedata", inputDataValue, executionContext)
+	var emptyOutput *data.StructValue
+	if methodResult.IsSuccess() {
+		output, errorInOutput := typeConverter.ConvertToGolang(methodResult.Output(), sessionsShowsensitivedataOutputType())
+		if errorInOutput != nil {
+			return emptyOutput, bindings.VAPIerrorsToError(errorInOutput)
+		}
+		return output.(*data.StructValue), nil
+	} else {
+		methodError, errorInError := typeConverter.ConvertToGolang(methodResult.Error(), sIface.GetErrorBindingType(methodResult.Error().Name()))
+		if errorInError != nil {
+			return emptyOutput, bindings.VAPIerrorsToError(errorInError)
+		}
+		return emptyOutput, methodError.(error)
+	}
+}
+
+func (sIface *sessionsClient) Update(tier1IdParam string, localeServiceIdParam string, serviceIdParam string, sessionIdParam string, ipSecVpnSessionParam *data.StructValue) (*data.StructValue, error) {
+	typeConverter := sIface.connector.TypeConverter()
+	executionContext := sIface.connector.NewExecutionContext()
+	sv := bindings.NewStructValueBuilder(sessionsUpdateInputType(), typeConverter)
+	sv.AddStructField("Tier1Id", tier1IdParam)
+	sv.AddStructField("LocaleServiceId", localeServiceIdParam)
+	sv.AddStructField("ServiceId", serviceIdParam)
+	sv.AddStructField("SessionId", sessionIdParam)
+	sv.AddStructField("IpSecVpnSession", ipSecVpnSessionParam)
+	inputDataValue, inputError := sv.GetStructValue()
+	if inputError != nil {
+		var emptyOutput *data.StructValue
+		return emptyOutput, bindings.VAPIerrorsToError(inputError)
+	}
+	operationRestMetaData := sessionsUpdateRestMetadata()
+	connectionMetadata := map[string]interface{}{lib.REST_METADATA: operationRestMetaData}
+	connectionMetadata["isStreamingResponse"] = false
+	sIface.connector.SetConnectionMetadata(connectionMetadata)
+	methodResult := sIface.connector.GetApiProvider().Invoke("com.vmware.nsx_policy.infra.tier_1s.locale_services.ipsec_vpn_services.sessions", "update", inputDataValue, executionContext)
+	var emptyOutput *data.StructValue
+	if methodResult.IsSuccess() {
+		output, errorInOutput := typeConverter.ConvertToGolang(methodResult.Output(), sessionsUpdateOutputType())
+		if errorInOutput != nil {
+			return emptyOutput, bindings.VAPIerrorsToError(errorInOutput)
+		}
+		return output.(*data.StructValue), nil
+	} else {
+		methodError, errorInError := typeConverter.ConvertToGolang(methodResult.Error(), sIface.GetErrorBindingType(methodResult.Error().Name()))
+		if errorInError != nil {
+			return emptyOutput, bindings.VAPIerrorsToError(errorInError)
+		}
+		return emptyOutput, methodError.(error)
+	}
+}

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_1s/locale_services/ipsec_vpn_services/SessionsTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_1s/locale_services/ipsec_vpn_services/SessionsTypes.go
@@ -1,0 +1,484 @@
+// Copyright © 2019-2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+
+// Auto generated code. DO NOT EDIT.
+
+// Data type definitions file for service: Sessions.
+// Includes binding types of a structures and enumerations defined in the service.
+// Shared by client-side stubs and server-side skeletons to ensure type
+// compatibility.
+
+package ipsec_vpn_services
+
+import (
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/bindings"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/data"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+	"reflect"
+)
+
+func sessionsDeleteInputType() bindings.StructType {
+	fields := make(map[string]bindings.BindingType)
+	fieldNameMap := make(map[string]string)
+	fields["tier1_id"] = bindings.NewStringType()
+	fields["locale_service_id"] = bindings.NewStringType()
+	fields["service_id"] = bindings.NewStringType()
+	fields["session_id"] = bindings.NewStringType()
+	fieldNameMap["tier1_id"] = "Tier1Id"
+	fieldNameMap["locale_service_id"] = "LocaleServiceId"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["session_id"] = "SessionId"
+	var validators = []bindings.Validator{}
+	return bindings.NewStructType("operation-input", fields, reflect.TypeOf(data.StructValue{}), fieldNameMap, validators)
+}
+
+func sessionsDeleteOutputType() bindings.BindingType {
+	return bindings.NewVoidType()
+}
+
+func sessionsDeleteRestMetadata() protocol.OperationRestMetadata {
+	fields := map[string]bindings.BindingType{}
+	fieldNameMap := map[string]string{}
+	paramsTypeMap := map[string]bindings.BindingType{}
+	pathParams := map[string]string{}
+	queryParams := map[string]string{}
+	headerParams := map[string]string{}
+	dispatchHeaderParams := map[string]string{}
+	bodyFieldsMap := map[string]string{}
+	fields["tier1_id"] = bindings.NewStringType()
+	fields["locale_service_id"] = bindings.NewStringType()
+	fields["service_id"] = bindings.NewStringType()
+	fields["session_id"] = bindings.NewStringType()
+	fieldNameMap["tier1_id"] = "Tier1Id"
+	fieldNameMap["locale_service_id"] = "LocaleServiceId"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["session_id"] = "SessionId"
+	paramsTypeMap["locale_service_id"] = bindings.NewStringType()
+	paramsTypeMap["tier1_id"] = bindings.NewStringType()
+	paramsTypeMap["service_id"] = bindings.NewStringType()
+	paramsTypeMap["session_id"] = bindings.NewStringType()
+	paramsTypeMap["tier1Id"] = bindings.NewStringType()
+	paramsTypeMap["localeServiceId"] = bindings.NewStringType()
+	paramsTypeMap["serviceId"] = bindings.NewStringType()
+	paramsTypeMap["sessionId"] = bindings.NewStringType()
+	pathParams["tier1_id"] = "tier1Id"
+	pathParams["session_id"] = "sessionId"
+	pathParams["locale_service_id"] = "localeServiceId"
+	pathParams["service_id"] = "serviceId"
+	resultHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
+	return protocol.NewOperationRestMetadata(
+		fields,
+		fieldNameMap,
+		paramsTypeMap,
+		pathParams,
+		queryParams,
+		headerParams,
+		dispatchHeaderParams,
+		bodyFieldsMap,
+		"",
+		"",
+		"DELETE",
+		"/policy/api/v1/infra/tier-1s/{tier1Id}/locale-services/{localeServiceId}/ipsec-vpn-services/{serviceId}/sessions/{sessionId}",
+		"",
+		resultHeaders,
+		204,
+		"",
+		errorHeaders,
+		map[string]int{"com.vmware.vapi.std.errors.invalid_request": 400, "com.vmware.vapi.std.errors.unauthorized": 403, "com.vmware.vapi.std.errors.service_unavailable": 503, "com.vmware.vapi.std.errors.internal_server_error": 500, "com.vmware.vapi.std.errors.not_found": 404})
+}
+
+func sessionsGetInputType() bindings.StructType {
+	fields := make(map[string]bindings.BindingType)
+	fieldNameMap := make(map[string]string)
+	fields["tier1_id"] = bindings.NewStringType()
+	fields["locale_service_id"] = bindings.NewStringType()
+	fields["service_id"] = bindings.NewStringType()
+	fields["session_id"] = bindings.NewStringType()
+	fieldNameMap["tier1_id"] = "Tier1Id"
+	fieldNameMap["locale_service_id"] = "LocaleServiceId"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["session_id"] = "SessionId"
+	var validators = []bindings.Validator{}
+	return bindings.NewStructType("operation-input", fields, reflect.TypeOf(data.StructValue{}), fieldNameMap, validators)
+}
+
+func sessionsGetOutputType() bindings.BindingType {
+	return bindings.NewDynamicStructType([]bindings.ReferenceType{bindings.NewReferenceType(model.IPSecVpnSessionBindingType)}, bindings.REST)
+}
+
+func sessionsGetRestMetadata() protocol.OperationRestMetadata {
+	fields := map[string]bindings.BindingType{}
+	fieldNameMap := map[string]string{}
+	paramsTypeMap := map[string]bindings.BindingType{}
+	pathParams := map[string]string{}
+	queryParams := map[string]string{}
+	headerParams := map[string]string{}
+	dispatchHeaderParams := map[string]string{}
+	bodyFieldsMap := map[string]string{}
+	fields["tier1_id"] = bindings.NewStringType()
+	fields["locale_service_id"] = bindings.NewStringType()
+	fields["service_id"] = bindings.NewStringType()
+	fields["session_id"] = bindings.NewStringType()
+	fieldNameMap["tier1_id"] = "Tier1Id"
+	fieldNameMap["locale_service_id"] = "LocaleServiceId"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["session_id"] = "SessionId"
+	paramsTypeMap["locale_service_id"] = bindings.NewStringType()
+	paramsTypeMap["tier1_id"] = bindings.NewStringType()
+	paramsTypeMap["service_id"] = bindings.NewStringType()
+	paramsTypeMap["session_id"] = bindings.NewStringType()
+	paramsTypeMap["tier1Id"] = bindings.NewStringType()
+	paramsTypeMap["localeServiceId"] = bindings.NewStringType()
+	paramsTypeMap["serviceId"] = bindings.NewStringType()
+	paramsTypeMap["sessionId"] = bindings.NewStringType()
+	pathParams["tier1_id"] = "tier1Id"
+	pathParams["session_id"] = "sessionId"
+	pathParams["locale_service_id"] = "localeServiceId"
+	pathParams["service_id"] = "serviceId"
+	resultHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
+	return protocol.NewOperationRestMetadata(
+		fields,
+		fieldNameMap,
+		paramsTypeMap,
+		pathParams,
+		queryParams,
+		headerParams,
+		dispatchHeaderParams,
+		bodyFieldsMap,
+		"",
+		"",
+		"GET",
+		"/policy/api/v1/infra/tier-1s/{tier1Id}/locale-services/{localeServiceId}/ipsec-vpn-services/{serviceId}/sessions/{sessionId}",
+		"",
+		resultHeaders,
+		200,
+		"",
+		errorHeaders,
+		map[string]int{"com.vmware.vapi.std.errors.invalid_request": 400, "com.vmware.vapi.std.errors.unauthorized": 403, "com.vmware.vapi.std.errors.service_unavailable": 503, "com.vmware.vapi.std.errors.internal_server_error": 500, "com.vmware.vapi.std.errors.not_found": 404})
+}
+
+func sessionsListInputType() bindings.StructType {
+	fields := make(map[string]bindings.BindingType)
+	fieldNameMap := make(map[string]string)
+	fields["tier1_id"] = bindings.NewStringType()
+	fields["locale_service_id"] = bindings.NewStringType()
+	fields["service_id"] = bindings.NewStringType()
+	fields["cursor"] = bindings.NewOptionalType(bindings.NewStringType())
+	fields["include_mark_for_delete_objects"] = bindings.NewOptionalType(bindings.NewBooleanType())
+	fields["included_fields"] = bindings.NewOptionalType(bindings.NewStringType())
+	fields["page_size"] = bindings.NewOptionalType(bindings.NewIntegerType())
+	fields["sort_ascending"] = bindings.NewOptionalType(bindings.NewBooleanType())
+	fields["sort_by"] = bindings.NewOptionalType(bindings.NewStringType())
+	fieldNameMap["tier1_id"] = "Tier1Id"
+	fieldNameMap["locale_service_id"] = "LocaleServiceId"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["cursor"] = "Cursor"
+	fieldNameMap["include_mark_for_delete_objects"] = "IncludeMarkForDeleteObjects"
+	fieldNameMap["included_fields"] = "IncludedFields"
+	fieldNameMap["page_size"] = "PageSize"
+	fieldNameMap["sort_ascending"] = "SortAscending"
+	fieldNameMap["sort_by"] = "SortBy"
+	var validators = []bindings.Validator{}
+	return bindings.NewStructType("operation-input", fields, reflect.TypeOf(data.StructValue{}), fieldNameMap, validators)
+}
+
+func sessionsListOutputType() bindings.BindingType {
+	return bindings.NewReferenceType(model.IPSecVpnSessionListResultBindingType)
+}
+
+func sessionsListRestMetadata() protocol.OperationRestMetadata {
+	fields := map[string]bindings.BindingType{}
+	fieldNameMap := map[string]string{}
+	paramsTypeMap := map[string]bindings.BindingType{}
+	pathParams := map[string]string{}
+	queryParams := map[string]string{}
+	headerParams := map[string]string{}
+	dispatchHeaderParams := map[string]string{}
+	bodyFieldsMap := map[string]string{}
+	fields["tier1_id"] = bindings.NewStringType()
+	fields["locale_service_id"] = bindings.NewStringType()
+	fields["service_id"] = bindings.NewStringType()
+	fields["cursor"] = bindings.NewOptionalType(bindings.NewStringType())
+	fields["include_mark_for_delete_objects"] = bindings.NewOptionalType(bindings.NewBooleanType())
+	fields["included_fields"] = bindings.NewOptionalType(bindings.NewStringType())
+	fields["page_size"] = bindings.NewOptionalType(bindings.NewIntegerType())
+	fields["sort_ascending"] = bindings.NewOptionalType(bindings.NewBooleanType())
+	fields["sort_by"] = bindings.NewOptionalType(bindings.NewStringType())
+	fieldNameMap["tier1_id"] = "Tier1Id"
+	fieldNameMap["locale_service_id"] = "LocaleServiceId"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["cursor"] = "Cursor"
+	fieldNameMap["include_mark_for_delete_objects"] = "IncludeMarkForDeleteObjects"
+	fieldNameMap["included_fields"] = "IncludedFields"
+	fieldNameMap["page_size"] = "PageSize"
+	fieldNameMap["sort_ascending"] = "SortAscending"
+	fieldNameMap["sort_by"] = "SortBy"
+	paramsTypeMap["locale_service_id"] = bindings.NewStringType()
+	paramsTypeMap["tier1_id"] = bindings.NewStringType()
+	paramsTypeMap["service_id"] = bindings.NewStringType()
+	paramsTypeMap["included_fields"] = bindings.NewOptionalType(bindings.NewStringType())
+	paramsTypeMap["page_size"] = bindings.NewOptionalType(bindings.NewIntegerType())
+	paramsTypeMap["include_mark_for_delete_objects"] = bindings.NewOptionalType(bindings.NewBooleanType())
+	paramsTypeMap["cursor"] = bindings.NewOptionalType(bindings.NewStringType())
+	paramsTypeMap["sort_by"] = bindings.NewOptionalType(bindings.NewStringType())
+	paramsTypeMap["sort_ascending"] = bindings.NewOptionalType(bindings.NewBooleanType())
+	paramsTypeMap["tier1Id"] = bindings.NewStringType()
+	paramsTypeMap["localeServiceId"] = bindings.NewStringType()
+	paramsTypeMap["serviceId"] = bindings.NewStringType()
+	pathParams["tier1_id"] = "tier1Id"
+	pathParams["locale_service_id"] = "localeServiceId"
+	pathParams["service_id"] = "serviceId"
+	queryParams["cursor"] = "cursor"
+	queryParams["sort_ascending"] = "sort_ascending"
+	queryParams["included_fields"] = "included_fields"
+	queryParams["sort_by"] = "sort_by"
+	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
+	queryParams["page_size"] = "page_size"
+	resultHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
+	return protocol.NewOperationRestMetadata(
+		fields,
+		fieldNameMap,
+		paramsTypeMap,
+		pathParams,
+		queryParams,
+		headerParams,
+		dispatchHeaderParams,
+		bodyFieldsMap,
+		"",
+		"",
+		"GET",
+		"/policy/api/v1/infra/tier-1s/{tier1Id}/locale-services/{localeServiceId}/ipsec-vpn-services/{serviceId}/sessions",
+		"",
+		resultHeaders,
+		200,
+		"",
+		errorHeaders,
+		map[string]int{"com.vmware.vapi.std.errors.invalid_request": 400, "com.vmware.vapi.std.errors.unauthorized": 403, "com.vmware.vapi.std.errors.service_unavailable": 503, "com.vmware.vapi.std.errors.internal_server_error": 500, "com.vmware.vapi.std.errors.not_found": 404})
+}
+
+func sessionsPatchInputType() bindings.StructType {
+	fields := make(map[string]bindings.BindingType)
+	fieldNameMap := make(map[string]string)
+	fields["tier1_id"] = bindings.NewStringType()
+	fields["locale_service_id"] = bindings.NewStringType()
+	fields["service_id"] = bindings.NewStringType()
+	fields["session_id"] = bindings.NewStringType()
+	fields["ip_sec_vpn_session"] = bindings.NewDynamicStructType([]bindings.ReferenceType{bindings.NewReferenceType(model.IPSecVpnSessionBindingType)}, bindings.REST)
+	fieldNameMap["tier1_id"] = "Tier1Id"
+	fieldNameMap["locale_service_id"] = "LocaleServiceId"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["session_id"] = "SessionId"
+	fieldNameMap["ip_sec_vpn_session"] = "IpSecVpnSession"
+	var validators = []bindings.Validator{}
+	return bindings.NewStructType("operation-input", fields, reflect.TypeOf(data.StructValue{}), fieldNameMap, validators)
+}
+
+func sessionsPatchOutputType() bindings.BindingType {
+	return bindings.NewVoidType()
+}
+
+func sessionsPatchRestMetadata() protocol.OperationRestMetadata {
+	fields := map[string]bindings.BindingType{}
+	fieldNameMap := map[string]string{}
+	paramsTypeMap := map[string]bindings.BindingType{}
+	pathParams := map[string]string{}
+	queryParams := map[string]string{}
+	headerParams := map[string]string{}
+	dispatchHeaderParams := map[string]string{}
+	bodyFieldsMap := map[string]string{}
+	fields["tier1_id"] = bindings.NewStringType()
+	fields["locale_service_id"] = bindings.NewStringType()
+	fields["service_id"] = bindings.NewStringType()
+	fields["session_id"] = bindings.NewStringType()
+	fields["ip_sec_vpn_session"] = bindings.NewDynamicStructType([]bindings.ReferenceType{bindings.NewReferenceType(model.IPSecVpnSessionBindingType)}, bindings.REST)
+	fieldNameMap["tier1_id"] = "Tier1Id"
+	fieldNameMap["locale_service_id"] = "LocaleServiceId"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["session_id"] = "SessionId"
+	fieldNameMap["ip_sec_vpn_session"] = "IpSecVpnSession"
+	paramsTypeMap["locale_service_id"] = bindings.NewStringType()
+	paramsTypeMap["tier1_id"] = bindings.NewStringType()
+	paramsTypeMap["service_id"] = bindings.NewStringType()
+	paramsTypeMap["session_id"] = bindings.NewStringType()
+	paramsTypeMap["ip_sec_vpn_session"] = bindings.NewDynamicStructType([]bindings.ReferenceType{bindings.NewReferenceType(model.IPSecVpnSessionBindingType)}, bindings.REST)
+	paramsTypeMap["tier1Id"] = bindings.NewStringType()
+	paramsTypeMap["localeServiceId"] = bindings.NewStringType()
+	paramsTypeMap["serviceId"] = bindings.NewStringType()
+	paramsTypeMap["sessionId"] = bindings.NewStringType()
+	pathParams["tier1_id"] = "tier1Id"
+	pathParams["session_id"] = "sessionId"
+	pathParams["locale_service_id"] = "localeServiceId"
+	pathParams["service_id"] = "serviceId"
+	resultHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
+	return protocol.NewOperationRestMetadata(
+		fields,
+		fieldNameMap,
+		paramsTypeMap,
+		pathParams,
+		queryParams,
+		headerParams,
+		dispatchHeaderParams,
+		bodyFieldsMap,
+		"",
+		"ip_sec_vpn_session",
+		"PATCH",
+		"/policy/api/v1/infra/tier-1s/{tier1Id}/locale-services/{localeServiceId}/ipsec-vpn-services/{serviceId}/sessions/{sessionId}",
+		"",
+		resultHeaders,
+		204,
+		"",
+		errorHeaders,
+		map[string]int{"com.vmware.vapi.std.errors.invalid_request": 400, "com.vmware.vapi.std.errors.unauthorized": 403, "com.vmware.vapi.std.errors.service_unavailable": 503, "com.vmware.vapi.std.errors.internal_server_error": 500, "com.vmware.vapi.std.errors.not_found": 404})
+}
+
+func sessionsShowsensitivedataInputType() bindings.StructType {
+	fields := make(map[string]bindings.BindingType)
+	fieldNameMap := make(map[string]string)
+	fields["tier1_id"] = bindings.NewStringType()
+	fields["locale_service_id"] = bindings.NewStringType()
+	fields["service_id"] = bindings.NewStringType()
+	fields["session_id"] = bindings.NewStringType()
+	fieldNameMap["tier1_id"] = "Tier1Id"
+	fieldNameMap["locale_service_id"] = "LocaleServiceId"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["session_id"] = "SessionId"
+	var validators = []bindings.Validator{}
+	return bindings.NewStructType("operation-input", fields, reflect.TypeOf(data.StructValue{}), fieldNameMap, validators)
+}
+
+func sessionsShowsensitivedataOutputType() bindings.BindingType {
+	return bindings.NewDynamicStructType([]bindings.ReferenceType{bindings.NewReferenceType(model.IPSecVpnSessionBindingType)}, bindings.REST)
+}
+
+func sessionsShowsensitivedataRestMetadata() protocol.OperationRestMetadata {
+	fields := map[string]bindings.BindingType{}
+	fieldNameMap := map[string]string{}
+	paramsTypeMap := map[string]bindings.BindingType{}
+	pathParams := map[string]string{}
+	queryParams := map[string]string{}
+	headerParams := map[string]string{}
+	dispatchHeaderParams := map[string]string{}
+	bodyFieldsMap := map[string]string{}
+	fields["tier1_id"] = bindings.NewStringType()
+	fields["locale_service_id"] = bindings.NewStringType()
+	fields["service_id"] = bindings.NewStringType()
+	fields["session_id"] = bindings.NewStringType()
+	fieldNameMap["tier1_id"] = "Tier1Id"
+	fieldNameMap["locale_service_id"] = "LocaleServiceId"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["session_id"] = "SessionId"
+	paramsTypeMap["locale_service_id"] = bindings.NewStringType()
+	paramsTypeMap["tier1_id"] = bindings.NewStringType()
+	paramsTypeMap["service_id"] = bindings.NewStringType()
+	paramsTypeMap["session_id"] = bindings.NewStringType()
+	paramsTypeMap["tier1Id"] = bindings.NewStringType()
+	paramsTypeMap["localeServiceId"] = bindings.NewStringType()
+	paramsTypeMap["serviceId"] = bindings.NewStringType()
+	paramsTypeMap["sessionId"] = bindings.NewStringType()
+	pathParams["tier1_id"] = "tier1Id"
+	pathParams["session_id"] = "sessionId"
+	pathParams["locale_service_id"] = "localeServiceId"
+	pathParams["service_id"] = "serviceId"
+	resultHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
+	return protocol.NewOperationRestMetadata(
+		fields,
+		fieldNameMap,
+		paramsTypeMap,
+		pathParams,
+		queryParams,
+		headerParams,
+		dispatchHeaderParams,
+		bodyFieldsMap,
+		"action=show_sensitive_data",
+		"",
+		"GET",
+		"/policy/api/v1/infra/tier-1s/{tier1Id}/locale-services/{localeServiceId}/ipsec-vpn-services/{serviceId}/sessions/{sessionId}",
+		"",
+		resultHeaders,
+		200,
+		"",
+		errorHeaders,
+		map[string]int{"com.vmware.vapi.std.errors.invalid_request": 400, "com.vmware.vapi.std.errors.unauthorized": 403, "com.vmware.vapi.std.errors.service_unavailable": 503, "com.vmware.vapi.std.errors.internal_server_error": 500, "com.vmware.vapi.std.errors.not_found": 404})
+}
+
+func sessionsUpdateInputType() bindings.StructType {
+	fields := make(map[string]bindings.BindingType)
+	fieldNameMap := make(map[string]string)
+	fields["tier1_id"] = bindings.NewStringType()
+	fields["locale_service_id"] = bindings.NewStringType()
+	fields["service_id"] = bindings.NewStringType()
+	fields["session_id"] = bindings.NewStringType()
+	fields["ip_sec_vpn_session"] = bindings.NewDynamicStructType([]bindings.ReferenceType{bindings.NewReferenceType(model.IPSecVpnSessionBindingType)}, bindings.REST)
+	fieldNameMap["tier1_id"] = "Tier1Id"
+	fieldNameMap["locale_service_id"] = "LocaleServiceId"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["session_id"] = "SessionId"
+	fieldNameMap["ip_sec_vpn_session"] = "IpSecVpnSession"
+	var validators = []bindings.Validator{}
+	return bindings.NewStructType("operation-input", fields, reflect.TypeOf(data.StructValue{}), fieldNameMap, validators)
+}
+
+func sessionsUpdateOutputType() bindings.BindingType {
+	return bindings.NewDynamicStructType([]bindings.ReferenceType{bindings.NewReferenceType(model.IPSecVpnSessionBindingType)}, bindings.REST)
+}
+
+func sessionsUpdateRestMetadata() protocol.OperationRestMetadata {
+	fields := map[string]bindings.BindingType{}
+	fieldNameMap := map[string]string{}
+	paramsTypeMap := map[string]bindings.BindingType{}
+	pathParams := map[string]string{}
+	queryParams := map[string]string{}
+	headerParams := map[string]string{}
+	dispatchHeaderParams := map[string]string{}
+	bodyFieldsMap := map[string]string{}
+	fields["tier1_id"] = bindings.NewStringType()
+	fields["locale_service_id"] = bindings.NewStringType()
+	fields["service_id"] = bindings.NewStringType()
+	fields["session_id"] = bindings.NewStringType()
+	fields["ip_sec_vpn_session"] = bindings.NewDynamicStructType([]bindings.ReferenceType{bindings.NewReferenceType(model.IPSecVpnSessionBindingType)}, bindings.REST)
+	fieldNameMap["tier1_id"] = "Tier1Id"
+	fieldNameMap["locale_service_id"] = "LocaleServiceId"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["session_id"] = "SessionId"
+	fieldNameMap["ip_sec_vpn_session"] = "IpSecVpnSession"
+	paramsTypeMap["locale_service_id"] = bindings.NewStringType()
+	paramsTypeMap["tier1_id"] = bindings.NewStringType()
+	paramsTypeMap["service_id"] = bindings.NewStringType()
+	paramsTypeMap["session_id"] = bindings.NewStringType()
+	paramsTypeMap["ip_sec_vpn_session"] = bindings.NewDynamicStructType([]bindings.ReferenceType{bindings.NewReferenceType(model.IPSecVpnSessionBindingType)}, bindings.REST)
+	paramsTypeMap["tier1Id"] = bindings.NewStringType()
+	paramsTypeMap["localeServiceId"] = bindings.NewStringType()
+	paramsTypeMap["serviceId"] = bindings.NewStringType()
+	paramsTypeMap["sessionId"] = bindings.NewStringType()
+	pathParams["tier1_id"] = "tier1Id"
+	pathParams["session_id"] = "sessionId"
+	pathParams["locale_service_id"] = "localeServiceId"
+	pathParams["service_id"] = "serviceId"
+	resultHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
+	return protocol.NewOperationRestMetadata(
+		fields,
+		fieldNameMap,
+		paramsTypeMap,
+		pathParams,
+		queryParams,
+		headerParams,
+		dispatchHeaderParams,
+		bodyFieldsMap,
+		"",
+		"ip_sec_vpn_session",
+		"PUT",
+		"/policy/api/v1/infra/tier-1s/{tier1Id}/locale-services/{localeServiceId}/ipsec-vpn-services/{serviceId}/sessions/{sessionId}",
+		"",
+		resultHeaders,
+		200,
+		"",
+		errorHeaders,
+		map[string]int{"com.vmware.vapi.std.errors.invalid_request": 400, "com.vmware.vapi.std.errors.unauthorized": 403, "com.vmware.vapi.std.errors.service_unavailable": 503, "com.vmware.vapi.std.errors.internal_server_error": 500, "com.vmware.vapi.std.errors.not_found": 404})
+}

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_1s/locale_services/ipsec_vpn_services/SummaryClient.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_1s/locale_services/ipsec_vpn_services/SummaryClient.go
@@ -1,0 +1,98 @@
+// Copyright © 2019-2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+
+// Auto generated code. DO NOT EDIT.
+
+// Interface file for service: Summary
+// Used by client-side stubs.
+
+package ipsec_vpn_services
+
+import (
+	"github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/bindings"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/core"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/lib"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+)
+
+const _ = core.SupportedByRuntimeVersion1
+
+type SummaryClient interface {
+
+	// Summarized view of all tier-1 IPSec VPN sessions for a specified service. This API is deprecated. Please use GET /infra/tier-1s/<tier-1-id>/ipsec-vpn-services/<service-id>/summary instead.
+	//
+	// @param tier1IdParam (required)
+	// @param localeServiceIdParam (required)
+	// @param serviceIdParam (required)
+	// @param enforcementPointPathParam String Path of the enforcement point (optional)
+	// @param sourceParam Data source type. (optional)
+	// @return com.vmware.nsx_policy.model.PolicyIpsecVpnIkeServiceSummary
+	// @throws InvalidRequest  Bad Request, Precondition Failed
+	// @throws Unauthorized  Forbidden
+	// @throws ServiceUnavailable  Service Unavailable
+	// @throws InternalServerError  Internal Server Error
+	// @throws NotFound  Not Found
+	Get(tier1IdParam string, localeServiceIdParam string, serviceIdParam string, enforcementPointPathParam *string, sourceParam *string) (model.PolicyIpsecVpnIkeServiceSummary, error)
+}
+
+type summaryClient struct {
+	connector           client.Connector
+	interfaceDefinition core.InterfaceDefinition
+	errorsBindingMap    map[string]bindings.BindingType
+}
+
+func NewSummaryClient(connector client.Connector) *summaryClient {
+	interfaceIdentifier := core.NewInterfaceIdentifier("com.vmware.nsx_policy.infra.tier_1s.locale_services.ipsec_vpn_services.summary")
+	methodIdentifiers := map[string]core.MethodIdentifier{
+		"get": core.NewMethodIdentifier(interfaceIdentifier, "get"),
+	}
+	interfaceDefinition := core.NewInterfaceDefinition(interfaceIdentifier, methodIdentifiers)
+	errorsBindingMap := make(map[string]bindings.BindingType)
+
+	sIface := summaryClient{interfaceDefinition: interfaceDefinition, errorsBindingMap: errorsBindingMap, connector: connector}
+	return &sIface
+}
+
+func (sIface *summaryClient) GetErrorBindingType(errorName string) bindings.BindingType {
+	if entry, ok := sIface.errorsBindingMap[errorName]; ok {
+		return entry
+	}
+	return errors.ERROR_BINDINGS_MAP[errorName]
+}
+
+func (sIface *summaryClient) Get(tier1IdParam string, localeServiceIdParam string, serviceIdParam string, enforcementPointPathParam *string, sourceParam *string) (model.PolicyIpsecVpnIkeServiceSummary, error) {
+	typeConverter := sIface.connector.TypeConverter()
+	executionContext := sIface.connector.NewExecutionContext()
+	sv := bindings.NewStructValueBuilder(summaryGetInputType(), typeConverter)
+	sv.AddStructField("Tier1Id", tier1IdParam)
+	sv.AddStructField("LocaleServiceId", localeServiceIdParam)
+	sv.AddStructField("ServiceId", serviceIdParam)
+	sv.AddStructField("EnforcementPointPath", enforcementPointPathParam)
+	sv.AddStructField("Source", sourceParam)
+	inputDataValue, inputError := sv.GetStructValue()
+	if inputError != nil {
+		var emptyOutput model.PolicyIpsecVpnIkeServiceSummary
+		return emptyOutput, bindings.VAPIerrorsToError(inputError)
+	}
+	operationRestMetaData := summaryGetRestMetadata()
+	connectionMetadata := map[string]interface{}{lib.REST_METADATA: operationRestMetaData}
+	connectionMetadata["isStreamingResponse"] = false
+	sIface.connector.SetConnectionMetadata(connectionMetadata)
+	methodResult := sIface.connector.GetApiProvider().Invoke("com.vmware.nsx_policy.infra.tier_1s.locale_services.ipsec_vpn_services.summary", "get", inputDataValue, executionContext)
+	var emptyOutput model.PolicyIpsecVpnIkeServiceSummary
+	if methodResult.IsSuccess() {
+		output, errorInOutput := typeConverter.ConvertToGolang(methodResult.Output(), summaryGetOutputType())
+		if errorInOutput != nil {
+			return emptyOutput, bindings.VAPIerrorsToError(errorInOutput)
+		}
+		return output.(model.PolicyIpsecVpnIkeServiceSummary), nil
+	} else {
+		methodError, errorInError := typeConverter.ConvertToGolang(methodResult.Error(), sIface.GetErrorBindingType(methodResult.Error().Name()))
+		if errorInError != nil {
+			return emptyOutput, bindings.VAPIerrorsToError(errorInError)
+		}
+		return emptyOutput, methodError.(error)
+	}
+}

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_1s/locale_services/ipsec_vpn_services/SummaryTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_1s/locale_services/ipsec_vpn_services/SummaryTypes.go
@@ -1,0 +1,101 @@
+// Copyright © 2019-2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+
+// Auto generated code. DO NOT EDIT.
+
+// Data type definitions file for service: Summary.
+// Includes binding types of a structures and enumerations defined in the service.
+// Shared by client-side stubs and server-side skeletons to ensure type
+// compatibility.
+
+package ipsec_vpn_services
+
+import (
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/bindings"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/data"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+	"reflect"
+)
+
+// Possible value for ``source`` of method Summary#get.
+const Summary_GET_SOURCE_REALTIME = "realtime"
+
+// Possible value for ``source`` of method Summary#get.
+const Summary_GET_SOURCE_CACHED = "cached"
+
+func summaryGetInputType() bindings.StructType {
+	fields := make(map[string]bindings.BindingType)
+	fieldNameMap := make(map[string]string)
+	fields["tier1_id"] = bindings.NewStringType()
+	fields["locale_service_id"] = bindings.NewStringType()
+	fields["service_id"] = bindings.NewStringType()
+	fields["enforcement_point_path"] = bindings.NewOptionalType(bindings.NewStringType())
+	fields["source"] = bindings.NewOptionalType(bindings.NewStringType())
+	fieldNameMap["tier1_id"] = "Tier1Id"
+	fieldNameMap["locale_service_id"] = "LocaleServiceId"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["enforcement_point_path"] = "EnforcementPointPath"
+	fieldNameMap["source"] = "Source"
+	var validators = []bindings.Validator{}
+	return bindings.NewStructType("operation-input", fields, reflect.TypeOf(data.StructValue{}), fieldNameMap, validators)
+}
+
+func summaryGetOutputType() bindings.BindingType {
+	return bindings.NewReferenceType(model.PolicyIpsecVpnIkeServiceSummaryBindingType)
+}
+
+func summaryGetRestMetadata() protocol.OperationRestMetadata {
+	fields := map[string]bindings.BindingType{}
+	fieldNameMap := map[string]string{}
+	paramsTypeMap := map[string]bindings.BindingType{}
+	pathParams := map[string]string{}
+	queryParams := map[string]string{}
+	headerParams := map[string]string{}
+	dispatchHeaderParams := map[string]string{}
+	bodyFieldsMap := map[string]string{}
+	fields["tier1_id"] = bindings.NewStringType()
+	fields["locale_service_id"] = bindings.NewStringType()
+	fields["service_id"] = bindings.NewStringType()
+	fields["enforcement_point_path"] = bindings.NewOptionalType(bindings.NewStringType())
+	fields["source"] = bindings.NewOptionalType(bindings.NewStringType())
+	fieldNameMap["tier1_id"] = "Tier1Id"
+	fieldNameMap["locale_service_id"] = "LocaleServiceId"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["enforcement_point_path"] = "EnforcementPointPath"
+	fieldNameMap["source"] = "Source"
+	paramsTypeMap["source"] = bindings.NewOptionalType(bindings.NewStringType())
+	paramsTypeMap["enforcement_point_path"] = bindings.NewOptionalType(bindings.NewStringType())
+	paramsTypeMap["locale_service_id"] = bindings.NewStringType()
+	paramsTypeMap["tier1_id"] = bindings.NewStringType()
+	paramsTypeMap["service_id"] = bindings.NewStringType()
+	paramsTypeMap["tier1Id"] = bindings.NewStringType()
+	paramsTypeMap["localeServiceId"] = bindings.NewStringType()
+	paramsTypeMap["serviceId"] = bindings.NewStringType()
+	pathParams["tier1_id"] = "tier1Id"
+	pathParams["locale_service_id"] = "localeServiceId"
+	pathParams["service_id"] = "serviceId"
+	queryParams["enforcement_point_path"] = "enforcement_point_path"
+	queryParams["source"] = "source"
+	resultHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
+	return protocol.NewOperationRestMetadata(
+		fields,
+		fieldNameMap,
+		paramsTypeMap,
+		pathParams,
+		queryParams,
+		headerParams,
+		dispatchHeaderParams,
+		bodyFieldsMap,
+		"",
+		"",
+		"GET",
+		"/policy/api/v1/infra/tier-1s/{tier1Id}/locale-services/{localeServiceId}/ipsec-vpn-services/{serviceId}/summary",
+		"",
+		resultHeaders,
+		200,
+		"",
+		errorHeaders,
+		map[string]int{"com.vmware.vapi.std.errors.invalid_request": 400, "com.vmware.vapi.std.errors.unauthorized": 403, "com.vmware.vapi.std.errors.service_unavailable": 503, "com.vmware.vapi.std.errors.internal_server_error": 500, "com.vmware.vapi.std.errors.not_found": 404})
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -214,11 +214,14 @@ github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/sites/enforcemen
 github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_0s
 github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_0s/locale_services
 github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_0s/locale_services/bgp
+github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_0s/locale_services/ipsec_vpn_services
+github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_0s/locale_services/l2vpn_services
 github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_0s/locale_services/ospf
 github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_0s/nat
 github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_0s/static_routes
 github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_1s
 github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_1s/locale_services
+github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_1s/locale_services/ipsec_vpn_services
 github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_1s/nat
 github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_1s/segments
 github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model

--- a/website/docs/d/policy_ipsec_vpn_local_endpoint.html.markdown
+++ b/website/docs/d/policy_ipsec_vpn_local_endpoint.html.markdown
@@ -1,0 +1,34 @@
+---
+subcategory: "Policy - Gateways and Routing"
+layout: "nsxt"
+page_title: "NSXT: policy_local_endpoint"
+description: Policy Local Endpoint data source.
+---
+
+# nsxt_policy_local_endpoint
+
+This data source provides information about policy local endpoint configured on NSX.
+
+This data source is applicable to NSX Global Manager, NSX Policy Manager and VMC.
+
+## Example Usage
+
+```hcl
+data "nsxt_policy_local_endpoint" "test" {
+  display_name = "local_endpoint1"
+}
+```
+
+## Argument Reference
+
+* `id` - (Optional) The ID of Local Endpoint to retrieve.
+
+* `display_name` - (Optional) The Display Name prefix of the Local Endpoint to retrieve. With VMC on AWS, the user can either choose the "Private IP1" or "Public IP1" values.
+
+## Attributes Reference
+
+In addition to arguments listed above, the following attributes are exported:
+
+* `description` - The description of the resource.
+
+* `path` - The NSX path of the policy resource.

--- a/website/docs/d/policy_ipsec_vpn_service.html.markdown
+++ b/website/docs/d/policy_ipsec_vpn_service.html.markdown
@@ -1,0 +1,34 @@
+---
+subcategory: "Policy - VPN"
+layout: "nsxt"
+page_title: "NSXT: policy_ipsec_vpn_service"
+description: Policy IPSec VPN Service.
+---
+
+# nsxt_policy_vpn_service
+
+This data source provides information about policy ipsec vpn service configured on NSX.
+
+This data source is applicable to NSX Policy Manager and VMC.
+
+## Example Usage
+
+```hcl
+data "nsxt_policy_ipsec_vpn_service" "test" {
+  display_name = "ipsec_vpn_service1"
+}
+```
+
+## Argument Reference
+
+* `id` - (Optional) The ID of IPSec VPN Service to retrieve.
+
+* `display_name` - (Optional) The Display Name of the IPSec VPN Service.
+
+## Attributes Reference
+
+In addition to arguments listed above, the following attributes are exported:
+
+* `description` - The description of the resource.
+
+* `path` - The NSX path of the policy resource.

--- a/website/docs/d/policy_l2_vpn_service.html.markdown
+++ b/website/docs/d/policy_l2_vpn_service.html.markdown
@@ -1,0 +1,34 @@
+---
+subcategory: "Policy - VPN"
+layout: "nsxt"
+page_title: "NSXT: policy_l2_vpn_service"
+description: Policy L2 VPN Service.
+---
+
+# nsxt_policy_vpn_service
+
+This data source provides information about policy l2 vpn service configured on NSX.
+
+This data source is applicable to NSX Policy Manager and VMC.
+
+## Example Usage
+
+```hcl
+data "nsxt_policy_l2_vpn_service" "test" {
+  display_name = "l2_vpn_service1"
+}
+```
+
+## Argument Reference
+
+* `id` - (Optional) The ID of L2 VPN Service to retrieve.
+
+* `display_name` - (Optional) The Display Name of the L2 VPN Service.
+
+## Attributes Reference
+
+In addition to arguments listed above, the following attributes are exported:
+
+* `description` - The description of the resource.
+
+* `path` - The NSX path of the policy resource.

--- a/website/docs/r/policy_ipsec_vpn_local_endpoint.html.markdown
+++ b/website/docs/r/policy_ipsec_vpn_local_endpoint.html.markdown
@@ -1,0 +1,48 @@
+---
+subcategory: "Policy - VPN"
+layout: "nsxt"
+page_title: "NSXT: nsxt_policy_ipsec_vpn_local_endpoint"
+description: A resource to configure a IPSec VPN Local Endpoint.
+---
+# nsxt_policy_ipsec_vpn_local_endpoint
+
+This resource provides a method for the management of a IPSec VPN Local Endpoint.
+
+This resource is applicable to NSX Policy Manager and VMC.
+
+## Example Usage
+
+```hcl
+resource "nsxt_policy_ipsec_vpn_local_endpoint" "test" {
+  display_name          = "test"
+  description           = "Terraform provisioned IPSec VPN Local Endpoint"
+  local_address         = "20.20.0.10"
+  local_id              = "test-create"
+  service_path          = nsxt_policy_ipsec_vpn_service.test.path
+  certificate_path      = data.nsxt_policy_certificate.cert.path
+  trust_ca_paths        = [data.nsxt_policy_certificate.trust_ca.path]
+  trust_crl_paths       = [data.nsxt_policy_certificate.trust_crl_path]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `display_name` - (Required) Display name of the resource.
+* `description` - (Optional) Description of the resource.
+* `tag` - (Optional) A list of scope + tag pairs to associate with this resource.
+* `nsx_id` - (Optional) The NSX ID of this resource. If set, this ID will be used to create the resource.
+* `local_id` - (Optional) Local id for the local endpoint.
+* `certificate_path` - (Optional) Policy path referencing site certificate.
+* `trust_ca_paths` - (Optional) List of trust ca certificate path.
+* `trust_crl_paths` - (Optional) List of trust crl certificate path.
+
+
+## Attributes Reference
+
+In addition to arguments listed above, the following attributes are exported:
+
+* `id` - ID of the resource.
+* `revision` - Indicates current revision number of the object as seen by NSX-T API server. This attribute can be useful for debugging.
+* `path` - The NSX path of the policy resource.

--- a/website/docs/r/policy_ipsec_vpn_service.html.markdown
+++ b/website/docs/r/policy_ipsec_vpn_service.html.markdown
@@ -1,0 +1,67 @@
+---
+subcategory: "Policy - VPN"
+layout: "nsxt"
+page_title: "NSXT: nsxt_policy_ipsec_vpn_service"
+description: A resource to configure a IPSec VPN Service.
+---
+
+# nsxt_policy_ipsec_vpn_service
+
+This resource provides a method for the management of a IPSec VPN Service.
+
+This resource is applicable to NSX Policy Manager and VMC.
+
+## Example Usage
+
+```hcl
+resource "nsxt_policy_ipsec_vpn_service" "test" {
+  display_name          = "ipsec-vpn-service1"
+  description           = "Terraform provisioned IPSec VPN service"
+  locale_service_path   = /infra/tier-0s/aaa/locale-services/default
+  enabled               = true
+  ha_sync               = true
+  ike_log_level         = "INFO"
+  bypass_rule {
+    sources             = ["192.168.10.0/24"]
+    destinations        = ["192.169.10.0/24"]
+    action              = "BYPASS"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `display_name` - (Required) Display name of the resource.
+* `description` - (Optional) Description of the resource.
+* `tag` - (Optional) A list of scope + tag pairs to associate with this resource.
+* `nsx_id` - (Optional) The NSX ID of this resource. If set, this ID will be used to create the resource.
+* `locale_service_path` - (Required) Path of the locale_service associated with the IPSec VPN Service.
+* `enabled` - (Optional) Whether this IPSec VPN Service is enabled. Default is `true`.
+* `ha_sync` - (Optional) Enable/Disable IPSec VPN service HA state sync. Default is `true`.
+* `ike_log_level` - (Optional) Set of algorithms to be used for message digest during IKE negotiation. Value is one of `DEBUG`, `INFO`, `WARN`, `ERROR` and `EMERGENCY`. Default is `INFO`. 
+* `bypass_rule` - (Optional) Set the bypass rules for this IPSec VPN Service. `sources` and `destinations` are list of `ipv4-cidr-block`, `Action` value must be set to `BYPASS` or `PROTECT`.
+  * `sources` - (Required) List of source subnets. Subnet format is `ipv4-cidr`.
+  * `destinations` - (Required) List of distination subnets. Subnet format is `ipv4-cidr`.
+  * `action` - (Required) `PROTECT` or `BYPASS`.
+
+## Attributes Reference
+
+In addition to arguments listed above, the following attributes are exported:
+
+* `id` - ID of the resource.
+* `revision` - Indicates current revision number of the object as seen by NSX-T API server. This attribute can be useful for debugging.
+* `path` - The NSX path of the policy resource.
+
+## Importing
+
+An existing object can be [imported][docs-import] into this resource, via the following command:
+
+[docs-import]: https://www.terraform.io/cli/import
+
+```
+terraform import nsxt_policy_ipsec_vpn_service.test UUID
+```
+
+The above command imports IPSec VPN Service named `test` with the NSX ID `UUID`.

--- a/website/docs/r/policy_ipsec_vpn_session.markdown
+++ b/website/docs/r/policy_ipsec_vpn_session.markdown
@@ -1,0 +1,105 @@
+---
+subcategory: "Policy - Gateways and Routing"
+layout: "nsxt"
+page_title: "NSXT: nsxt_policy_ipsec_vpn_session"
+description: A resource to configure a IPSec VPN session.
+---
+
+# nsxt_policy_ipsec_vpn_session
+
+This resource provides a method for the management of a IPSec VPN session.
+
+This resource is applicable to NSX Policy Manager and VMC.
+
+## Example Usage
+
+```hcl
+resource "nsxt_policy_ipsec_vpn_session" "test" {
+    display_name               = "Route-Based VPN Session"
+    description                = "Terraform-provisioned IPsec Route-Based VPN"
+    ike_profile_path           = nsxt_policy_ipsec_vpn_ike_profile.profile_ike_l3vpn.path
+    tunnel_profile_path        = nsxt_policy_ipsec_vpn_tunnel_profile.profile_tunnel_l3vpn.path
+    local_endpoint_path        = data.nsxt_policy_ipsec_vpn_local_endpoint.private_endpoint.path
+    dpd_profile_path           = nsxt_policy_ipsec_vpn_dpd_profile.test.path
+    enabled                    = true
+    service_path               = "/infra/tier-1s/aaa/locale-services/default/ipsec-vpn-services/ccc"
+    vpn_type                   = "RouteBased"
+    authentication_mode        = "PSK"
+    compliance_suite           = "NONE"
+    ip_addresses               = ["169.254.152.2"]
+    prefix_length              = 30
+    peer_address               = "18.18.18.19"
+    peer_id                    = "18.18.18.19"
+    psk                        = "VMware123!"
+    connection_initiation_mode = "INITIATOR"
+}
+
+resource "nsxt_policy_ipsec_vpn_session" "test2" {
+    display_name               = "Policy-Based VPN Session"
+    description                = "Terraform-provisioned IPsec Policy-Based VPN"
+    ike_profile_path           = nsxt_policy_ipsec_vpn_ike_profile.profile_ike_l3vpn.path
+    tunnel_profile_path        = nsxt_policy_ipsec_vpn_tunnel_profile.profile_tunnel_l3vpn.path
+    local_endpoint_path        = data.nsxt_policy_ipsec_vpn_local_endpoint.private_endpoint.path
+    dpd_profile_path           = nsxt_policy_ipsec_vpn_dpd_profile.test.path
+    enabled                    = true
+    service_path               = "/infra/tier-1s/aaa/locale-services/default/ipsec-vpn-services/ccc"
+    vpn_type                   = "PolicyBased"
+    authentication_mode        = "PSK"
+    compliance_suite           = "NONE"
+    peer_address               = "18.18.18.19"
+    peer_id                    = "18.18.18.19"
+    psk                        = "VMware123!"
+    connection_initiation_mode = "INITIATOR"
+    rule {
+        sources             = ["192.168.10.0/24"]
+        destinations        = ["192.169.10.0/24"]
+        action              = "BYPASS"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `display_name` - (Required) Display name of the resource.
+* `description` - (Optional) Description of the resource.
+* `tag` - (Optional) A list of scope + tag pairs to associate with this resource.
+* `nsx_id` - (Optional) The NSX ID of this resource. If set, this ID will be used to create the resource.
+* `ike_profile_path` - (Optional) Policy path referencing IKE profile.
+* `tunnel_profile_path` - (Required) Policy path referencing Tunnel profile to be used.
+* `enabled` - (Optional) Boolean. Enable/Disable IPsec VPN session. Default is "true" (session enabled).
+* `service_path` - (Required) The path of the IPSec VPN service for the VPN session.
+* `dpd_profile_path` - (Optional) Policy path referencing Dead Peer Detection (DPD) profile. Default is set to system default profile.
+* `vpn_type` - (Required) `RouteBased` or `PolicyBased`. Policy Based VPN requires to define protect rules that match local and peer subnets. IPSec security associations is negotiated for each pair of local and peer subnet. A Route Based VPN is more flexible, more powerful and recommended over policy based VPN. IP Tunnel port is created and all traffic routed via tunnel port is protected. Routes can be configured statically or can be learned through BGP. A route based VPN is must for establishing redundant VPN session to remote site.
+* `compliance_suite` -  (Optional) Compliance suite. Value is one of `CNSA`, `SUITE_B_GCM_128`, `SUITE_B_GCM_256`, `PRIME`, `FOUNDATION`, `FIPS`, `None`.
+* `compliance_initiaion_mode` - (Optional) Connection initiation mode used by local endpoint to establish ike connection with peer site. `INITIATOR` - In this mode local endpoint initiates tunnel setup and will also respond to incoming tunnel setup requests from peer gateway. `RESPOND_ONLY` - In this mode, local endpoint shall only respond to incoming tunnel setup requests. It shall not initiate the tunnel setup. `ON_DEMAND` - In this mode local endpoint will initiate tunnel creation once first packet matching the policy rule is received and will also respond to incoming initiation request.
+* `ip_addresses` - (Optional) IP Tunnel interface (commonly referred as VTI) ip_addresses. Only applied for Route Based VPN Session. 
+* `prefix_length` - (Optional) Subnet Prefix Length. Only applied for Route Based VPN Session. 
+* `peer_address` - (Optional) Public IPV4 address of the remote device terminating the VPN connection.
+* `peer_id` - (Optional) Peer ID to uniquely identify the peer site. The peer ID is the public IP address of the remote device terminating the VPN tunnel. When NAT is configured for the peer, enter the private IP address of the peer.
+* `local_endpoint_path` - (Required) Policy path referencing Local endpoint. In VMC, Local Endpoints are pre-configured the user can refer to their path using `data nsxt_policy_ipsec_vpn_local_endpoint` and using the "Private IP1" or "Public IP1" values to refer to the private and public endpoints respectively.
+* `rule` - (Optional) Bypass rules for this IPSec VPN Session. `sources` and `destinations` are list of `ipv4-cidr-block`, `Action` value must be set to `BYPASS` or `PROTECT`. Only applied for Policy Based VPN Session. 
+  * `sources` - (Required) List of source subnets. Subnet format is `ipv4-cidr`.
+  * `destinations` - (Required) List of distination subnets. Subnet format is `ipv4-cidr`.
+  * `action` - (Required) `PROTECT` or `BYPASS`.
+
+## Attributes Reference
+
+In addition to arguments listed above, the following attributes are exported:
+
+* `id` - ID of the resource.
+* `revision` - Indicates current revision number of the object as seen by NSX-T API server. This attribute can be useful for debugging.
+* `path` - The NSX path of the policy resource.
+
+## Importing
+
+An existing object can be [imported][docs-import] into this resource, via the following command:
+
+[docs-import]: /docs/import/index.html
+
+```
+terraform import nsxt_policy_ipsec_vpn_session.test UUID
+```
+
+The above command imports IPSec VPN  session named `test` with the NSX IPSec VPN Ike session ID `UUID`.

--- a/website/docs/r/policy_l2_vpn_service.html.markdown
+++ b/website/docs/r/policy_l2_vpn_service.html.markdown
@@ -1,0 +1,59 @@
+---
+subcategory: "Policy - VPN"
+layout: "nsxt"
+page_title: "NSXT: nsxt_policy_l2_vpn_service"
+description: A resource to configure a L2 VPN Service.
+---
+
+# nsxt_policy_l2_vpn_service
+
+This resource provides a method for the management of a L2 VPN Service.
+
+This resource is applicable to NSX Policy Manager and VMC.
+
+## Example Usage
+
+```hcl
+resource "nsxt_policy_l2_vpn_service" "test" {
+  display_name          = "l2-vpn-service1"
+  description           = "Terraform provisioned L2 VPN service"
+  locale_service_path   = data.nsxt_policy_gateway_locale_service.test.path
+  enable_hub            = true
+  mode                  = "SERVER"
+  encap_ip_pool         = ["192.168.10.0/24"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `display_name` - (Required) Display name of the resource.
+* `description` - (Optional) Description of the resource.
+* `tag` - (Optional) A list of scope + tag pairs to associate with this resource.
+* `nsx_id` - (Optional) The NSX ID of this resource. If set, this ID will be used to create the resource.
+* `locale_service_path` - (Required) Path of the locale_service associated with the L2 VPN Service.
+* `enable_hub` - (Optional) This property applies only in SERVER mode. If set to true, traffic from any client will be replicated to all other clients. If set to false, traffic received from clients is only replicated to the local VPN endpoint.. Default is `true`.
+* `mode` - (Optional) Specify an L2VPN service mode as SERVER or CLIENT. Value is one of `SERVER`, `CLIENT`. Default is `SERVER`.
+* `encap_ip_pool` - (Optional) IP Pool to allocate local and peer endpoint IPs. Format is `ipv4-cidr-block`.
+
+
+## Attributes Reference
+
+In addition to arguments listed above, the following attributes are exported:
+
+* `id` - ID of the resource.
+* `revision` - Indicates current revision number of the object as seen by NSX-T API server. This attribute can be useful for debugging.
+* `path` - The NSX path of the policy resource.
+
+## Importing
+
+An existing object can be [imported][docs-import] into this resource, via the following command:
+
+[docs-import]: https://www.terraform.io/cli/import
+
+```
+terraform import nsxt_policy_l2_vpn_service.test UUID
+```
+
+The above command imports L2 VPN Service named `test` with the NSX ID `UUID`.

--- a/website/docs/r/policy_l2vpn_vpn_session.markdown
+++ b/website/docs/r/policy_l2vpn_vpn_session.markdown
@@ -1,0 +1,60 @@
+---
+subcategory: "Policy - Gateways and Routing"
+layout: "nsxt"
+page_title: "NSXT: nsxt_policy_l2vpn_vpn_session"
+description: A resource to configure a L2VPN VPN session.
+---
+
+# nsxt_policy_l2vpn_vpn_session
+
+This resource provides a method for the management of a L2VPN VPN session.
+
+This resource is applicable to NSX Policy Manager and VMC.
+
+## Example Usage
+
+```hcl
+resource "nsxt_policy_l2_vpn_session" "test" {
+    display_name      = "L2 VPN Session"
+    description       = "Terraform-provisioned L2 VPN Tunnel"
+    service_path      = "/infra/tier-1s/aaa/locale-services/default/l2vpn-services/ccc"
+    transport_tunnels = [nsxt_policy_ipsec_vpn_session.ipsec_vpn_session_for_l2vpn.path]
+}
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `display_name` - (Required) Display name of the resource.
+* `description` - (Optional) Description of the resource.
+* `tag` - (Optional) A list of scope + tag pairs to associate with this resource.
+* `nsx_id` - (Optional) The NSX ID of this resource. If set, this ID will be used to create the resource.
+* `service_path` - (Required) The path of the L2 VPN service for the VPN session.
+* `transport_tunnels` - (Required) List of transport tunnels paths for redundancy. L2VPN supports only `AES_GCM_128` encryption algorithm for IPSec tunnel profile.
+* `direction` - (Optional) The traffic direction apply to the MSS clamping. `BOTH` or `NONE`.
+* `max_segment_size` - (Optional) Maximum amount of data the host will accept in a Tcp segment. Value should be between `108` and `8860`
+* `local_address` - (Optional) IP Address of the local tunnel port. This property only applies in `CLIENT` mode.
+* `peer_address` - (Optional) IP Address of the peer tunnel port. This property only applies in `CLIENT` mode.
+* `protocol` - (Optional) Encapsulation protocol used by the tunnel. `GRE` is the only supported value.
+
+## Attributes Reference
+
+In addition to arguments listed above, the following attributes are exported:
+
+* `id` - ID of the resource.
+* `revision` - Indicates current revision number of the object as seen by NSX-T API server. This attribute can be useful for debugging.
+* `path` - The NSX path of the policy resource.
+
+## Importing
+
+An existing object can be [imported][docs-import] into this resource, via the following command:
+
+[docs-import]: /docs/import/index.html
+
+```
+terraform import nsxt_policy_l2_vpn_session.test UUID
+```
+
+The above command imports l2vpn VPN  session named `test` with the NSX L2VPN VPN Ike session ID `UUID`.


### PR DESCRIPTION
Add support for several VPN resources.
The PR includes support for:
Data sources:
- nsxt_policy_ipsec_vpn_local_endpoint
- nsxt_policy_ipsec_vpn_service 
- nsxt_policy_l2vpn_service

Resources:
- nsxt_policy_ipsec_vpn_session
- nsxt_policy_ipsec_vpn_service 
- nsxt_policy_ipsec_vpn_local_endpoint
- nsxt_policy_l2vpn_session
- nsxt_policy_l2vpn_service

Co-authered-by: Nico Vibert, Anna Khmelnitsky
Signed-off-by: Shizhao Liu <lshizhao@vmware.com>