### PR TITLE
API Refactoring for VPN resources

### DIFF
--- a/nsxt/resource_nsxt_policy_ipsec_vpn_service_test.go
+++ b/nsxt/resource_nsxt_policy_ipsec_vpn_service_test.go
@@ -44,7 +44,7 @@ func TestAccResourceNsxtPolicyIPSecVpnService_basic(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNsxtPolicyIPSecVpnServiceTemplate(true),
+				Config: testAccNsxtPolicyIPSecVpnServiceTemplate(true, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNsxtPolicyIPSecVpnServiceExists(accTestPolicyIPSecVpnServiceCreateAttributes["display_name"], testResourceName),
 					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestPolicyIPSecVpnServiceCreateAttributes["display_name"]),
@@ -64,7 +64,7 @@ func TestAccResourceNsxtPolicyIPSecVpnService_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNsxtPolicyIPSecVpnServiceTemplate(false),
+				Config: testAccNsxtPolicyIPSecVpnServiceTemplate(false, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNsxtPolicyIPSecVpnServiceExists(accTestPolicyIPSecVpnServiceUpdateAttributes["display_name"], testResourceName),
 					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestPolicyIPSecVpnServiceUpdateAttributes["display_name"]),
@@ -84,7 +84,7 @@ func TestAccResourceNsxtPolicyIPSecVpnService_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNsxtPolicyIPSecVpnServiceMinimalistic(),
+				Config: testAccNsxtPolicyIPSecVpnServiceMinimalistic(false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNsxtPolicyIPSecVpnServiceExists(accTestPolicyIPSecVpnServiceCreateAttributes["display_name"], testResourceName),
 					resource.TestCheckResourceAttr(testResourceName, "description", ""),
@@ -103,6 +103,127 @@ func TestAccResourceNsxtPolicyIPSecVpnService_basic(t *testing.T) {
 	})
 }
 
