### PR TITLE
Ensure ordered list when preferred edges are set

### DIFF
--- a/nsxt/gateway_common.go
+++ b/nsxt/gateway_common.go
@@ -96,7 +96,7 @@ func getPolicyLocaleServiceSchema(isTier1 bool) *schema.Schema {
 			ValidateFunc: validatePolicyPath(),
 		},
 		"preferred_edge_paths": {
-			Type:          schema.TypeSet,
+			Type:          schema.TypeList,
 			Description:   "Paths of specific edge nodes",
 			Optional:      true,
 			Elem:          getElemPolicyPathSchema(),
@@ -300,7 +300,7 @@ func initGatewayLocaleServices(d *schema.ResourceData, connector *client.RestCon
 	for _, service := range services {
 		cfg := service.(map[string]interface{})
 		edgeClusterPath := cfg["edge_cluster_path"].(string)
-		edgeNodes := interface2StringList(cfg["preferred_edge_paths"].(*schema.Set).List())
+		edgeNodes := interfaceListToStringList(cfg["preferred_edge_paths"].([]interface{}))
 		path := cfg["path"].(string)
 
 		var serviceID string

--- a/nsxt/resource_nsxt_policy_tier0_gateway_gm_test.go
+++ b/nsxt/resource_nsxt_policy_tier0_gateway_gm_test.go
@@ -156,6 +156,11 @@ data "nsxt_policy_edge_cluster" "ec_site2" {
 data "nsxt_policy_edge_node" "en_site1" {
   edge_cluster_path = data.nsxt_policy_edge_cluster.ec_site1.path
   member_index      = 0
+}
+
+data "nsxt_policy_edge_node" "en_site2" {
+  edge_cluster_path = data.nsxt_policy_edge_cluster.ec_site1.path
+  member_index      = 1
 }`, getTestSiteName(), getTestAnotherSiteName())
 }
 

--- a/nsxt/resource_nsxt_policy_tier1_gateway_gm_test.go
+++ b/nsxt/resource_nsxt_policy_tier1_gateway_gm_test.go
@@ -111,6 +111,7 @@ func TestAccResourceNsxtPolicyTier1Gateway_globalManagerWithQos(t *testing.T) {
 					resource.TestCheckResourceAttr(testResourceName, "route_advertisement_types.#", "2"),
 					resource.TestCheckResourceAttr(testResourceName, "route_advertisement_rule.#", "0"),
 					resource.TestCheckResourceAttr(testResourceName, "locale_service.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "locale_service.0.preferred_edge_paths.#", "2"),
 					resource.TestCheckResourceAttr(testResourceName, "intersite_config.#", "1"),
 					resource.TestCheckResourceAttr(testResourceName, "intersite_config.0.transit_subnet", testAccGmGatewayIntersiteSubnet),
 					resource.TestCheckResourceAttrSet(testResourceName, "intersite_config.0.primary_site_path"),
@@ -163,6 +164,7 @@ func TestAccResourceNsxtPolicyTier1Gateway_globalManagerNoSubnet(t *testing.T) {
 					resource.TestCheckResourceAttr(testResourceName, "route_advertisement_types.#", "2"),
 					resource.TestCheckResourceAttr(testResourceName, "route_advertisement_rule.#", "0"),
 					resource.TestCheckResourceAttr(testResourceName, "locale_service.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "locale_service.0.preferred_edge_paths.#", "2"),
 					resource.TestCheckResourceAttr(testResourceName, "intersite_config.#", "1"),
 					resource.TestCheckResourceAttrSet(testResourceName, "intersite_config.0.transit_subnet"),
 					resource.TestCheckResourceAttrSet(testResourceName, "intersite_config.0.primary_site_path"),
@@ -203,7 +205,7 @@ resource "nsxt_policy_tier1_gateway" "test" {
 
   locale_service {
     edge_cluster_path    = data.nsxt_policy_edge_cluster.ec_site1.path
-    preferred_edge_paths = [data.nsxt_policy_edge_node.en_site1.path]
+    preferred_edge_paths = [data.nsxt_policy_edge_node.en_site2.path, data.nsxt_policy_edge_node.en_site1.path]
   }
 
   intersite_config {
@@ -261,7 +263,7 @@ resource "nsxt_policy_tier1_gateway" "test" {
 
   locale_service {
     edge_cluster_path    = data.nsxt_policy_edge_cluster.ec_site1.path
-    preferred_edge_paths = [data.nsxt_policy_edge_node.en_site1.path]
+    preferred_edge_paths = [data.nsxt_policy_edge_node.en_site1.path, data.nsxt_policy_edge_node.en_site2.path]
   }
 
   intersite_config {


### PR DESCRIPTION
In Gateway locale service definition, preferred_edge_paths attribute should be an ordered list rather than set.

Signed-off-by: Anna Khmelnitsky <akhmelnitsky@vmware.com>