### PR TITLE
Fix delete scenario in VPN tests

### DIFF
--- a/nsxt/data_source_nsxt_policy_ipsec_vpn_local_endpoint_test.go
+++ b/nsxt/data_source_nsxt_policy_ipsec_vpn_local_endpoint_test.go
@@ -74,8 +74,7 @@ data "nsxt_policy_ipsec_vpn_local_endpoint" "test" {
 }
 
 func testAccNsxtPolicyDataSourceIPSecVpnLocalEndpointPreconfig(name string) string {
-	return testAccNsxtPolicyEdgeClusterReadTemplate(getEdgeClusterName()) +
-		testAccNsxtPolicyTier0WithEdgeClusterForVPN("test") + fmt.Sprintf(`
+	return testAccNsxtPolicyTier0WithEdgeClusterForVPN() + fmt.Sprintf(`
 resource "nsxt_policy_ipsec_vpn_service" "test" {
   display_name        = "%s"
   locale_service_path =  one(nsxt_policy_tier0_gateway.test.locale_service).path

--- a/nsxt/data_source_nsxt_policy_ipsec_vpn_service_test.go
+++ b/nsxt/data_source_nsxt_policy_ipsec_vpn_service_test.go
@@ -56,8 +56,7 @@ func TestAccDataSourceNsxtPolicyIPSecVpnService_withGateway(t *testing.T) {
 }
 
 func testAccNsxtPolicyIPSecVpnServiceReadTemplate(name string) string {
-	return testAccNsxtPolicyEdgeClusterReadTemplate(getEdgeClusterName()) +
-		testAccNsxtPolicyTier0WithEdgeClusterForVPN("test") + fmt.Sprintf(`
+	return testAccNsxtPolicyTier0WithEdgeClusterForVPN() + fmt.Sprintf(`
 resource "nsxt_policy_ipsec_vpn_service" "test" {
  display_name        = "%s"
  locale_service_path = one(nsxt_policy_tier0_gateway.test.locale_service).path
@@ -68,8 +67,7 @@ data "nsxt_policy_ipsec_vpn_service" "test" {
 }
 
 func testAccNsxtPolicyIPSecVpnServiceReadTemplateWithGateway(name string) string {
-	return testAccNsxtPolicyEdgeClusterReadTemplate(getEdgeClusterName()) +
-		testAccNsxtPolicyTier0WithEdgeClusterForVPN("test") + fmt.Sprintf(`
+	return testAccNsxtPolicyTier0WithEdgeClusterForVPN() + fmt.Sprintf(`
 resource "nsxt_policy_ipsec_vpn_service" "test" {
  display_name          = "%s"
  locale_service_path   = one(nsxt_policy_tier0_gateway.test.locale_service).path

--- a/nsxt/data_source_nsxt_policy_l2_vpn_service_test.go
+++ b/nsxt/data_source_nsxt_policy_l2_vpn_service_test.go
@@ -56,8 +56,7 @@ func TestAccDataSourceNsxtPolicyL2VpnService_withGateway(t *testing.T) {
 }
 
 func testAccNsxtPolicyL2VpnServiceReadTemplate(name string) string {
-	return testAccNsxtPolicyEdgeClusterReadTemplate(getEdgeClusterName()) +
-		testAccNsxtPolicyTier0WithEdgeClusterForVPN("test") + fmt.Sprintf(`
+	return testAccNsxtPolicyTier0WithEdgeClusterForVPN() + fmt.Sprintf(`
    resource "nsxt_policy_l2_vpn_service" "test" {
 	display_name          = "%s"
 	locale_service_path   = one(nsxt_policy_tier0_gateway.test.locale_service).path
@@ -68,8 +67,7 @@ func testAccNsxtPolicyL2VpnServiceReadTemplate(name string) string {
 }
 
 func testAccNsxtPolicyL2VpnServiceReadTemplateWithGateway(name string) string {
-	return testAccNsxtPolicyEdgeClusterReadTemplate(getEdgeClusterName()) +
-		testAccNsxtPolicyTier0WithEdgeClusterForVPN("test") + fmt.Sprintf(`
+	return testAccNsxtPolicyTier0WithEdgeClusterForVPN() + fmt.Sprintf(`
    resource "nsxt_policy_l2_vpn_service" "test" {
 	display_name          = "%s"
 	locale_service_path   = one(nsxt_policy_tier0_gateway.test.locale_service).path

--- a/nsxt/resource_nsxt_policy_ipsec_vpn_local_endpoint_test.go
+++ b/nsxt/resource_nsxt_policy_ipsec_vpn_local_endpoint_test.go
@@ -78,6 +78,9 @@ func TestAccResourceNsxtPolicyIPSecVpnLocalEndpoint_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(testResourceName, "tag.#", "0"),
 				),
 			},
+			{
+				Config: testAccNsxtPolicyGatewayTemplate(true),
+			},
 		},
 	})
 }

--- a/nsxt/resource_nsxt_policy_ipsec_vpn_service_test.go
+++ b/nsxt/resource_nsxt_policy_ipsec_vpn_service_test.go
@@ -96,6 +96,9 @@ func TestAccResourceNsxtPolicyIPSecVpnService_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(testResourceName, "tag.#", "0"),
 				),
 			},
+			{
+				Config: testAccNsxtPolicyGatewayTemplate(true),
+			},
 		},
 	})
 }
@@ -198,8 +201,7 @@ func testAccNsxtPolicyIPSecVpnServiceTemplate(createFlow bool) string {
 	} else {
 		attrMap = accTestPolicyIPSecVpnServiceUpdateAttributes
 	}
-	return testAccNsxtPolicyEdgeClusterReadTemplate(getEdgeClusterName()) +
-		testAccNsxtPolicyTier0WithEdgeClusterForVPN("test") + fmt.Sprintf(`
+	return testAccNsxtPolicyTier0WithEdgeClusterForVPN() + fmt.Sprintf(`
 resource "nsxt_policy_ipsec_vpn_service" "test" {
 	display_name                   = "%s"
 	description                    = "%s"
@@ -221,8 +223,7 @@ resource "nsxt_policy_ipsec_vpn_service" "test" {
 }
 
 func testAccNsxtPolicyIPSecVpnServiceMinimalistic() string {
-	return testAccNsxtPolicyEdgeClusterReadTemplate(getEdgeClusterName()) +
-		testAccNsxtPolicyTier0WithEdgeClusterForVPN("test") + fmt.Sprintf(`
+	return testAccNsxtPolicyTier0WithEdgeClusterForVPN() + fmt.Sprintf(`
    resource "nsxt_policy_ipsec_vpn_service" "test" {
 	 display_name          = "%s"
 	 locale_service_path   = one(nsxt_policy_tier0_gateway.test.locale_service).path

--- a/nsxt/resource_nsxt_policy_ipsec_vpn_session_test.go
+++ b/nsxt/resource_nsxt_policy_ipsec_vpn_session_test.go
@@ -168,6 +168,9 @@ func TestAccResourceNsxtPolicyIPSecVpnSessionRouteBased_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(testResourceName, "tag.#", "0"),
 				),
 			},
+			{
+				Config: testAccNsxtPolicyGatewayTemplate(true),
+			},
 		},
 	})
 }
@@ -263,6 +266,9 @@ func TestAccResourceNsxtPolicyIPSecVpnSessionPolicyBased_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
 				),
 			},
