### PR TITLE
 Add FQDN or URL Custom support for context profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 dist/
+.idea/

--- a/nsxt/provider.go
+++ b/nsxt/provider.go
@@ -378,6 +378,7 @@ func Provider() *schema.Provider {
 			"nsxt_policy_l2_vpn_service":                   resourceNsxtPolicyL2VpnService(),
 			"nsxt_policy_ipsec_vpn_local_endpoint":         resourceNsxtPolicyIPSecVpnLocalEndpoint(),
 			"nsxt_policy_ip_discovery_profile":             resourceNsxtPolicyIPDiscoveryProfile(),
+			"nsxt_policy_context_profile_custom_attribute": resourceNsxtPolicyContextProfileCustomAttribute(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/nsxt/resource_nsxt_policy_context_profile_custom_attribute.go
+++ b/nsxt/resource_nsxt_policy_context_profile_custom_attribute.go
@@ -1,0 +1,207 @@
+/* Copyright © 2023 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: MPL-2.0 */
+
+package nsxt
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
+	gm_infra "github.com/vmware/vsphere-automation-sdk-go/services/nsxt-gm/global_infra/context_profiles/custom_attributes"
+	gm_model "github.com/vmware/vsphere-automation-sdk-go/services/nsxt-gm/model"
+	infra "github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/context_profiles/custom_attributes"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+)
+
+var customAttributeKeys = []string{
+	model.PolicyCustomAttributes_KEY_DOMAIN_NAME,
+	model.PolicyCustomAttributes_KEY_CUSTOM_URL,
+}
+
+func splitCustomAttributeID(id string) (string, string) {
+	s := strings.Split(id, "~")
+	return s[0], s[1]
+}
+
+func makeCustomAttributeID(key string, attribute string) string {
+	return fmt.Sprintf("%s~%s", key, attribute)
+}
+
+func resourceNsxtPolicyContextProfileCustomAttribute() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceNsxtPolicyContextProfileCustomAttributeCreate,
+		Read:   resourceNsxtPolicyContextProfileCustomAttributeRead,
+		Delete: resourceNsxtPolicyContextProfileCustomAttributeDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"key": {
+				Type:         schema.TypeString,
+				Description:  "Key for attribute",
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice(customAttributeKeys, false),
+			},
+			"attribute": {
+				Type:        schema.TypeString,
+				Description: "Custom Attribute",
+				Required:    true,
+				ForceNew:    true,
+			},
+		},
+	}
+}
+
+func resourceNsxtPolicyContextProfileCustomAttributeExists(id string, connector *client.RestConnector, isGlobalmodel bool) (bool, error) {
+	var err error
+	var attrList model.PolicyContextProfileListResult
+
+	key, attribute := splitCustomAttributeID(id)
+	source := model.PolicyCustomAttributes_ATTRIBUTE_SOURCE_CUSTOM
+	if isGlobalmodel {
+		var gmAttrList gm_model.PolicyContextProfileListResult
+		client := gm_infra.NewDefaultClient(connector)
+		gmAttrList, err = client.List(&key, &source, nil, nil, nil, nil, nil, nil)
+
+		al, err1 := convertModelBindingType(gmAttrList, gm_model.PolicyContextProfileListResultBindingType(), model.PolicyContextProfileListResultBindingType())
+		if err1 != nil {
+			return false, err1
+		}
+
+		attrList = al.(model.PolicyContextProfileListResult)
+	} else {
+		client := infra.NewDefaultClient(connector)
+		attrList, err = client.List(&key, &source, nil, nil, nil, nil, nil, nil)
+		if err != nil {
+			return false, err
+		}
+	}
+
+	if *attrList.ResultCount == 0 {
+		return false, nil
+	}
+	if isNotFoundError(err) {
+		return false, nil
+	}
+
+	if err == nil {
+		for _, c := range attrList.Results {
+			for _, a := range c.Attributes {
+				if *a.Key == key {
+					for _, v := range a.Value {
+						if v == attribute {
+							return true, nil
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return false, err
+}
+
+func resourceNsxtPolicyContextProfileCustomAttributeRead(d *schema.ResourceData, m interface{}) error {
+	id := d.Id()
+	key, attribute := splitCustomAttributeID(id)
+
+	log.Printf("[INFO] Reading ContextProfileCustomAttribute with ID %s", d.Id())
+
+	connector := getPolicyConnector(m)
+	exists, err := resourceNsxtPolicyContextProfileCustomAttributeExists(id, connector, isPolicyGlobalManager(m))
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return errors.NotFound{}
+	}
+	d.Set("key", key)
+	d.Set("attribute", attribute)
+	return nil
+}
+
+func resourceNsxtPolicyContextProfileCustomAttributeCreate(d *schema.ResourceData, m interface{}) error {
+	var err error
+	key := d.Get("key").(string)
+	attribute := d.Get("attribute").(string)
+	attributes := []string{attribute}
+	log.Printf("[INFO] Creating ContextProfileCustomAttribute with ID %s", attribute)
+
+	connector := getPolicyConnector(m)
+
+	dataTypeString := model.PolicyCustomAttributes_DATATYPE_STRING
+	obj := model.PolicyCustomAttributes{
+		Datatype: &dataTypeString,
+		Key:      &key,
+		Value:    attributes,
+	}
+
+	// PATCH the resource
+	if isPolicyGlobalManager(m) {
+		gmObj, err1 := convertModelBindingType(obj, model.PolicyCustomAttributesBindingType(), gm_model.PolicyCustomAttributesBindingType())
+		if err1 != nil {
+			return err1
+		}
+
+		client := gm_infra.NewDefaultClient(connector)
+		err = client.Create(gmObj.(gm_model.PolicyCustomAttributes), "add")
+	} else {
+		client := infra.NewDefaultClient(connector)
+		err = client.Create(obj, "add")
+	}
+	if err != nil {
+		return handleCreateError("ContextProfileCustomAttribute", attribute, err)
+	}
+
+	d.Set("key", key)
+	d.Set("attribute", attribute)
+	d.SetId(makeCustomAttributeID(key, attribute))
+
+	return resourceNsxtPolicyContextProfileCustomAttributeRead(d, m)
+}
+
+func resourceNsxtPolicyContextProfileCustomAttributeDelete(d *schema.ResourceData, m interface{}) error {
+	key, attribute := splitCustomAttributeID(d.Id())
+	log.Printf("[INFO] Deleting ContextProfileCustomAttribute with ID %s", attribute)
+	attributes := []string{attribute}
+	err := resourceNsxtPolicyContextProfileCustomAttributeRead(d, m)
+
+	if err != nil {
+		return err
+	}
+
+	connector := getPolicyConnector(m)
+
+	dataTypeString := model.PolicyCustomAttributes_DATATYPE_STRING
+	obj := model.PolicyCustomAttributes{
+		Datatype: &dataTypeString,
+		Key:      &key,
+		Value:    attributes,
+	}
+
+	// PATCH the resource
+	if isPolicyGlobalManager(m) {
+		gmObj, err1 := convertModelBindingType(obj, model.PolicyCustomAttributesBindingType(), gm_model.PolicyCustomAttributesBindingType())
+		if err1 != nil {
+			return err1
+		}
+
+		client := gm_infra.NewDefaultClient(connector)
+		err = client.Create(gmObj.(gm_model.PolicyCustomAttributes), "remove")
+	} else {
+		client := infra.NewDefaultClient(connector)
+		err = client.Create(obj, "remove")
+	}
+
+	if err != nil {
+		return handleDeleteError("ContextProfileCustomAttribute", attribute, err)
+	}
+	return err
+}

--- a/nsxt/resource_nsxt_policy_context_profile_custom_attribute_test.go
+++ b/nsxt/resource_nsxt_policy_context_profile_custom_attribute_test.go
@@ -1,0 +1,119 @@
+/* Copyright © 2023 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: MPL-2.0 */
+
+package nsxt
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+)
+
+var accTestPolicyContextProfileCustomAttributeAttributes = map[string]string{
+	"key":       model.PolicyCustomAttributes_KEY_DOMAIN_NAME,
+	"attribute": "test.fqdn.org",
+}
+
+func TestAccResourceNsxtPolicyContextProfileCustomAttribute_basic(t *testing.T) {
+	testResourceName := "nsxt_policy_context_profile_custom_attribute.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyContextProfileCustomAttributeCheckDestroy(state, accTestPolicyContextProfileCustomAttributeAttributes["attribute"])
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyContextProfileCustomAttributeTemplate(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicyContextProfileCustomAttributeExists(accTestPolicyContextProfileCustomAttributeAttributes["attribute"], testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "key", accTestPolicyContextProfileCustomAttributeAttributes["key"]),
+					resource.TestCheckResourceAttr(testResourceName, "attribute", accTestPolicyContextProfileCustomAttributeAttributes["attribute"]),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceNsxtPolicyContextProfileCustomAttribute_importBasic(t *testing.T) {
+	name := getAccTestResourceName()
+	testResourceName := "nsxt_policy_context_profile_custom_attribute.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyContextProfileCustomAttributeCheckDestroy(state, name)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyContextProfileCustomAttributeTemplate(),
+			},
+			{
+				ResourceName:      testResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccNsxtPolicyContextProfileCustomAttributeExists(displayName string, resourceName string) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+
+		connector := getPolicyConnector(testAccProvider.Meta().(nsxtClients))
+
+		rs, ok := state.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Policy ContextProfileCustomAttribute resource %s not found in resources", resourceName)
+		}
+
+		resourceID := rs.Primary.ID
+		if resourceID == "" {
+			return fmt.Errorf("Policy ContextProfileCustomAttribute resource ID not set in resources")
+		}
+
+		exists, err := resourceNsxtPolicyContextProfileCustomAttributeExists(resourceID, connector, testAccIsGlobalManager())
+		if err != nil {
+			return err
+		}
+		if !exists {
+			return fmt.Errorf("Policy ContextProfileCustomAttribute %s does not exist", resourceID)
+		}
+
+		return nil
+	}
+}
+
+func testAccNsxtPolicyContextProfileCustomAttributeCheckDestroy(state *terraform.State, attribute string) error {
+	connector := getPolicyConnector(testAccProvider.Meta().(nsxtClients))
+	for _, rs := range state.RootModule().Resources {
+
+		if rs.Type != "nsxt_policy_context_profile_custom_attribute" {
+			continue
+		}
+
+		resourceID := makeCustomAttributeID(model.PolicyCustomAttributes_KEY_DOMAIN_NAME, rs.Primary.Attributes["attribute"])
+		exists, err := resourceNsxtPolicyContextProfileCustomAttributeExists(resourceID, connector, testAccIsGlobalManager())
+		if err == nil {
+			return err
+		}
+
+		if exists {
+			return fmt.Errorf("Policy ContextProfileCustomAttribute %s still exists", attribute)
+		}
+	}
+	return nil
+}
+
+func testAccNsxtPolicyContextProfileCustomAttributeTemplate() string {
+	return fmt.Sprintf(`
+resource "nsxt_policy_context_profile_custom_attribute" "test" {
+  key = "%s"
+  attribute = "%s"
+}`, accTestPolicyContextProfileCustomAttributeAttributes["key"], accTestPolicyContextProfileCustomAttributeAttributes["attribute"])
+}

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt-gm/global_infra/context_profiles/custom_attributes/CustomAttributesPackageTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt-gm/global_infra/context_profiles/custom_attributes/CustomAttributesPackageTypes.go
@@ -1,0 +1,11 @@
+// Copyright © 2019-2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+
+// Auto generated code. DO NOT EDIT.
+
+// Data type definitions file for package: com.vmware.nsx_global_policy.global_infra.context_profiles.custom_attributes.
+// Includes binding types of a top level structures and enumerations.
+// Shared by client-side stubs and server-side skeletons to ensure type
+// compatibility.
+
+package custom_attributes

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt-gm/global_infra/context_profiles/custom_attributes/DefaultClient.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt-gm/global_infra/context_profiles/custom_attributes/DefaultClient.go
@@ -1,0 +1,178 @@
+// Copyright © 2019-2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+
+// Auto generated code. DO NOT EDIT.
+
+// Interface file for service: Default
+// Used by client-side stubs.
+
+package custom_attributes
+
+import (
+	"github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/bindings"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/core"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/lib"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt-gm/model"
+)
+
+const _ = core.SupportedByRuntimeVersion1
+
+type DefaultClient interface {
+
+	// This API adds/removes custom attribute values from list for a given attribute key.
+	//
+	// @param policyCustomAttributesParam (required)
+	// @param actionParam Add or Remove Custom Context Profile Attribute values. (required)
+	// @throws InvalidRequest  Bad Request, Precondition Failed
+	// @throws Unauthorized  Forbidden
+	// @throws ServiceUnavailable  Service Unavailable
+	// @throws InternalServerError  Internal Server Error
+	// @throws NotFound  Not Found
+	Create(policyCustomAttributesParam model.PolicyCustomAttributes, actionParam string) error
+
+	// This API updates custom attribute value list for given key.
+	//
+	// @param attributeKeyParam Fetch attributes and sub-attributes for the given attribute key (optional)
+	// @param attributeSourceParam Source of the attribute, System Defined or custom (optional, default to SYSTEM)
+	// @param cursorParam Opaque cursor to be used for getting next page of records (supplied by current result page) (optional)
+	// @param includeMarkForDeleteObjectsParam Include objects that are marked for deletion in results (optional, default to false)
+	// @param includedFieldsParam Comma separated list of fields that should be included in query result (optional)
+	// @param pageSizeParam Maximum number of results to return in this page (server may return fewer) (optional, default to 1000)
+	// @param sortAscendingParam (optional)
+	// @param sortByParam Field by which records are sorted (optional)
+	// @return com.vmware.nsx_global_policy.model.PolicyContextProfileListResult
+	// @throws InvalidRequest  Bad Request, Precondition Failed
+	// @throws Unauthorized  Forbidden
+	// @throws ServiceUnavailable  Service Unavailable
+	// @throws InternalServerError  Internal Server Error
+	// @throws NotFound  Not Found
+	List(attributeKeyParam *string, attributeSourceParam *string, cursorParam *string, includeMarkForDeleteObjectsParam *bool, includedFieldsParam *string, pageSizeParam *int64, sortAscendingParam *bool, sortByParam *string) (model.PolicyContextProfileListResult, error)
+
+	// This API updates custom attribute value list for given key.
+	//
+	// @param policyCustomAttributesParam (required)
+	// @throws InvalidRequest  Bad Request, Precondition Failed
+	// @throws Unauthorized  Forbidden
+	// @throws ServiceUnavailable  Service Unavailable
+	// @throws InternalServerError  Internal Server Error
+	// @throws NotFound  Not Found
+	Patch(policyCustomAttributesParam model.PolicyCustomAttributes) error
+}
+
+type defaultClient struct {
+	connector           client.Connector
+	interfaceDefinition core.InterfaceDefinition
+	errorsBindingMap    map[string]bindings.BindingType
+}
+
+func NewDefaultClient(connector client.Connector) *defaultClient {
+	interfaceIdentifier := core.NewInterfaceIdentifier("com.vmware.nsx_global_policy.global_infra.context_profiles.custom_attributes.default")
+	methodIdentifiers := map[string]core.MethodIdentifier{
+		"create": core.NewMethodIdentifier(interfaceIdentifier, "create"),
+		"list":   core.NewMethodIdentifier(interfaceIdentifier, "list"),
+		"patch":  core.NewMethodIdentifier(interfaceIdentifier, "patch"),
+	}
+	interfaceDefinition := core.NewInterfaceDefinition(interfaceIdentifier, methodIdentifiers)
+	errorsBindingMap := make(map[string]bindings.BindingType)
+
+	dIface := defaultClient{interfaceDefinition: interfaceDefinition, errorsBindingMap: errorsBindingMap, connector: connector}
+	return &dIface
+}
+
+func (dIface *defaultClient) GetErrorBindingType(errorName string) bindings.BindingType {
+	if entry, ok := dIface.errorsBindingMap[errorName]; ok {
+		return entry
+	}
+	return errors.ERROR_BINDINGS_MAP[errorName]
+}
+
+func (dIface *defaultClient) Create(policyCustomAttributesParam model.PolicyCustomAttributes, actionParam string) error {
+	typeConverter := dIface.connector.TypeConverter()
+	executionContext := dIface.connector.NewExecutionContext()
+	sv := bindings.NewStructValueBuilder(defaultCreateInputType(), typeConverter)
+	sv.AddStructField("PolicyCustomAttributes", policyCustomAttributesParam)
+	sv.AddStructField("Action", actionParam)
+	inputDataValue, inputError := sv.GetStructValue()
+	if inputError != nil {
+		return bindings.VAPIerrorsToError(inputError)
+	}
+	operationRestMetaData := defaultCreateRestMetadata()
+	connectionMetadata := map[string]interface{}{lib.REST_METADATA: operationRestMetaData}
+	connectionMetadata["isStreamingResponse"] = false
+	dIface.connector.SetConnectionMetadata(connectionMetadata)
+	methodResult := dIface.connector.GetApiProvider().Invoke("com.vmware.nsx_global_policy.global_infra.context_profiles.custom_attributes.default", "create", inputDataValue, executionContext)
+	if methodResult.IsSuccess() {
+		return nil
+	} else {
+		methodError, errorInError := typeConverter.ConvertToGolang(methodResult.Error(), dIface.GetErrorBindingType(methodResult.Error().Name()))
+		if errorInError != nil {
+			return bindings.VAPIerrorsToError(errorInError)
+		}
+		return methodError.(error)
+	}
+}
+
+func (dIface *defaultClient) List(attributeKeyParam *string, attributeSourceParam *string, cursorParam *string, includeMarkForDeleteObjectsParam *bool, includedFieldsParam *string, pageSizeParam *int64, sortAscendingParam *bool, sortByParam *string) (model.PolicyContextProfileListResult, error) {
+	typeConverter := dIface.connector.TypeConverter()
+	executionContext := dIface.connector.NewExecutionContext()
+	sv := bindings.NewStructValueBuilder(defaultListInputType(), typeConverter)
+	sv.AddStructField("AttributeKey", attributeKeyParam)
+	sv.AddStructField("AttributeSource", attributeSourceParam)
+	sv.AddStructField("Cursor", cursorParam)
+	sv.AddStructField("IncludeMarkForDeleteObjects", includeMarkForDeleteObjectsParam)
+	sv.AddStructField("IncludedFields", includedFieldsParam)
+	sv.AddStructField("PageSize", pageSizeParam)
+	sv.AddStructField("SortAscending", sortAscendingParam)
+	sv.AddStructField("SortBy", sortByParam)
+	inputDataValue, inputError := sv.GetStructValue()
+	if inputError != nil {
+		var emptyOutput model.PolicyContextProfileListResult
+		return emptyOutput, bindings.VAPIerrorsToError(inputError)
+	}
+	operationRestMetaData := defaultListRestMetadata()
+	connectionMetadata := map[string]interface{}{lib.REST_METADATA: operationRestMetaData}
+	connectionMetadata["isStreamingResponse"] = false
+	dIface.connector.SetConnectionMetadata(connectionMetadata)
+	methodResult := dIface.connector.GetApiProvider().Invoke("com.vmware.nsx_global_policy.global_infra.context_profiles.custom_attributes.default", "list", inputDataValue, executionContext)
+	var emptyOutput model.PolicyContextProfileListResult
+	if methodResult.IsSuccess() {
+		output, errorInOutput := typeConverter.ConvertToGolang(methodResult.Output(), defaultListOutputType())
+		if errorInOutput != nil {
+			return emptyOutput, bindings.VAPIerrorsToError(errorInOutput)
+		}
+		return output.(model.PolicyContextProfileListResult), nil
+	} else {
+		methodError, errorInError := typeConverter.ConvertToGolang(methodResult.Error(), dIface.GetErrorBindingType(methodResult.Error().Name()))
+		if errorInError != nil {
+			return emptyOutput, bindings.VAPIerrorsToError(errorInError)
+		}
+		return emptyOutput, methodError.(error)
+	}
+}
+
+func (dIface *defaultClient) Patch(policyCustomAttributesParam model.PolicyCustomAttributes) error {
+	typeConverter := dIface.connector.TypeConverter()
+	executionContext := dIface.connector.NewExecutionContext()
+	sv := bindings.NewStructValueBuilder(defaultPatchInputType(), typeConverter)
+	sv.AddStructField("PolicyCustomAttributes", policyCustomAttributesParam)
+	inputDataValue, inputError := sv.GetStructValue()
+	if inputError != nil {
+		return bindings.VAPIerrorsToError(inputError)
+	}
+	operationRestMetaData := defaultPatchRestMetadata()
+	connectionMetadata := map[string]interface{}{lib.REST_METADATA: operationRestMetaData}
+	connectionMetadata["isStreamingResponse"] = false
+	dIface.connector.SetConnectionMetadata(connectionMetadata)
+	methodResult := dIface.connector.GetApiProvider().Invoke("com.vmware.nsx_global_policy.global_infra.context_profiles.custom_attributes.default", "patch", inputDataValue, executionContext)
+	if methodResult.IsSuccess() {
+		return nil
+	} else {
+		methodError, errorInError := typeConverter.ConvertToGolang(methodResult.Error(), dIface.GetErrorBindingType(methodResult.Error().Name()))
+		if errorInError != nil {
+			return bindings.VAPIerrorsToError(errorInError)
+		}
+		return methodError.(error)
+	}
+}

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt-gm/global_infra/context_profiles/custom_attributes/DefaultTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt-gm/global_infra/context_profiles/custom_attributes/DefaultTypes.go
@@ -1,0 +1,227 @@
+// Copyright © 2019-2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+
+// Auto generated code. DO NOT EDIT.
+
+// Data type definitions file for service: Default.
+// Includes binding types of a structures and enumerations defined in the service.
+// Shared by client-side stubs and server-side skeletons to ensure type
+// compatibility.
+
+package custom_attributes
+
+import (
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/bindings"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/data"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt-gm/model"
+	"reflect"
+)
+
+// Possible value for ``action`` of method Default#create.
+const Default_CREATE_ACTION_ADD = "add"
+
+// Possible value for ``action`` of method Default#create.
+const Default_CREATE_ACTION_REMOVE = "remove"
+
+// Possible value for ``attributeSource`` of method Default#list.
+const Default_LIST_ATTRIBUTE_SOURCE_ALL = "ALL"
+
+// Possible value for ``attributeSource`` of method Default#list.
+const Default_LIST_ATTRIBUTE_SOURCE_CUSTOM = "CUSTOM"
+
+// Possible value for ``attributeSource`` of method Default#list.
+const Default_LIST_ATTRIBUTE_SOURCE_SYSTEM = "SYSTEM"
+
+func defaultCreateInputType() bindings.StructType {
+	fields := make(map[string]bindings.BindingType)
+	fieldNameMap := make(map[string]string)
+	fields["policy_custom_attributes"] = bindings.NewReferenceType(model.PolicyCustomAttributesBindingType)
+	fields["action"] = bindings.NewStringType()
+	fieldNameMap["policy_custom_attributes"] = "PolicyCustomAttributes"
+	fieldNameMap["action"] = "Action"
+	var validators = []bindings.Validator{}
+	return bindings.NewStructType("operation-input", fields, reflect.TypeOf(data.StructValue{}), fieldNameMap, validators)
+}
+
+func defaultCreateOutputType() bindings.BindingType {
+	return bindings.NewVoidType()
+}
+
+func defaultCreateRestMetadata() protocol.OperationRestMetadata {
+	fields := map[string]bindings.BindingType{}
+	fieldNameMap := map[string]string{}
+	paramsTypeMap := map[string]bindings.BindingType{}
+	pathParams := map[string]string{}
+	queryParams := map[string]string{}
+	headerParams := map[string]string{}
+	dispatchHeaderParams := map[string]string{}
+	bodyFieldsMap := map[string]string{}
+	fields["policy_custom_attributes"] = bindings.NewReferenceType(model.PolicyCustomAttributesBindingType)
+	fields["action"] = bindings.NewStringType()
+	fieldNameMap["policy_custom_attributes"] = "PolicyCustomAttributes"
+	fieldNameMap["action"] = "Action"
+	paramsTypeMap["action"] = bindings.NewStringType()
+	paramsTypeMap["policy_custom_attributes"] = bindings.NewReferenceType(model.PolicyCustomAttributesBindingType)
+	queryParams["action"] = "action"
+	resultHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
+	return protocol.NewOperationRestMetadata(
+		fields,
+		fieldNameMap,
+		paramsTypeMap,
+		pathParams,
+		queryParams,
+		headerParams,
+		dispatchHeaderParams,
+		bodyFieldsMap,
+		"",
+		"policy_custom_attributes",
+		"POST",
+		"/global-manager/api/v1/global-infra/context-profiles/custom-attributes/default",
+		"",
+		resultHeaders,
+		204,
+		"",
+		errorHeaders,
+		map[string]int{"com.vmware.vapi.std.errors.invalid_request": 400, "com.vmware.vapi.std.errors.unauthorized": 403, "com.vmware.vapi.std.errors.service_unavailable": 503, "com.vmware.vapi.std.errors.internal_server_error": 500, "com.vmware.vapi.std.errors.not_found": 404})
+}
+
+func defaultListInputType() bindings.StructType {
+	fields := make(map[string]bindings.BindingType)
+	fieldNameMap := make(map[string]string)
+	fields["attribute_key"] = bindings.NewOptionalType(bindings.NewStringType())
+	fields["attribute_source"] = bindings.NewOptionalType(bindings.NewStringType())
+	fields["cursor"] = bindings.NewOptionalType(bindings.NewStringType())
+	fields["include_mark_for_delete_objects"] = bindings.NewOptionalType(bindings.NewBooleanType())
+	fields["included_fields"] = bindings.NewOptionalType(bindings.NewStringType())
+	fields["page_size"] = bindings.NewOptionalType(bindings.NewIntegerType())
+	fields["sort_ascending"] = bindings.NewOptionalType(bindings.NewBooleanType())
+	fields["sort_by"] = bindings.NewOptionalType(bindings.NewStringType())
+	fieldNameMap["attribute_key"] = "AttributeKey"
+	fieldNameMap["attribute_source"] = "AttributeSource"
+	fieldNameMap["cursor"] = "Cursor"
+	fieldNameMap["include_mark_for_delete_objects"] = "IncludeMarkForDeleteObjects"
+	fieldNameMap["included_fields"] = "IncludedFields"
+	fieldNameMap["page_size"] = "PageSize"
+	fieldNameMap["sort_ascending"] = "SortAscending"
+	fieldNameMap["sort_by"] = "SortBy"
+	var validators = []bindings.Validator{}
+	return bindings.NewStructType("operation-input", fields, reflect.TypeOf(data.StructValue{}), fieldNameMap, validators)
+}
+
+func defaultListOutputType() bindings.BindingType {
+	return bindings.NewReferenceType(model.PolicyContextProfileListResultBindingType)
+}
+
+func defaultListRestMetadata() protocol.OperationRestMetadata {
+	fields := map[string]bindings.BindingType{}
+	fieldNameMap := map[string]string{}
+	paramsTypeMap := map[string]bindings.BindingType{}
+	pathParams := map[string]string{}
+	queryParams := map[string]string{}
+	headerParams := map[string]string{}
+	dispatchHeaderParams := map[string]string{}
+	bodyFieldsMap := map[string]string{}
+	fields["attribute_key"] = bindings.NewOptionalType(bindings.NewStringType())
+	fields["attribute_source"] = bindings.NewOptionalType(bindings.NewStringType())
+	fields["cursor"] = bindings.NewOptionalType(bindings.NewStringType())
+	fields["include_mark_for_delete_objects"] = bindings.NewOptionalType(bindings.NewBooleanType())
+	fields["included_fields"] = bindings.NewOptionalType(bindings.NewStringType())
+	fields["page_size"] = bindings.NewOptionalType(bindings.NewIntegerType())
+	fields["sort_ascending"] = bindings.NewOptionalType(bindings.NewBooleanType())
+	fields["sort_by"] = bindings.NewOptionalType(bindings.NewStringType())
+	fieldNameMap["attribute_key"] = "AttributeKey"
+	fieldNameMap["attribute_source"] = "AttributeSource"
+	fieldNameMap["cursor"] = "Cursor"
+	fieldNameMap["include_mark_for_delete_objects"] = "IncludeMarkForDeleteObjects"
+	fieldNameMap["included_fields"] = "IncludedFields"
+	fieldNameMap["page_size"] = "PageSize"
+	fieldNameMap["sort_ascending"] = "SortAscending"
+	fieldNameMap["sort_by"] = "SortBy"
+	paramsTypeMap["attribute_key"] = bindings.NewOptionalType(bindings.NewStringType())
+	paramsTypeMap["included_fields"] = bindings.NewOptionalType(bindings.NewStringType())
+	paramsTypeMap["page_size"] = bindings.NewOptionalType(bindings.NewIntegerType())
+	paramsTypeMap["include_mark_for_delete_objects"] = bindings.NewOptionalType(bindings.NewBooleanType())
+	paramsTypeMap["cursor"] = bindings.NewOptionalType(bindings.NewStringType())
+	paramsTypeMap["sort_by"] = bindings.NewOptionalType(bindings.NewStringType())
+	paramsTypeMap["attribute_source"] = bindings.NewOptionalType(bindings.NewStringType())
+	paramsTypeMap["sort_ascending"] = bindings.NewOptionalType(bindings.NewBooleanType())
+	queryParams["cursor"] = "cursor"
+	queryParams["attribute_source"] = "attribute_source"
+	queryParams["sort_ascending"] = "sort_ascending"
+	queryParams["included_fields"] = "included_fields"
+	queryParams["attribute_key"] = "attribute_key"
+	queryParams["sort_by"] = "sort_by"
+	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
+	queryParams["page_size"] = "page_size"
+	resultHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
+	return protocol.NewOperationRestMetadata(
+		fields,
+		fieldNameMap,
+		paramsTypeMap,
+		pathParams,
+		queryParams,
+		headerParams,
+		dispatchHeaderParams,
+		bodyFieldsMap,
+		"",
+		"",
+		"GET",
+		"/global-manager/api/v1/global-infra/context-profiles/custom-attributes/default",
+		"",
+		resultHeaders,
+		200,
+		"",
+		errorHeaders,
+		map[string]int{"com.vmware.vapi.std.errors.invalid_request": 400, "com.vmware.vapi.std.errors.unauthorized": 403, "com.vmware.vapi.std.errors.service_unavailable": 503, "com.vmware.vapi.std.errors.internal_server_error": 500, "com.vmware.vapi.std.errors.not_found": 404})
+}
+
+func defaultPatchInputType() bindings.StructType {
+	fields := make(map[string]bindings.BindingType)
+	fieldNameMap := make(map[string]string)
+	fields["policy_custom_attributes"] = bindings.NewReferenceType(model.PolicyCustomAttributesBindingType)
+	fieldNameMap["policy_custom_attributes"] = "PolicyCustomAttributes"
+	var validators = []bindings.Validator{}
+	return bindings.NewStructType("operation-input", fields, reflect.TypeOf(data.StructValue{}), fieldNameMap, validators)
+}
+
+func defaultPatchOutputType() bindings.BindingType {
+	return bindings.NewVoidType()
+}
+
+func defaultPatchRestMetadata() protocol.OperationRestMetadata {
+	fields := map[string]bindings.BindingType{}
+	fieldNameMap := map[string]string{}
+	paramsTypeMap := map[string]bindings.BindingType{}
+	pathParams := map[string]string{}
+	queryParams := map[string]string{}
+	headerParams := map[string]string{}
+	dispatchHeaderParams := map[string]string{}
+	bodyFieldsMap := map[string]string{}
+	fields["policy_custom_attributes"] = bindings.NewReferenceType(model.PolicyCustomAttributesBindingType)
+	fieldNameMap["policy_custom_attributes"] = "PolicyCustomAttributes"
+	paramsTypeMap["policy_custom_attributes"] = bindings.NewReferenceType(model.PolicyCustomAttributesBindingType)
+	resultHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
+	return protocol.NewOperationRestMetadata(
+		fields,
+		fieldNameMap,
+		paramsTypeMap,
+		pathParams,
+		queryParams,
+		headerParams,
+		dispatchHeaderParams,
+		bodyFieldsMap,
+		"",
+		"policy_custom_attributes",
+		"PATCH",
+		"/global-manager/api/v1/global-infra/context-profiles/custom-attributes/default",
+		"",
+		resultHeaders,
+		204,
+		"",
+		errorHeaders,
+		map[string]int{"com.vmware.vapi.std.errors.invalid_request": 400, "com.vmware.vapi.std.errors.unauthorized": 403, "com.vmware.vapi.std.errors.service_unavailable": 503, "com.vmware.vapi.std.errors.internal_server_error": 500, "com.vmware.vapi.std.errors.not_found": 404})
+}

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/context_profiles/custom_attributes/CustomAttributesPackageTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/context_profiles/custom_attributes/CustomAttributesPackageTypes.go
@@ -1,0 +1,11 @@
+// Copyright © 2019-2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+
+// Auto generated code. DO NOT EDIT.
+
+// Data type definitions file for package: com.vmware.nsx_policy.infra.context_profiles.custom_attributes.
+// Includes binding types of a top level structures and enumerations.
+// Shared by client-side stubs and server-side skeletons to ensure type
+// compatibility.
+
+package custom_attributes

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/context_profiles/custom_attributes/DefaultClient.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/context_profiles/custom_attributes/DefaultClient.go
@@ -1,0 +1,178 @@
+// Copyright © 2019-2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+
+// Auto generated code. DO NOT EDIT.
+
+// Interface file for service: Default
+// Used by client-side stubs.
+
+package custom_attributes
+
+import (
+	"github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/bindings"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/core"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/lib"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+)
+
+const _ = core.SupportedByRuntimeVersion1
+
+type DefaultClient interface {
+
+	// This API adds/removes custom attribute values from list for a given attribute key.
+	//
+	// @param policyCustomAttributesParam (required)
+	// @param actionParam Add or Remove Custom Context Profile Attribute values. (required)
+	// @throws InvalidRequest  Bad Request, Precondition Failed
+	// @throws Unauthorized  Forbidden
+	// @throws ServiceUnavailable  Service Unavailable
+	// @throws InternalServerError  Internal Server Error
+	// @throws NotFound  Not Found
+	Create(policyCustomAttributesParam model.PolicyCustomAttributes, actionParam string) error
+
+	// This API updates custom attribute value list for given key.
+	//
+	// @param attributeKeyParam Fetch attributes and sub-attributes for the given attribute key (optional)
+	// @param attributeSourceParam Source of the attribute, System Defined or custom (optional, default to SYSTEM)
+	// @param cursorParam Opaque cursor to be used for getting next page of records (supplied by current result page) (optional)
+	// @param includeMarkForDeleteObjectsParam Include objects that are marked for deletion in results (optional, default to false)
+	// @param includedFieldsParam Comma separated list of fields that should be included in query result (optional)
+	// @param pageSizeParam Maximum number of results to return in this page (server may return fewer) (optional, default to 1000)
+	// @param sortAscendingParam (optional)
+	// @param sortByParam Field by which records are sorted (optional)
+	// @return com.vmware.nsx_policy.model.PolicyContextProfileListResult
+	// @throws InvalidRequest  Bad Request, Precondition Failed
+	// @throws Unauthorized  Forbidden
+	// @throws ServiceUnavailable  Service Unavailable
+	// @throws InternalServerError  Internal Server Error
+	// @throws NotFound  Not Found
+	List(attributeKeyParam *string, attributeSourceParam *string, cursorParam *string, includeMarkForDeleteObjectsParam *bool, includedFieldsParam *string, pageSizeParam *int64, sortAscendingParam *bool, sortByParam *string) (model.PolicyContextProfileListResult, error)
+
+	// This API updates custom attribute value list for given key.
+	//
+	// @param policyCustomAttributesParam (required)
+	// @throws InvalidRequest  Bad Request, Precondition Failed
+	// @throws Unauthorized  Forbidden
+	// @throws ServiceUnavailable  Service Unavailable
+	// @throws InternalServerError  Internal Server Error
+	// @throws NotFound  Not Found
+	Patch(policyCustomAttributesParam model.PolicyCustomAttributes) error
+}
+
+type defaultClient struct {
+	connector           client.Connector
+	interfaceDefinition core.InterfaceDefinition
+	errorsBindingMap    map[string]bindings.BindingType
+}
+
+func NewDefaultClient(connector client.Connector) *defaultClient {
+	interfaceIdentifier := core.NewInterfaceIdentifier("com.vmware.nsx_policy.infra.context_profiles.custom_attributes.default")
+	methodIdentifiers := map[string]core.MethodIdentifier{
+		"create": core.NewMethodIdentifier(interfaceIdentifier, "create"),
+		"list":   core.NewMethodIdentifier(interfaceIdentifier, "list"),
+		"patch":  core.NewMethodIdentifier(interfaceIdentifier, "patch"),
+	}
+	interfaceDefinition := core.NewInterfaceDefinition(interfaceIdentifier, methodIdentifiers)
+	errorsBindingMap := make(map[string]bindings.BindingType)
+
+	dIface := defaultClient{interfaceDefinition: interfaceDefinition, errorsBindingMap: errorsBindingMap, connector: connector}
+	return &dIface
+}
+
+func (dIface *defaultClient) GetErrorBindingType(errorName string) bindings.BindingType {
+	if entry, ok := dIface.errorsBindingMap[errorName]; ok {
+		return entry
+	}
+	return errors.ERROR_BINDINGS_MAP[errorName]
+}
+
+func (dIface *defaultClient) Create(policyCustomAttributesParam model.PolicyCustomAttributes, actionParam string) error {
+	typeConverter := dIface.connector.TypeConverter()
+	executionContext := dIface.connector.NewExecutionContext()
+	sv := bindings.NewStructValueBuilder(defaultCreateInputType(), typeConverter)
+	sv.AddStructField("PolicyCustomAttributes", policyCustomAttributesParam)
+	sv.AddStructField("Action", actionParam)
+	inputDataValue, inputError := sv.GetStructValue()
+	if inputError != nil {
+		return bindings.VAPIerrorsToError(inputError)
+	}
+	operationRestMetaData := defaultCreateRestMetadata()
+	connectionMetadata := map[string]interface{}{lib.REST_METADATA: operationRestMetaData}
+	connectionMetadata["isStreamingResponse"] = false
+	dIface.connector.SetConnectionMetadata(connectionMetadata)
+	methodResult := dIface.connector.GetApiProvider().Invoke("com.vmware.nsx_policy.infra.context_profiles.custom_attributes.default", "create", inputDataValue, executionContext)
+	if methodResult.IsSuccess() {
+		return nil
+	} else {
+		methodError, errorInError := typeConverter.ConvertToGolang(methodResult.Error(), dIface.GetErrorBindingType(methodResult.Error().Name()))
+		if errorInError != nil {
+			return bindings.VAPIerrorsToError(errorInError)
+		}
+		return methodError.(error)
+	}
+}
+
+func (dIface *defaultClient) List(attributeKeyParam *string, attributeSourceParam *string, cursorParam *string, includeMarkForDeleteObjectsParam *bool, includedFieldsParam *string, pageSizeParam *int64, sortAscendingParam *bool, sortByParam *string) (model.PolicyContextProfileListResult, error) {
+	typeConverter := dIface.connector.TypeConverter()
+	executionContext := dIface.connector.NewExecutionContext()
+	sv := bindings.NewStructValueBuilder(defaultListInputType(), typeConverter)
+	sv.AddStructField("AttributeKey", attributeKeyParam)
+	sv.AddStructField("AttributeSource", attributeSourceParam)
+	sv.AddStructField("Cursor", cursorParam)
+	sv.AddStructField("IncludeMarkForDeleteObjects", includeMarkForDeleteObjectsParam)
+	sv.AddStructField("IncludedFields", includedFieldsParam)
+	sv.AddStructField("PageSize", pageSizeParam)
+	sv.AddStructField("SortAscending", sortAscendingParam)
+	sv.AddStructField("SortBy", sortByParam)
+	inputDataValue, inputError := sv.GetStructValue()
+	if inputError != nil {
+		var emptyOutput model.PolicyContextProfileListResult
+		return emptyOutput, bindings.VAPIerrorsToError(inputError)
+	}
+	operationRestMetaData := defaultListRestMetadata()
+	connectionMetadata := map[string]interface{}{lib.REST_METADATA: operationRestMetaData}
+	connectionMetadata["isStreamingResponse"] = false
+	dIface.connector.SetConnectionMetadata(connectionMetadata)
+	methodResult := dIface.connector.GetApiProvider().Invoke("com.vmware.nsx_policy.infra.context_profiles.custom_attributes.default", "list", inputDataValue, executionContext)
+	var emptyOutput model.PolicyContextProfileListResult
+	if methodResult.IsSuccess() {
+		output, errorInOutput := typeConverter.ConvertToGolang(methodResult.Output(), defaultListOutputType())
+		if errorInOutput != nil {
+			return emptyOutput, bindings.VAPIerrorsToError(errorInOutput)
+		}
+		return output.(model.PolicyContextProfileListResult), nil
+	} else {
+		methodError, errorInError := typeConverter.ConvertToGolang(methodResult.Error(), dIface.GetErrorBindingType(methodResult.Error().Name()))
+		if errorInError != nil {
+			return emptyOutput, bindings.VAPIerrorsToError(errorInError)
+		}
+		return emptyOutput, methodError.(error)
+	}
+}
+
+func (dIface *defaultClient) Patch(policyCustomAttributesParam model.PolicyCustomAttributes) error {
+	typeConverter := dIface.connector.TypeConverter()
+	executionContext := dIface.connector.NewExecutionContext()
+	sv := bindings.NewStructValueBuilder(defaultPatchInputType(), typeConverter)
+	sv.AddStructField("PolicyCustomAttributes", policyCustomAttributesParam)
+	inputDataValue, inputError := sv.GetStructValue()
+	if inputError != nil {
+		return bindings.VAPIerrorsToError(inputError)
+	}
+	operationRestMetaData := defaultPatchRestMetadata()
+	connectionMetadata := map[string]interface{}{lib.REST_METADATA: operationRestMetaData}
+	connectionMetadata["isStreamingResponse"] = false
+	dIface.connector.SetConnectionMetadata(connectionMetadata)
+	methodResult := dIface.connector.GetApiProvider().Invoke("com.vmware.nsx_policy.infra.context_profiles.custom_attributes.default", "patch", inputDataValue, executionContext)
+	if methodResult.IsSuccess() {
+		return nil
+	} else {
+		methodError, errorInError := typeConverter.ConvertToGolang(methodResult.Error(), dIface.GetErrorBindingType(methodResult.Error().Name()))
+		if errorInError != nil {
+			return bindings.VAPIerrorsToError(errorInError)
+		}
+		return methodError.(error)
+	}
+}

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/context_profiles/custom_attributes/DefaultTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/context_profiles/custom_attributes/DefaultTypes.go
@@ -1,0 +1,227 @@
+// Copyright © 2019-2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+
+// Auto generated code. DO NOT EDIT.
+
+// Data type definitions file for service: Default.
+// Includes binding types of a structures and enumerations defined in the service.
+// Shared by client-side stubs and server-side skeletons to ensure type
+// compatibility.
+
+package custom_attributes
+
+import (
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/bindings"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/data"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+	"reflect"
+)
+
+// Possible value for ``action`` of method Default#create.
+const Default_CREATE_ACTION_ADD = "add"
+
+// Possible value for ``action`` of method Default#create.
+const Default_CREATE_ACTION_REMOVE = "remove"
+
+// Possible value for ``attributeSource`` of method Default#list.
+const Default_LIST_ATTRIBUTE_SOURCE_ALL = "ALL"
+
+// Possible value for ``attributeSource`` of method Default#list.
+const Default_LIST_ATTRIBUTE_SOURCE_CUSTOM = "CUSTOM"
+
+// Possible value for ``attributeSource`` of method Default#list.
+const Default_LIST_ATTRIBUTE_SOURCE_SYSTEM = "SYSTEM"
+
+func defaultCreateInputType() bindings.StructType {
+	fields := make(map[string]bindings.BindingType)
+	fieldNameMap := make(map[string]string)
+	fields["policy_custom_attributes"] = bindings.NewReferenceType(model.PolicyCustomAttributesBindingType)
+	fields["action"] = bindings.NewStringType()
+	fieldNameMap["policy_custom_attributes"] = "PolicyCustomAttributes"
+	fieldNameMap["action"] = "Action"
+	var validators = []bindings.Validator{}
+	return bindings.NewStructType("operation-input", fields, reflect.TypeOf(data.StructValue{}), fieldNameMap, validators)
+}
+
+func defaultCreateOutputType() bindings.BindingType {
+	return bindings.NewVoidType()
+}
+
+func defaultCreateRestMetadata() protocol.OperationRestMetadata {
+	fields := map[string]bindings.BindingType{}
+	fieldNameMap := map[string]string{}
+	paramsTypeMap := map[string]bindings.BindingType{}
+	pathParams := map[string]string{}
+	queryParams := map[string]string{}
+	headerParams := map[string]string{}
+	dispatchHeaderParams := map[string]string{}
+	bodyFieldsMap := map[string]string{}
+	fields["policy_custom_attributes"] = bindings.NewReferenceType(model.PolicyCustomAttributesBindingType)
+	fields["action"] = bindings.NewStringType()
+	fieldNameMap["policy_custom_attributes"] = "PolicyCustomAttributes"
+	fieldNameMap["action"] = "Action"
+	paramsTypeMap["action"] = bindings.NewStringType()
+	paramsTypeMap["policy_custom_attributes"] = bindings.NewReferenceType(model.PolicyCustomAttributesBindingType)
+	queryParams["action"] = "action"
+	resultHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
+	return protocol.NewOperationRestMetadata(
+		fields,
+		fieldNameMap,
+		paramsTypeMap,
+		pathParams,
+		queryParams,
+		headerParams,
+		dispatchHeaderParams,
+		bodyFieldsMap,
+		"",
+		"policy_custom_attributes",
+		"POST",
+		"/policy/api/v1/infra/context-profiles/custom-attributes/default",
+		"",
+		resultHeaders,
+		204,
+		"",
+		errorHeaders,
+		map[string]int{"com.vmware.vapi.std.errors.invalid_request": 400, "com.vmware.vapi.std.errors.unauthorized": 403, "com.vmware.vapi.std.errors.service_unavailable": 503, "com.vmware.vapi.std.errors.internal_server_error": 500, "com.vmware.vapi.std.errors.not_found": 404})
+}
+
+func defaultListInputType() bindings.StructType {
+	fields := make(map[string]bindings.BindingType)
+	fieldNameMap := make(map[string]string)
+	fields["attribute_key"] = bindings.NewOptionalType(bindings.NewStringType())
+	fields["attribute_source"] = bindings.NewOptionalType(bindings.NewStringType())
+	fields["cursor"] = bindings.NewOptionalType(bindings.NewStringType())
+	fields["include_mark_for_delete_objects"] = bindings.NewOptionalType(bindings.NewBooleanType())
+	fields["included_fields"] = bindings.NewOptionalType(bindings.NewStringType())
+	fields["page_size"] = bindings.NewOptionalType(bindings.NewIntegerType())
+	fields["sort_ascending"] = bindings.NewOptionalType(bindings.NewBooleanType())
+	fields["sort_by"] = bindings.NewOptionalType(bindings.NewStringType())
+	fieldNameMap["attribute_key"] = "AttributeKey"
+	fieldNameMap["attribute_source"] = "AttributeSource"
+	fieldNameMap["cursor"] = "Cursor"
+	fieldNameMap["include_mark_for_delete_objects"] = "IncludeMarkForDeleteObjects"
+	fieldNameMap["included_fields"] = "IncludedFields"
+	fieldNameMap["page_size"] = "PageSize"
+	fieldNameMap["sort_ascending"] = "SortAscending"
+	fieldNameMap["sort_by"] = "SortBy"
+	var validators = []bindings.Validator{}
+	return bindings.NewStructType("operation-input", fields, reflect.TypeOf(data.StructValue{}), fieldNameMap, validators)
+}
+
+func defaultListOutputType() bindings.BindingType {
+	return bindings.NewReferenceType(model.PolicyContextProfileListResultBindingType)
+}
+
+func defaultListRestMetadata() protocol.OperationRestMetadata {
+	fields := map[string]bindings.BindingType{}
+	fieldNameMap := map[string]string{}
+	paramsTypeMap := map[string]bindings.BindingType{}
+	pathParams := map[string]string{}
+	queryParams := map[string]string{}
+	headerParams := map[string]string{}
+	dispatchHeaderParams := map[string]string{}
+	bodyFieldsMap := map[string]string{}
+	fields["attribute_key"] = bindings.NewOptionalType(bindings.NewStringType())
+	fields["attribute_source"] = bindings.NewOptionalType(bindings.NewStringType())
+	fields["cursor"] = bindings.NewOptionalType(bindings.NewStringType())
+	fields["include_mark_for_delete_objects"] = bindings.NewOptionalType(bindings.NewBooleanType())
+	fields["included_fields"] = bindings.NewOptionalType(bindings.NewStringType())
+	fields["page_size"] = bindings.NewOptionalType(bindings.NewIntegerType())
+	fields["sort_ascending"] = bindings.NewOptionalType(bindings.NewBooleanType())
+	fields["sort_by"] = bindings.NewOptionalType(bindings.NewStringType())
+	fieldNameMap["attribute_key"] = "AttributeKey"
+	fieldNameMap["attribute_source"] = "AttributeSource"
+	fieldNameMap["cursor"] = "Cursor"
+	fieldNameMap["include_mark_for_delete_objects"] = "IncludeMarkForDeleteObjects"
+	fieldNameMap["included_fields"] = "IncludedFields"
+	fieldNameMap["page_size"] = "PageSize"
+	fieldNameMap["sort_ascending"] = "SortAscending"
+	fieldNameMap["sort_by"] = "SortBy"
+	paramsTypeMap["attribute_key"] = bindings.NewOptionalType(bindings.NewStringType())
+	paramsTypeMap["included_fields"] = bindings.NewOptionalType(bindings.NewStringType())
+	paramsTypeMap["page_size"] = bindings.NewOptionalType(bindings.NewIntegerType())
+	paramsTypeMap["include_mark_for_delete_objects"] = bindings.NewOptionalType(bindings.NewBooleanType())
+	paramsTypeMap["cursor"] = bindings.NewOptionalType(bindings.NewStringType())
+	paramsTypeMap["sort_by"] = bindings.NewOptionalType(bindings.NewStringType())
+	paramsTypeMap["attribute_source"] = bindings.NewOptionalType(bindings.NewStringType())
+	paramsTypeMap["sort_ascending"] = bindings.NewOptionalType(bindings.NewBooleanType())
+	queryParams["cursor"] = "cursor"
+	queryParams["attribute_source"] = "attribute_source"
+	queryParams["sort_ascending"] = "sort_ascending"
+	queryParams["included_fields"] = "included_fields"
+	queryParams["attribute_key"] = "attribute_key"
+	queryParams["sort_by"] = "sort_by"
+	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
+	queryParams["page_size"] = "page_size"
+	resultHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
+	return protocol.NewOperationRestMetadata(
+		fields,
+		fieldNameMap,
+		paramsTypeMap,
+		pathParams,
+		queryParams,
+		headerParams,
+		dispatchHeaderParams,
+		bodyFieldsMap,
+		"",
+		"",
+		"GET",
+		"/policy/api/v1/infra/context-profiles/custom-attributes/default",
+		"",
+		resultHeaders,
+		200,
+		"",
+		errorHeaders,
+		map[string]int{"com.vmware.vapi.std.errors.invalid_request": 400, "com.vmware.vapi.std.errors.unauthorized": 403, "com.vmware.vapi.std.errors.service_unavailable": 503, "com.vmware.vapi.std.errors.internal_server_error": 500, "com.vmware.vapi.std.errors.not_found": 404})
+}
+
+func defaultPatchInputType() bindings.StructType {
+	fields := make(map[string]bindings.BindingType)
+	fieldNameMap := make(map[string]string)
+	fields["policy_custom_attributes"] = bindings.NewReferenceType(model.PolicyCustomAttributesBindingType)
+	fieldNameMap["policy_custom_attributes"] = "PolicyCustomAttributes"
+	var validators = []bindings.Validator{}
+	return bindings.NewStructType("operation-input", fields, reflect.TypeOf(data.StructValue{}), fieldNameMap, validators)
+}
+
+func defaultPatchOutputType() bindings.BindingType {
+	return bindings.NewVoidType()
+}
+
+func defaultPatchRestMetadata() protocol.OperationRestMetadata {
+	fields := map[string]bindings.BindingType{}
+	fieldNameMap := map[string]string{}
+	paramsTypeMap := map[string]bindings.BindingType{}
+	pathParams := map[string]string{}
+	queryParams := map[string]string{}
+	headerParams := map[string]string{}
+	dispatchHeaderParams := map[string]string{}
+	bodyFieldsMap := map[string]string{}
+	fields["policy_custom_attributes"] = bindings.NewReferenceType(model.PolicyCustomAttributesBindingType)
+	fieldNameMap["policy_custom_attributes"] = "PolicyCustomAttributes"
+	paramsTypeMap["policy_custom_attributes"] = bindings.NewReferenceType(model.PolicyCustomAttributesBindingType)
+	resultHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
+	return protocol.NewOperationRestMetadata(
+		fields,
+		fieldNameMap,
+		paramsTypeMap,
+		pathParams,
+		queryParams,
+		headerParams,
+		dispatchHeaderParams,
+		bodyFieldsMap,
+		"",
+		"policy_custom_attributes",
+		"PATCH",
+		"/policy/api/v1/infra/context-profiles/custom-attributes/default",
+		"",
+		resultHeaders,
+		204,
+		"",
+		errorHeaders,
+		map[string]int{"com.vmware.vapi.std.errors.invalid_request": 400, "com.vmware.vapi.std.errors.unauthorized": 403, "com.vmware.vapi.std.errors.service_unavailable": 503, "com.vmware.vapi.std.errors.internal_server_error": 500, "com.vmware.vapi.std.errors.not_found": 404})
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -203,6 +203,7 @@ github.com/vmware/vsphere-automation-sdk-go/runtime/security
 github.com/vmware/vsphere-automation-sdk-go/services/nsxt
 github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra
 github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/context_profiles
+github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/context_profiles/custom_attributes
 github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/domains
 github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/ip_pools
 github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/realized_state
@@ -234,6 +235,7 @@ github.com/vmware/vsphere-automation-sdk-go/services/nsxt/search
 github.com/vmware/vsphere-automation-sdk-go/services/nsxt-gm
 github.com/vmware/vsphere-automation-sdk-go/services/nsxt-gm/global_infra
 github.com/vmware/vsphere-automation-sdk-go/services/nsxt-gm/global_infra/context_profiles
+github.com/vmware/vsphere-automation-sdk-go/services/nsxt-gm/global_infra/context_profiles/custom_attributes
 github.com/vmware/vsphere-automation-sdk-go/services/nsxt-gm/global_infra/domains
 github.com/vmware/vsphere-automation-sdk-go/services/nsxt-gm/global_infra/realized_state
 github.com/vmware/vsphere-automation-sdk-go/services/nsxt-gm/global_infra/segments

--- a/website/docs/r/policy_context_profile_custom_attribute.html.markdown
+++ b/website/docs/r/policy_context_profile_custom_attribute.html.markdown
@@ -1,0 +1,41 @@
+---
+subcategory: "Policy - Firewall"
+layout: "nsxt"
+page_title: "NSXT: nsxt_policy_context_profile_custom_attribute"
+description: A resource to configure a Context Profile FQDN or URL Custom attribute.
+---
+
+# nsxt_policy_context_profile_custom_attribute
+
+This resource provides a method for the management of a Context Profile FQDN or URL Custom attributes.
+This resource is supported with NSX 4.1.0 onwards.
+
+## Example Usage
+
+```hcl
+resource "nsxt_policy_context_profile_custom_attribute" "test" {
+  key       = "DOMAIN_NAME"
+  attribute = "test.somesite.com"
+}
+
+```
+
+## Argument Reference
+
+The following arguments are supported:
+Note: `key`, `attribute` must be present.
+
+* `key` - (Required) Policy Custom Attribute Key. Valid values are "DOMAIN_NAME" and "CUSTOM_URL"
+* `attribute` - (Required) FQDN or URL to be used as custom attribute.
+
+## Importing
+
+An existing Context Profile can be [imported][docs-import] into this resource, via the following command:
+
+[docs-import]: https://www.terraform.io/cli/import
+
+```
+terraform import nsxt_policy_context_profile_custom_attribute.test DOMAIN_NAME~test.somesite.com
+```
+
+The above command imports Context Profile FQDN attribute named `test` with FQDN `test.somesite.com`.


### PR DESCRIPTION
To allow addition of custom URLs or FQDNs to context profile objects.

Fixes: #699, #721

Signed-off-by: Kobi Samoray <ksamoray@vmware.com>