### PR TITLE
Fix mixup in condition to address lb rules

### DIFF
--- a/nsxt/resource_nsxt_policy_lb_virtual_server.go
+++ b/nsxt/resource_nsxt_policy_lb_virtual_server.go
@@ -1781,8 +1781,8 @@ func resourceNsxtPolicyLBVirtualServerUpdate(d *schema.ResourceData, m interface
 		   rules in resource /    rules in state /    rules in NSX => rules will be changed
 		no rules in resource /    rules in state /    rules in NSX => rules will be deleted
 	*/
-	if d.HasChange("rule") {
-		log.Printf("[INFO] Changes detected in rule section")
+	if !d.HasChange("rule") {
+		log.Printf("[INFO] No changes detected in rule section")
 		existingObj, err := client.Get(id)
 		if err != nil {
 			return handleUpdateError("LBVirtualServer", id, err)
@@ -1792,7 +1792,7 @@ func resourceNsxtPolicyLBVirtualServerUpdate(d *schema.ResourceData, m interface
 			obj.Rules = existingObj.Rules
 		}
 	} else {
-		log.Printf("[INFO] No changes in rule section")
+		log.Printf("[INFO] Changes detected in rule section")
 	}
 
 	if maxNewConnectionRate > 0 {

--- a/website/docs/d/policy_segment_realization.html.markdown
+++ b/website/docs/d/policy_segment_realization.html.markdown
@@ -28,7 +28,7 @@ data "nsxt_policy_segment_realization" "s1" {
 
 # usage in vsphere provider
 data "vsphere_network" "net" {
-  name          = data.nsxt_policy_segment_realization.s1.network_name
+  name          = nsxt_policy_segment_realization.s1.network_name
   datacenter_id = data.vsphere_datacenter.datacenter.id
 }
 ```

--- a/website/docs/r/policy_lb_virtual_server.html.markdown
+++ b/website/docs/r/policy_lb_virtual_server.html.markdown
@@ -52,13 +52,8 @@ resource "nsxt_policy_lb_virtual_server" "test" {
     phase          = "HTTP_REQUEST_REWRITE"
 
     action {
-      http_redirect {
-        redirect_status = "301"
-        redirect_url    = "dummy"
-      }
-      http_redirect {
-        redirect_status = "302"
-        redirect_url    = "other_dummy"
+      http_request_header_delete {
+        header_name = "X-something"
       }
     }
     condition {


### PR DESCRIPTION
A negation was missing in assesment of rule change, that relates to provider version upgrade workaround. When no change in rules is detected, we assume current rules should be preserved, for sake of rules that were added manually on NSX when rule feature was not present in proveder.

In addition, fix inconsistent documentation.
Signed-off-by: Anna Khmelnitsky <akhmelnitsky@vmware.com>