### PR TITLE
Add custom attribute support to context profile

### DIFF
--- a/nsxt/resource_nsxt_policy_context_profile_custom_attribute_test.go
+++ b/nsxt/resource_nsxt_policy_context_profile_custom_attribute_test.go
@@ -111,9 +111,15 @@ func testAccNsxtPolicyContextProfileCustomAttributeCheckDestroy(state *terraform
 }
 
 func testAccNsxtPolicyContextProfileCustomAttributeTemplate() string {
+	return testAccNsxtPolicyContextProfileCustomAttributeArgTemplate(
+		accTestPolicyContextProfileCustomAttributeAttributes["key"],
+		accTestPolicyContextProfileCustomAttributeAttributes["attribute"])
+}
+
+func testAccNsxtPolicyContextProfileCustomAttributeArgTemplate(key string, attribute string) string {
 	return fmt.Sprintf(`
 resource "nsxt_policy_context_profile_custom_attribute" "test" {
   key = "%s"
   attribute = "%s"
-}`, accTestPolicyContextProfileCustomAttributeAttributes["key"], accTestPolicyContextProfileCustomAttributeAttributes["attribute"])
+}`, key, attribute)
 }

--- a/nsxt/resource_nsxt_policy_security_policy_test.go
+++ b/nsxt/resource_nsxt_policy_security_policy_test.go
@@ -839,5 +839,5 @@ func testAccNsxtPolicySecurityPolicyWithProfiles(name string, direction string, 
 	profiles := `
 profiles = [nsxt_policy_context_profile.test.path]
 `
-	return testAccNsxtPolicyContextProfileTemplate("security-policy-test-profile", testAccNsxtPolicyContextProfileAttributeDomainNameTemplate()) + testAccNsxtPolicySecurityPolicyWithRule(name, direction, protocol, ruleTag, domainName, profiles)
+	return testAccNsxtPolicyContextProfileTemplate("security-policy-test-profile", testAccNsxtPolicyContextProfileAttributeDomainNameTemplate(testSystemDomainName)) + testAccNsxtPolicySecurityPolicyWithRule(name, direction, protocol, ruleTag, domainName, profiles)
 }

--- a/nsxt/utils_test.go
+++ b/nsxt/utils_test.go
@@ -52,6 +52,7 @@ const doubleTags string = `
   }`
 
 var randomized = false
+var letterRunes = []rune("abcdefghijklmnopqrstuvwxyz")
 
 func initRand() {
 	if randomized {
@@ -69,6 +70,15 @@ func getAccTestDataSourceName() string {
 func getAccTestResourceName() string {
 	initRand()
 	return fmt.Sprintf("%s-%d", testAccResourceName, rand.Intn(100000))
+}
+
+func getAccTestFQDN() string {
+	initRand()
+	b := make([]rune, 10)
+	for i := range b {
+		b[i] = letterRunes[rand.Intn(len(letterRunes))]
+	}
+	return fmt.Sprintf("test.%s.org", string(b))
 }
 
 func getTier0RouterName() string {

--- a/website/docs/r/policy_context_profile.html.markdown
+++ b/website/docs/r/policy_context_profile.html.markdown
@@ -31,10 +31,29 @@ resource "nsxt_policy_context_profile" "test" {
 
 ```
 
+With a custom attribute:
+
+```hcl
+resource "nsxt_policy_context_profile_custom_attribute" "test1" {
+  key       = "CUSTOM_URL"
+  attribute = "test.some.org"
+}
+
+resource "nsxt_policy_context_profile" "test2" {
+  display_name = "test2"
+  description  = "Terraform provisioned ContextProfile"
+  custom_url {
+    value = ["test.some.org"]
+  }
+  depends_on = [nsxt_policy_context_profile_custom_attribute.test1]
+}
+
+```
+
 ## Argument Reference
 
 The following arguments are supported:
-Note: At least one of `app_id`, `domain_name`, or `url_category` must present.
+Note: At least one of `app_id`, `custom_url`, domain_name`, or `url_category` must present.
 
 * `display_name` - (Required) Display name of the resource.
 * `description` - (Optional) Description of the resource.
@@ -47,6 +66,9 @@ Note: At least one of `app_id`, `domain_name`, or `url_category` must present.
     * `tls_cipher_suite` - (Optional) A list of string indicating values for `tls_cipher_suite`, only applicable to `SSL`.
     * `tls_version` - (Optional) A list of string indicating values for `tls_version`, only applicable to `SSL`.
     * `cifs_smb_version` - (Optional) A list of string indicating values for `cifs_smb_version`, only applicable to `CIFS`.
+* `custom_url` - (Optional) A block to specify custom URL attributes for the context profile. Only one block is allowed.
+  * `description` - (Optional) Description of the attribute.
+  * `value` - (Required) A list of string indicating values for the `custom_url`. Must be a subset of valid values for `custom_url` on NSX.
 * `domain_name` - (Optional) A block to specify domain name (FQDN) attributes for the context profile. Only one block is allowed.
   * `description` - (Optional) Description of the attribute.
   * `value` - (Required) A list of string indicating values for the `domain_name`. Must be a subset of valid values for `domain_name` on NSX.


### PR DESCRIPTION
Allow usage of custom attributes in context profile objects.

Fixes: #698, #839