### PR TITLE
Remove test for default GW policy data source

### DIFF
--- a/nsxt/data_source_nsxt_policy_gateway_policy_test.go
+++ b/nsxt/data_source_nsxt_policy_gateway_policy_test.go
@@ -53,31 +53,6 @@ func TestAccDataSourceNsxtPolicyGatewayPolicy_basic(t *testing.T) {
 	})
 }
 
-// The test case is disabled for now because VPN session adds VTI tunnel to gateway policies
-// and after VPN resources were deleted, the change on gateway policy is not rollbacked.
-
-// This test is applicable to earlier NSX versions, where a single default GW
-// policy is auto-created. In later versions a policy is created per GW.
-// func TestAccDataSourceNsxtPolicyGatewayPolicy_default(t *testing.T) {
-// 	testResourceName := "data.nsxt_policy_gateway_policy.test"
-
-// 	resource.Test(t, resource.TestCase{
-// 		PreCheck:  func() { testAccPreCheck(t); testAccNSXVersionLessThan(t, "3.1.0") },
-// 		Providers: testAccProviders,
-// 		Steps: []resource.TestStep{
-// 			{
-// 				Config: testAccNsxtPolicyDefaultGatewayPolicyTemplate(),
-// 				Check: resource.ComposeTestCheckFunc(
-// 					resource.TestCheckResourceAttrSet(testResourceName, "display_name"),
-// 					resource.TestCheckResourceAttrSet(testResourceName, "description"),
-// 					resource.TestCheckResourceAttr(testResourceName, "category", "Default"),
-// 					resource.TestCheckResourceAttrSet(testResourceName, "path"),
-// 				),
-// 			},
-// 		},
-// 	})
-// }
-
 func testAccNsxtPolicyGatewayPolicyTemplate(name string, category string, extra string) string {
 	return fmt.Sprintf(`
 resource "nsxt_policy_gateway_policy" "test" {
@@ -91,10 +66,3 @@ data "nsxt_policy_gateway_policy" "test" {
   %s
 }`, name, name, category, extra)
 }
-
-// func testAccNsxtPolicyDefaultGatewayPolicyTemplate() string {
-// 	return `
-// data "nsxt_policy_gateway_policy" "test" {
-//   category     = "Default"
-// }`
-// }

--- a/nsxt/policy_common.go
+++ b/nsxt/policy_common.go
@@ -452,7 +452,6 @@ func getPolicyRulesFromSchema(d *schema.ResourceData) []model.Rule {
 		}
 
 		ruleList = append(ruleList, elem)
-		seq = seq + 1
 	}
 
 	return ruleList


### PR DESCRIPTION
This test was only relevant for early NSX versions, and VPN configuration breaks the tests since one extra GW policy is added.
Signed-off-by: Anna Khmelnitsky <akhmelnitsky@vmware.com>