### PR TITLE
Add custom_url_partial_match to context profile

### DIFF
--- a/nsxt/resource_nsxt_policy_context_profile_test.go
+++ b/nsxt/resource_nsxt_policy_context_profile_test.go
@@ -289,6 +289,42 @@ func TestAccResourceNsxtPolicyContextProfile_subAttributes(t *testing.T) {
 	})
 }
 
+func TestAccResourceNsxtPolicyContextProfile_customUrl(t *testing.T) {
+	name := getAccTestResourceName()
+	testResourceName := "nsxt_policy_context_profile.test"
+	fqdn := getAccTestFQDN()
+	attributes := testAccNsxtPolicyContextProfileAttributeCustomURLTemplate("false", fqdn)
+	dependsOn := testAccNsxtPolicyContextProfileDependsOnTemplate("nsxt_policy_context_profile_custom_attribute.test")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t); testAccNSXVersion(t, "4.0.0") },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyContextProfileCheckDestroy(state, testResourceName)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyContextProfileCustomAttributeArgTemplate("CUSTOM_URL", fqdn) + testAccNsxtPolicyContextProfileTemplate(name, attributes+dependsOn),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicyContextProfileExists(testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", name),
+					resource.TestCheckResourceAttr(testResourceName, "description", "Acceptance Test"),
+					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "app_id.#", "0"),
+					resource.TestCheckResourceAttr(testResourceName, "custom_url.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "url_category.#", "0"),
+					resource.TestCheckResourceAttr(testResourceName, "custom_url.0.value.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "custom_url.0.value.0", fqdn),
+					resource.TestCheckResourceAttr(testResourceName, "custom_url.0.custom_url_partial_match", "false"),
+				),
+			},
+		},
+	})
+}
+
 func testAccNsxtPolicyContextProfileExists(resourceName string) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
 		rs, ok := state.RootModule().Resources[resourceName]
@@ -357,6 +393,14 @@ func testAccNsxtPolicyContextProfileAttributeDomainNameTemplate(domain string) s
 domain_name {
   value     = ["%s"]
 }`, domain)
+}
+
+func testAccNsxtPolicyContextProfileAttributeCustomURLTemplate(partialMatch, url string) string {
+	return fmt.Sprintf(`
+custom_url {
+  custom_url_partial_match = %s
+  value     = ["%s"]
+}`, partialMatch, url)
 }
 
 func testAccNsxtPolicyContextProfileAttributeAppIDTemplate() string {

--- a/website/docs/r/policy_context_profile.html.markdown
+++ b/website/docs/r/policy_context_profile.html.markdown
@@ -67,6 +67,7 @@ Note: At least one of `app_id`, `custom_url`, domain_name`, or `url_category` mu
     * `tls_version` - (Optional) A list of string indicating values for `tls_version`, only applicable to `SSL`.
     * `cifs_smb_version` - (Optional) A list of string indicating values for `cifs_smb_version`, only applicable to `CIFS`.
 * `custom_url` - (Optional) A block to specify custom URL attributes for the context profile. Only one block is allowed.
+  * `custom_url_partial_match` - True value for this flag will be treated as a partial match for custom url.  Attribute is supported with NSX version 4.0.0 and above.
   * `description` - (Optional) Description of the attribute.
   * `value` - (Required) A list of string indicating values for the `custom_url`. Must be a subset of valid values for `custom_url` on NSX.
 * `domain_name` - (Optional) A block to specify domain name (FQDN) attributes for the context profile. Only one block is allowed.


### PR DESCRIPTION
Context profile attributes are missing custom_url_partial_match field which was added in NSX 4.0