### PR TITLE
Support session auth for policy resources

### DIFF
--- a/nsxt/provider.go
+++ b/nsxt/provider.go
@@ -43,6 +43,8 @@ type nsxtClients struct {
 	CommonConfig commonProviderConfig
 	// NSX Manager client - based on go-vmware-nsxt SDK
 	NsxtClient *api.APIClient
+	// Config for the above client
+	NsxtClientConfig *api.Configuration
 	// Data for NSX Policy client - based on vsphere-automation-sdk-go SDK
 	// First offering of Policy SDK does not support concurrent
 	// operations in single connector. In order to avoid heavy locks,
@@ -82,6 +84,11 @@ func Provider() *schema.Provider {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("NSXT_REMOTE_AUTH", false),
+			},
+			"session_auth": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("NSXT_SESSION_AUTH", true),
 			},
 			"host": {
 				Type:         schema.TypeString,
@@ -439,6 +446,8 @@ func configureNsxtClient(d *schema.ResourceData, clients *nsxtClients) error {
 
 	caFile := d.Get("ca_file").(string)
 	caString := d.Get("ca").(string)
+	sessionAuth := d.Get("session_auth").(bool)
+	skipSessionAuth := !sessionAuth
 
 	retriesConfig := api.ClientRetriesConfiguration{
 		MaxRetries:      clients.CommonConfig.MaxRetries,
@@ -447,7 +456,7 @@ func configureNsxtClient(d *schema.ResourceData, clients *nsxtClients) error {
 		RetryOnStatuses: clients.CommonConfig.RetryStatusCodes,
 	}
 
-	cfg := api.Configuration{
+	clients.NsxtClientConfig = &api.Configuration{
 		BasePath:             "/api/v1",
 		Host:                 host,
 		Scheme:               "https",
@@ -463,9 +472,10 @@ func configureNsxtClient(d *schema.ResourceData, clients *nsxtClients) error {
 		CAString:             caString,
 		Insecure:             insecure,
 		RetriesConfiguration: retriesConfig,
+		SkipSessionAuth:      skipSessionAuth,
 	}
 
-	nsxClient, err := api.NewAPIClient(&cfg)
+	nsxClient, err := api.NewAPIClient(clients.NsxtClientConfig)
 	if err != nil {
 		return err
 	}
@@ -694,6 +704,24 @@ func (processor bearerAuthHeaderProcessor) Process(req *http.Request) error {
 	return nil
 }
 
+type sessionHeaderProcessor struct {
+	cookie string
+	xsrf   string
+}
+
+func newSessionHeaderProcessor(cookie string, xsrf string) *sessionHeaderProcessor {
+	return &sessionHeaderProcessor{
+		cookie: cookie,
+		xsrf:   xsrf,
+	}
+}
+
+func (processor sessionHeaderProcessor) Process(req *http.Request) error {
+	req.Header.Set("Cookie", processor.cookie)
+	req.Header.Set("X-XSRF-TOKEN", processor.xsrf)
+	return nil
+}
+
 func applyLicense(c *api.APIClient, licenseKey string) error {
 	if c == nil {
 		return fmt.Errorf("API client not configured")
@@ -816,6 +844,19 @@ func getPolicyConnector(clients interface{}) *client.RestConnector {
 	}
 	if len(c.CommonConfig.BearerToken) > 0 {
 		connector.AddRequestProcessor(newBearerAuthHeaderProcessor(c.CommonConfig.BearerToken))
+	}
+	// Session support for policy resources (main rationale - vIDM environment where auth is slow)
+	// Currently session creation is done via old MP sdk.
+	// TODO - when MP resources are removed, switch to official SDK to initiate session/create API
+	// TODO - re-trigger session/create when token is expired
+	if len(c.NsxtClientConfig.DefaultHeader["Cookie"]) > 0 {
+		cookie := c.NsxtClientConfig.DefaultHeader["Cookie"]
+		xsrf := ""
+		if len(c.NsxtClientConfig.DefaultHeader["X-XSRF-TOKEN"]) > 0 {
+			xsrf = c.NsxtClientConfig.DefaultHeader["X-XSRF-TOKEN"]
+		}
+		connector.AddRequestProcessor(newSessionHeaderProcessor(cookie, xsrf))
+		log.Printf("[INFO]: Session headers configured for policy objects")
 	}
 
 	return connector

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -211,7 +211,10 @@ The following arguments are used to configure the VMware NSX-T Provider:
   policy resources: `409, 429, 500, 503, 504`. Can also be specified with the
   `NSXT_RETRY_ON_STATUS_CODES` environment variable.
 * `remote_auth` - (Optional) Would trigger remote authorization instead of basic
-  authorization. This is required for users based on vIDM authentication.
+  authorization. This is required for users based on vIDM authentication for early
+  NSX versions.
+* `session_auth` - (Optional) Creates session to avoid re-authentication for every
+  request. Speeds up terraform execution for vIDM based environments. Defaults to `true`
   The default for this flag is false. Can also be specified with the
   `NSXT_REMOTE_AUTH` environment variable.
 * `tolerate_partial_success` - (Optional) Setting this flag to true would treat


### PR DESCRIPTION
In addition, support ability to disable session auth for both MP and policy resources on provider level.
This change does not cover session reestablishment when xsrf token expires. This will be addressed in a follow-up.