+			{
+				Config: testAccNsxtPolicyGatewayTemplate(true),
+			},
 		},
 	})
 }
@@ -334,6 +340,9 @@ func TestAccResourceNsxtPolicyIPSecVpnSessionPolicyBased_tier1(t *testing.T) {
 					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
 				),
 			},
+			{
+				Config: testAccNsxtPolicyGatewayTemplate(false),
+			},
 		},
 	})
 }
@@ -400,6 +409,9 @@ func TestAccResourceNsxtPolicyIPSecVpnSessionRouteBased_tier1(t *testing.T) {
 					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
 					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
 				),
+			},
+			{
+				Config: testAccNsxtPolicyGatewayTemplate(false),
 			},
 		},
 	})
@@ -528,8 +540,7 @@ resource "nsxt_policy_ipsec_vpn_local_endpoint" "test" {
 
 func testAccNsxtPolicyIPSecVpnSessionRouteBasedMinimalistic() string {
 	attrMap := accTestPolicyIPSecVpnSessionRouteBasedCreateAttributes
-	return testAccNsxtPolicyEdgeClusterReadTemplate(getEdgeClusterName()) +
-		testAccNsxtPolicyTier0WithEdgeClusterForVPN("test") +
+	return testAccNsxtPolicyTier0WithEdgeClusterForVPN() +
 		testAccNsxtPolicyIPSecVpnSessionPreConditionTemplate(true) +
 		fmt.Sprintf(`
 resource "nsxt_policy_ipsec_vpn_session" "test" {
@@ -546,13 +557,6 @@ resource "nsxt_policy_ipsec_vpn_session" "test" {
 }`, attrMap["display_name"], attrMap["vpn_type"], attrMap["peer_address"], attrMap["peer_id"], attrMap["ip_addresses"], attrMap["prefix_length"], attrMap["psk"])
 }
 
-func gatewayTemplate(isT0 bool) string {
-	if isT0 {
-		return testAccNsxtPolicyTier0WithEdgeClusterForVPN("test")
-	}
-	return testAccNsxtPolicyTier1WithEdgeClusterForVPN("test")
-}
-
 func testAccNsxtPolicyIPSecVpnSessionRouteBasedTemplate(createFlow bool, isT0 bool) string {
 	var attrMap map[string]string
 	if createFlow {
@@ -560,8 +564,7 @@ func testAccNsxtPolicyIPSecVpnSessionRouteBasedTemplate(createFlow bool, isT0 bo
 	} else {
 		attrMap = accTestPolicyIPSecVpnSessionRouteBasedUpdateAttributes
 	}
-	return testAccNsxtPolicyEdgeClusterReadTemplate(getEdgeClusterName()) +
-		gatewayTemplate(isT0) + testAccNsxtPolicyIPSecVpnSessionPreConditionTemplate(isT0) +
+	return testAccNsxtPolicyGatewayTemplate(isT0) + testAccNsxtPolicyIPSecVpnSessionPreConditionTemplate(isT0) +
 		fmt.Sprintf(`
 resource "nsxt_policy_ipsec_vpn_session" "test" {
 	display_name               = "%s"
@@ -597,8 +600,7 @@ func testAccNsxtPolicyIPSecVpnSessionPolicyBasedTemplate(createFlow bool, isT0 b
 	} else {
 		attrMap = accTestPolicyIPSecVpnSessionPolicyBasedUpdateAttributes
 	}
-	return testAccNsxtPolicyEdgeClusterReadTemplate(getEdgeClusterName()) +
-		gatewayTemplate(isT0) + testAccNsxtPolicyIPSecVpnSessionPreConditionTemplate(isT0) +
+	return testAccNsxtPolicyGatewayTemplate(isT0) + testAccNsxtPolicyIPSecVpnSessionPreConditionTemplate(isT0) +
 		fmt.Sprintf(`
 resource "nsxt_policy_ipsec_vpn_session" "test" {
 	display_name               = "%s"

--- a/nsxt/resource_nsxt_policy_l2_vpn_service_test.go
+++ b/nsxt/resource_nsxt_policy_l2_vpn_service_test.go
@@ -91,6 +91,9 @@ func TestAccResourceNsxtPolicyL2VpnService_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
 				),
 			},
+			{
+				Config: testAccNsxtPolicyGatewayTemplate(true),
+			},
 		},
 	})
 }
