### PR TITLE
Update golangci-lint github action

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -8,12 +8,12 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.45
+          version: v1.52
           args: --issues-exit-code=1
           only-new-issues: true
           skip-pkg-cache: true


### PR DESCRIPTION
Github action used golang 1.18 which broke the CI.