### PR TITLE
Fix an issue in Policy-Based VPN session import

### DIFF
--- a/nsxt/resource_nsxt_policy_ipsec_vpn_session.go
+++ b/nsxt/resource_nsxt_policy_ipsec_vpn_session.go
@@ -305,7 +305,7 @@ func getIPSecVPNSessionFromSchema(d *schema.ResourceData) (*data.StructValue, er
 func getIPSecVPNRulesSchema() *schema.Schema {
 	return &schema.Schema{
 		Type:        schema.TypeList,
-		Description: "For policy-based IPsec VPNs, a security policy specifies as its action the VPN tunnel to be used for transit traffic that meets the policy’s match criteria.",
+		Description: "For policy-based IPsec VPNs, a security policy specifies as its action the VPN tunnel to be used for transit traffic that meets the policy match criteria",
 		Optional:    true,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
@@ -317,16 +317,16 @@ func getIPSecVPNRulesSchema() *schema.Schema {
 						Type:         schema.TypeString,
 						ValidateFunc: validateCidr(),
 					},
-					Required: true,
+					Optional: true,
 				},
 				"destinations": {
 					Type:        schema.TypeSet,
-					Description: "List of remote subnets used in policy-based L3Vpn.",
+					Description: "List of remote subnets",
 					Elem: &schema.Schema{
 						Type:         schema.TypeString,
 						ValidateFunc: validateCidr(),
 					},
-					Required: true,
+					Optional: true,
 				},
 				"action": {
 					Type:         schema.TypeString,
@@ -475,28 +475,27 @@ func getIPSecVPNRulesFromSchema(d *schema.ResourceData) []model.IPSecVpnRule {
 			sourceRanges := interface2StringList(data["sources"].(*schema.Set).List())
 			destinationRanges := interface2StringList(data["destinations"].(*schema.Set).List())
 
-			/// Source Subnets
-
-			SourceIPSecVpnSubnetList := make([]model.IPSecVpnSubnet, 0)
+			// Source Subnets
+			sourceIPSecVpnSubnetList := make([]model.IPSecVpnSubnet, 0)
 			if len(sourceRanges) > 0 {
 				for _, element := range sourceRanges {
 					subnet := element
-					IPSecVpnSubnet := model.IPSecVpnSubnet{
+					ipSecVpnSubnet := model.IPSecVpnSubnet{
 						Subnet: &subnet,
 					}
-					SourceIPSecVpnSubnetList = append(SourceIPSecVpnSubnetList, IPSecVpnSubnet)
+					sourceIPSecVpnSubnetList = append(sourceIPSecVpnSubnetList, ipSecVpnSubnet)
 				}
 			}
 
-			/// Destination Subnets
-			DestinationIPSecVpnSubnetList := make([]model.IPSecVpnSubnet, 0)
+			// Destination Subnets
+			destinationIPSecVpnSubnetList := make([]model.IPSecVpnSubnet, 0)
 			if len(destinationRanges) > 0 {
 				for _, element := range destinationRanges {
 					subnet := element
-					IPSecVpnSubnet := model.IPSecVpnSubnet{
+					ipSecVpnSubnet := model.IPSecVpnSubnet{
 						Subnet: &subnet,
 					}
-					DestinationIPSecVpnSubnetList = append(DestinationIPSecVpnSubnetList, IPSecVpnSubnet)
+					destinationIPSecVpnSubnetList = append(destinationIPSecVpnSubnetList, ipSecVpnSubnet)
 				}
 			}
 			ruleID := data["nsx_id"].(string)
@@ -505,8 +504,8 @@ func getIPSecVPNRulesFromSchema(d *schema.ResourceData) []model.IPSecVpnRule {
 			}
 			elem := model.IPSecVpnRule{
 				Action:       &action,
-				Sources:      SourceIPSecVpnSubnetList,
-				Destinations: DestinationIPSecVpnSubnetList,
+				Sources:      sourceIPSecVpnSubnetList,
+				Destinations: destinationIPSecVpnSubnetList,
 				UniqueId:     &ruleID,
 				Id:           &ruleID,
 			}
@@ -679,6 +678,8 @@ func resourceNsxtPolicyIPSecVpnSessionRead(d *schema.ResourceData, m interface{}
 		d.Set("local_endpoint_path", blockVPN.LocalEndpointPath)
 		d.Set("dpd_profile_path", blockVPN.DpdProfilePath)
 		d.Set("tunnel_profile_path", blockVPN.TunnelProfilePath)
+		d.Set("peer_address", blockVPN.PeerAddress)
+		d.Set("peer_id", blockVPN.PeerId)
 		if blockVPN.Rules != nil {
 			setRuleInSchema(d, blockVPN.Rules)
 		}

--- a/website/docs/r/policy_ipsec_vpn_session.html.markdown
+++ b/website/docs/r/policy_ipsec_vpn_session.html.markdown
@@ -79,12 +79,12 @@ The following arguments are supported:
 * `peer_address` - (Optional) Public IPV4 address of the remote device terminating the VPN connection.
 * `peer_id` - (Optional) Peer ID to uniquely identify the peer site. The peer ID is the public IP address of the remote device terminating the VPN tunnel. When NAT is configured for the peer, enter the private IP address of the peer.
 * `local_endpoint_path` - (Required) Policy path referencing Local endpoint. In VMC, Local Endpoints are pre-configured the user can refer to their path using `data nsxt_policy_ipsec_vpn_local_endpoint` and using the "Private IP1" or "Public IP1" values to refer to the private and public endpoints respectively.
-* `rule` - (Optional) Bypass rules for this IPSec VPN Session. `sources` and `destinations` are list of `ipv4-cidr-block`, `Action` value must be set to `BYPASS` or `PROTECT`. Only applied for Policy Based VPN Session. 
-  * `sources` - (Required) List of source subnets. Subnet format is `ipv4-cidr`.
-  * `destinations` - (Required) List of distination subnets. Subnet format is `ipv4-cidr`.
-  * `action` - (Required) `PROTECT` or `BYPASS`.
+* `rule` - (Optional) Bypass rules for this IPSec VPN Session. Only applicable to `PolicyBased` VPN Session. 
+  * `sources` - (Optional) List of source subnets. Subnet format is ipv4 CIDR.
+  * `destinations` - (Optional) List of distination subnets. Subnet format is ipv4 CIDR.
+  * `action` - (Optional) `PROTECT` or `BYPASS`. Default is `PROTECT`.
 * `direction` - (Optional) The traffic direction apply to the MSS clamping. Value is one of `NONE`, `INBOUND_CONNECTION`, `OUTBOUND_CONNECTION` AND `BOTH`. Must be specified together with `max_segment_size`.
-* `max_segment_size` - (Optional) Maximum amount of data the host will accept in a Tcp segment. Value is an int between `108` and `8860`. Must be specified together with `direction`.
+* `max_segment_size` - (Optional) Maximum amount of data the host will accept in a TCP segment. Value is an int between `108` and `8860`. Must be specified together with `direction`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
In addition, make sources and destinations Optional rather than Required to match NSX validation.