@@ -121,6 +124,9 @@ func TestAccResourceNsxtPolicyL2VpnService_ClientMode(t *testing.T) {
 					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
 					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
 				),
+			},
+			{
+				Config: testAccNsxtPolicyGatewayTemplate(true),
 			},
 		},
 	})
@@ -228,15 +234,14 @@ func testAccNsxtPolicyL2VpnServiceTemplate(createFlow bool, clientMode bool) str
 			attrMap = accTestPolicyL2VpnServiceUpdateAttributes
 		}
 	}
-	return testAccNsxtPolicyEdgeClusterReadTemplate(getEdgeClusterName()) +
-		testAccNsxtPolicyTier0WithEdgeClusterForVPN("test") + fmt.Sprintf(`
+	return testAccNsxtPolicyTier0WithEdgeClusterForVPN() + fmt.Sprintf(`
 	  resource "nsxt_policy_l2_vpn_service" "test" {
-		display_name                   = "%s"
-		description                    = "%s"
-		locale_service_path   		   = one(nsxt_policy_tier0_gateway.test.locale_service).path
-		enable_hub                     = "%s"
-		mode               			   = "%s"
-		encap_ip_pool 				   = ["%s"]
+		display_name         = "%s"
+		description          = "%s"
+		locale_service_path  = one(nsxt_policy_tier0_gateway.test.locale_service).path
+		enable_hub           = "%s"
+		mode                 = "%s"
+		encap_ip_pool 	     = ["%s"]
 		tag {
 		  scope = "scope1"
 		  tag   = "tag1"
@@ -245,8 +250,7 @@ func testAccNsxtPolicyL2VpnServiceTemplate(createFlow bool, clientMode bool) str
 }
 
 func testAccNsxtPolicyL2VpnServiceMinimalistic() string {
-	return testAccNsxtPolicyEdgeClusterReadTemplate(getEdgeClusterName()) +
-		testAccNsxtPolicyTier0WithEdgeClusterForVPN("test") + fmt.Sprintf(`
+	return testAccNsxtPolicyTier0WithEdgeClusterForVPN() + fmt.Sprintf(`
 	  resource "nsxt_policy_l2_vpn_service" "test" {
 		display_name          = "%s"
 		locale_service_path   = one(nsxt_policy_tier0_gateway.test.locale_service).path

--- a/nsxt/resource_nsxt_policy_l2_vpn_session_test.go
+++ b/nsxt/resource_nsxt_policy_l2_vpn_session_test.go
@@ -101,6 +101,9 @@ func TestAccResourceNsxtPolicyL2VpnSession_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(testResourceName, "tag.#", "0"),
 				),
 			},
+			{
+				Config: testAccNsxtPolicyGatewayTemplate(true),
+			},
 		},
 	})
 }
