### PR TITLE
Add tofu_enabled attr to ip_discovery_profile

### DIFF
--- a/nsxt/resource_nsxt_policy_ip_discovery_profile.go
+++ b/nsxt/resource_nsxt_policy_ip_discovery_profile.go
@@ -96,6 +96,12 @@ func resourceNsxtPolicyIPDiscoveryProfile() *schema.Resource {
 				Optional:    true,
 				Default:     false,
 			},
+			"tofu_enabled": {
+				Type:        schema.TypeBool,
+				Description: "Is TOFU enabled or not",
+				Optional:    true,
+				Default:     true,
+			},
 		},
 	}
 }
@@ -117,6 +123,7 @@ func ipDiscoveryProfileObjFromSchema(d *schema.ResourceData) model.IPDiscoveryPr
 	ndSnoopingEnabled := d.Get("nd_snooping_enabled").(bool)
 	ndSnoopingLimit := int64(d.Get("nd_snooping_limit").(int))
 	vmtoolsV6Enabled := d.Get("vmtools_v6_enabled").(bool)
+	toFuEnabled := d.Get("tofu_enabled").(bool)
 
 	return model.IPDiscoveryProfile{
 		DisplayName:         &displayName,
@@ -142,6 +149,7 @@ func ipDiscoveryProfileObjFromSchema(d *schema.ResourceData) model.IPDiscoveryPr
 			},
 			VmtoolsV6Enabled: &vmtoolsV6Enabled,
 		},
+		TofuEnabled: &toFuEnabled,
 	}
 }
 
@@ -248,6 +256,7 @@ func resourceNsxtPolicyIPDiscoveryProfileRead(d *schema.ResourceData, m interfac
 	d.Set("nd_snooping_enabled", obj.IpV6DiscoveryOptions.NdSnoopingConfig.NdSnoopingEnabled)
 	d.Set("nd_snooping_limit", obj.IpV6DiscoveryOptions.NdSnoopingConfig.NdSnoopingLimit)
 	d.Set("vmtools_v6_enabled", obj.IpV6DiscoveryOptions.VmtoolsV6Enabled)
+	d.Set("tofu_enabled", obj.TofuEnabled)
 
 	return nil
 }

--- a/nsxt/resource_nsxt_policy_ip_discovery_profile_test.go
+++ b/nsxt/resource_nsxt_policy_ip_discovery_profile_test.go
@@ -24,6 +24,7 @@ var accTestPolicyIPDiscoveryProfileCreateAttributes = map[string]string{
 	"nd_snooping_enabled":            "true",
 	"nd_snooping_limit":              "8",
 	"vmtools_v6_enabled":             "true",
+	"tofu_enabled":                   "true",
 }
 
 var accTestPolicyIPDiscoveryProfileUpdateAttributes = map[string]string{
@@ -39,6 +40,7 @@ var accTestPolicyIPDiscoveryProfileUpdateAttributes = map[string]string{
 	"nd_snooping_enabled":            "false",
 	"nd_snooping_limit":              "12",
 	"vmtools_v6_enabled":             "false",
+	"tofu_enabled":                   "false",
 }
 
 func TestAccResourceNsxtPolicyIPDiscoveryProfile_basic(t *testing.T) {
@@ -67,6 +69,7 @@ func TestAccResourceNsxtPolicyIPDiscoveryProfile_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(testResourceName, "nd_snooping_enabled", accTestPolicyIPDiscoveryProfileCreateAttributes["nd_snooping_enabled"]),
 					resource.TestCheckResourceAttr(testResourceName, "nd_snooping_limit", accTestPolicyIPDiscoveryProfileCreateAttributes["nd_snooping_limit"]),
 					resource.TestCheckResourceAttr(testResourceName, "vmtools_v6_enabled", accTestPolicyIPDiscoveryProfileCreateAttributes["vmtools_v6_enabled"]),
+					resource.TestCheckResourceAttr(testResourceName, "tofu_enabled", accTestPolicyIPDiscoveryProfileCreateAttributes["tofu_enabled"]),
 
 					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
 					resource.TestCheckResourceAttrSet(testResourceName, "path"),
@@ -90,6 +93,7 @@ func TestAccResourceNsxtPolicyIPDiscoveryProfile_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(testResourceName, "nd_snooping_enabled", accTestPolicyIPDiscoveryProfileUpdateAttributes["nd_snooping_enabled"]),
 					resource.TestCheckResourceAttr(testResourceName, "nd_snooping_limit", accTestPolicyIPDiscoveryProfileUpdateAttributes["nd_snooping_limit"]),
 					resource.TestCheckResourceAttr(testResourceName, "vmtools_v6_enabled", accTestPolicyIPDiscoveryProfileUpdateAttributes["vmtools_v6_enabled"]),
+					resource.TestCheckResourceAttr(testResourceName, "tofu_enabled", accTestPolicyIPDiscoveryProfileUpdateAttributes["tofu_enabled"]),
 
 					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
 					resource.TestCheckResourceAttrSet(testResourceName, "path"),
@@ -116,6 +120,7 @@ func TestAccResourceNsxtPolicyIPDiscoveryProfile_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(testResourceName, "nd_snooping_enabled", "false"),
 					resource.TestCheckResourceAttr(testResourceName, "nd_snooping_limit", "3"),
 					resource.TestCheckResourceAttr(testResourceName, "vmtools_v6_enabled", "false"),
+					resource.TestCheckResourceAttr(testResourceName, "tofu_enabled", "true"),
 				),
 			},
 		},
