### PR TITLE
Fix VPN data sources for newer NSX version

### DIFF
--- a/.github/workflows/website-lint.yml
+++ b/.github/workflows/website-lint.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.18
+        go-version: 1.19
 
     - name: Install tools
       run: make tools

--- a/nsxt/data_source_nsxt_policy_ipsec_vpn_local_endpoint_test.go
+++ b/nsxt/data_source_nsxt_policy_ipsec_vpn_local_endpoint_test.go
@@ -8,8 +8,9 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
+
+var dataSourceNsxtPolicyTestAddress = "20.20.0.2"
 
 func TestAccDataSourceNsxtPolicyIPSecVpnLocalEndpoint(t *testing.T) {
 	name := getAccTestResourceName()
@@ -21,14 +22,12 @@ func TestAccDataSourceNsxtPolicyIPSecVpnLocalEndpoint(t *testing.T) {
 			testAccOnlyLocalManager(t)
 		},
 		Providers: testAccProviders,
-		CheckDestroy: func(state *terraform.State) error {
-			return testAccNsxtPolicyIPSecVpnLocalEndpointCheckDestroy(state, name)
-		},
 		Steps: []resource.TestStep{
 			{
 				Config: testAccNsxtPolicyIPSecVpnLocalEndpointDataSourceTemplate(name),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(testResourceName, "display_name", name),
+					resource.TestCheckResourceAttr(testResourceName, "local_address", dataSourceNsxtPolicyTestAddress),
 					resource.TestCheckResourceAttrSet(testResourceName, "path"),
 				),
 			},
@@ -46,14 +45,12 @@ func TestAccDataSourceNsxtPolicyIPSecVpnLocalEndpoint_withService(t *testing.T) 
 			testAccOnlyLocalManager(t)
 		},
 		Providers: testAccProviders,
-		CheckDestroy: func(state *terraform.State) error {
-			return testAccNsxtPolicyIPSecVpnLocalEndpointCheckDestroy(state, name)
-		},
 		Steps: []resource.TestStep{
 			{
 				Config: testAccNsxtPolicyIPSecVpnLocalEndpointDataSourceTemplateWithService(name),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(testResourceName, "display_name", name),
+					resource.TestCheckResourceAttr(testResourceName, "local_address", dataSourceNsxtPolicyTestAddress),
 					resource.TestCheckResourceAttrSet(testResourceName, "path"),
 				),
 			},
@@ -88,5 +85,5 @@ resource "nsxt_policy_ipsec_vpn_local_endpoint" "test" {
   service_path  = nsxt_policy_ipsec_vpn_service.test.path
   display_name  = "%s"
   local_address = "%s"
-}`, name, name, "20.20.0.10")
+}`, name, name, dataSourceNsxtPolicyTestAddress)
 }

--- a/nsxt/data_source_nsxt_policy_ipsec_vpn_service.go
+++ b/nsxt/data_source_nsxt_policy_ipsec_vpn_service.go
@@ -29,7 +29,7 @@ func dataSourceNsxtPolicyIPSecVpnServiceRead(d *schema.ResourceData, m interface
 	gwPath := d.Get("gateway_path").(string)
 	query := make(map[string]string)
 	if len(gwPath) > 0 {
-		query["parent_path"] = fmt.Sprintf("%s/*", gwPath)
+		query["parent_path"] = fmt.Sprintf("%s*", gwPath)
 	}
 	_, err := policyDataSourceResourceReadWithValidation(d, connector, isPolicyGlobalManager(m), "IPSecVpnService", query, false)
 	if err != nil {

--- a/nsxt/data_source_nsxt_policy_l2_vpn_service.go
+++ b/nsxt/data_source_nsxt_policy_l2_vpn_service.go
@@ -29,7 +29,7 @@ func dataSourceNsxtPolicyL2VpnServiceRead(d *schema.ResourceData, m interface{})
 	gwPath := d.Get("gateway_path").(string)
 	query := make(map[string]string)
 	if len(gwPath) > 0 {
-		query["parent_path"] = fmt.Sprintf("%s/*", gwPath)
+		query["parent_path"] = fmt.Sprintf("%s*", gwPath)
 	}
 	_, err := policyDataSourceResourceReadWithValidation(d, connector, isPolicyGlobalManager(m), "L2VPNService", query, false)
 	if err != nil {

--- a/nsxt/data_source_nsxt_policy_qos_profile_test.go
+++ b/nsxt/data_source_nsxt_policy_qos_profile_test.go
@@ -19,7 +19,7 @@ func TestAccDataSourceNsxtPolicyQosProfile_basic(t *testing.T) {
 	name := getAccTestDataSourceName()
 	testResourceName := "data.nsxt_policy_qos_profile.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {

--- a/nsxt/resource_nsxt_policy_ipsec_vpn_local_endpoint.go
+++ b/nsxt/resource_nsxt_policy_ipsec_vpn_local_endpoint.go
@@ -100,6 +100,34 @@ func (c *localEndpointClient) Get(connector *client.RestConnector, id string) (m
 	return client.Get(c.gwID, c.serviceID, id)
 }
 
+// Note: we don't expect pagination to be relevant here
+func (c *localEndpointClient) List(connector *client.RestConnector) ([]model.IPSecVpnLocalEndpoint, error) {
+	boolFalse := false
+	var cursor string
+	var result model.IPSecVpnLocalEndpointListResult
+	var err error
+	if c.isT0 {
+		if len(c.localeServiceID) > 0 {
+			client := t0_nested_service.NewLocalEndpointsClient(connector)
+			result, err = client.List(c.gwID, c.localeServiceID, c.serviceID, &cursor, &boolFalse, nil, nil, nil, nil)
+		} else {
+			client := t0_service.NewLocalEndpointsClient(connector)
+			result, err = client.List(c.gwID, c.serviceID, &cursor, &boolFalse, nil, nil, nil, nil)
+		}
+
+	} else {
+		if len(c.localeServiceID) > 0 {
+			client := t1_nested_service.NewLocalEndpointsClient(connector)
+			result, err = client.List(c.gwID, c.localeServiceID, c.serviceID, &cursor, &boolFalse, nil, nil, nil, nil)
+		} else {
+			client := t1_service.NewLocalEndpointsClient(connector)
+			result, err = client.List(c.gwID, c.serviceID, &cursor, &boolFalse, nil, nil, nil, nil)
+		}
+	}
+
+	return result.Results, err
+}
+
 func (c *localEndpointClient) Patch(connector *client.RestConnector, id string, obj model.IPSecVpnLocalEndpoint) error {
 	if c.isT0 {
 		if len(c.localeServiceID) > 0 {


### PR DESCRIPTION
With latest NSX, search API result omits locale-service component, which data sources use in filtering.
This breaks vpn local endpoint data source when used with service_path. This change switches from search API to List API for such cases.
In addition, expose local_address in local enpoint data source.