### PR TITLE
Allow creation of Ethernet category rules

### DIFF
--- a/nsxt/policy_common.go
+++ b/nsxt/policy_common.go
@@ -13,7 +13,7 @@ var defaultDomain = "default"
 var defaultSite = "default"
 var securityPolicyCategoryValues = []string{"Ethernet", "Emergency", "Infrastructure", "Environment", "Application"}
 var securityPolicyDirectionValues = []string{model.Rule_DIRECTION_IN, model.Rule_DIRECTION_OUT, model.Rule_DIRECTION_IN_OUT}
-var securityPolicyIPProtocolValues = []string{model.Rule_IP_PROTOCOL_IPV4, model.Rule_IP_PROTOCOL_IPV6, model.Rule_IP_PROTOCOL_IPV4_IPV6}
+var securityPolicyIPProtocolValues = []string{"NONE", model.Rule_IP_PROTOCOL_IPV4, model.Rule_IP_PROTOCOL_IPV6, model.Rule_IP_PROTOCOL_IPV4_IPV6}
 
 // TODO: change last string to sdk constant when available
 var securityPolicyActionValues = []string{model.Rule_ACTION_ALLOW, model.Rule_ACTION_DROP, model.Rule_ACTION_REJECT, "JUMP_TO_APPLICATION"}
@@ -373,7 +373,11 @@ func setPolicyRulesInSchema(d *schema.ResourceData, rules []model.Rule) error {
 		elem["action"] = rule.Action
 		elem["destinations_excluded"] = rule.DestinationsExcluded
 		elem["sources_excluded"] = rule.SourcesExcluded
-		elem["ip_version"] = rule.IpProtocol
+		if rule.IpProtocol == nil {
+			elem["ip_version"] = "NONE"
+		} else {
+			elem["ip_version"] = rule.IpProtocol
+		}
 		elem["direction"] = rule.Direction
 		elem["disabled"] = rule.Disabled
 		elem["revision"] = rule.Revision
@@ -414,7 +418,12 @@ func getPolicyRulesFromSchema(d *schema.ResourceData) []model.Rule {
 		disabled := data["disabled"].(bool)
 		sourcesExcluded := data["sources_excluded"].(bool)
 		destinationsExcluded := data["destinations_excluded"].(bool)
-		ipProtocol := data["ip_version"].(string)
+
+		var ipProtocol *string
+		ipp := data["ip_version"].(string)
+		if ipp != "NONE" {
+			ipProtocol = &ipp
+		}
 		direction := data["direction"].(string)
 		notes := data["notes"].(string)
 		seq := data["sequence_number"].(int)
@@ -441,7 +450,7 @@ func getPolicyRulesFromSchema(d *schema.ResourceData) []model.Rule {
 			Disabled:             &disabled,
 			SourcesExcluded:      &sourcesExcluded,
 			DestinationsExcluded: &destinationsExcluded,
-			IpProtocol:           &ipProtocol,
+			IpProtocol:           ipProtocol,
 			Direction:            &direction,
 			SourceGroups:         getPathListFromMap(data, "source_groups"),
 			DestinationGroups:    getPathListFromMap(data, "destination_groups"),

--- a/website/docs/r/policy_security_policy.html.markdown
+++ b/website/docs/r/policy_security_policy.html.markdown
@@ -119,7 +119,7 @@ The following arguments are supported:
   * `sources_excluded` - (Optional) A boolean value indicating negation of source groups.
   * `direction` - (Optional) Traffic direction, one of `IN`, `OUT` or `IN_OUT`. Default is `IN_OUT`.
   * `disabled` - (Optional) Flag to disable this rule. Default is false.
-  * `ip_version` - (Optional) Version of IP protocol, one of `IPV4`, `IPV6`, `IPV4_IPV6`. Default is `IPV4_IPV6`.
+  * `ip_version` - (Optional) Version of IP protocol, one of `NONE`, IPV4`, `IPV6`, `IPV4_IPV6`. Default is `IPV4_IPV6`. For `Ethernet` category rules, use `NONE` value.
   * `logged` - (Optional) Flag to enable packet logging. Default is false.
   * `notes` - (Optional) Additional notes on changes.
   * `profiles` - (Optional) Set of profile paths relevant for this rule.


### PR DESCRIPTION
Creation of Ethernet rules fails when ip_protocol is not null

Fixes: #841