### PR TITLE
Support bridge confguration on segment

### DIFF
--- a/nsxt/data_source_nsxt_policy_bridge_profile.go
+++ b/nsxt/data_source_nsxt_policy_bridge_profile.go
@@ -1,0 +1,32 @@
+/* Copyright © 2022 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: MPL-2.0 */
+
+package nsxt
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceNsxtPolicyBridgeProfile() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceNsxtPolicyBridgeProfileRead,
+
+		Schema: map[string]*schema.Schema{
+			"id":           getDataSourceIDSchema(),
+			"display_name": getDataSourceExtendedDisplayNameSchema(),
+			"description":  getDataSourceDescriptionSchema(),
+			"path":         getPathSchema(),
+		},
+	}
+}
+
+func dataSourceNsxtPolicyBridgeProfileRead(d *schema.ResourceData, m interface{}) error {
+	connector := getPolicyConnector(m)
+
+	_, err := policyDataSourceResourceRead(d, connector, isPolicyGlobalManager(m), "L2BridgeEndpointProfile", nil)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/nsxt/data_source_nsxt_policy_bridge_profile_test.go
+++ b/nsxt/data_source_nsxt_policy_bridge_profile_test.go
@@ -1,0 +1,95 @@
+/* Copyright © 2022 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: MPL-2.0 */
+
+package nsxt
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	ep "github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/sites/enforcement_points"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+)
+
+func TestAccDataSourceNsxtPolicyBridgeProfile_basic(t *testing.T) {
+	name := getAccTestDataSourceName()
+	testResourceName := "data.nsxt_policy_bridge_profile.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t); testAccOnlyLocalManager(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccDataSourceNsxtPolicyBridgeProfileDeleteByName(name)
+		},
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {
+					if err := testAccDataSourceNsxtPolicyBridgeProfileCreate(name); err != nil {
+						panic(err)
+					}
+				},
+				Config: testAccNsxtPolicyBridgeProfileReadTemplate(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(testResourceName, "display_name", name),
+					resource.TestCheckResourceAttr(testResourceName, "description", name),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceNsxtPolicyBridgeProfileCreate(name string) error {
+	connector, err := testAccGetPolicyConnector()
+	if err != nil {
+		return fmt.Errorf("Error during test client initialization: %v", err)
+	}
+
+	displayName := name
+	description := name
+	obj := model.L2BridgeEndpointProfile{
+		Description: &description,
+		DisplayName: &displayName,
+	}
+
+	// Generate a random ID for the resource
+	uuid, _ := uuid.NewRandom()
+	id := uuid.String()
+
+	client := ep.NewEdgeBridgeProfilesClient(connector)
+	err = client.Patch(defaultSite, defaultEnforcementPoint, id, obj)
+
+	if err != nil {
+		return fmt.Errorf("Error during Bridge Profile creation: %v", err)
+	}
+	return nil
+}
+
+func testAccDataSourceNsxtPolicyBridgeProfileDeleteByName(name string) error {
+	connector, err := testAccGetPolicyConnector()
+	if err != nil {
+		return fmt.Errorf("Error during test client initialization: %v", err)
+	}
+
+	// Find the object by name
+	objID, err := testGetObjIDByName(name, "L2BridgeEndpointProfile")
+	if err != nil {
+		return nil
+	}
+	client := ep.NewEdgeBridgeProfilesClient(connector)
+	err = client.Delete(defaultSite, defaultEnforcementPoint, objID)
+	if err != nil {
+		return fmt.Errorf("Error during Bridge Profile deletion: %v", err)
+	}
+	return nil
+}
+
+func testAccNsxtPolicyBridgeProfileReadTemplate(name string) string {
+	return fmt.Sprintf(`
+data "nsxt_policy_bridge_profile" "test" {
+  display_name = "%s"
+}`, name)
+}

--- a/nsxt/provider.go
+++ b/nsxt/provider.go
@@ -254,6 +254,7 @@ func Provider() *schema.Provider {
 			"nsxt_policy_bfd_profile":               dataSourceNsxtPolicyBfdProfile(),
 			"nsxt_policy_intrusion_service_profile": dataSourceNsxtPolicyIntrusionServiceProfile(),
 			"nsxt_policy_lb_service":                dataSourceNsxtPolicyLbService(),
+			"nsxt_policy_bridge_profile":            dataSourceNsxtPolicyBridgeProfile(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{

--- a/nsxt/utils_test.go
+++ b/nsxt/utils_test.go
@@ -27,6 +27,7 @@ const edgeClusterDefaultName string = "edgecluster1"
 const vlanTransportZoneName string = "transportzone2"
 const overlayTransportZoneNamePrefix string = "1-transportzone"
 const macPoolDefaultName string = "DefaultMacPool"
+const defaultEnforcementPoint string = "default"
 
 const realizationResourceName string = "data.nsxt_policy_realization_info.realization_info"
 const defaultTestResourceName string = "terraform-acctest"

--- a/website/docs/d/policy_bridge_profile.html.markdown
+++ b/website/docs/d/policy_bridge_profile.html.markdown
@@ -1,0 +1,33 @@
+---
+subcategory: "Policy - Segments"
+layout: "nsxt"
+page_title: "NSXT: policy_bridge_profile"
+description: Policy Bridge Profile data source.
+---
+
+# nsxt_policy_bridge_profile
+
+This data source provides information about Edge Bridge Profile configured on NSX.
+This data source is applicable to NSX Policy Manager.
+
+## Example Usage
+
+```hcl
+data "nsxt_policy_bridge_profile" "test" {
+  display_name = "profile1"
+}
+```
+
+## Argument Reference
+
+* `id` - (Optional) The ID of Profile to retrieve. If ID is specified, no additional argument should be configured.
+
+* `display_name` - (Optional) The Display Name prefix of the Profile to retrieve.
+
+## Attributes Reference
+
+In addition to arguments listed above, the following attributes are exported:
+
+* `description` - The description of the resource.
+
+* `path` - The NSX path of the policy resource.

--- a/website/docs/r/policy_segment.html.markdown
+++ b/website/docs/r/policy_segment.html.markdown
@@ -105,6 +105,11 @@ The following arguments are supported:
   * `security_profile_path` - (Optional) Path for segment security profile to be associated with the segment.
 * `qos_profile` - (Optional) QoS profile specification for the segment.
   * `qos_profile_path` - (Optional) Path for qos profile to be associated with the segment.
+* `bridge_config` - (Optional) List of edge bridge configuration for the segment. This setting is not supported on Global Manager.
+  * `profile_path` - (Required) Path for edge bridge profile to be associated with the segment.
+  * `transport_zone_path` - (Required) Path for vlan transport zone for the bridge.
+  * `vlan_ids` - (Required) List of VLAN IDs or ranges.
+  * `uplink_teaming_policy` - (Optional) The name of the switching uplink teaming policy for the bridge endpoint.
 
 ## Attributes Reference
 

--- a/website/docs/r/policy_vlan_segment.html.markdown
+++ b/website/docs/r/policy_vlan_segment.html.markdown
@@ -108,6 +108,11 @@ The following arguments are supported:
   * `security_profile_path` - (Optional) Path for segment security profile to be associated with the segment.
 * `qos_profile` - (Optional) QoS profile specification for the segment.
   * `qos_profile_path` - (Optional) Path for qos profile to be associated with the segment.
+* `bridge_config` - (Optional) List of edge bridge configuration for the segment. This setting is not supported on Global Manager.
+  * `profile_path` - (Required) Path for edge bridge profile to be associated with the segment.
+  * `transport_zone_path` - (Required) Path for vlan transport zone for the bridge.
+  * `vlan_ids` - (Required) List of VLAN IDs or ranges.
+  * `uplink_teaming_policy` - (Optional) The name of the switching uplink teaming policy for the bridge endpoint.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Add policy_bridge_profile data source and bridge_config clause
on segments.

Signed-off-by: Anna Khmelnitsky <akhmelnitsky@vmware.com>