@@ -177,6 +180,9 @@ func TestAccResourceNsxtPolicyL2VpnSession_tier1(t *testing.T) {
 					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
 					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
 				),
+			},
+			{
+				Config: testAccNsxtPolicyGatewayTemplate(false),
 			},
 		},
 	})
@@ -341,8 +347,7 @@ resource "nsxt_policy_ipsec_vpn_session" "test" {
 }
 
 func testAccNsxtPolicyL2VpnSessionTestTemplate(createFlow bool, isT0 bool) string {
-	return testAccNsxtPolicyEdgeClusterReadTemplate(getEdgeClusterName()) +
-		gatewayTemplate(isT0) +
+	return testAccNsxtPolicyGatewayTemplate(isT0) +
 		testAccNsxtPolicyL2VpnSessionPreConditionTemplate(isT0) +
 		testAccNsxtPolicyL2VpnSessionTemplate(createFlow)
 }
@@ -377,8 +382,7 @@ resource "nsxt_policy_l2_vpn_session" "test" {
 
 func testAccNsxtPolicyL2VpnSessionMinimalistic() string {
 	attrMap := accTestPolicyL2VpnSessionCreateAttributes
-	return testAccNsxtPolicyEdgeClusterReadTemplate(getEdgeClusterName()) +
-		testAccNsxtPolicyTier0WithEdgeClusterForVPN("test") +
+	return testAccNsxtPolicyTier0WithEdgeClusterForVPN() +
 		testAccNsxtPolicyL2VpnSessionPreConditionTemplate(true) + fmt.Sprintf(`
 resource "nsxt_policy_l2_vpn_session" "test" {
 	display_name      = "%s"

--- a/nsxt/utils_test.go
+++ b/nsxt/utils_test.go
@@ -455,21 +455,22 @@ resource "nsxt_policy_tier%s_gateway" "test" {
 }`, tier, tier, edgeClusterName, haMode)
 }
 
-func testAccNsxtPolicyTier0WithEdgeClusterForVPN(edgeClusterName string) string {
-	return fmt.Sprintf(`
+var testAccNsxtPolicyVPNGatewayHelperName = getAccTestResourceName()
+
+func testAccNsxtPolicyTier0WithEdgeClusterForVPN() string {
+	return testAccNsxtPolicyEdgeClusterReadTemplate(getEdgeClusterName()) + fmt.Sprintf(`
 resource "nsxt_policy_tier0_gateway" "test" {
   display_name = "%s"
   description  = "Acceptance Test"
   locale_service {
-    edge_cluster_path = data.nsxt_policy_edge_cluster.%s.path
+    edge_cluster_path = data.nsxt_policy_edge_cluster.test.path
   }
   ha_mode = "ACTIVE_STANDBY"
-}`, getAccTestResourceName(), edgeClusterName)
+}`, testAccNsxtPolicyVPNGatewayHelperName)
 }
 
-func testAccNsxtPolicyTier1WithEdgeClusterForVPN(edgeClusterName string) string {
-	gatewayName := getAccTestResourceName()
-	return fmt.Sprintf(`
+func testAccNsxtPolicyTier1WithEdgeClusterForVPN() string {
+	return testAccNsxtPolicyEdgeClusterReadTemplate(getEdgeClusterName()) + fmt.Sprintf(`
 resource "nsxt_policy_tier0_gateway" "test" {
 	display_name = "%s"
 	description  = "Acceptance Test"
@@ -479,10 +480,17 @@ resource "nsxt_policy_tier1_gateway" "test" {
 	description               = "Acceptance Test"
 	display_name              = "%s"
 	locale_service {
-		edge_cluster_path = data.nsxt_policy_edge_cluster.%s.path
+		edge_cluster_path = data.nsxt_policy_edge_cluster.test.path
 	}
 	tier0_path                = nsxt_policy_tier0_gateway.test.path
-}`, gatewayName, gatewayName, edgeClusterName)
+}`, testAccNsxtPolicyVPNGatewayHelperName, testAccNsxtPolicyVPNGatewayHelperName)
+}
+
+func testAccNsxtPolicyGatewayTemplate(isT0 bool) string {
+	if isT0 {
+		return testAccNsxtPolicyTier0WithEdgeClusterForVPN()
+	}
+	return testAccNsxtPolicyTier1WithEdgeClusterForVPN()
 }
 
 func testAccNsxtPolicyResourceExists(resourceName string, presenceChecker func(string, client.Connector, bool) (bool, error)) resource.TestCheckFunc {


### PR DESCRIPTION
When VPN objects are deleted, the test still needs to leave the gateway intact, otherwise all VPN objects get auto-deleted together with parent gateway.
Signed-off-by: Anna Khmelnitsky <akhmelnitsky@vmware.com>