### PR TITLE
Support replication mode in Segment resources

### DIFF
--- a/nsxt/resource_nsxt_policy_fixed_segment_test.go
+++ b/nsxt/resource_nsxt_policy_fixed_segment_test.go
@@ -142,6 +142,7 @@ func TestAccResourceNsxtPolicyFixedSegment_updateAdvConfig(t *testing.T) {
 					testAccNsxtPolicyFixedSegmentExists(testResourceName),
 					resource.TestCheckResourceAttr(testResourceName, "display_name", name),
 					resource.TestCheckResourceAttr(testResourceName, "description", "Acceptance Test"),
+					resource.TestCheckResourceAttr(testResourceName, "replication_mode", "SOURCE"),
 					resource.TestCheckResourceAttr(testResourceName, "subnet.#", "1"),
 					resource.TestCheckResourceAttr(testResourceName, "subnet.0.cidr", "12.12.2.1/24"),
 					resource.TestCheckResourceAttr(testResourceName, "domain_name", "tftest.org"),
@@ -158,6 +159,7 @@ func TestAccResourceNsxtPolicyFixedSegment_updateAdvConfig(t *testing.T) {
 					testAccNsxtPolicyFixedSegmentExists(testResourceName),
 					resource.TestCheckResourceAttr(testResourceName, "display_name", name),
 					resource.TestCheckResourceAttr(testResourceName, "description", "Acceptance Test"),
+					resource.TestCheckResourceAttr(testResourceName, "replication_mode", "MTEP"),
 					resource.TestCheckResourceAttr(testResourceName, "subnet.#", "1"),
 					resource.TestCheckResourceAttr(testResourceName, "subnet.0.cidr", "12.12.2.1/24"),
 					resource.TestCheckResourceAttr(testResourceName, "domain_name", "tftest.org"),
@@ -406,11 +408,12 @@ func testAccNsxtPolicyFixedSegmentBasicAdvConfigTemplate(tzName string, name str
 	return testAccNsxtPolicySegmentDeps(tzName) + fmt.Sprintf(`
 
 resource "nsxt_policy_fixed_segment" "test" {
-  display_name = "%s"
-  description  = "Acceptance Test"
-  domain_name  = "tftest.org"
-  overlay_id   = 1011
-  vlan_ids     = ["101", "102"]
+  display_name     = "%s"
+  description      = "Acceptance Test"
+  replication_mode = "SOURCE"
+  domain_name      = "tftest.org"
+  overlay_id       = 1011
+  vlan_ids         = ["101", "102"]
 
   connectivity_path   = nsxt_policy_tier1_gateway.anotherTier1ForSegments.path
 
@@ -435,11 +438,12 @@ func testAccNsxtPolicyFixedSegmentBasicAdvConfigUpdateTemplate(tzName string, na
 	return testAccNsxtPolicySegmentDeps(tzName) + fmt.Sprintf(`
 
 resource "nsxt_policy_fixed_segment" "test" {
-  display_name = "%s"
-  description  = "Acceptance Test"
-  domain_name  = "tftest.org"
-  overlay_id   = 1011
-  vlan_ids     = ["101-104"]
+  display_name     = "%s"
+  description      = "Acceptance Test"
+  replication_mode = "MTEP"
+  domain_name      = "tftest.org"
+  overlay_id       = 1011
+  vlan_ids         = ["101-104"]
 
   connectivity_path   = nsxt_policy_tier1_gateway.anotherTier1ForSegments.path
 

--- a/nsxt/resource_nsxt_policy_segment_test.go
+++ b/nsxt/resource_nsxt_policy_segment_test.go
@@ -297,6 +297,7 @@ func TestAccResourceNsxtPolicySegment_withDhcp(t *testing.T) {
 	preferredTimes := []string{"3200", "32000"}
 	dnsServersV4 := []string{"2.2.2.2", "3.3.3.3"}
 	dnsServersV6 := []string{"2000::2", "3000::3"}
+	replicationModes := []string{"SOURCE", "MTEP"}
 	tzName := getOverlayTransportZoneName()
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -307,10 +308,11 @@ func TestAccResourceNsxtPolicySegment_withDhcp(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNsxtPolicySegmentWithDhcpTemplate(tzName, name, dnsServersV4[0], dnsServersV6[0], leaseTimes[0], preferredTimes[0]),
+				Config: testAccNsxtPolicySegmentWithDhcpTemplate(tzName, name, dnsServersV4[0], dnsServersV6[0], leaseTimes[0], preferredTimes[0], replicationModes[0]),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNsxtPolicySegmentExists(testResourceName),
 					resource.TestCheckResourceAttr(testResourceName, "display_name", name),
+					resource.TestCheckResourceAttr(testResourceName, "replication_mode", replicationModes[0]),
 					resource.TestCheckResourceAttr(testResourceName, "subnet.#", "2"),
 					resource.TestCheckResourceAttr(testResourceName, "subnet.0.cidr", "12.12.2.1/24"),
 					resource.TestCheckResourceAttr(testResourceName, "subnet.0.dhcp_v6_config.#", "0"),
@@ -334,10 +336,11 @@ func TestAccResourceNsxtPolicySegment_withDhcp(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNsxtPolicySegmentWithDhcpTemplate(tzName, name, dnsServersV4[1], dnsServersV6[1], leaseTimes[1], preferredTimes[1]),
+				Config: testAccNsxtPolicySegmentWithDhcpTemplate(tzName, name, dnsServersV4[1], dnsServersV6[1], leaseTimes[1], preferredTimes[1], replicationModes[1]),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNsxtPolicySegmentExists(testResourceName),
 					resource.TestCheckResourceAttr(testResourceName, "display_name", name),
+					resource.TestCheckResourceAttr(testResourceName, "replication_mode", replicationModes[1]),
 					resource.TestCheckResourceAttr(testResourceName, "subnet.#", "2"),
 					resource.TestCheckResourceAttr(testResourceName, "subnet.0.cidr", "12.12.2.1/24"),
 					resource.TestCheckResourceAttr(testResourceName, "subnet.0.dhcp_v6_config.#", "0"),
@@ -640,7 +643,7 @@ data "nsxt_policy_edge_cluster" "EC" {
 }`, name)
 }
 
-func testAccNsxtPolicySegmentWithDhcpTemplate(tzName string, name string, dnsServerV4 string, dnsServerV6 string, lease string, preferred string) string {
+func testAccNsxtPolicySegmentWithDhcpTemplate(tzName string, name string, dnsServerV4 string, dnsServerV6 string, lease string, preferred string, replicationMode string) string {
 	return testAccNsxtPolicySegmentDeps(tzName) +
 		testAccNsxtPolicyEdgeCluster(getEdgeClusterName()) + fmt.Sprintf(`
 
@@ -652,6 +655,7 @@ resource "nsxt_policy_dhcp_server" "test" {
 resource "nsxt_policy_segment" "test" {
   display_name        = "%s"
   transport_zone_path = data.nsxt_policy_transport_zone.test.path
+  replication_mode    = "%s"
 
   subnet {
     cidr = "12.12.2.1/24"
@@ -696,7 +700,7 @@ resource "nsxt_policy_segment" "test" {
   dhcp_config_path = nsxt_policy_dhcp_server.test.path
 
 }
-`, name, lease, dnsServerV4, lease, preferred, dnsServerV6)
+`, name, replicationMode, lease, dnsServerV4, lease, preferred, dnsServerV6)
 }
 
 func testAccNsxtPolicySegmentNoTransportZoneTemplate(name string, cidr string) string {

--- a/nsxt/resource_nsxt_policy_vlan_segment_test.go
+++ b/nsxt/resource_nsxt_policy_vlan_segment_test.go
@@ -86,6 +86,7 @@ func TestAccResourceNsxtPolicyVlanSegment_updateAdvConfig(t *testing.T) {
 					testAccNsxtPolicyVlanSegmentExists(testResourceName),
 					resource.TestCheckResourceAttr(testResourceName, "display_name", name),
 					resource.TestCheckResourceAttr(testResourceName, "description", "Acceptance Test"),
+					resource.TestCheckResourceAttr(testResourceName, "replication_mode", "SOURCE"),
 					resource.TestCheckResourceAttr(testResourceName, "domain_name", "tftest.org"),
 					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
 					resource.TestCheckResourceAttr(testResourceName, "advanced_config.0.connectivity", "OFF"),
@@ -99,6 +100,7 @@ func TestAccResourceNsxtPolicyVlanSegment_updateAdvConfig(t *testing.T) {
 					testAccNsxtPolicyVlanSegmentExists(testResourceName),
 					resource.TestCheckResourceAttr(testResourceName, "display_name", name),
 					resource.TestCheckResourceAttr(testResourceName, "description", "Acceptance Test"),
+					resource.TestCheckResourceAttr(testResourceName, "replication_mode", "MTEP"),
 					resource.TestCheckResourceAttr(testResourceName, "domain_name", "tftest.org"),
 					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
 					resource.TestCheckResourceAttr(testResourceName, "advanced_config.0.connectivity", "ON"),
@@ -343,6 +345,7 @@ resource "nsxt_policy_vlan_segment" "test" {
   description         = "Acceptance Test"
   domain_name         = "tftest.org"
   transport_zone_path = data.nsxt_policy_transport_zone.test.path
+  replication_mode    = "SOURCE"
   vlan_ids            = ["101", "102"]
 
   tag {


### PR DESCRIPTION
This attribute was added in NSX 3.0.0
In addition, remove cidr requirement for segment subnet, as
its no longer required on the platform.

Signed-off-by: Anna Khmelnitsky <akhmelnitsky@vmware.com>