+func TestAccResourceNsxtPolicyIPSecVpnService_withGateway(t *testing.T) {
+	testResourceName := "nsxt_policy_ipsec_vpn_service.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t); testAccOnlyLocalManager(t); testAccNSXVersion(t, "3.2.0") },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyIPSecVpnServiceCheckDestroy(state, accTestPolicyIPSecVpnServiceUpdateAttributes["display_name"])
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyIPSecVpnServiceTemplate(true, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicyIPSecVpnServiceExists(accTestPolicyIPSecVpnServiceCreateAttributes["display_name"], testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestPolicyIPSecVpnServiceCreateAttributes["display_name"]),
+					resource.TestCheckResourceAttr(testResourceName, "description", accTestPolicyIPSecVpnServiceCreateAttributes["description"]),
+					resource.TestCheckResourceAttrSet(testResourceName, "gateway_path"),
+					resource.TestCheckResourceAttr(testResourceName, "enabled", accTestPolicyIPSecVpnServiceCreateAttributes["enabled"]),
+					resource.TestCheckResourceAttr(testResourceName, "ha_sync", accTestPolicyIPSecVpnServiceCreateAttributes["ha_sync"]),
+					resource.TestCheckResourceAttr(testResourceName, "ike_log_level", accTestPolicyIPSecVpnServiceCreateAttributes["ike_log_level"]),
+					resource.TestCheckResourceAttr(testResourceName, "bypass_rule.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "bypass_rule.0.sources.0", accTestPolicyIPSecVpnServiceCreateAttributes["sources"]),
+					resource.TestCheckResourceAttr(testResourceName, "bypass_rule.0.destinations.0", accTestPolicyIPSecVpnServiceCreateAttributes["destinations"]),
+					resource.TestCheckResourceAttr(testResourceName, "bypass_rule.0.action", accTestPolicyIPSecVpnServiceCreateAttributes["action"]),
+					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
+				),
+			},
+			{
+				Config: testAccNsxtPolicyIPSecVpnServiceTemplate(false, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicyIPSecVpnServiceExists(accTestPolicyIPSecVpnServiceUpdateAttributes["display_name"], testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestPolicyIPSecVpnServiceUpdateAttributes["display_name"]),
+					resource.TestCheckResourceAttr(testResourceName, "description", accTestPolicyIPSecVpnServiceUpdateAttributes["description"]),
+					resource.TestCheckResourceAttrSet(testResourceName, "gateway_path"),
+					resource.TestCheckResourceAttr(testResourceName, "enabled", accTestPolicyIPSecVpnServiceUpdateAttributes["enabled"]),
+					resource.TestCheckResourceAttr(testResourceName, "ha_sync", accTestPolicyIPSecVpnServiceUpdateAttributes["ha_sync"]),
+					resource.TestCheckResourceAttr(testResourceName, "ike_log_level", accTestPolicyIPSecVpnServiceUpdateAttributes["ike_log_level"]),
+					resource.TestCheckResourceAttr(testResourceName, "bypass_rule.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "bypass_rule.0.sources.0", accTestPolicyIPSecVpnServiceUpdateAttributes["sources"]),
+					resource.TestCheckResourceAttr(testResourceName, "bypass_rule.0.destinations.0", accTestPolicyIPSecVpnServiceUpdateAttributes["destinations"]),
+					resource.TestCheckResourceAttr(testResourceName, "bypass_rule.0.action", accTestPolicyIPSecVpnServiceUpdateAttributes["action"]),
+					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
+				),
+			},
+			{
+				Config: testAccNsxtPolicyIPSecVpnServiceMinimalistic(true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicyIPSecVpnServiceExists(accTestPolicyIPSecVpnServiceCreateAttributes["display_name"], testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "description", ""),
+					resource.TestCheckResourceAttrSet(testResourceName, "gateway_path"),
+					resource.TestCheckResourceAttr(testResourceName, "bypass_rule.#", "0"),
+					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+					resource.TestCheckResourceAttr(testResourceName, "tag.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceNsxtPolicyIPSecVpnService_updateFromlocaleServicePathToGatewayPath(t *testing.T) {
+	testResourceName := "nsxt_policy_ipsec_vpn_service.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t); testAccOnlyLocalManager(t); testAccNSXVersion(t, "3.2.0") },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyIPSecVpnServiceCheckDestroy(state, accTestPolicyIPSecVpnServiceCreateAttributes["display_name"])
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyIPSecVpnServiceTemplate(true, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicyIPSecVpnServiceExists(accTestPolicyIPSecVpnServiceCreateAttributes["display_name"], testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestPolicyIPSecVpnServiceCreateAttributes["display_name"]),
+					resource.TestCheckResourceAttr(testResourceName, "description", accTestPolicyIPSecVpnServiceCreateAttributes["description"]),
+					resource.TestCheckResourceAttrSet(testResourceName, "locale_service_path"),
+					resource.TestCheckResourceAttr(testResourceName, "enabled", accTestPolicyIPSecVpnServiceCreateAttributes["enabled"]),
+					resource.TestCheckResourceAttr(testResourceName, "ha_sync", accTestPolicyIPSecVpnServiceCreateAttributes["ha_sync"]),
+					resource.TestCheckResourceAttr(testResourceName, "ike_log_level", accTestPolicyIPSecVpnServiceCreateAttributes["ike_log_level"]),
+					resource.TestCheckResourceAttr(testResourceName, "bypass_rule.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "bypass_rule.0.sources.0", accTestPolicyIPSecVpnServiceCreateAttributes["sources"]),
+					resource.TestCheckResourceAttr(testResourceName, "bypass_rule.0.destinations.0", accTestPolicyIPSecVpnServiceCreateAttributes["destinations"]),
+					resource.TestCheckResourceAttr(testResourceName, "bypass_rule.0.action", accTestPolicyIPSecVpnServiceCreateAttributes["action"]),
+					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
+				),
+			},
+			{
+				Config: testAccNsxtPolicyIPSecVpnServiceTemplate(true, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicyIPSecVpnServiceExists(accTestPolicyIPSecVpnServiceCreateAttributes["display_name"], testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestPolicyIPSecVpnServiceCreateAttributes["display_name"]),
+					resource.TestCheckResourceAttr(testResourceName, "description", accTestPolicyIPSecVpnServiceCreateAttributes["description"]),
+					resource.TestCheckResourceAttrSet(testResourceName, "gateway_path"),
+					resource.TestCheckResourceAttr(testResourceName, "enabled", accTestPolicyIPSecVpnServiceCreateAttributes["enabled"]),
+					resource.TestCheckResourceAttr(testResourceName, "ha_sync", accTestPolicyIPSecVpnServiceCreateAttributes["ha_sync"]),
+					resource.TestCheckResourceAttr(testResourceName, "ike_log_level", accTestPolicyIPSecVpnServiceCreateAttributes["ike_log_level"]),
+					resource.TestCheckResourceAttr(testResourceName, "bypass_rule.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "bypass_rule.0.sources.0", accTestPolicyIPSecVpnServiceCreateAttributes["sources"]),
+					resource.TestCheckResourceAttr(testResourceName, "bypass_rule.0.destinations.0", accTestPolicyIPSecVpnServiceCreateAttributes["destinations"]),
+					resource.TestCheckResourceAttr(testResourceName, "bypass_rule.0.action", accTestPolicyIPSecVpnServiceCreateAttributes["action"]),
+					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccResourceNsxtPolicyIPSecVpnService_Import(t *testing.T) {
 	resourceName := "nsxt_policy_ipsec_vpn_service.test"
 
@@ -114,7 +235,7 @@ func TestAccResourceNsxtPolicyIPSecVpnService_Import(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNsxtPolicyIPSecVpnServiceTemplate(true),
+				Config: testAccNsxtPolicyIPSecVpnServiceTemplate(true, false),
 			},
 			{
 				ResourceName:      resourceName,
@@ -137,7 +258,14 @@ func testAccNsxtPolicyIPSecVpnServiceImporterGetID(s *terraform.State) (string, 
 		return "", fmt.Errorf("Policy IPSecVpnService resource ID not set in resources")
 	}
 	localeServicePath := rs.Primary.Attributes["locale_service_path"]
-	return fmt.Sprintf("%s/ipsec-vpn-services/%s", localeServicePath, resourceID), nil
+	gatewayPath := rs.Primary.Attributes["gateway_path"]
+	if gatewayPath == "" && localeServicePath == "" {
+		return "", fmt.Errorf("At least one of gateway path and locale service path should be provided for VPN resources")
+	}
+	if localeServicePath != "" {
+		return fmt.Sprintf("%s/ipsec-vpn-services/%s", localeServicePath, resourceID), nil
+	}
+	return fmt.Sprintf("%s/ipsec-vpn-services/%s", gatewayPath, resourceID), nil
 }
 
 func testAccNsxtPolicyIPSecVpnServiceExists(displayName string, resourceName string) resource.TestCheckFunc {
@@ -156,10 +284,16 @@ func testAccNsxtPolicyIPSecVpnServiceExists(displayName string, resourceName str
 		}
 
 		localeServicePath := rs.Primary.Attributes["locale_service_path"]
+		gatewayPath := rs.Primary.Attributes["gateway_path"]
+		if gatewayPath == "" && localeServicePath == "" {
+			return fmt.Errorf("At least one of gateway path and locale service path should be provided for VPN resources")
+		}
 		isT0, gwID, localeServiceID, err := parseLocaleServicePolicyPath(localeServicePath)
-
-		if err != nil {
-			return nil
+		if localeServiceID == "" {
+			isT0, gwID = parseGatewayPolicyPath(gatewayPath)
+		}
+		if err != nil && gatewayPath == "" {
+			return fmt.Errorf("Invalid locale service path %s", localeServicePath)
 		}
 		_, err1 := getNsxtPolicyIPSecVpnServiceByID(connector, gwID, isT0, localeServiceID, resourceID, testAccIsGlobalManager())
 		if err1 != nil {
@@ -180,9 +314,12 @@ func testAccNsxtPolicyIPSecVpnServiceCheckDestroy(state *terraform.State, displa
 
 		resourceID := rs.Primary.Attributes["id"]
 		localeServicePath := rs.Primary.Attributes["locale_service_path"]
+		gatewayPath := rs.Primary.Attributes["gateway_path"]
 		isT0, gwID, localeServiceID, err := parseLocaleServicePolicyPath(localeServicePath)
-
-		if err != nil {
+		if localeServiceID == "" {
+			isT0, gwID = parseGatewayPolicyPath(gatewayPath)
+		}
+		if err != nil && gatewayPath == "" {
 			return nil
 		}
 
@@ -194,18 +331,19 @@ func testAccNsxtPolicyIPSecVpnServiceCheckDestroy(state *terraform.State, displa
 	return nil
 }
 
-func testAccNsxtPolicyIPSecVpnServiceTemplate(createFlow bool) string {
+func testAccNsxtPolicyIPSecVpnServiceTemplate(createFlow bool, useGatewayPath bool) string {
 	var attrMap map[string]string
 	if createFlow {
 		attrMap = accTestPolicyIPSecVpnServiceCreateAttributes
 	} else {
 		attrMap = accTestPolicyIPSecVpnServiceUpdateAttributes
 	}
+	gatewayOrLocaleServicePath := getGatewayOrLocaleServicePath(useGatewayPath, true)
 	return testAccNsxtPolicyTier0WithEdgeClusterForVPN() + fmt.Sprintf(`
 resource "nsxt_policy_ipsec_vpn_service" "test" {
 	display_name                   = "%s"
 	description                    = "%s"
-	locale_service_path   		   = one(nsxt_policy_tier0_gateway.test.locale_service).path
+	%s
 	enabled                        = "%s"
 	ha_sync                        = "%s"
 	ike_log_level                  = "%s"
@@ -219,13 +357,28 @@ resource "nsxt_policy_ipsec_vpn_service" "test" {
 	scope = "scope1"
 	tag   = "tag1"
 	}
-   }`, attrMap["display_name"], attrMap["description"], attrMap["enabled"], attrMap["ha_sync"], attrMap["ike_log_level"], attrMap["sources"], attrMap["destinations"], attrMap["action"])
+   }`, attrMap["display_name"], attrMap["description"], gatewayOrLocaleServicePath, attrMap["enabled"], attrMap["ha_sync"], attrMap["ike_log_level"], attrMap["sources"], attrMap["destinations"], attrMap["action"])
 }
 
-func testAccNsxtPolicyIPSecVpnServiceMinimalistic() string {
+func getGatewayOrLocaleServicePath(useGatewayPath bool, isT0 bool) string {
+	if useGatewayPath {
+		if isT0 {
+			return "gateway_path = nsxt_policy_tier0_gateway.test.path"
+		}
+		return "gateway_path = nsxt_policy_tier1_gateway.test.path"
+	}
+	if isT0 {
+		return "locale_service_path = one(nsxt_policy_tier0_gateway.test.locale_service).path"
+	}
+	return "locale_service_path = one(nsxt_policy_tier1_gateway.test.locale_service).path"
+
+}
+
+func testAccNsxtPolicyIPSecVpnServiceMinimalistic(useGatewayPath bool) string {
+	gatewayOrLocaleServicePath := getGatewayOrLocaleServicePath(useGatewayPath, true)
 	return testAccNsxtPolicyTier0WithEdgeClusterForVPN() + fmt.Sprintf(`
    resource "nsxt_policy_ipsec_vpn_service" "test" {
 	 display_name          = "%s"
-	 locale_service_path   = one(nsxt_policy_tier0_gateway.test.locale_service).path
-   }`, accTestPolicyIPSecVpnServiceUpdateAttributes["display_name"])
+	 %s
+   }`, accTestPolicyIPSecVpnServiceUpdateAttributes["display_name"], gatewayOrLocaleServicePath)
 }

--- a/nsxt/resource_nsxt_policy_l2_vpn_service_test.go
+++ b/nsxt/resource_nsxt_policy_l2_vpn_service_test.go
@@ -46,7 +46,7 @@ func TestAccResourceNsxtPolicyL2VpnService_basic(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNsxtPolicyL2VpnServiceMinimalistic(),
+				Config: testAccNsxtPolicyL2VpnServiceMinimalistic(false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNsxtPolicyL2VpnServiceExists(accTestPolicyL2VpnServiceCreateAttributes["display_name"], testResourceName),
 					resource.TestCheckResourceAttr(testResourceName, "description", ""),
@@ -58,7 +58,7 @@ func TestAccResourceNsxtPolicyL2VpnService_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNsxtPolicyL2VpnServiceTemplate(true, false),
+				Config: testAccNsxtPolicyL2VpnServiceTemplate(true, false, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNsxtPolicyL2VpnServiceExists(accTestPolicyL2VpnServiceCreateAttributes["display_name"], testResourceName),
 					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestPolicyL2VpnServiceCreateAttributes["display_name"]),
@@ -75,7 +75,7 @@ func TestAccResourceNsxtPolicyL2VpnService_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNsxtPolicyL2VpnServiceTemplate(false, false),
+				Config: testAccNsxtPolicyL2VpnServiceTemplate(false, false, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNsxtPolicyL2VpnServiceExists(accTestPolicyL2VpnServiceUpdateAttributes["display_name"], testResourceName),
 					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestPolicyL2VpnServiceUpdateAttributes["display_name"]),
@@ -98,6 +98,114 @@ func TestAccResourceNsxtPolicyL2VpnService_basic(t *testing.T) {
 	})
 }
 
+func TestAccResourceNsxtPolicyL2VpnService_updateFromlocaleServicePathToGatewayPath(t *testing.T) {
+	testResourceName := "nsxt_policy_l2_vpn_service.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t); testAccOnlyLocalManager(t); testAccNSXVersion(t, "3.2.0") },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyL2VpnServiceCheckDestroy(state, accTestPolicyL2VpnServiceUpdateAttributes["display_name"])
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyL2VpnServiceTemplate(true, false, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicyL2VpnServiceExists(accTestPolicyL2VpnServiceCreateAttributes["display_name"], testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestPolicyL2VpnServiceCreateAttributes["display_name"]),
+					resource.TestCheckResourceAttr(testResourceName, "description", accTestPolicyL2VpnServiceCreateAttributes["description"]),
+					resource.TestCheckResourceAttrSet(testResourceName, "locale_service_path"),
+					resource.TestCheckResourceAttr(testResourceName, "enable_hub", accTestPolicyL2VpnServiceCreateAttributes["enable_hub"]),
+					resource.TestCheckResourceAttr(testResourceName, "mode", accTestPolicyL2VpnServiceCreateAttributes["mode"]),
+					resource.TestCheckResourceAttr(testResourceName, "encap_ip_pool.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "encap_ip_pool.0", accTestPolicyL2VpnServiceCreateAttributes["encap_ip_pool"]),
+					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
+				),
+			},
+			{
+				Config: testAccNsxtPolicyL2VpnServiceTemplate(true, false, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicyL2VpnServiceExists(accTestPolicyL2VpnServiceCreateAttributes["display_name"], testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestPolicyL2VpnServiceCreateAttributes["display_name"]),
+					resource.TestCheckResourceAttr(testResourceName, "description", accTestPolicyL2VpnServiceCreateAttributes["description"]),
+					resource.TestCheckResourceAttrSet(testResourceName, "gateway_path"),
+					resource.TestCheckResourceAttr(testResourceName, "enable_hub", accTestPolicyL2VpnServiceCreateAttributes["enable_hub"]),
+					resource.TestCheckResourceAttr(testResourceName, "mode", accTestPolicyL2VpnServiceCreateAttributes["mode"]),
+					resource.TestCheckResourceAttr(testResourceName, "encap_ip_pool.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "encap_ip_pool.0", accTestPolicyL2VpnServiceCreateAttributes["encap_ip_pool"]),
+					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceNsxtPolicyL2VpnService_withGateway(t *testing.T) {
+	testResourceName := "nsxt_policy_l2_vpn_service.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t); testAccOnlyLocalManager(t); testAccNSXVersion(t, "3.2.0") },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyL2VpnServiceCheckDestroy(state, accTestPolicyL2VpnServiceUpdateAttributes["display_name"])
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyL2VpnServiceMinimalistic(true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicyL2VpnServiceExists(accTestPolicyL2VpnServiceCreateAttributes["display_name"], testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "description", ""),
+					resource.TestCheckResourceAttrSet(testResourceName, "gateway_path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+					resource.TestCheckResourceAttr(testResourceName, "tag.#", "0"),
+				),
+			},
+			{
+				Config: testAccNsxtPolicyL2VpnServiceTemplate(true, false, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicyL2VpnServiceExists(accTestPolicyL2VpnServiceCreateAttributes["display_name"], testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestPolicyL2VpnServiceCreateAttributes["display_name"]),
+					resource.TestCheckResourceAttr(testResourceName, "description", accTestPolicyL2VpnServiceCreateAttributes["description"]),
+					resource.TestCheckResourceAttrSet(testResourceName, "gateway_path"),
+					resource.TestCheckResourceAttr(testResourceName, "enable_hub", accTestPolicyL2VpnServiceCreateAttributes["enable_hub"]),
+					resource.TestCheckResourceAttr(testResourceName, "mode", accTestPolicyL2VpnServiceCreateAttributes["mode"]),
+					resource.TestCheckResourceAttr(testResourceName, "encap_ip_pool.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "encap_ip_pool.0", accTestPolicyL2VpnServiceCreateAttributes["encap_ip_pool"]),
+					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
+				),
+			},
+			{
+				Config: testAccNsxtPolicyL2VpnServiceTemplate(false, false, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicyL2VpnServiceExists(accTestPolicyL2VpnServiceUpdateAttributes["display_name"], testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestPolicyL2VpnServiceUpdateAttributes["display_name"]),
+					resource.TestCheckResourceAttr(testResourceName, "description", accTestPolicyL2VpnServiceUpdateAttributes["description"]),
+					resource.TestCheckResourceAttrSet(testResourceName, "gateway_path"),
+					resource.TestCheckResourceAttr(testResourceName, "enable_hub", accTestPolicyL2VpnServiceUpdateAttributes["enable_hub"]),
+					resource.TestCheckResourceAttr(testResourceName, "mode", accTestPolicyL2VpnServiceUpdateAttributes["mode"]),
+					resource.TestCheckResourceAttr(testResourceName, "encap_ip_pool.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "encap_ip_pool.0", accTestPolicyL2VpnServiceUpdateAttributes["encap_ip_pool"]),
+					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccResourceNsxtPolicyL2VpnService_ClientMode(t *testing.T) {
 	testResourceName := "nsxt_policy_l2_vpn_service.test"
 
@@ -109,7 +217,7 @@ func TestAccResourceNsxtPolicyL2VpnService_ClientMode(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNsxtPolicyL2VpnServiceTemplate(false, true),
+				Config: testAccNsxtPolicyL2VpnServiceTemplate(false, true, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNsxtPolicyL2VpnServiceExists(accTestPolicyL2VpnServiceCreateClientModeAttributes["display_name"], testResourceName),
 					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestPolicyL2VpnServiceCreateClientModeAttributes["display_name"]),
@@ -132,6 +240,37 @@ func TestAccResourceNsxtPolicyL2VpnService_ClientMode(t *testing.T) {
 	})
 }
 
+func TestAccResourceNsxtPolicyL2VpnService_ClientMode_withGateway(t *testing.T) {
+	testResourceName := "nsxt_policy_l2_vpn_service.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t); testAccOnlyLocalManager(t); testAccNSXVersion(t, "3.2.0") },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyL2VpnServiceCheckDestroy(state, accTestPolicyL2VpnServiceCreateClientModeAttributes["display_name"])
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyL2VpnServiceTemplate(false, true, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicyL2VpnServiceExists(accTestPolicyL2VpnServiceCreateClientModeAttributes["display_name"], testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestPolicyL2VpnServiceCreateClientModeAttributes["display_name"]),
+					resource.TestCheckResourceAttr(testResourceName, "description", accTestPolicyL2VpnServiceCreateClientModeAttributes["description"]),
+					resource.TestCheckResourceAttrSet(testResourceName, "gateway_path"),
+					resource.TestCheckResourceAttr(testResourceName, "enable_hub", accTestPolicyL2VpnServiceCreateClientModeAttributes["enable_hub"]),
+					resource.TestCheckResourceAttr(testResourceName, "mode", accTestPolicyL2VpnServiceCreateClientModeAttributes["mode"]),
+					resource.TestCheckResourceAttr(testResourceName, "encap_ip_pool.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "encap_ip_pool.0", accTestPolicyL2VpnServiceCreateClientModeAttributes["encap_ip_pool"]),
+					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccResourceNsxtPolicyL2VpnService_Import(t *testing.T) {
 	resourceName := "nsxt_policy_l2_vpn_service.test"
 
@@ -143,7 +282,7 @@ func TestAccResourceNsxtPolicyL2VpnService_Import(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNsxtPolicyL2VpnServiceTemplate(true, false),
+				Config: testAccNsxtPolicyL2VpnServiceTemplate(true, false, false),
 			},
 			{
 				ResourceName:      resourceName,
@@ -166,7 +305,14 @@ func testAccNsxtPolicyL2VpnServiceImporterGetID(s *terraform.State) (string, err
 		return "", fmt.Errorf("Policy L2VpnService resource ID not set in resources")
 	}
 	localeServicePath := rs.Primary.Attributes["locale_service_path"]
-	return fmt.Sprintf("%s/l2vpn-services/%s", localeServicePath, resourceID), nil
+	gatewayPath := rs.Primary.Attributes["gateway_path"]
+	if gatewayPath == "" && localeServicePath == "" {
+		return "", fmt.Errorf("At least one of gateway path and locale service path should be provided for VPN resources")
+	}
+	if localeServicePath != "" {
+		return fmt.Sprintf("%s/l2vpn-services/%s", localeServicePath, resourceID), nil
+	}
+	return fmt.Sprintf("%s/l2vpn-services/%s", gatewayPath, resourceID), nil
 }
 
 func testAccNsxtPolicyL2VpnServiceExists(displayName string, resourceName string) resource.TestCheckFunc {
@@ -185,10 +331,16 @@ func testAccNsxtPolicyL2VpnServiceExists(displayName string, resourceName string
 		}
 
 		localeServicePath := rs.Primary.Attributes["locale_service_path"]
+		gatewayPath := rs.Primary.Attributes["gateway_path"]
+		if gatewayPath == "" && localeServicePath == "" {
+			return fmt.Errorf("At least one of gateway path and locale service path should be provided for VPN resources")
+		}
 		isT0, gwID, localeServiceID, err := parseLocaleServicePolicyPath(localeServicePath)
-
-		if err != nil {
-			return nil
+		if localeServiceID == "" {
+			isT0, gwID = parseGatewayPolicyPath(gatewayPath)
+		}
+		if err != nil && gatewayPath == "" {
+			return fmt.Errorf("Invalid locale service path %s", localeServicePath)
 		}
 		_, err1 := getNsxtPolicyL2VpnServiceByID(connector, gwID, isT0, localeServiceID, resourceID, testAccIsGlobalManager())
 		if err1 != nil {
@@ -209,9 +361,12 @@ func testAccNsxtPolicyL2VpnServiceCheckDestroy(state *terraform.State, displayNa
 
 		resourceID := rs.Primary.Attributes["id"]
 		localeServicePath := rs.Primary.Attributes["locale_service_path"]
+		gatewayPath := rs.Primary.Attributes["gateway_path"]
 		isT0, gwID, localeServiceID, err := parseLocaleServicePolicyPath(localeServicePath)
-
-		if err != nil {
+		if localeServiceID == "" {
+			isT0, gwID = parseGatewayPolicyPath(gatewayPath)
+		}
+		if err != nil && gatewayPath == "" {
 			return nil
 		}
 
@@ -223,7 +378,7 @@ func testAccNsxtPolicyL2VpnServiceCheckDestroy(state *terraform.State, displayNa
 	return nil
 }
 
-func testAccNsxtPolicyL2VpnServiceTemplate(createFlow bool, clientMode bool) string {
+func testAccNsxtPolicyL2VpnServiceTemplate(createFlow bool, clientMode bool, useGatewayPath bool) string {
 	var attrMap map[string]string
 	if clientMode {
 		attrMap = accTestPolicyL2VpnServiceCreateClientModeAttributes
@@ -234,25 +389,27 @@ func testAccNsxtPolicyL2VpnServiceTemplate(createFlow bool, clientMode bool) str
 			attrMap = accTestPolicyL2VpnServiceUpdateAttributes
 		}
 	}
+	gatewayOrLocaleServicePath := getGatewayOrLocaleServicePath(useGatewayPath, true)
 	return testAccNsxtPolicyTier0WithEdgeClusterForVPN() + fmt.Sprintf(`
 	  resource "nsxt_policy_l2_vpn_service" "test" {
-		display_name         = "%s"
-		description          = "%s"
-		locale_service_path  = one(nsxt_policy_tier0_gateway.test.locale_service).path
-		enable_hub           = "%s"
-		mode                 = "%s"
-		encap_ip_pool 	     = ["%s"]
+		display_name                   = "%s"
+		description                    = "%s"
+		%s
+		enable_hub                     = "%s"
+		mode               			   = "%s"
+		encap_ip_pool 				   = ["%s"]
 		tag {
 		  scope = "scope1"
 		  tag   = "tag1"
 		}
-	  }`, attrMap["display_name"], attrMap["description"], attrMap["enable_hub"], attrMap["mode"], attrMap["encap_ip_pool"])
+	  }`, attrMap["display_name"], attrMap["description"], gatewayOrLocaleServicePath, attrMap["enable_hub"], attrMap["mode"], attrMap["encap_ip_pool"])
 }
 
-func testAccNsxtPolicyL2VpnServiceMinimalistic() string {
+func testAccNsxtPolicyL2VpnServiceMinimalistic(useGatewayPath bool) string {
+	gatewayOrLocaleServicePath := getGatewayOrLocaleServicePath(useGatewayPath, true)
 	return testAccNsxtPolicyTier0WithEdgeClusterForVPN() + fmt.Sprintf(`
 	  resource "nsxt_policy_l2_vpn_service" "test" {
 		display_name          = "%s"
-		locale_service_path   = one(nsxt_policy_tier0_gateway.test.locale_service).path
-	  }`, accTestPolicyL2VpnServiceUpdateAttributes["display_name"])
+		%s
+	  }`, accTestPolicyL2VpnServiceUpdateAttributes["display_name"], gatewayOrLocaleServicePath)
 }

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_0s/l2vpn_services/L2vpnServicesPackageTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_0s/l2vpn_services/L2vpnServicesPackageTypes.go
@@ -1,0 +1,11 @@
+// Copyright © 2019-2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+
+// Auto generated code. DO NOT EDIT.
+
+// Data type definitions file for package: com.vmware.nsx_policy.infra.tier_0s.l2vpn_services.
+// Includes binding types of a top level structures and enumerations.
+// Shared by client-side stubs and server-side skeletons to ensure type
+// compatibility.
+
+package l2vpn_services

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_0s/l2vpn_services/SessionsClient.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_0s/l2vpn_services/SessionsClient.go
@@ -1,0 +1,335 @@
+// Copyright © 2019-2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+
+// Auto generated code. DO NOT EDIT.
+
+// Interface file for service: Sessions
+// Used by client-side stubs.
+
+package l2vpn_services
+
+import (
+	vapiStdErrors_ "github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
+	vapiBindings_ "github.com/vmware/vsphere-automation-sdk-go/runtime/bindings"
+	vapiCore_ "github.com/vmware/vsphere-automation-sdk-go/runtime/core"
+	vapiProtocolClient_ "github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
+	nsx_policyModel "github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+)
+
+const _ = vapiCore_.SupportedByRuntimeVersion2
+
+type SessionsClient interface {
+
+	// Create or patch an L2VPN session under Tier-0 from Peer Codes. In addition to the L2VPN Session, the IPSec VPN Session, along with the IKE, Tunnel, and DPD Profiles are created and owned by the system. IPSec VPN Service and Local Endpoint are created only when required, i.e., an IPSec VPN Service does not already exist, or an IPSec VPN Local Endpoint with same local address does not already exist. Updating the L2VPN Session can be performed only through this API by specifying new peer codes. Use of specific APIs to update the L2VPN Session and the different resources associated with it is not allowed, except for IPSec VPN Service and Local Endpoint, resources that are not system owned. API supported only when L2VPN Service is in Client Mode.
+	//
+	// @param tier0IdParam (required)
+	// @param serviceIdParam (required)
+	// @param sessionIdParam (required)
+	// @param l2VPNSessionDataParam (required)
+	//
+	// @throws InvalidRequest  Bad Request, Precondition Failed
+	// @throws Unauthorized  Forbidden
+	// @throws ServiceUnavailable  Service Unavailable
+	// @throws InternalServerError  Internal Server Error
+	// @throws NotFound  Not Found
+	Createwithpeercode(tier0IdParam string, serviceIdParam string, sessionIdParam string, l2VPNSessionDataParam nsx_policyModel.L2VPNSessionData) error
+
+	// Delete L2VPN session under Tier-0. When L2VPN Service is in CLIENT Mode, the L2VPN Session is deleted along with its transpot tunnels and related resources.
+	//
+	// @param tier0IdParam (required)
+	// @param serviceIdParam (required)
+	// @param sessionIdParam (required)
+	//
+	// @throws InvalidRequest  Bad Request, Precondition Failed
+	// @throws Unauthorized  Forbidden
+	// @throws ServiceUnavailable  Service Unavailable
+	// @throws InternalServerError  Internal Server Error
+	// @throws NotFound  Not Found
+	Delete(tier0IdParam string, serviceIdParam string, sessionIdParam string) error
+
+	// Get L2VPN session under Tier-0.
+	//
+	// @param tier0IdParam (required)
+	// @param serviceIdParam (required)
+	// @param sessionIdParam (required)
+	// @return com.vmware.nsx_policy.model.L2VPNSession
+	//
+	// @throws InvalidRequest  Bad Request, Precondition Failed
+	// @throws Unauthorized  Forbidden
+	// @throws ServiceUnavailable  Service Unavailable
+	// @throws InternalServerError  Internal Server Error
+	// @throws NotFound  Not Found
+	Get(tier0IdParam string, serviceIdParam string, sessionIdParam string) (nsx_policyModel.L2VPNSession, error)
+
+	// Get paginated list of all L2VPN sessions under Tier-0.
+	//
+	// @param tier0IdParam (required)
+	// @param serviceIdParam (required)
+	// @param cursorParam Opaque cursor to be used for getting next page of records (supplied by current result page) (optional)
+	// @param includeMarkForDeleteObjectsParam Include objects that are marked for deletion in results (optional, default to false)
+	// @param includedFieldsParam Comma separated list of fields that should be included in query result (optional)
+	// @param pageSizeParam Maximum number of results to return in this page (server may return fewer) (optional, default to 1000)
+	// @param sortAscendingParam (optional)
+	// @param sortByParam Field by which records are sorted (optional)
+	// @return com.vmware.nsx_policy.model.L2VPNSessionListResult
+	//
+	// @throws InvalidRequest  Bad Request, Precondition Failed
+	// @throws Unauthorized  Forbidden
+	// @throws ServiceUnavailable  Service Unavailable
+	// @throws InternalServerError  Internal Server Error
+	// @throws NotFound  Not Found
+	List(tier0IdParam string, serviceIdParam string, cursorParam *string, includeMarkForDeleteObjectsParam *bool, includedFieldsParam *string, pageSizeParam *int64, sortAscendingParam *bool, sortByParam *string) (nsx_policyModel.L2VPNSessionListResult, error)
+
+	// Create or patch an L2VPN session under Tier-0. API supported only when L2VPN Service is in Server Mode.
+	//
+	// @param tier0IdParam (required)
+	// @param serviceIdParam (required)
+	// @param sessionIdParam (required)
+	// @param l2VPNSessionParam (required)
+	//
+	// @throws InvalidRequest  Bad Request, Precondition Failed
+	// @throws Unauthorized  Forbidden
+	// @throws ServiceUnavailable  Service Unavailable
+	// @throws InternalServerError  Internal Server Error
+	// @throws NotFound  Not Found
+	Patch(tier0IdParam string, serviceIdParam string, sessionIdParam string, l2VPNSessionParam nsx_policyModel.L2VPNSession) error
+
+	// Create or fully replace L2VPN session under Tier-0. API supported only when L2VPN Service is in Server Mode. Revision is optional for creation and required for update.
+	//
+	// @param tier0IdParam (required)
+	// @param serviceIdParam (required)
+	// @param sessionIdParam (required)
+	// @param l2VPNSessionParam (required)
+	// @return com.vmware.nsx_policy.model.L2VPNSession
+	//
+	// @throws InvalidRequest  Bad Request, Precondition Failed
+	// @throws Unauthorized  Forbidden
+	// @throws ServiceUnavailable  Service Unavailable
+	// @throws InternalServerError  Internal Server Error
+	// @throws NotFound  Not Found
+	Update(tier0IdParam string, serviceIdParam string, sessionIdParam string, l2VPNSessionParam nsx_policyModel.L2VPNSession) (nsx_policyModel.L2VPNSession, error)
+}
+
+type sessionsClient struct {
+	connector           vapiProtocolClient_.Connector
+	interfaceDefinition vapiCore_.InterfaceDefinition
+	errorsBindingMap    map[string]vapiBindings_.BindingType
+}
+
+func NewSessionsClient(connector vapiProtocolClient_.Connector) *sessionsClient {
+	interfaceIdentifier := vapiCore_.NewInterfaceIdentifier("com.vmware.nsx_policy.infra.tier_0s.l2vpn_services.sessions")
+	methodIdentifiers := map[string]vapiCore_.MethodIdentifier{
+		"createwithpeercode": vapiCore_.NewMethodIdentifier(interfaceIdentifier, "createwithpeercode"),
+		"delete":             vapiCore_.NewMethodIdentifier(interfaceIdentifier, "delete"),
+		"get":                vapiCore_.NewMethodIdentifier(interfaceIdentifier, "get"),
+		"list":               vapiCore_.NewMethodIdentifier(interfaceIdentifier, "list"),
+		"patch":              vapiCore_.NewMethodIdentifier(interfaceIdentifier, "patch"),
+		"update":             vapiCore_.NewMethodIdentifier(interfaceIdentifier, "update"),
+	}
+	interfaceDefinition := vapiCore_.NewInterfaceDefinition(interfaceIdentifier, methodIdentifiers)
+	errorsBindingMap := make(map[string]vapiBindings_.BindingType)
+
+	sIface := sessionsClient{interfaceDefinition: interfaceDefinition, errorsBindingMap: errorsBindingMap, connector: connector}
+	return &sIface
+}
+
+func (sIface *sessionsClient) GetErrorBindingType(errorName string) vapiBindings_.BindingType {
+	if entry, ok := sIface.errorsBindingMap[errorName]; ok {
+		return entry
+	}
+	return vapiStdErrors_.ERROR_BINDINGS_MAP[errorName]
+}
+
+func (sIface *sessionsClient) Createwithpeercode(tier0IdParam string, serviceIdParam string, sessionIdParam string, l2VPNSessionDataParam nsx_policyModel.L2VPNSessionData) error {
+	typeConverter := sIface.connector.TypeConverter()
+	executionContext := sIface.connector.NewExecutionContext()
+	operationRestMetaData := sessionsCreatewithpeercodeRestMetadata()
+	executionContext.SetConnectionMetadata(vapiCore_.RESTMetadataKey, operationRestMetaData)
+	executionContext.SetConnectionMetadata(vapiCore_.ResponseTypeKey, vapiCore_.NewResponseType(true, false))
+
+	sv := vapiBindings_.NewStructValueBuilder(sessionsCreatewithpeercodeInputType(), typeConverter)
+	sv.AddStructField("Tier0Id", tier0IdParam)
+	sv.AddStructField("ServiceId", serviceIdParam)
+	sv.AddStructField("SessionId", sessionIdParam)
+	sv.AddStructField("L2VPNSessionData", l2VPNSessionDataParam)
+	inputDataValue, inputError := sv.GetStructValue()
+	if inputError != nil {
+		return vapiBindings_.VAPIerrorsToError(inputError)
+	}
+
+	methodResult := sIface.connector.GetApiProvider().Invoke("com.vmware.nsx_policy.infra.tier_0s.l2vpn_services.sessions", "createwithpeercode", inputDataValue, executionContext)
+	if methodResult.IsSuccess() {
+		return nil
+	} else {
+		methodError, errorInError := typeConverter.ConvertToGolang(methodResult.Error(), sIface.GetErrorBindingType(methodResult.Error().Name()))
+		if errorInError != nil {
+			return vapiBindings_.VAPIerrorsToError(errorInError)
+		}
+		return methodError.(error)
+	}
+}
+
+func (sIface *sessionsClient) Delete(tier0IdParam string, serviceIdParam string, sessionIdParam string) error {
+	typeConverter := sIface.connector.TypeConverter()
+	executionContext := sIface.connector.NewExecutionContext()
+	operationRestMetaData := sessionsDeleteRestMetadata()
+	executionContext.SetConnectionMetadata(vapiCore_.RESTMetadataKey, operationRestMetaData)
+	executionContext.SetConnectionMetadata(vapiCore_.ResponseTypeKey, vapiCore_.NewResponseType(true, false))
+
+	sv := vapiBindings_.NewStructValueBuilder(sessionsDeleteInputType(), typeConverter)
+	sv.AddStructField("Tier0Id", tier0IdParam)
+	sv.AddStructField("ServiceId", serviceIdParam)
+	sv.AddStructField("SessionId", sessionIdParam)
+	inputDataValue, inputError := sv.GetStructValue()
+	if inputError != nil {
+		return vapiBindings_.VAPIerrorsToError(inputError)
+	}
+
+	methodResult := sIface.connector.GetApiProvider().Invoke("com.vmware.nsx_policy.infra.tier_0s.l2vpn_services.sessions", "delete", inputDataValue, executionContext)
+	if methodResult.IsSuccess() {
+		return nil
+	} else {
+		methodError, errorInError := typeConverter.ConvertToGolang(methodResult.Error(), sIface.GetErrorBindingType(methodResult.Error().Name()))
+		if errorInError != nil {
+			return vapiBindings_.VAPIerrorsToError(errorInError)
+		}
+		return methodError.(error)
+	}
+}
+
+func (sIface *sessionsClient) Get(tier0IdParam string, serviceIdParam string, sessionIdParam string) (nsx_policyModel.L2VPNSession, error) {
+	typeConverter := sIface.connector.TypeConverter()
+	executionContext := sIface.connector.NewExecutionContext()
+	operationRestMetaData := sessionsGetRestMetadata()
+	executionContext.SetConnectionMetadata(vapiCore_.RESTMetadataKey, operationRestMetaData)
+	executionContext.SetConnectionMetadata(vapiCore_.ResponseTypeKey, vapiCore_.NewResponseType(true, false))
+
+	sv := vapiBindings_.NewStructValueBuilder(sessionsGetInputType(), typeConverter)
+	sv.AddStructField("Tier0Id", tier0IdParam)
+	sv.AddStructField("ServiceId", serviceIdParam)
+	sv.AddStructField("SessionId", sessionIdParam)
+	inputDataValue, inputError := sv.GetStructValue()
+	if inputError != nil {
+		var emptyOutput nsx_policyModel.L2VPNSession
+		return emptyOutput, vapiBindings_.VAPIerrorsToError(inputError)
+	}
+
+	methodResult := sIface.connector.GetApiProvider().Invoke("com.vmware.nsx_policy.infra.tier_0s.l2vpn_services.sessions", "get", inputDataValue, executionContext)
+	var emptyOutput nsx_policyModel.L2VPNSession
+	if methodResult.IsSuccess() {
+		output, errorInOutput := typeConverter.ConvertToGolang(methodResult.Output(), SessionsGetOutputType())
+		if errorInOutput != nil {
+			return emptyOutput, vapiBindings_.VAPIerrorsToError(errorInOutput)
+		}
+		return output.(nsx_policyModel.L2VPNSession), nil
+	} else {
+		methodError, errorInError := typeConverter.ConvertToGolang(methodResult.Error(), sIface.GetErrorBindingType(methodResult.Error().Name()))
+		if errorInError != nil {
+			return emptyOutput, vapiBindings_.VAPIerrorsToError(errorInError)
+		}
+		return emptyOutput, methodError.(error)
+	}
+}
+
+func (sIface *sessionsClient) List(tier0IdParam string, serviceIdParam string, cursorParam *string, includeMarkForDeleteObjectsParam *bool, includedFieldsParam *string, pageSizeParam *int64, sortAscendingParam *bool, sortByParam *string) (nsx_policyModel.L2VPNSessionListResult, error) {
+	typeConverter := sIface.connector.TypeConverter()
+	executionContext := sIface.connector.NewExecutionContext()
+	operationRestMetaData := sessionsListRestMetadata()
+	executionContext.SetConnectionMetadata(vapiCore_.RESTMetadataKey, operationRestMetaData)
+	executionContext.SetConnectionMetadata(vapiCore_.ResponseTypeKey, vapiCore_.NewResponseType(true, false))
+
+	sv := vapiBindings_.NewStructValueBuilder(sessionsListInputType(), typeConverter)
+	sv.AddStructField("Tier0Id", tier0IdParam)
+	sv.AddStructField("ServiceId", serviceIdParam)
+	sv.AddStructField("Cursor", cursorParam)
+	sv.AddStructField("IncludeMarkForDeleteObjects", includeMarkForDeleteObjectsParam)
+	sv.AddStructField("IncludedFields", includedFieldsParam)
+	sv.AddStructField("PageSize", pageSizeParam)
+	sv.AddStructField("SortAscending", sortAscendingParam)
+	sv.AddStructField("SortBy", sortByParam)
+	inputDataValue, inputError := sv.GetStructValue()
+	if inputError != nil {
+		var emptyOutput nsx_policyModel.L2VPNSessionListResult
+		return emptyOutput, vapiBindings_.VAPIerrorsToError(inputError)
+	}
+
+	methodResult := sIface.connector.GetApiProvider().Invoke("com.vmware.nsx_policy.infra.tier_0s.l2vpn_services.sessions", "list", inputDataValue, executionContext)
+	var emptyOutput nsx_policyModel.L2VPNSessionListResult
+	if methodResult.IsSuccess() {
+		output, errorInOutput := typeConverter.ConvertToGolang(methodResult.Output(), SessionsListOutputType())
+		if errorInOutput != nil {
+			return emptyOutput, vapiBindings_.VAPIerrorsToError(errorInOutput)
+		}
+		return output.(nsx_policyModel.L2VPNSessionListResult), nil
+	} else {
+		methodError, errorInError := typeConverter.ConvertToGolang(methodResult.Error(), sIface.GetErrorBindingType(methodResult.Error().Name()))
+		if errorInError != nil {
+			return emptyOutput, vapiBindings_.VAPIerrorsToError(errorInError)
+		}
+		return emptyOutput, methodError.(error)
+	}
+}
+
+func (sIface *sessionsClient) Patch(tier0IdParam string, serviceIdParam string, sessionIdParam string, l2VPNSessionParam nsx_policyModel.L2VPNSession) error {
+	typeConverter := sIface.connector.TypeConverter()
+	executionContext := sIface.connector.NewExecutionContext()
+	operationRestMetaData := sessionsPatchRestMetadata()
+	executionContext.SetConnectionMetadata(vapiCore_.RESTMetadataKey, operationRestMetaData)
+	executionContext.SetConnectionMetadata(vapiCore_.ResponseTypeKey, vapiCore_.NewResponseType(true, false))
+
+	sv := vapiBindings_.NewStructValueBuilder(sessionsPatchInputType(), typeConverter)
+	sv.AddStructField("Tier0Id", tier0IdParam)
+	sv.AddStructField("ServiceId", serviceIdParam)
+	sv.AddStructField("SessionId", sessionIdParam)
+	sv.AddStructField("L2VPNSession", l2VPNSessionParam)
+	inputDataValue, inputError := sv.GetStructValue()
+	if inputError != nil {
+		return vapiBindings_.VAPIerrorsToError(inputError)
+	}
+
+	methodResult := sIface.connector.GetApiProvider().Invoke("com.vmware.nsx_policy.infra.tier_0s.l2vpn_services.sessions", "patch", inputDataValue, executionContext)
+	if methodResult.IsSuccess() {
+		return nil
+	} else {
+		methodError, errorInError := typeConverter.ConvertToGolang(methodResult.Error(), sIface.GetErrorBindingType(methodResult.Error().Name()))
+		if errorInError != nil {
+			return vapiBindings_.VAPIerrorsToError(errorInError)
+		}
+		return methodError.(error)
+	}
+}
+
+func (sIface *sessionsClient) Update(tier0IdParam string, serviceIdParam string, sessionIdParam string, l2VPNSessionParam nsx_policyModel.L2VPNSession) (nsx_policyModel.L2VPNSession, error) {
+	typeConverter := sIface.connector.TypeConverter()
+	executionContext := sIface.connector.NewExecutionContext()
+	operationRestMetaData := sessionsUpdateRestMetadata()
+	executionContext.SetConnectionMetadata(vapiCore_.RESTMetadataKey, operationRestMetaData)
+	executionContext.SetConnectionMetadata(vapiCore_.ResponseTypeKey, vapiCore_.NewResponseType(true, false))
+
+	sv := vapiBindings_.NewStructValueBuilder(sessionsUpdateInputType(), typeConverter)
+	sv.AddStructField("Tier0Id", tier0IdParam)
+	sv.AddStructField("ServiceId", serviceIdParam)
+	sv.AddStructField("SessionId", sessionIdParam)
+	sv.AddStructField("L2VPNSession", l2VPNSessionParam)
+	inputDataValue, inputError := sv.GetStructValue()
+	if inputError != nil {
+		var emptyOutput nsx_policyModel.L2VPNSession
+		return emptyOutput, vapiBindings_.VAPIerrorsToError(inputError)
+	}
+
+	methodResult := sIface.connector.GetApiProvider().Invoke("com.vmware.nsx_policy.infra.tier_0s.l2vpn_services.sessions", "update", inputDataValue, executionContext)
+	var emptyOutput nsx_policyModel.L2VPNSession
+	if methodResult.IsSuccess() {
+		output, errorInOutput := typeConverter.ConvertToGolang(methodResult.Output(), SessionsUpdateOutputType())
+		if errorInOutput != nil {
+			return emptyOutput, vapiBindings_.VAPIerrorsToError(errorInOutput)
+		}
+		return output.(nsx_policyModel.L2VPNSession), nil
+	} else {
+		methodError, errorInError := typeConverter.ConvertToGolang(methodResult.Error(), sIface.GetErrorBindingType(methodResult.Error().Name()))
+		if errorInError != nil {
+			return emptyOutput, vapiBindings_.VAPIerrorsToError(errorInError)
+		}
+		return emptyOutput, methodError.(error)
+	}
+}

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_0s/l2vpn_services/SessionsTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_0s/l2vpn_services/SessionsTypes.go
@@ -1,0 +1,447 @@
+// Copyright © 2019-2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+
+// Auto generated code. DO NOT EDIT.
+
+// Data type definitions file for service: Sessions.
+// Includes binding types of a structures and enumerations defined in the service.
+// Shared by client-side stubs and server-side skeletons to ensure type
+// compatibility.
+
+package l2vpn_services
+
+import (
+	vapiBindings_ "github.com/vmware/vsphere-automation-sdk-go/runtime/bindings"
+	vapiData_ "github.com/vmware/vsphere-automation-sdk-go/runtime/data"
+	vapiProtocol_ "github.com/vmware/vsphere-automation-sdk-go/runtime/protocol"
+	nsx_policyModel "github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+	"reflect"
+)
+
+func sessionsCreatewithpeercodeInputType() vapiBindings_.StructType {
+	fields := make(map[string]vapiBindings_.BindingType)
+	fieldNameMap := make(map[string]string)
+	fields["tier0_id"] = vapiBindings_.NewStringType()
+	fields["service_id"] = vapiBindings_.NewStringType()
+	fields["session_id"] = vapiBindings_.NewStringType()
+	fields["l2_VPN_session_data"] = vapiBindings_.NewReferenceType(nsx_policyModel.L2VPNSessionDataBindingType)
+	fieldNameMap["tier0_id"] = "Tier0Id"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["session_id"] = "SessionId"
+	fieldNameMap["l2_VPN_session_data"] = "L2VPNSessionData"
+	var validators = []vapiBindings_.Validator{}
+	return vapiBindings_.NewStructType("operation-input", fields, reflect.TypeOf(vapiData_.StructValue{}), fieldNameMap, validators)
+}
+
+func SessionsCreatewithpeercodeOutputType() vapiBindings_.BindingType {
+	return vapiBindings_.NewVoidType()
+}
+
+func sessionsCreatewithpeercodeRestMetadata() vapiProtocol_.OperationRestMetadata {
+	fields := map[string]vapiBindings_.BindingType{}
+	fieldNameMap := map[string]string{}
+	paramsTypeMap := map[string]vapiBindings_.BindingType{}
+	pathParams := map[string]string{}
+	queryParams := map[string]string{}
+	headerParams := map[string]string{}
+	dispatchHeaderParams := map[string]string{}
+	bodyFieldsMap := map[string]string{}
+	fields["tier0_id"] = vapiBindings_.NewStringType()
+	fields["service_id"] = vapiBindings_.NewStringType()
+	fields["session_id"] = vapiBindings_.NewStringType()
+	fields["l2_VPN_session_data"] = vapiBindings_.NewReferenceType(nsx_policyModel.L2VPNSessionDataBindingType)
+	fieldNameMap["tier0_id"] = "Tier0Id"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["session_id"] = "SessionId"
+	fieldNameMap["l2_VPN_session_data"] = "L2VPNSessionData"
+	paramsTypeMap["tier0_id"] = vapiBindings_.NewStringType()
+	paramsTypeMap["service_id"] = vapiBindings_.NewStringType()
+	paramsTypeMap["session_id"] = vapiBindings_.NewStringType()
+	paramsTypeMap["l2_VPN_session_data"] = vapiBindings_.NewReferenceType(nsx_policyModel.L2VPNSessionDataBindingType)
+	paramsTypeMap["tier0Id"] = vapiBindings_.NewStringType()
+	paramsTypeMap["serviceId"] = vapiBindings_.NewStringType()
+	paramsTypeMap["sessionId"] = vapiBindings_.NewStringType()
+	pathParams["tier0_id"] = "tier0Id"
+	pathParams["session_id"] = "sessionId"
+	pathParams["service_id"] = "serviceId"
+	resultHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
+	return vapiProtocol_.NewOperationRestMetadata(
+		fields,
+		fieldNameMap,
+		paramsTypeMap,
+		pathParams,
+		queryParams,
+		headerParams,
+		dispatchHeaderParams,
+		bodyFieldsMap,
+		"action=create_with_peer_code",
+		"l2_VPN_session_data",
+		"POST",
+		"/policy/api/v1/infra/tier-0s/{tier0Id}/l2vpn-services/{serviceId}/sessions/{sessionId}",
+		"",
+		resultHeaders,
+		204,
+		"",
+		errorHeaders,
+		map[string]int{"com.vmware.vapi.std.errors.invalid_request": 400, "com.vmware.vapi.std.errors.unauthorized": 403, "com.vmware.vapi.std.errors.service_unavailable": 503, "com.vmware.vapi.std.errors.internal_server_error": 500, "com.vmware.vapi.std.errors.not_found": 404})
+}
+
+func sessionsDeleteInputType() vapiBindings_.StructType {
+	fields := make(map[string]vapiBindings_.BindingType)
+	fieldNameMap := make(map[string]string)
+	fields["tier0_id"] = vapiBindings_.NewStringType()
+	fields["service_id"] = vapiBindings_.NewStringType()
+	fields["session_id"] = vapiBindings_.NewStringType()
+	fieldNameMap["tier0_id"] = "Tier0Id"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["session_id"] = "SessionId"
+	var validators = []vapiBindings_.Validator{}
+	return vapiBindings_.NewStructType("operation-input", fields, reflect.TypeOf(vapiData_.StructValue{}), fieldNameMap, validators)
+}
+
+func SessionsDeleteOutputType() vapiBindings_.BindingType {
+	return vapiBindings_.NewVoidType()
+}
+
+func sessionsDeleteRestMetadata() vapiProtocol_.OperationRestMetadata {
+	fields := map[string]vapiBindings_.BindingType{}
+	fieldNameMap := map[string]string{}
+	paramsTypeMap := map[string]vapiBindings_.BindingType{}
+	pathParams := map[string]string{}
+	queryParams := map[string]string{}
+	headerParams := map[string]string{}
+	dispatchHeaderParams := map[string]string{}
+	bodyFieldsMap := map[string]string{}
+	fields["tier0_id"] = vapiBindings_.NewStringType()
+	fields["service_id"] = vapiBindings_.NewStringType()
+	fields["session_id"] = vapiBindings_.NewStringType()
+	fieldNameMap["tier0_id"] = "Tier0Id"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["session_id"] = "SessionId"
+	paramsTypeMap["tier0_id"] = vapiBindings_.NewStringType()
+	paramsTypeMap["service_id"] = vapiBindings_.NewStringType()
+	paramsTypeMap["session_id"] = vapiBindings_.NewStringType()
+	paramsTypeMap["tier0Id"] = vapiBindings_.NewStringType()
+	paramsTypeMap["serviceId"] = vapiBindings_.NewStringType()
+	paramsTypeMap["sessionId"] = vapiBindings_.NewStringType()
+	pathParams["tier0_id"] = "tier0Id"
+	pathParams["session_id"] = "sessionId"
+	pathParams["service_id"] = "serviceId"
+	resultHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
+	return vapiProtocol_.NewOperationRestMetadata(
+		fields,
+		fieldNameMap,
+		paramsTypeMap,
+		pathParams,
+		queryParams,
+		headerParams,
+		dispatchHeaderParams,
+		bodyFieldsMap,
+		"",
+		"",
+		"DELETE",
+		"/policy/api/v1/infra/tier-0s/{tier0Id}/l2vpn-services/{serviceId}/sessions/{sessionId}",
+		"",
+		resultHeaders,
+		204,
+		"",
+		errorHeaders,
+		map[string]int{"com.vmware.vapi.std.errors.invalid_request": 400, "com.vmware.vapi.std.errors.unauthorized": 403, "com.vmware.vapi.std.errors.service_unavailable": 503, "com.vmware.vapi.std.errors.internal_server_error": 500, "com.vmware.vapi.std.errors.not_found": 404})
+}
+
+func sessionsGetInputType() vapiBindings_.StructType {
+	fields := make(map[string]vapiBindings_.BindingType)
+	fieldNameMap := make(map[string]string)
+	fields["tier0_id"] = vapiBindings_.NewStringType()
+	fields["service_id"] = vapiBindings_.NewStringType()
+	fields["session_id"] = vapiBindings_.NewStringType()
+	fieldNameMap["tier0_id"] = "Tier0Id"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["session_id"] = "SessionId"
+	var validators = []vapiBindings_.Validator{}
+	return vapiBindings_.NewStructType("operation-input", fields, reflect.TypeOf(vapiData_.StructValue{}), fieldNameMap, validators)
+}
+
+func SessionsGetOutputType() vapiBindings_.BindingType {
+	return vapiBindings_.NewReferenceType(nsx_policyModel.L2VPNSessionBindingType)
+}
+
+func sessionsGetRestMetadata() vapiProtocol_.OperationRestMetadata {
+	fields := map[string]vapiBindings_.BindingType{}
+	fieldNameMap := map[string]string{}
+	paramsTypeMap := map[string]vapiBindings_.BindingType{}
+	pathParams := map[string]string{}
+	queryParams := map[string]string{}
+	headerParams := map[string]string{}
+	dispatchHeaderParams := map[string]string{}
+	bodyFieldsMap := map[string]string{}
+	fields["tier0_id"] = vapiBindings_.NewStringType()
+	fields["service_id"] = vapiBindings_.NewStringType()
+	fields["session_id"] = vapiBindings_.NewStringType()
+	fieldNameMap["tier0_id"] = "Tier0Id"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["session_id"] = "SessionId"
+	paramsTypeMap["tier0_id"] = vapiBindings_.NewStringType()
+	paramsTypeMap["service_id"] = vapiBindings_.NewStringType()
+	paramsTypeMap["session_id"] = vapiBindings_.NewStringType()
+	paramsTypeMap["tier0Id"] = vapiBindings_.NewStringType()
+	paramsTypeMap["serviceId"] = vapiBindings_.NewStringType()
+	paramsTypeMap["sessionId"] = vapiBindings_.NewStringType()
+	pathParams["tier0_id"] = "tier0Id"
+	pathParams["session_id"] = "sessionId"
+	pathParams["service_id"] = "serviceId"
+	resultHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
+	return vapiProtocol_.NewOperationRestMetadata(
+		fields,
+		fieldNameMap,
+		paramsTypeMap,
+		pathParams,
+		queryParams,
+		headerParams,
+		dispatchHeaderParams,
+		bodyFieldsMap,
+		"",
+		"",
+		"GET",
+		"/policy/api/v1/infra/tier-0s/{tier0Id}/l2vpn-services/{serviceId}/sessions/{sessionId}",
+		"",
+		resultHeaders,
+		200,
+		"",
+		errorHeaders,
+		map[string]int{"com.vmware.vapi.std.errors.invalid_request": 400, "com.vmware.vapi.std.errors.unauthorized": 403, "com.vmware.vapi.std.errors.service_unavailable": 503, "com.vmware.vapi.std.errors.internal_server_error": 500, "com.vmware.vapi.std.errors.not_found": 404})
+}
+
+func sessionsListInputType() vapiBindings_.StructType {
+	fields := make(map[string]vapiBindings_.BindingType)
+	fieldNameMap := make(map[string]string)
+	fields["tier0_id"] = vapiBindings_.NewStringType()
+	fields["service_id"] = vapiBindings_.NewStringType()
+	fields["cursor"] = vapiBindings_.NewOptionalType(vapiBindings_.NewStringType())
+	fields["include_mark_for_delete_objects"] = vapiBindings_.NewOptionalType(vapiBindings_.NewBooleanType())
+	fields["included_fields"] = vapiBindings_.NewOptionalType(vapiBindings_.NewStringType())
+	fields["page_size"] = vapiBindings_.NewOptionalType(vapiBindings_.NewIntegerType())
+	fields["sort_ascending"] = vapiBindings_.NewOptionalType(vapiBindings_.NewBooleanType())
+	fields["sort_by"] = vapiBindings_.NewOptionalType(vapiBindings_.NewStringType())
+	fieldNameMap["tier0_id"] = "Tier0Id"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["cursor"] = "Cursor"
+	fieldNameMap["include_mark_for_delete_objects"] = "IncludeMarkForDeleteObjects"
+	fieldNameMap["included_fields"] = "IncludedFields"
+	fieldNameMap["page_size"] = "PageSize"
+	fieldNameMap["sort_ascending"] = "SortAscending"
+	fieldNameMap["sort_by"] = "SortBy"
+	var validators = []vapiBindings_.Validator{}
+	return vapiBindings_.NewStructType("operation-input", fields, reflect.TypeOf(vapiData_.StructValue{}), fieldNameMap, validators)
+}
+
+func SessionsListOutputType() vapiBindings_.BindingType {
+	return vapiBindings_.NewReferenceType(nsx_policyModel.L2VPNSessionListResultBindingType)
+}
+
+func sessionsListRestMetadata() vapiProtocol_.OperationRestMetadata {
+	fields := map[string]vapiBindings_.BindingType{}
+	fieldNameMap := map[string]string{}
+	paramsTypeMap := map[string]vapiBindings_.BindingType{}
+	pathParams := map[string]string{}
+	queryParams := map[string]string{}
+	headerParams := map[string]string{}
+	dispatchHeaderParams := map[string]string{}
+	bodyFieldsMap := map[string]string{}
+	fields["tier0_id"] = vapiBindings_.NewStringType()
+	fields["service_id"] = vapiBindings_.NewStringType()
+	fields["cursor"] = vapiBindings_.NewOptionalType(vapiBindings_.NewStringType())
+	fields["include_mark_for_delete_objects"] = vapiBindings_.NewOptionalType(vapiBindings_.NewBooleanType())
+	fields["included_fields"] = vapiBindings_.NewOptionalType(vapiBindings_.NewStringType())
+	fields["page_size"] = vapiBindings_.NewOptionalType(vapiBindings_.NewIntegerType())
+	fields["sort_ascending"] = vapiBindings_.NewOptionalType(vapiBindings_.NewBooleanType())
+	fields["sort_by"] = vapiBindings_.NewOptionalType(vapiBindings_.NewStringType())
+	fieldNameMap["tier0_id"] = "Tier0Id"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["cursor"] = "Cursor"
+	fieldNameMap["include_mark_for_delete_objects"] = "IncludeMarkForDeleteObjects"
+	fieldNameMap["included_fields"] = "IncludedFields"
+	fieldNameMap["page_size"] = "PageSize"
+	fieldNameMap["sort_ascending"] = "SortAscending"
+	fieldNameMap["sort_by"] = "SortBy"
+	paramsTypeMap["cursor"] = vapiBindings_.NewOptionalType(vapiBindings_.NewStringType())
+	paramsTypeMap["tier0_id"] = vapiBindings_.NewStringType()
+	paramsTypeMap["sort_ascending"] = vapiBindings_.NewOptionalType(vapiBindings_.NewBooleanType())
+	paramsTypeMap["included_fields"] = vapiBindings_.NewOptionalType(vapiBindings_.NewStringType())
+	paramsTypeMap["service_id"] = vapiBindings_.NewStringType()
+	paramsTypeMap["sort_by"] = vapiBindings_.NewOptionalType(vapiBindings_.NewStringType())
+	paramsTypeMap["include_mark_for_delete_objects"] = vapiBindings_.NewOptionalType(vapiBindings_.NewBooleanType())
+	paramsTypeMap["page_size"] = vapiBindings_.NewOptionalType(vapiBindings_.NewIntegerType())
+	paramsTypeMap["tier0Id"] = vapiBindings_.NewStringType()
+	paramsTypeMap["serviceId"] = vapiBindings_.NewStringType()
+	pathParams["tier0_id"] = "tier0Id"
+	pathParams["service_id"] = "serviceId"
+	queryParams["cursor"] = "cursor"
+	queryParams["sort_ascending"] = "sort_ascending"
+	queryParams["included_fields"] = "included_fields"
+	queryParams["sort_by"] = "sort_by"
+	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
+	queryParams["page_size"] = "page_size"
+	resultHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
+	return vapiProtocol_.NewOperationRestMetadata(
+		fields,
+		fieldNameMap,
+		paramsTypeMap,
+		pathParams,
+		queryParams,
+		headerParams,
+		dispatchHeaderParams,
+		bodyFieldsMap,
+		"",
+		"",
+		"GET",
+		"/policy/api/v1/infra/tier-0s/{tier0Id}/l2vpn-services/{serviceId}/sessions",
+		"",
+		resultHeaders,
+		200,
+		"",
+		errorHeaders,
+		map[string]int{"com.vmware.vapi.std.errors.invalid_request": 400, "com.vmware.vapi.std.errors.unauthorized": 403, "com.vmware.vapi.std.errors.service_unavailable": 503, "com.vmware.vapi.std.errors.internal_server_error": 500, "com.vmware.vapi.std.errors.not_found": 404})
+}
+
+func sessionsPatchInputType() vapiBindings_.StructType {
+	fields := make(map[string]vapiBindings_.BindingType)
+	fieldNameMap := make(map[string]string)
+	fields["tier0_id"] = vapiBindings_.NewStringType()
+	fields["service_id"] = vapiBindings_.NewStringType()
+	fields["session_id"] = vapiBindings_.NewStringType()
+	fields["l2_VPN_session"] = vapiBindings_.NewReferenceType(nsx_policyModel.L2VPNSessionBindingType)
+	fieldNameMap["tier0_id"] = "Tier0Id"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["session_id"] = "SessionId"
+	fieldNameMap["l2_VPN_session"] = "L2VPNSession"
+	var validators = []vapiBindings_.Validator{}
+	return vapiBindings_.NewStructType("operation-input", fields, reflect.TypeOf(vapiData_.StructValue{}), fieldNameMap, validators)
+}
+
+func SessionsPatchOutputType() vapiBindings_.BindingType {
+	return vapiBindings_.NewVoidType()
+}
+
+func sessionsPatchRestMetadata() vapiProtocol_.OperationRestMetadata {
+	fields := map[string]vapiBindings_.BindingType{}
+	fieldNameMap := map[string]string{}
+	paramsTypeMap := map[string]vapiBindings_.BindingType{}
+	pathParams := map[string]string{}
+	queryParams := map[string]string{}
+	headerParams := map[string]string{}
+	dispatchHeaderParams := map[string]string{}
+	bodyFieldsMap := map[string]string{}
+	fields["tier0_id"] = vapiBindings_.NewStringType()
+	fields["service_id"] = vapiBindings_.NewStringType()
+	fields["session_id"] = vapiBindings_.NewStringType()
+	fields["l2_VPN_session"] = vapiBindings_.NewReferenceType(nsx_policyModel.L2VPNSessionBindingType)
+	fieldNameMap["tier0_id"] = "Tier0Id"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["session_id"] = "SessionId"
+	fieldNameMap["l2_VPN_session"] = "L2VPNSession"
+	paramsTypeMap["tier0_id"] = vapiBindings_.NewStringType()
+	paramsTypeMap["l2_VPN_session"] = vapiBindings_.NewReferenceType(nsx_policyModel.L2VPNSessionBindingType)
+	paramsTypeMap["service_id"] = vapiBindings_.NewStringType()
+	paramsTypeMap["session_id"] = vapiBindings_.NewStringType()
+	paramsTypeMap["tier0Id"] = vapiBindings_.NewStringType()
+	paramsTypeMap["serviceId"] = vapiBindings_.NewStringType()
+	paramsTypeMap["sessionId"] = vapiBindings_.NewStringType()
+	pathParams["tier0_id"] = "tier0Id"
+	pathParams["session_id"] = "sessionId"
+	pathParams["service_id"] = "serviceId"
+	resultHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
+	return vapiProtocol_.NewOperationRestMetadata(
+		fields,
+		fieldNameMap,
+		paramsTypeMap,
+		pathParams,
+		queryParams,
+		headerParams,
+		dispatchHeaderParams,
+		bodyFieldsMap,
+		"",
+		"l2_VPN_session",
+		"PATCH",
+		"/policy/api/v1/infra/tier-0s/{tier0Id}/l2vpn-services/{serviceId}/sessions/{sessionId}",
+		"",
+		resultHeaders,
+		204,
+		"",
+		errorHeaders,
+		map[string]int{"com.vmware.vapi.std.errors.invalid_request": 400, "com.vmware.vapi.std.errors.unauthorized": 403, "com.vmware.vapi.std.errors.service_unavailable": 503, "com.vmware.vapi.std.errors.internal_server_error": 500, "com.vmware.vapi.std.errors.not_found": 404})
+}
+
+func sessionsUpdateInputType() vapiBindings_.StructType {
+	fields := make(map[string]vapiBindings_.BindingType)
+	fieldNameMap := make(map[string]string)
+	fields["tier0_id"] = vapiBindings_.NewStringType()
+	fields["service_id"] = vapiBindings_.NewStringType()
+	fields["session_id"] = vapiBindings_.NewStringType()
+	fields["l2_VPN_session"] = vapiBindings_.NewReferenceType(nsx_policyModel.L2VPNSessionBindingType)
+	fieldNameMap["tier0_id"] = "Tier0Id"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["session_id"] = "SessionId"
+	fieldNameMap["l2_VPN_session"] = "L2VPNSession"
+	var validators = []vapiBindings_.Validator{}
+	return vapiBindings_.NewStructType("operation-input", fields, reflect.TypeOf(vapiData_.StructValue{}), fieldNameMap, validators)
+}
+
+func SessionsUpdateOutputType() vapiBindings_.BindingType {
+	return vapiBindings_.NewReferenceType(nsx_policyModel.L2VPNSessionBindingType)
+}
+
+func sessionsUpdateRestMetadata() vapiProtocol_.OperationRestMetadata {
+	fields := map[string]vapiBindings_.BindingType{}
+	fieldNameMap := map[string]string{}
+	paramsTypeMap := map[string]vapiBindings_.BindingType{}
+	pathParams := map[string]string{}
+	queryParams := map[string]string{}
+	headerParams := map[string]string{}
+	dispatchHeaderParams := map[string]string{}
+	bodyFieldsMap := map[string]string{}
+	fields["tier0_id"] = vapiBindings_.NewStringType()
+	fields["service_id"] = vapiBindings_.NewStringType()
+	fields["session_id"] = vapiBindings_.NewStringType()
+	fields["l2_VPN_session"] = vapiBindings_.NewReferenceType(nsx_policyModel.L2VPNSessionBindingType)
+	fieldNameMap["tier0_id"] = "Tier0Id"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["session_id"] = "SessionId"
+	fieldNameMap["l2_VPN_session"] = "L2VPNSession"
+	paramsTypeMap["tier0_id"] = vapiBindings_.NewStringType()
+	paramsTypeMap["l2_VPN_session"] = vapiBindings_.NewReferenceType(nsx_policyModel.L2VPNSessionBindingType)
+	paramsTypeMap["service_id"] = vapiBindings_.NewStringType()
+	paramsTypeMap["session_id"] = vapiBindings_.NewStringType()
+	paramsTypeMap["tier0Id"] = vapiBindings_.NewStringType()
+	paramsTypeMap["serviceId"] = vapiBindings_.NewStringType()
+	paramsTypeMap["sessionId"] = vapiBindings_.NewStringType()
+	pathParams["tier0_id"] = "tier0Id"
+	pathParams["session_id"] = "sessionId"
+	pathParams["service_id"] = "serviceId"
+	resultHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
+	return vapiProtocol_.NewOperationRestMetadata(
+		fields,
+		fieldNameMap,
+		paramsTypeMap,
+		pathParams,
+		queryParams,
+		headerParams,
+		dispatchHeaderParams,
+		bodyFieldsMap,
+		"",
+		"l2_VPN_session",
+		"PUT",
+		"/policy/api/v1/infra/tier-0s/{tier0Id}/l2vpn-services/{serviceId}/sessions/{sessionId}",
+		"",
+		resultHeaders,
+		200,
+		"",
+		errorHeaders,
+		map[string]int{"com.vmware.vapi.std.errors.invalid_request": 400, "com.vmware.vapi.std.errors.unauthorized": 403, "com.vmware.vapi.std.errors.service_unavailable": 503, "com.vmware.vapi.std.errors.internal_server_error": 500, "com.vmware.vapi.std.errors.not_found": 404})
+}

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_1s/l2vpn_services/L2vpnServicesPackageTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_1s/l2vpn_services/L2vpnServicesPackageTypes.go
@@ -1,0 +1,11 @@
+// Copyright © 2019-2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+
+// Auto generated code. DO NOT EDIT.
+
+// Data type definitions file for package: com.vmware.nsx_policy.infra.tier_1s.l2vpn_services.
+// Includes binding types of a top level structures and enumerations.
+// Shared by client-side stubs and server-side skeletons to ensure type
+// compatibility.
+
+package l2vpn_services

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_1s/l2vpn_services/SessionsClient.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_1s/l2vpn_services/SessionsClient.go
@@ -1,0 +1,335 @@
+// Copyright © 2019-2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+
+// Auto generated code. DO NOT EDIT.
+
+// Interface file for service: Sessions
+// Used by client-side stubs.
+
+package l2vpn_services
+
+import (
+	vapiStdErrors_ "github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
+	vapiBindings_ "github.com/vmware/vsphere-automation-sdk-go/runtime/bindings"
+	vapiCore_ "github.com/vmware/vsphere-automation-sdk-go/runtime/core"
+	vapiProtocolClient_ "github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
+	nsx_policyModel "github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+)
+
+const _ = vapiCore_.SupportedByRuntimeVersion2
+
+type SessionsClient interface {
+
+	// Create or patch an L2VPN session under Tier-1 from Peer Codes. In addition to the L2VPN Session, the IPSec VPN Session, along with the IKE, Tunnel, and DPD Profiles are created and owned by the system. IPSec VPN Service and Local Endpoint are created only when required, i.e., an IPSec VPN Service does not already exist, or an IPSec VPN Local Endpoint with same local address does not already exist. Updating the L2VPN Session can be performed only through this API by specifying new peer codes. Use of specific APIs to update the L2VPN Session and the different resources associated with it is not allowed, except for IPSec VPN Service and Local Endpoint, resources that are not system owned. API supported only when L2VPN Service is in Client Mode.
+	//
+	// @param tier1IdParam (required)
+	// @param serviceIdParam (required)
+	// @param sessionIdParam (required)
+	// @param l2VPNSessionDataParam (required)
+	//
+	// @throws InvalidRequest  Bad Request, Precondition Failed
+	// @throws Unauthorized  Forbidden
+	// @throws ServiceUnavailable  Service Unavailable
+	// @throws InternalServerError  Internal Server Error
+	// @throws NotFound  Not Found
+	Createwithpeercode(tier1IdParam string, serviceIdParam string, sessionIdParam string, l2VPNSessionDataParam nsx_policyModel.L2VPNSessionData) error
+
+	// Delete L2VPN session under Tier-1. When L2VPN Service is in CLIENT Mode, the L2VPN Session is deleted along with its transpot tunnels and related resources.
+	//
+	// @param tier1IdParam (required)
+	// @param serviceIdParam (required)
+	// @param sessionIdParam (required)
+	//
+	// @throws InvalidRequest  Bad Request, Precondition Failed
+	// @throws Unauthorized  Forbidden
+	// @throws ServiceUnavailable  Service Unavailable
+	// @throws InternalServerError  Internal Server Error
+	// @throws NotFound  Not Found
+	Delete(tier1IdParam string, serviceIdParam string, sessionIdParam string) error
+
+	// Get L2VPN session under Tier-1.
+	//
+	// @param tier1IdParam (required)
+	// @param serviceIdParam (required)
+	// @param sessionIdParam (required)
+	// @return com.vmware.nsx_policy.model.L2VPNSession
+	//
+	// @throws InvalidRequest  Bad Request, Precondition Failed
+	// @throws Unauthorized  Forbidden
+	// @throws ServiceUnavailable  Service Unavailable
+	// @throws InternalServerError  Internal Server Error
+	// @throws NotFound  Not Found
+	Get(tier1IdParam string, serviceIdParam string, sessionIdParam string) (nsx_policyModel.L2VPNSession, error)
+
+	// Get paginated list of all L2VPN sessions under Tier-1.
+	//
+	// @param tier1IdParam (required)
+	// @param serviceIdParam (required)
+	// @param cursorParam Opaque cursor to be used for getting next page of records (supplied by current result page) (optional)
+	// @param includeMarkForDeleteObjectsParam Include objects that are marked for deletion in results (optional, default to false)
+	// @param includedFieldsParam Comma separated list of fields that should be included in query result (optional)
+	// @param pageSizeParam Maximum number of results to return in this page (server may return fewer) (optional, default to 1000)
+	// @param sortAscendingParam (optional)
+	// @param sortByParam Field by which records are sorted (optional)
+	// @return com.vmware.nsx_policy.model.L2VPNSessionListResult
+	//
+	// @throws InvalidRequest  Bad Request, Precondition Failed
+	// @throws Unauthorized  Forbidden
+	// @throws ServiceUnavailable  Service Unavailable
+	// @throws InternalServerError  Internal Server Error
+	// @throws NotFound  Not Found
+	List(tier1IdParam string, serviceIdParam string, cursorParam *string, includeMarkForDeleteObjectsParam *bool, includedFieldsParam *string, pageSizeParam *int64, sortAscendingParam *bool, sortByParam *string) (nsx_policyModel.L2VPNSessionListResult, error)
+
+	// Create or patch an L2VPN session under Tier-1. API supported only when L2VPN Service is in Server Mode.
+	//
+	// @param tier1IdParam (required)
+	// @param serviceIdParam (required)
+	// @param sessionIdParam (required)
+	// @param l2VPNSessionParam (required)
+	//
+	// @throws InvalidRequest  Bad Request, Precondition Failed
+	// @throws Unauthorized  Forbidden
+	// @throws ServiceUnavailable  Service Unavailable
+	// @throws InternalServerError  Internal Server Error
+	// @throws NotFound  Not Found
+	Patch(tier1IdParam string, serviceIdParam string, sessionIdParam string, l2VPNSessionParam nsx_policyModel.L2VPNSession) error
+
+	// Create or fully replace L2VPN session under Tier-1. API supported only when L2VPN Service is in Server Mode. Revision is optional for creation and required for update.
+	//
+	// @param tier1IdParam (required)
+	// @param serviceIdParam (required)
+	// @param sessionIdParam (required)
+	// @param l2VPNSessionParam (required)
+	// @return com.vmware.nsx_policy.model.L2VPNSession
+	//
+	// @throws InvalidRequest  Bad Request, Precondition Failed
+	// @throws Unauthorized  Forbidden
+	// @throws ServiceUnavailable  Service Unavailable
+	// @throws InternalServerError  Internal Server Error
+	// @throws NotFound  Not Found
+	Update(tier1IdParam string, serviceIdParam string, sessionIdParam string, l2VPNSessionParam nsx_policyModel.L2VPNSession) (nsx_policyModel.L2VPNSession, error)
+}
+
+type sessionsClient struct {
+	connector           vapiProtocolClient_.Connector
+	interfaceDefinition vapiCore_.InterfaceDefinition
+	errorsBindingMap    map[string]vapiBindings_.BindingType
+}
+
+func NewSessionsClient(connector vapiProtocolClient_.Connector) *sessionsClient {
+	interfaceIdentifier := vapiCore_.NewInterfaceIdentifier("com.vmware.nsx_policy.infra.tier_1s.l2vpn_services.sessions")
+	methodIdentifiers := map[string]vapiCore_.MethodIdentifier{
+		"createwithpeercode": vapiCore_.NewMethodIdentifier(interfaceIdentifier, "createwithpeercode"),
+		"delete":             vapiCore_.NewMethodIdentifier(interfaceIdentifier, "delete"),
+		"get":                vapiCore_.NewMethodIdentifier(interfaceIdentifier, "get"),
+		"list":               vapiCore_.NewMethodIdentifier(interfaceIdentifier, "list"),
+		"patch":              vapiCore_.NewMethodIdentifier(interfaceIdentifier, "patch"),
+		"update":             vapiCore_.NewMethodIdentifier(interfaceIdentifier, "update"),
+	}
+	interfaceDefinition := vapiCore_.NewInterfaceDefinition(interfaceIdentifier, methodIdentifiers)
+	errorsBindingMap := make(map[string]vapiBindings_.BindingType)
+
+	sIface := sessionsClient{interfaceDefinition: interfaceDefinition, errorsBindingMap: errorsBindingMap, connector: connector}
+	return &sIface
+}
+
+func (sIface *sessionsClient) GetErrorBindingType(errorName string) vapiBindings_.BindingType {
+	if entry, ok := sIface.errorsBindingMap[errorName]; ok {
+		return entry
+	}
+	return vapiStdErrors_.ERROR_BINDINGS_MAP[errorName]
+}
+
+func (sIface *sessionsClient) Createwithpeercode(tier1IdParam string, serviceIdParam string, sessionIdParam string, l2VPNSessionDataParam nsx_policyModel.L2VPNSessionData) error {
+	typeConverter := sIface.connector.TypeConverter()
+	executionContext := sIface.connector.NewExecutionContext()
+	operationRestMetaData := sessionsCreatewithpeercodeRestMetadata()
+	executionContext.SetConnectionMetadata(vapiCore_.RESTMetadataKey, operationRestMetaData)
+	executionContext.SetConnectionMetadata(vapiCore_.ResponseTypeKey, vapiCore_.NewResponseType(true, false))
+
+	sv := vapiBindings_.NewStructValueBuilder(sessionsCreatewithpeercodeInputType(), typeConverter)
+	sv.AddStructField("Tier1Id", tier1IdParam)
+	sv.AddStructField("ServiceId", serviceIdParam)
+	sv.AddStructField("SessionId", sessionIdParam)
+	sv.AddStructField("L2VPNSessionData", l2VPNSessionDataParam)
+	inputDataValue, inputError := sv.GetStructValue()
+	if inputError != nil {
+		return vapiBindings_.VAPIerrorsToError(inputError)
+	}
+
+	methodResult := sIface.connector.GetApiProvider().Invoke("com.vmware.nsx_policy.infra.tier_1s.l2vpn_services.sessions", "createwithpeercode", inputDataValue, executionContext)
+	if methodResult.IsSuccess() {
+		return nil
+	} else {
+		methodError, errorInError := typeConverter.ConvertToGolang(methodResult.Error(), sIface.GetErrorBindingType(methodResult.Error().Name()))
+		if errorInError != nil {
+			return vapiBindings_.VAPIerrorsToError(errorInError)
+		}
+		return methodError.(error)
+	}
+}
+
+func (sIface *sessionsClient) Delete(tier1IdParam string, serviceIdParam string, sessionIdParam string) error {
+	typeConverter := sIface.connector.TypeConverter()
+	executionContext := sIface.connector.NewExecutionContext()
+	operationRestMetaData := sessionsDeleteRestMetadata()
+	executionContext.SetConnectionMetadata(vapiCore_.RESTMetadataKey, operationRestMetaData)
+	executionContext.SetConnectionMetadata(vapiCore_.ResponseTypeKey, vapiCore_.NewResponseType(true, false))
+
+	sv := vapiBindings_.NewStructValueBuilder(sessionsDeleteInputType(), typeConverter)
+	sv.AddStructField("Tier1Id", tier1IdParam)
+	sv.AddStructField("ServiceId", serviceIdParam)
+	sv.AddStructField("SessionId", sessionIdParam)
+	inputDataValue, inputError := sv.GetStructValue()
+	if inputError != nil {
+		return vapiBindings_.VAPIerrorsToError(inputError)
+	}
+
+	methodResult := sIface.connector.GetApiProvider().Invoke("com.vmware.nsx_policy.infra.tier_1s.l2vpn_services.sessions", "delete", inputDataValue, executionContext)
+	if methodResult.IsSuccess() {
+		return nil
+	} else {
+		methodError, errorInError := typeConverter.ConvertToGolang(methodResult.Error(), sIface.GetErrorBindingType(methodResult.Error().Name()))
+		if errorInError != nil {
+			return vapiBindings_.VAPIerrorsToError(errorInError)
+		}
+		return methodError.(error)
+	}
+}
+
+func (sIface *sessionsClient) Get(tier1IdParam string, serviceIdParam string, sessionIdParam string) (nsx_policyModel.L2VPNSession, error) {
+	typeConverter := sIface.connector.TypeConverter()
+	executionContext := sIface.connector.NewExecutionContext()
+	operationRestMetaData := sessionsGetRestMetadata()
+	executionContext.SetConnectionMetadata(vapiCore_.RESTMetadataKey, operationRestMetaData)
+	executionContext.SetConnectionMetadata(vapiCore_.ResponseTypeKey, vapiCore_.NewResponseType(true, false))
+
+	sv := vapiBindings_.NewStructValueBuilder(sessionsGetInputType(), typeConverter)
+	sv.AddStructField("Tier1Id", tier1IdParam)
+	sv.AddStructField("ServiceId", serviceIdParam)
+	sv.AddStructField("SessionId", sessionIdParam)
+	inputDataValue, inputError := sv.GetStructValue()
+	if inputError != nil {
+		var emptyOutput nsx_policyModel.L2VPNSession
+		return emptyOutput, vapiBindings_.VAPIerrorsToError(inputError)
+	}
+
+	methodResult := sIface.connector.GetApiProvider().Invoke("com.vmware.nsx_policy.infra.tier_1s.l2vpn_services.sessions", "get", inputDataValue, executionContext)
+	var emptyOutput nsx_policyModel.L2VPNSession
+	if methodResult.IsSuccess() {
+		output, errorInOutput := typeConverter.ConvertToGolang(methodResult.Output(), SessionsGetOutputType())
+		if errorInOutput != nil {
+			return emptyOutput, vapiBindings_.VAPIerrorsToError(errorInOutput)
+		}
+		return output.(nsx_policyModel.L2VPNSession), nil
+	} else {
+		methodError, errorInError := typeConverter.ConvertToGolang(methodResult.Error(), sIface.GetErrorBindingType(methodResult.Error().Name()))
+		if errorInError != nil {
+			return emptyOutput, vapiBindings_.VAPIerrorsToError(errorInError)
+		}
+		return emptyOutput, methodError.(error)
+	}
+}
+
+func (sIface *sessionsClient) List(tier1IdParam string, serviceIdParam string, cursorParam *string, includeMarkForDeleteObjectsParam *bool, includedFieldsParam *string, pageSizeParam *int64, sortAscendingParam *bool, sortByParam *string) (nsx_policyModel.L2VPNSessionListResult, error) {
+	typeConverter := sIface.connector.TypeConverter()
+	executionContext := sIface.connector.NewExecutionContext()
+	operationRestMetaData := sessionsListRestMetadata()
+	executionContext.SetConnectionMetadata(vapiCore_.RESTMetadataKey, operationRestMetaData)
+	executionContext.SetConnectionMetadata(vapiCore_.ResponseTypeKey, vapiCore_.NewResponseType(true, false))
+
+	sv := vapiBindings_.NewStructValueBuilder(sessionsListInputType(), typeConverter)
+	sv.AddStructField("Tier1Id", tier1IdParam)
+	sv.AddStructField("ServiceId", serviceIdParam)
+	sv.AddStructField("Cursor", cursorParam)
+	sv.AddStructField("IncludeMarkForDeleteObjects", includeMarkForDeleteObjectsParam)
+	sv.AddStructField("IncludedFields", includedFieldsParam)
+	sv.AddStructField("PageSize", pageSizeParam)
+	sv.AddStructField("SortAscending", sortAscendingParam)
+	sv.AddStructField("SortBy", sortByParam)
+	inputDataValue, inputError := sv.GetStructValue()
+	if inputError != nil {
+		var emptyOutput nsx_policyModel.L2VPNSessionListResult
+		return emptyOutput, vapiBindings_.VAPIerrorsToError(inputError)
+	}
+
+	methodResult := sIface.connector.GetApiProvider().Invoke("com.vmware.nsx_policy.infra.tier_1s.l2vpn_services.sessions", "list", inputDataValue, executionContext)
+	var emptyOutput nsx_policyModel.L2VPNSessionListResult
+	if methodResult.IsSuccess() {
+		output, errorInOutput := typeConverter.ConvertToGolang(methodResult.Output(), SessionsListOutputType())
+		if errorInOutput != nil {
+			return emptyOutput, vapiBindings_.VAPIerrorsToError(errorInOutput)
+		}
+		return output.(nsx_policyModel.L2VPNSessionListResult), nil
+	} else {
+		methodError, errorInError := typeConverter.ConvertToGolang(methodResult.Error(), sIface.GetErrorBindingType(methodResult.Error().Name()))
+		if errorInError != nil {
+			return emptyOutput, vapiBindings_.VAPIerrorsToError(errorInError)
+		}
+		return emptyOutput, methodError.(error)
+	}
+}
+
+func (sIface *sessionsClient) Patch(tier1IdParam string, serviceIdParam string, sessionIdParam string, l2VPNSessionParam nsx_policyModel.L2VPNSession) error {
+	typeConverter := sIface.connector.TypeConverter()
+	executionContext := sIface.connector.NewExecutionContext()
+	operationRestMetaData := sessionsPatchRestMetadata()
+	executionContext.SetConnectionMetadata(vapiCore_.RESTMetadataKey, operationRestMetaData)
+	executionContext.SetConnectionMetadata(vapiCore_.ResponseTypeKey, vapiCore_.NewResponseType(true, false))
+
+	sv := vapiBindings_.NewStructValueBuilder(sessionsPatchInputType(), typeConverter)
+	sv.AddStructField("Tier1Id", tier1IdParam)
+	sv.AddStructField("ServiceId", serviceIdParam)
+	sv.AddStructField("SessionId", sessionIdParam)
+	sv.AddStructField("L2VPNSession", l2VPNSessionParam)
+	inputDataValue, inputError := sv.GetStructValue()
+	if inputError != nil {
+		return vapiBindings_.VAPIerrorsToError(inputError)
+	}
+
+	methodResult := sIface.connector.GetApiProvider().Invoke("com.vmware.nsx_policy.infra.tier_1s.l2vpn_services.sessions", "patch", inputDataValue, executionContext)
+	if methodResult.IsSuccess() {
+		return nil
+	} else {
+		methodError, errorInError := typeConverter.ConvertToGolang(methodResult.Error(), sIface.GetErrorBindingType(methodResult.Error().Name()))
+		if errorInError != nil {
+			return vapiBindings_.VAPIerrorsToError(errorInError)
+		}
+		return methodError.(error)
+	}
+}
+
+func (sIface *sessionsClient) Update(tier1IdParam string, serviceIdParam string, sessionIdParam string, l2VPNSessionParam nsx_policyModel.L2VPNSession) (nsx_policyModel.L2VPNSession, error) {
+	typeConverter := sIface.connector.TypeConverter()
+	executionContext := sIface.connector.NewExecutionContext()
+	operationRestMetaData := sessionsUpdateRestMetadata()
+	executionContext.SetConnectionMetadata(vapiCore_.RESTMetadataKey, operationRestMetaData)
+	executionContext.SetConnectionMetadata(vapiCore_.ResponseTypeKey, vapiCore_.NewResponseType(true, false))
+
+	sv := vapiBindings_.NewStructValueBuilder(sessionsUpdateInputType(), typeConverter)
+	sv.AddStructField("Tier1Id", tier1IdParam)
+	sv.AddStructField("ServiceId", serviceIdParam)
+	sv.AddStructField("SessionId", sessionIdParam)
+	sv.AddStructField("L2VPNSession", l2VPNSessionParam)
+	inputDataValue, inputError := sv.GetStructValue()
+	if inputError != nil {
+		var emptyOutput nsx_policyModel.L2VPNSession
+		return emptyOutput, vapiBindings_.VAPIerrorsToError(inputError)
+	}
+
+	methodResult := sIface.connector.GetApiProvider().Invoke("com.vmware.nsx_policy.infra.tier_1s.l2vpn_services.sessions", "update", inputDataValue, executionContext)
+	var emptyOutput nsx_policyModel.L2VPNSession
+	if methodResult.IsSuccess() {
+		output, errorInOutput := typeConverter.ConvertToGolang(methodResult.Output(), SessionsUpdateOutputType())
+		if errorInOutput != nil {
+			return emptyOutput, vapiBindings_.VAPIerrorsToError(errorInOutput)
+		}
+		return output.(nsx_policyModel.L2VPNSession), nil
+	} else {
+		methodError, errorInError := typeConverter.ConvertToGolang(methodResult.Error(), sIface.GetErrorBindingType(methodResult.Error().Name()))
+		if errorInError != nil {
+			return emptyOutput, vapiBindings_.VAPIerrorsToError(errorInError)
+		}
+		return emptyOutput, methodError.(error)
+	}
+}

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_1s/l2vpn_services/SessionsTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_1s/l2vpn_services/SessionsTypes.go
@@ -1,0 +1,447 @@
+// Copyright © 2019-2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+
+// Auto generated code. DO NOT EDIT.
+
+// Data type definitions file for service: Sessions.
+// Includes binding types of a structures and enumerations defined in the service.
+// Shared by client-side stubs and server-side skeletons to ensure type
+// compatibility.
+
+package l2vpn_services
+
+import (
+	vapiBindings_ "github.com/vmware/vsphere-automation-sdk-go/runtime/bindings"
+	vapiData_ "github.com/vmware/vsphere-automation-sdk-go/runtime/data"
+	vapiProtocol_ "github.com/vmware/vsphere-automation-sdk-go/runtime/protocol"
+	nsx_policyModel "github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+	"reflect"
+)
+
+func sessionsCreatewithpeercodeInputType() vapiBindings_.StructType {
+	fields := make(map[string]vapiBindings_.BindingType)
+	fieldNameMap := make(map[string]string)
+	fields["tier1_id"] = vapiBindings_.NewStringType()
+	fields["service_id"] = vapiBindings_.NewStringType()
+	fields["session_id"] = vapiBindings_.NewStringType()
+	fields["l2_VPN_session_data"] = vapiBindings_.NewReferenceType(nsx_policyModel.L2VPNSessionDataBindingType)
+	fieldNameMap["tier1_id"] = "Tier1Id"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["session_id"] = "SessionId"
+	fieldNameMap["l2_VPN_session_data"] = "L2VPNSessionData"
+	var validators = []vapiBindings_.Validator{}
+	return vapiBindings_.NewStructType("operation-input", fields, reflect.TypeOf(vapiData_.StructValue{}), fieldNameMap, validators)
+}
+
+func SessionsCreatewithpeercodeOutputType() vapiBindings_.BindingType {
+	return vapiBindings_.NewVoidType()
+}
+
+func sessionsCreatewithpeercodeRestMetadata() vapiProtocol_.OperationRestMetadata {
+	fields := map[string]vapiBindings_.BindingType{}
+	fieldNameMap := map[string]string{}
+	paramsTypeMap := map[string]vapiBindings_.BindingType{}
+	pathParams := map[string]string{}
+	queryParams := map[string]string{}
+	headerParams := map[string]string{}
+	dispatchHeaderParams := map[string]string{}
+	bodyFieldsMap := map[string]string{}
+	fields["tier1_id"] = vapiBindings_.NewStringType()
+	fields["service_id"] = vapiBindings_.NewStringType()
+	fields["session_id"] = vapiBindings_.NewStringType()
+	fields["l2_VPN_session_data"] = vapiBindings_.NewReferenceType(nsx_policyModel.L2VPNSessionDataBindingType)
+	fieldNameMap["tier1_id"] = "Tier1Id"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["session_id"] = "SessionId"
+	fieldNameMap["l2_VPN_session_data"] = "L2VPNSessionData"
+	paramsTypeMap["tier1_id"] = vapiBindings_.NewStringType()
+	paramsTypeMap["service_id"] = vapiBindings_.NewStringType()
+	paramsTypeMap["session_id"] = vapiBindings_.NewStringType()
+	paramsTypeMap["l2_VPN_session_data"] = vapiBindings_.NewReferenceType(nsx_policyModel.L2VPNSessionDataBindingType)
+	paramsTypeMap["tier1Id"] = vapiBindings_.NewStringType()
+	paramsTypeMap["serviceId"] = vapiBindings_.NewStringType()
+	paramsTypeMap["sessionId"] = vapiBindings_.NewStringType()
+	pathParams["tier1_id"] = "tier1Id"
+	pathParams["session_id"] = "sessionId"
+	pathParams["service_id"] = "serviceId"
+	resultHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
+	return vapiProtocol_.NewOperationRestMetadata(
+		fields,
+		fieldNameMap,
+		paramsTypeMap,
+		pathParams,
+		queryParams,
+		headerParams,
+		dispatchHeaderParams,
+		bodyFieldsMap,
+		"action=create_with_peer_code",
+		"l2_VPN_session_data",
+		"POST",
+		"/policy/api/v1/infra/tier-1s/{tier1Id}/l2vpn-services/{serviceId}/sessions/{sessionId}",
+		"",
+		resultHeaders,
+		204,
+		"",
+		errorHeaders,
+		map[string]int{"com.vmware.vapi.std.errors.invalid_request": 400, "com.vmware.vapi.std.errors.unauthorized": 403, "com.vmware.vapi.std.errors.service_unavailable": 503, "com.vmware.vapi.std.errors.internal_server_error": 500, "com.vmware.vapi.std.errors.not_found": 404})
+}
+
+func sessionsDeleteInputType() vapiBindings_.StructType {
+	fields := make(map[string]vapiBindings_.BindingType)
+	fieldNameMap := make(map[string]string)
+	fields["tier1_id"] = vapiBindings_.NewStringType()
+	fields["service_id"] = vapiBindings_.NewStringType()
+	fields["session_id"] = vapiBindings_.NewStringType()
+	fieldNameMap["tier1_id"] = "Tier1Id"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["session_id"] = "SessionId"
+	var validators = []vapiBindings_.Validator{}
+	return vapiBindings_.NewStructType("operation-input", fields, reflect.TypeOf(vapiData_.StructValue{}), fieldNameMap, validators)
+}
+
+func SessionsDeleteOutputType() vapiBindings_.BindingType {
+	return vapiBindings_.NewVoidType()
+}
+
+func sessionsDeleteRestMetadata() vapiProtocol_.OperationRestMetadata {
+	fields := map[string]vapiBindings_.BindingType{}
+	fieldNameMap := map[string]string{}
+	paramsTypeMap := map[string]vapiBindings_.BindingType{}
+	pathParams := map[string]string{}
+	queryParams := map[string]string{}
+	headerParams := map[string]string{}
+	dispatchHeaderParams := map[string]string{}
+	bodyFieldsMap := map[string]string{}
+	fields["tier1_id"] = vapiBindings_.NewStringType()
+	fields["service_id"] = vapiBindings_.NewStringType()
+	fields["session_id"] = vapiBindings_.NewStringType()
+	fieldNameMap["tier1_id"] = "Tier1Id"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["session_id"] = "SessionId"
+	paramsTypeMap["tier1_id"] = vapiBindings_.NewStringType()
+	paramsTypeMap["service_id"] = vapiBindings_.NewStringType()
+	paramsTypeMap["session_id"] = vapiBindings_.NewStringType()
+	paramsTypeMap["tier1Id"] = vapiBindings_.NewStringType()
+	paramsTypeMap["serviceId"] = vapiBindings_.NewStringType()
+	paramsTypeMap["sessionId"] = vapiBindings_.NewStringType()
+	pathParams["tier1_id"] = "tier1Id"
+	pathParams["session_id"] = "sessionId"
+	pathParams["service_id"] = "serviceId"
+	resultHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
+	return vapiProtocol_.NewOperationRestMetadata(
+		fields,
+		fieldNameMap,
+		paramsTypeMap,
+		pathParams,
+		queryParams,
+		headerParams,
+		dispatchHeaderParams,
+		bodyFieldsMap,
+		"",
+		"",
+		"DELETE",
+		"/policy/api/v1/infra/tier-1s/{tier1Id}/l2vpn-services/{serviceId}/sessions/{sessionId}",
+		"",
+		resultHeaders,
+		204,
+		"",
+		errorHeaders,
+		map[string]int{"com.vmware.vapi.std.errors.invalid_request": 400, "com.vmware.vapi.std.errors.unauthorized": 403, "com.vmware.vapi.std.errors.service_unavailable": 503, "com.vmware.vapi.std.errors.internal_server_error": 500, "com.vmware.vapi.std.errors.not_found": 404})
+}
+
+func sessionsGetInputType() vapiBindings_.StructType {
+	fields := make(map[string]vapiBindings_.BindingType)
+	fieldNameMap := make(map[string]string)
+	fields["tier1_id"] = vapiBindings_.NewStringType()
+	fields["service_id"] = vapiBindings_.NewStringType()
+	fields["session_id"] = vapiBindings_.NewStringType()
+	fieldNameMap["tier1_id"] = "Tier1Id"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["session_id"] = "SessionId"
+	var validators = []vapiBindings_.Validator{}
+	return vapiBindings_.NewStructType("operation-input", fields, reflect.TypeOf(vapiData_.StructValue{}), fieldNameMap, validators)
+}
+
+func SessionsGetOutputType() vapiBindings_.BindingType {
+	return vapiBindings_.NewReferenceType(nsx_policyModel.L2VPNSessionBindingType)
+}
+
+func sessionsGetRestMetadata() vapiProtocol_.OperationRestMetadata {
+	fields := map[string]vapiBindings_.BindingType{}
+	fieldNameMap := map[string]string{}
+	paramsTypeMap := map[string]vapiBindings_.BindingType{}
+	pathParams := map[string]string{}
+	queryParams := map[string]string{}
+	headerParams := map[string]string{}
+	dispatchHeaderParams := map[string]string{}
+	bodyFieldsMap := map[string]string{}
+	fields["tier1_id"] = vapiBindings_.NewStringType()
+	fields["service_id"] = vapiBindings_.NewStringType()
+	fields["session_id"] = vapiBindings_.NewStringType()
+	fieldNameMap["tier1_id"] = "Tier1Id"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["session_id"] = "SessionId"
+	paramsTypeMap["tier1_id"] = vapiBindings_.NewStringType()
+	paramsTypeMap["service_id"] = vapiBindings_.NewStringType()
+	paramsTypeMap["session_id"] = vapiBindings_.NewStringType()
+	paramsTypeMap["tier1Id"] = vapiBindings_.NewStringType()
+	paramsTypeMap["serviceId"] = vapiBindings_.NewStringType()
+	paramsTypeMap["sessionId"] = vapiBindings_.NewStringType()
+	pathParams["tier1_id"] = "tier1Id"
+	pathParams["session_id"] = "sessionId"
+	pathParams["service_id"] = "serviceId"
+	resultHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
+	return vapiProtocol_.NewOperationRestMetadata(
+		fields,
+		fieldNameMap,
+		paramsTypeMap,
+		pathParams,
+		queryParams,
+		headerParams,
+		dispatchHeaderParams,
+		bodyFieldsMap,
+		"",
+		"",
+		"GET",
+		"/policy/api/v1/infra/tier-1s/{tier1Id}/l2vpn-services/{serviceId}/sessions/{sessionId}",
+		"",
+		resultHeaders,
+		200,
+		"",
+		errorHeaders,
+		map[string]int{"com.vmware.vapi.std.errors.invalid_request": 400, "com.vmware.vapi.std.errors.unauthorized": 403, "com.vmware.vapi.std.errors.service_unavailable": 503, "com.vmware.vapi.std.errors.internal_server_error": 500, "com.vmware.vapi.std.errors.not_found": 404})
+}
+
+func sessionsListInputType() vapiBindings_.StructType {
+	fields := make(map[string]vapiBindings_.BindingType)
+	fieldNameMap := make(map[string]string)
+	fields["tier1_id"] = vapiBindings_.NewStringType()
+	fields["service_id"] = vapiBindings_.NewStringType()
+	fields["cursor"] = vapiBindings_.NewOptionalType(vapiBindings_.NewStringType())
+	fields["include_mark_for_delete_objects"] = vapiBindings_.NewOptionalType(vapiBindings_.NewBooleanType())
+	fields["included_fields"] = vapiBindings_.NewOptionalType(vapiBindings_.NewStringType())
+	fields["page_size"] = vapiBindings_.NewOptionalType(vapiBindings_.NewIntegerType())
+	fields["sort_ascending"] = vapiBindings_.NewOptionalType(vapiBindings_.NewBooleanType())
+	fields["sort_by"] = vapiBindings_.NewOptionalType(vapiBindings_.NewStringType())
+	fieldNameMap["tier1_id"] = "Tier1Id"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["cursor"] = "Cursor"
+	fieldNameMap["include_mark_for_delete_objects"] = "IncludeMarkForDeleteObjects"
+	fieldNameMap["included_fields"] = "IncludedFields"
+	fieldNameMap["page_size"] = "PageSize"
+	fieldNameMap["sort_ascending"] = "SortAscending"
+	fieldNameMap["sort_by"] = "SortBy"
+	var validators = []vapiBindings_.Validator{}
+	return vapiBindings_.NewStructType("operation-input", fields, reflect.TypeOf(vapiData_.StructValue{}), fieldNameMap, validators)
+}
+
+func SessionsListOutputType() vapiBindings_.BindingType {
+	return vapiBindings_.NewReferenceType(nsx_policyModel.L2VPNSessionListResultBindingType)
+}
+
+func sessionsListRestMetadata() vapiProtocol_.OperationRestMetadata {
+	fields := map[string]vapiBindings_.BindingType{}
+	fieldNameMap := map[string]string{}
+	paramsTypeMap := map[string]vapiBindings_.BindingType{}
+	pathParams := map[string]string{}
+	queryParams := map[string]string{}
+	headerParams := map[string]string{}
+	dispatchHeaderParams := map[string]string{}
+	bodyFieldsMap := map[string]string{}
+	fields["tier1_id"] = vapiBindings_.NewStringType()
+	fields["service_id"] = vapiBindings_.NewStringType()
+	fields["cursor"] = vapiBindings_.NewOptionalType(vapiBindings_.NewStringType())
+	fields["include_mark_for_delete_objects"] = vapiBindings_.NewOptionalType(vapiBindings_.NewBooleanType())
+	fields["included_fields"] = vapiBindings_.NewOptionalType(vapiBindings_.NewStringType())
+	fields["page_size"] = vapiBindings_.NewOptionalType(vapiBindings_.NewIntegerType())
+	fields["sort_ascending"] = vapiBindings_.NewOptionalType(vapiBindings_.NewBooleanType())
+	fields["sort_by"] = vapiBindings_.NewOptionalType(vapiBindings_.NewStringType())
+	fieldNameMap["tier1_id"] = "Tier1Id"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["cursor"] = "Cursor"
+	fieldNameMap["include_mark_for_delete_objects"] = "IncludeMarkForDeleteObjects"
+	fieldNameMap["included_fields"] = "IncludedFields"
+	fieldNameMap["page_size"] = "PageSize"
+	fieldNameMap["sort_ascending"] = "SortAscending"
+	fieldNameMap["sort_by"] = "SortBy"
+	paramsTypeMap["cursor"] = vapiBindings_.NewOptionalType(vapiBindings_.NewStringType())
+	paramsTypeMap["sort_ascending"] = vapiBindings_.NewOptionalType(vapiBindings_.NewBooleanType())
+	paramsTypeMap["tier1_id"] = vapiBindings_.NewStringType()
+	paramsTypeMap["included_fields"] = vapiBindings_.NewOptionalType(vapiBindings_.NewStringType())
+	paramsTypeMap["service_id"] = vapiBindings_.NewStringType()
+	paramsTypeMap["sort_by"] = vapiBindings_.NewOptionalType(vapiBindings_.NewStringType())
+	paramsTypeMap["include_mark_for_delete_objects"] = vapiBindings_.NewOptionalType(vapiBindings_.NewBooleanType())
+	paramsTypeMap["page_size"] = vapiBindings_.NewOptionalType(vapiBindings_.NewIntegerType())
+	paramsTypeMap["tier1Id"] = vapiBindings_.NewStringType()
+	paramsTypeMap["serviceId"] = vapiBindings_.NewStringType()
+	pathParams["tier1_id"] = "tier1Id"
+	pathParams["service_id"] = "serviceId"
+	queryParams["cursor"] = "cursor"
+	queryParams["sort_ascending"] = "sort_ascending"
+	queryParams["included_fields"] = "included_fields"
+	queryParams["sort_by"] = "sort_by"
+	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
+	queryParams["page_size"] = "page_size"
+	resultHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
+	return vapiProtocol_.NewOperationRestMetadata(
+		fields,
+		fieldNameMap,
+		paramsTypeMap,
+		pathParams,
+		queryParams,
+		headerParams,
+		dispatchHeaderParams,
+		bodyFieldsMap,
+		"",
+		"",
+		"GET",
+		"/policy/api/v1/infra/tier-1s/{tier1Id}/l2vpn-services/{serviceId}/sessions",
+		"",
+		resultHeaders,
+		200,
+		"",
+		errorHeaders,
+		map[string]int{"com.vmware.vapi.std.errors.invalid_request": 400, "com.vmware.vapi.std.errors.unauthorized": 403, "com.vmware.vapi.std.errors.service_unavailable": 503, "com.vmware.vapi.std.errors.internal_server_error": 500, "com.vmware.vapi.std.errors.not_found": 404})
+}
+
+func sessionsPatchInputType() vapiBindings_.StructType {
+	fields := make(map[string]vapiBindings_.BindingType)
+	fieldNameMap := make(map[string]string)
+	fields["tier1_id"] = vapiBindings_.NewStringType()
+	fields["service_id"] = vapiBindings_.NewStringType()
+	fields["session_id"] = vapiBindings_.NewStringType()
+	fields["l2_VPN_session"] = vapiBindings_.NewReferenceType(nsx_policyModel.L2VPNSessionBindingType)
+	fieldNameMap["tier1_id"] = "Tier1Id"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["session_id"] = "SessionId"
+	fieldNameMap["l2_VPN_session"] = "L2VPNSession"
+	var validators = []vapiBindings_.Validator{}
+	return vapiBindings_.NewStructType("operation-input", fields, reflect.TypeOf(vapiData_.StructValue{}), fieldNameMap, validators)
+}
+
+func SessionsPatchOutputType() vapiBindings_.BindingType {
+	return vapiBindings_.NewVoidType()
+}
+
+func sessionsPatchRestMetadata() vapiProtocol_.OperationRestMetadata {
+	fields := map[string]vapiBindings_.BindingType{}
+	fieldNameMap := map[string]string{}
+	paramsTypeMap := map[string]vapiBindings_.BindingType{}
+	pathParams := map[string]string{}
+	queryParams := map[string]string{}
+	headerParams := map[string]string{}
+	dispatchHeaderParams := map[string]string{}
+	bodyFieldsMap := map[string]string{}
+	fields["tier1_id"] = vapiBindings_.NewStringType()
+	fields["service_id"] = vapiBindings_.NewStringType()
+	fields["session_id"] = vapiBindings_.NewStringType()
+	fields["l2_VPN_session"] = vapiBindings_.NewReferenceType(nsx_policyModel.L2VPNSessionBindingType)
+	fieldNameMap["tier1_id"] = "Tier1Id"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["session_id"] = "SessionId"
+	fieldNameMap["l2_VPN_session"] = "L2VPNSession"
+	paramsTypeMap["l2_VPN_session"] = vapiBindings_.NewReferenceType(nsx_policyModel.L2VPNSessionBindingType)
+	paramsTypeMap["tier1_id"] = vapiBindings_.NewStringType()
+	paramsTypeMap["service_id"] = vapiBindings_.NewStringType()
+	paramsTypeMap["session_id"] = vapiBindings_.NewStringType()
+	paramsTypeMap["tier1Id"] = vapiBindings_.NewStringType()
+	paramsTypeMap["serviceId"] = vapiBindings_.NewStringType()
+	paramsTypeMap["sessionId"] = vapiBindings_.NewStringType()
+	pathParams["tier1_id"] = "tier1Id"
+	pathParams["session_id"] = "sessionId"
+	pathParams["service_id"] = "serviceId"
+	resultHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
+	return vapiProtocol_.NewOperationRestMetadata(
+		fields,
+		fieldNameMap,
+		paramsTypeMap,
+		pathParams,
+		queryParams,
+		headerParams,
+		dispatchHeaderParams,
+		bodyFieldsMap,
+		"",
+		"l2_VPN_session",
+		"PATCH",
+		"/policy/api/v1/infra/tier-1s/{tier1Id}/l2vpn-services/{serviceId}/sessions/{sessionId}",
+		"",
+		resultHeaders,
+		204,
+		"",
+		errorHeaders,
+		map[string]int{"com.vmware.vapi.std.errors.invalid_request": 400, "com.vmware.vapi.std.errors.unauthorized": 403, "com.vmware.vapi.std.errors.service_unavailable": 503, "com.vmware.vapi.std.errors.internal_server_error": 500, "com.vmware.vapi.std.errors.not_found": 404})
+}
+
+func sessionsUpdateInputType() vapiBindings_.StructType {
+	fields := make(map[string]vapiBindings_.BindingType)
+	fieldNameMap := make(map[string]string)
+	fields["tier1_id"] = vapiBindings_.NewStringType()
+	fields["service_id"] = vapiBindings_.NewStringType()
+	fields["session_id"] = vapiBindings_.NewStringType()
+	fields["l2_VPN_session"] = vapiBindings_.NewReferenceType(nsx_policyModel.L2VPNSessionBindingType)
+	fieldNameMap["tier1_id"] = "Tier1Id"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["session_id"] = "SessionId"
+	fieldNameMap["l2_VPN_session"] = "L2VPNSession"
+	var validators = []vapiBindings_.Validator{}
+	return vapiBindings_.NewStructType("operation-input", fields, reflect.TypeOf(vapiData_.StructValue{}), fieldNameMap, validators)
+}
+
+func SessionsUpdateOutputType() vapiBindings_.BindingType {
+	return vapiBindings_.NewReferenceType(nsx_policyModel.L2VPNSessionBindingType)
+}
+
+func sessionsUpdateRestMetadata() vapiProtocol_.OperationRestMetadata {
+	fields := map[string]vapiBindings_.BindingType{}
+	fieldNameMap := map[string]string{}
+	paramsTypeMap := map[string]vapiBindings_.BindingType{}
+	pathParams := map[string]string{}
+	queryParams := map[string]string{}
+	headerParams := map[string]string{}
+	dispatchHeaderParams := map[string]string{}
+	bodyFieldsMap := map[string]string{}
+	fields["tier1_id"] = vapiBindings_.NewStringType()
+	fields["service_id"] = vapiBindings_.NewStringType()
+	fields["session_id"] = vapiBindings_.NewStringType()
+	fields["l2_VPN_session"] = vapiBindings_.NewReferenceType(nsx_policyModel.L2VPNSessionBindingType)
+	fieldNameMap["tier1_id"] = "Tier1Id"
+	fieldNameMap["service_id"] = "ServiceId"
+	fieldNameMap["session_id"] = "SessionId"
+	fieldNameMap["l2_VPN_session"] = "L2VPNSession"
+	paramsTypeMap["l2_VPN_session"] = vapiBindings_.NewReferenceType(nsx_policyModel.L2VPNSessionBindingType)
+	paramsTypeMap["tier1_id"] = vapiBindings_.NewStringType()
+	paramsTypeMap["service_id"] = vapiBindings_.NewStringType()
+	paramsTypeMap["session_id"] = vapiBindings_.NewStringType()
+	paramsTypeMap["tier1Id"] = vapiBindings_.NewStringType()
+	paramsTypeMap["serviceId"] = vapiBindings_.NewStringType()
+	paramsTypeMap["sessionId"] = vapiBindings_.NewStringType()
+	pathParams["tier1_id"] = "tier1Id"
+	pathParams["session_id"] = "sessionId"
+	pathParams["service_id"] = "serviceId"
+	resultHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
+	return vapiProtocol_.NewOperationRestMetadata(
+		fields,
+		fieldNameMap,
+		paramsTypeMap,
+		pathParams,
+		queryParams,
+		headerParams,
+		dispatchHeaderParams,
+		bodyFieldsMap,
+		"",
+		"l2_VPN_session",
+		"PUT",
+		"/policy/api/v1/infra/tier-1s/{tier1Id}/l2vpn-services/{serviceId}/sessions/{sessionId}",
+		"",
+		resultHeaders,
+		200,
+		"",
+		errorHeaders,
+		map[string]int{"com.vmware.vapi.std.errors.invalid_request": 400, "com.vmware.vapi.std.errors.unauthorized": 403, "com.vmware.vapi.std.errors.service_unavailable": 503, "com.vmware.vapi.std.errors.internal_server_error": 500, "com.vmware.vapi.std.errors.not_found": 404})
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -259,6 +259,7 @@ github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/sites/enforcemen
 github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/sites/enforcement_points/edge_clusters
 github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_0s
 github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_0s/ipsec_vpn_services
+github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_0s/l2vpn_services
 github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_0s/locale_services
 github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_0s/locale_services/bgp
 github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_0s/locale_services/ipsec_vpn_services
@@ -268,6 +269,7 @@ github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_0s/nat
 github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_0s/static_routes
 github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_1s
 github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_1s/ipsec_vpn_services
+github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_1s/l2vpn_services
 github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_1s/locale_services
 github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_1s/locale_services/ipsec_vpn_services
 github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_1s/locale_services/l2vpn_services

--- a/website/docs/r/policy_ipsec_vpn_service.html.markdown
+++ b/website/docs/r/policy_ipsec_vpn_service.html.markdown
@@ -37,7 +37,8 @@ The following arguments are supported:
 * `description` - (Optional) Description of the resource.
 * `tag` - (Optional) A list of scope + tag pairs to associate with this resource.
 * `nsx_id` - (Optional) The NSX ID of this resource. If set, this ID will be used to create the resource.
-* `locale_service_path` - (Required) Path of the gateway locale service associated with the IPSec VPN Service.
+* `locale_service_path` - (Deprecated) Path of the gateway locale service associated with the IPSec VPN Service.
+* `gateway_path` - (Optional) Path of gateway associated with the IPSec VPN Service. Note that at least one of `gateway_path` and `locale_service_path` must be specified for the IPSec VPN Service object.
 * `enabled` - (Optional) Whether this IPSec VPN Service is enabled. Default is `true`.
 * `ha_sync` - (Optional) Enable/Disable IPSec VPN service HA state sync. Default is `true`.
 * `ike_log_level` - (Optional) Set of algorithms to be used for message digest during IKE negotiation. Value is one of `DEBUG`, `INFO`, `WARN`, `ERROR` and `EMERGENCY`. Default is `INFO`. 

--- a/website/docs/r/policy_ipsec_vpn_session.html.markdown
+++ b/website/docs/r/policy_ipsec_vpn_session.html.markdown
@@ -83,8 +83,8 @@ The following arguments are supported:
   * `sources` - (Optional) List of source subnets. Subnet format is ipv4 CIDR.
   * `destinations` - (Optional) List of distination subnets. Subnet format is ipv4 CIDR.
   * `action` - (Optional) `PROTECT` or `BYPASS`. Default is `PROTECT`.
-* `direction` - (Optional) The traffic direction apply to the MSS clamping. Value is one of `NONE`, `INBOUND_CONNECTION`, `OUTBOUND_CONNECTION` AND `BOTH`. Must be specified together with `max_segment_size`.
-* `max_segment_size` - (Optional) Maximum amount of data the host will accept in a TCP segment. Value is an int between `108` and `8860`. Must be specified together with `direction`.
+* `direction` - (Optional) The traffic direction apply to the MSS clamping. Value is one of `NONE`, `INBOUND_CONNECTION`, `OUTBOUND_CONNECTION` AND `BOTH`.
+* `max_segment_size` - (Optional) Maximum amount of data the host will accept in a TCP segment. Value is an int between `108` and `8860`. If not specified then the value would be the automatic calculated MSS value.
 
 ## Attributes Reference
 

--- a/website/docs/r/policy_l2_vpn_service.html.markdown
+++ b/website/docs/r/policy_l2_vpn_service.html.markdown
@@ -32,7 +32,8 @@ The following arguments are supported:
 * `description` - (Optional) Description of the resource.
 * `tag` - (Optional) A list of scope + tag pairs to associate with this resource.
 * `nsx_id` - (Optional) The NSX ID of this resource. If set, this ID will be used to create the resource.
-* `locale_service_path` - (Required) Path of the locale service associated with the L2 VPN Service.
+* `locale_service_path` - (Deprecated) Path of the locale service associated with the L2 VPN Service.
+* `gateway_path` - (Optional) Path of gateway associated with the L2 VPN Service. Note that at least one of `gateway_path` and `locale_service_path` must be specified for the L2 VPN Service object.
 * `enable_hub` - (Optional) This property applies only in `SERVER` mode. If set to true, traffic from any client will be replicated to all other clients. If set to false, traffic received from clients is only replicated to the local VPN endpoint. Default is `true`.
 * `mode` - (Optional) Specify an L2VPN service mode as SERVER or CLIENT. Value is one of `SERVER`, `CLIENT`. Default is `SERVER`.
 * `encap_ip_pool` - (Optional) IP Pool to allocate local and peer endpoint IPs. Format is ipv4 CIDR block.

--- a/website/docs/r/policy_l2_vpn_session.html.markdown
+++ b/website/docs/r/policy_l2_vpn_session.html.markdown
@@ -17,7 +17,7 @@ This resource is applicable to NSX Policy Manager and VMC.
 resource "nsxt_policy_l2_vpn_session" "test" {
   display_name      = "L2 VPN Session"
   description       = "Terraform-provisioned L2 VPN Tunnel"
-  service_path      = nsxt_policy_ipsec_vpn_service.test.path
+  service_path      = nsxt_policy_l2_vpn_service.test.path
   transport_tunnels = [nsxt_policy_ipsec_vpn_session.ipsec_vpn_session_for_l2vpn.path]
 }
 ```
@@ -32,8 +32,8 @@ The following arguments are supported:
 * `nsx_id` - (Optional) The NSX ID of this resource. If set, this ID will be used to create the resource.
 * `service_path` - (Required) The path of the L2 VPN service for the VPN session.
 * `transport_tunnels` - (Required) List of transport tunnels paths for redundancy. L2VPN supports only `AES_GCM_128` encryption algorithm for IPSec tunnel profile.
-* `direction` - (Optional) The traffic direction apply to the MSS clamping. `BOTH` or `NONE`. Must be specified together with `max_segment_size`.
-* `max_segment_size` - (Optional) Maximum amount of data the host will accept in a TCP segment. Value should be between `108` and `8860`. Must be specified together with `direction`.
+* `direction` - (Optional) The traffic direction apply to the MSS clamping. `BOTH` or `NONE`.
+* `max_segment_size` - (Optional) Maximum amount of data the host will accept in a TCP segment. Value should be between `108` and `8860`. If not specified then the value would be the automatic calculated MSS value.
 * `local_address` - (Optional) IP Address of the local tunnel port. This property only applies in `CLIENT` mode.
 * `peer_address` - (Optional) IP Address of the peer tunnel port. This property only applies in `CLIENT` mode.
 * `protocol` - (Optional) Encapsulation protocol used by the tunnel. `GRE` is the only supported value.


### PR DESCRIPTION
NSX API that uses locale service path of VPN resources will be deprecated this PR adds support for the new API that uses gateway path.

Also change data_source_nsxt_policy_ipsec_vpn_local_endpoint to use regex-based search API.

Signed-off-by: Shizhao Liu <lshizhao@vmware.com>