### PR TITLE
Disallow creating GW policy of Read-Only category

### DIFF
--- a/nsxt/data_source_nsxt_policy_gateway_policy.go
+++ b/nsxt/data_source_nsxt_policy_gateway_policy.go
@@ -16,6 +16,8 @@ import (
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 )
 
+var gatewayPolicyCategoryValues = []string{"Emergency", "SystemRules", "SharedPreRules", "LocalGatewayRules", "AutoServiceRules", "Default"}
+
 func dataSourceNsxtPolicyGatewayPolicy() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceNsxtPolicyGatewayPolicyRead,

--- a/nsxt/policy_common.go
+++ b/nsxt/policy_common.go
@@ -17,7 +17,7 @@ var securityPolicyIPProtocolValues = []string{"NONE", model.Rule_IP_PROTOCOL_IPV
 
 // TODO: change last string to sdk constant when available
 var securityPolicyActionValues = []string{model.Rule_ACTION_ALLOW, model.Rule_ACTION_DROP, model.Rule_ACTION_REJECT, "JUMP_TO_APPLICATION"}
-var gatewayPolicyCategoryValues = []string{"Emergency", "SystemRules", "SharedPreRules", "LocalGatewayRules", "AutoServiceRules", "Default"}
+var gatewayPolicyCategoryWritableValues = []string{"Emergency", "SharedPreRules", "LocalGatewayRules", "Default"}
 var policyFailOverModeValues = []string{model.Tier1_FAILOVER_MODE_PREEMPTIVE, model.Tier1_FAILOVER_MODE_NON_PREEMPTIVE}
 var failOverModeDefaultPolicyT0Value = model.Tier0_FAILOVER_MODE_NON_PREEMPTIVE
 var defaultPolicyLocaleServiceID = "default"
@@ -288,7 +288,7 @@ func getPolicyGatewayPolicySchema() map[string]*schema.Schema {
 	secPolicy := getPolicySecurityPolicySchema(false)
 	// GW Policies don't support scope
 	delete(secPolicy, "scope")
-	secPolicy["category"].ValidateFunc = validation.StringInSlice(gatewayPolicyCategoryValues, false)
+	secPolicy["category"].ValidateFunc = validation.StringInSlice(gatewayPolicyCategoryWritableValues, false)
 	// GW Policy rules require scope to be set
 	secPolicy["rule"] = getSecurityPolicyAndGatewayRulesSchema(true, false, true)
 	return secPolicy

--- a/nsxt/resource_nsxt_policy_predefined_gateway_policy.go
+++ b/nsxt/resource_nsxt_policy_predefined_gateway_policy.go
@@ -298,6 +298,10 @@ func updatePolicyPredefinedGatewayPolicy(id string, d *schema.ResourceData, m in
 		return err
 	}
 
+	if predefinedPolicy.Category != nil && *predefinedPolicy.Category == "SystemRules" {
+		return fmt.Errorf("System policy can not be modified")
+	}
+
 	if d.HasChange("description") {
 		description := d.Get("description").(string)
 		predefinedPolicy.Description = &description


### PR DESCRIPTION
For both GW policy and predefined GW policy resources, it makes no sense to configure categories that are reserved for system RO policies. GW policy data source is still allowed to read those categories.