@@ -214,11 +219,12 @@ resource "nsxt_policy_ip_discovery_profile" "test" {
   nd_snooping_enabled = %s
   nd_snooping_limit = %s
   vmtools_v6_enabled = %s
+  tofu_enabled = %s
   tag {
     scope = "scope1"
     tag   = "tag1"
   }
-}`, attrMap["display_name"], attrMap["description"], attrMap["arp_nd_binding_timeout"], attrMap["duplicate_ip_detection_enabled"], attrMap["arp_binding_limit"], attrMap["arp_snooping_enabled"], attrMap["dhcp_snooping_enabled"], attrMap["vmtools_enabled"], attrMap["dhcp_snooping_v6_enabled"], attrMap["nd_snooping_enabled"], attrMap["nd_snooping_limit"], attrMap["vmtools_v6_enabled"])
+}`, attrMap["display_name"], attrMap["description"], attrMap["arp_nd_binding_timeout"], attrMap["duplicate_ip_detection_enabled"], attrMap["arp_binding_limit"], attrMap["arp_snooping_enabled"], attrMap["dhcp_snooping_enabled"], attrMap["vmtools_enabled"], attrMap["dhcp_snooping_v6_enabled"], attrMap["nd_snooping_enabled"], attrMap["nd_snooping_limit"], attrMap["vmtools_v6_enabled"], attrMap["tofu_enabled"])
 }
 
 func testAccNsxtPolicyIPDiscoveryProfileMinimalistic() string {

--- a/website/docs/r/policy_ip_discovery_profile.html.markdown
+++ b/website/docs/r/policy_ip_discovery_profile.html.markdown
@@ -30,6 +30,7 @@ resource "nsxt_policy_ip_discovery_profile" "ip_discovery_profile" {
   nd_snooping_enabled      = false
   nd_snooping_limit        = 12
   vmtools_v6_enabled       = false
+  tofu_enabled             = false
 
   tag {
     scope = "color"
@@ -56,6 +57,7 @@ The following arguments are supported:
 * `nd_snooping_enabled` - (Optional) Is ND snooping enabled or not
 * `nd_snooping_limit` - (Optional) Maximum number of ND (Neighbor Discovery Protocol) bindings
 * `vmtools_v6_enabled` - (Optional) Use VMTools to learn the IPv6 addresses which are configured on interfaces of a VM
+* `tofu_enabled` - (Optional) Indicates whether "Trust on First Use(TOFU)" paradigm is enabled
 
 ## Attributes Reference
 


### PR DESCRIPTION
nsxt_policy_ip_discovery_profile was missing the tufo_enabled attribute (trust on first use).

Fixes: #833
Signed-off-by: Kobi Samoray <ksamoray@vmware.com>