### PR TITLE
Remove `Policy` prefix from categories in docs

### DIFF
--- a/tools/data_source_nsxt_policy_doc_template
+++ b/tools/data_source_nsxt_policy_doc_template
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - FIXME"
+subcategory: "FIXME"
 layout: "nsxt"
 page_title: "NSXT: policy_<!resource_lower!>"
 description: Policy <!RESOURCE!> data source.

--- a/tools/resource_nsxt_policy_doc_template
+++ b/tools/resource_nsxt_policy_doc_template
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - FIXME"
+subcategory: "FIXME"
 layout: "nsxt"
 page_title: "NSXT: nsxt_policy_<!resource_lower!>"
 description: A resource to configure a <!RESOURCE!>.

--- a/website/docs/d/policy_bfd_profile.html.markdown
+++ b/website/docs/d/policy_bfd_profile.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - Gateways and Routing"
+subcategory: "Gateways and Routing"
 layout: "nsxt"
 page_title: "NSXT: policy_bfd_profile"
 description: Policy BFD Profile data source.

--- a/website/docs/d/policy_bridge_profile.html.markdown
+++ b/website/docs/d/policy_bridge_profile.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - Segments"
+subcategory: "Segments"
 layout: "nsxt"
 page_title: "NSXT: policy_bridge_profile"
 description: Policy Bridge Profile data source.

--- a/website/docs/d/policy_certificate.html.markdown
+++ b/website/docs/d/policy_certificate.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - Certificates"
+subcategory: "Certificates"
 layout: "nsxt"
 page_title: "NSXT: policy_certificate"
 description: Policy Certificate data source.

--- a/website/docs/d/policy_context_profile.html.markdown
+++ b/website/docs/d/policy_context_profile.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - Firewall"
+subcategory: "Firewall"
 layout: "nsxt"
 page_title: "NSXT: policy_context_profile"
 description: Policy Context Profile Profile data source.

--- a/website/docs/d/policy_dhcp_server.html.markdown
+++ b/website/docs/d/policy_dhcp_server.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - DHCP"
+subcategory: "DHCP"
 layout: "nsxt"
 page_title: "NSXT: policy_dhcp_server"
 description: A policy DHCP server data source.

--- a/website/docs/d/policy_edge_cluster.html.markdown
+++ b/website/docs/d/policy_edge_cluster.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - Fabric"
+subcategory: "Fabric"
 layout: "nsxt"
 page_title: "NSXT: policy_edge cluster"
 description: A policy Edge Cluster data source.

--- a/website/docs/d/policy_edge_node.html.markdown
+++ b/website/docs/d/policy_edge_node.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - Fabric"
+subcategory: "Fabric"
 layout: "nsxt"
 page_title: "NSXT: policy_edge node"
 description: A policy Edge Node data source.

--- a/website/docs/d/policy_gateway_locale_service.html.markdown
+++ b/website/docs/d/policy_gateway_locale_service.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - Gateways and Routing"
+subcategory: "Gateways and Routing"
 layout: "nsxt"
 page_title: "NSXT: policy_gateway_locale_service"
 description: A policy gateway locale service data source.

--- a/website/docs/d/policy_gateway_policy.html.markdown
+++ b/website/docs/d/policy_gateway_policy.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - Firewall"
+subcategory: "Firewall"
 layout: "nsxt"
 page_title: "NSXT: policy_gateway_policy"
 description: A policy Gateway Policy data source.

--- a/website/docs/d/policy_gateway_qos_profile.html.markdown
+++ b/website/docs/d/policy_gateway_qos_profile.html.markdown
@@ -1,13 +1,13 @@
 ---
-subcategory: "Policy - Gateways and Routing"
+subcategory: "Gateways and Routing"
 layout: "nsxt"
 page_title: "NSXT: policy_gateway_qos_profile"
-description: Policy GatewayQosProfile data source.
+description: Policy Gateway QoS Profile data source.
 ---
 
 # nsxt_policy_gateway_qos_profile
 
-This data source provides information about policy GatewayQosProfile configured on NSX.
+This data source provides information about policy Gateway Quality of Service Profile configured on NSX.
 
 This data source is applicable to NSX Global Manager, and NSX Policy Manager.
 
@@ -23,7 +23,7 @@ data "nsxt_policy_gateway_qos_profile" "test" {
 
 * `id` - (Optional) The ID of GatewayQosProfile to retrieve.
 
-* `display_name` - (Optional) The Display Name prefix of the GatewayQosProfile to retrieve.
+* `display_name` - (Optional) The Display Name prefix of the Gateway QoS Profile to retrieve.
 
 ## Attributes Reference
 

--- a/website/docs/d/policy_group.html.markdown
+++ b/website/docs/d/policy_group.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - Grouping and Tagging"
+subcategory: "Grouping and Tagging"
 layout: "nsxt"
 page_title: "NSXT: policy_group"
 description: Policy Group data source.

--- a/website/docs/d/policy_intrusion_service_profile.html.markdown
+++ b/website/docs/d/policy_intrusion_service_profile.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - Firewall"
+subcategory: "Firewall"
 layout: "nsxt"
 page_title: "NSXT: policy_intrusion_service_profile"
 description: Policy Intrusion Service Profile data source.

--- a/website/docs/d/policy_ip_block.html.markdown
+++ b/website/docs/d/policy_ip_block.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - IPAM"
+subcategory: "IPAM"
 layout: "nsxt"
 page_title: "NSXT: policy_ip_block"
 description: Policy IP Block data source.

--- a/website/docs/d/policy_ip_discovery_profile.html.markdown
+++ b/website/docs/d/policy_ip_discovery_profile.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - Segments"
+subcategory: "Segments"
 layout: "nsxt"
 page_title: "NSXT: policy_ip_discovery_profile"
 description: Policy IP Discovery Profile data source.

--- a/website/docs/d/policy_ip_pool.html.markdown
+++ b/website/docs/d/policy_ip_pool.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - IPAM"
+subcategory: "IPAM"
 layout: "nsxt"
 page_title: "NSXT: policy_ip_pool"
 description: Policy IP Pool Config data source.

--- a/website/docs/d/policy_ipv6_dad_profile.html.markdown
+++ b/website/docs/d/policy_ipv6_dad_profile.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - Gateways and Routing"
+subcategory: "Gateways and Routing"
 layout: "nsxt"
 page_title: "NSXT: policy_ipv6_dad_profile"
 description: Policy IPv6 DAD Profile data source.

--- a/website/docs/d/policy_ipv6_ndra_profile.html.markdown
+++ b/website/docs/d/policy_ipv6_ndra_profile.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - Gateways and Routing"
+subcategory: "Gateways and Routing"
 layout: "nsxt"
 page_title: "NSXT: policy_ipv6_ndra_profile"
 description: Policy IPv6 NDRA Profile data source.

--- a/website/docs/d/policy_lb_app_profile.html.markdown
+++ b/website/docs/d/policy_lb_app_profile.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - Load Balancer"
+subcategory: "Load Balancer"
 layout: "nsxt"
 page_title: "NSXT: policy_lb_app_profile"
 description: Policy Load Balancer Application Profile data source.

--- a/website/docs/d/policy_lb_client_ssl_profile.html.markdown
+++ b/website/docs/d/policy_lb_client_ssl_profile.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - Load Balancer"
+subcategory: "Load Balancer"
 layout: "nsxt"
 page_title: "NSXT: policy_lb_client_ssl_profile"
 description: Policy Load Balancer Client SSL Profile data source.

--- a/website/docs/d/policy_lb_monitor.html.markdown
+++ b/website/docs/d/policy_lb_monitor.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - Load Balancer"
+subcategory: "Load Balancer"
 layout: "nsxt"
 page_title: "NSXT: policy_lb_monitor"
 description: Policy Load Balancer Monitor data source.

--- a/website/docs/d/policy_lb_persistence_profile.html.markdown
+++ b/website/docs/d/policy_lb_persistence_profile.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - Load Balancer"
+subcategory: "Load Balancer"
 layout: "nsxt"
 page_title: "NSXT: policy_lb_persistence_profile"
 description: Policy Load Balancer Persistence Profile data source.

--- a/website/docs/d/policy_lb_server_ssl_profile.html.markdown
+++ b/website/docs/d/policy_lb_server_ssl_profile.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - Load Balancer"
+subcategory: "Load Balancer"
 layout: "nsxt"
 page_title: "NSXT: policy_lb_server_ssl_profile"
 description: Policy Load Balancer Server SSL Profile data source.

--- a/website/docs/d/policy_lb_service.html.markdown
+++ b/website/docs/d/policy_lb_service.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Beta"
+subcategory: "Load Balancer"
 layout: "nsxt"
 page_title: "NSXT: policy_lb_service"
 description: Policy Load Balancer Service data source.

--- a/website/docs/d/policy_mac_discovery_profile.html.markdown
+++ b/website/docs/d/policy_mac_discovery_profile.html.markdown
@@ -1,8 +1,8 @@
 ---
-subcategory: "Policy - Segments"
+subcategory: "Segments"
 layout: "nsxt"
 page_title: "NSXT: policy_mac_discovery_profile"
-description: Policy MacDiscoveryProfile data source.
+description: Policy MAC Discovery Profile data source.
 ---
 
 # nsxt_policy_mac_discovery_profile

--- a/website/docs/d/policy_qos_profile.html.markdown
+++ b/website/docs/d/policy_qos_profile.html.markdown
@@ -1,8 +1,8 @@
 ---
-subcategory: "Policy - Segments"
+subcategory: "Segments"
 layout: "nsxt"
 page_title: "NSXT: policy_qos_profile"
-description: Policy QosProfile data source.
+description: Policy QoS Profile data source.
 ---
 
 # nsxt_policy_qos_profile

--- a/website/docs/d/policy_realization_info.html.markdown
+++ b/website/docs/d/policy_realization_info.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - Realization"
+subcategory: "Realization"
 layout: "nsxt"
 page_title: "NSXT: policy_realization_info"
 description: A policy resource realization information.

--- a/website/docs/d/policy_security_policy.html.markdown
+++ b/website/docs/d/policy_security_policy.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - Firewall"
+subcategory: "Firewall"
 layout: "nsxt"
 page_title: "NSXT: policy_security_policy"
 description: A policy Security Policy data source.

--- a/website/docs/d/policy_segment.html.markdown
+++ b/website/docs/d/policy_segment.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - Segments"
+subcategory: "Segments"
 layout: "nsxt"
 page_title: "NSXT: policy_segment"
 description: Policy Segment data source.

--- a/website/docs/d/policy_segment_realization.html.markdown
+++ b/website/docs/d/policy_segment_realization.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - Realization"
+subcategory: "Realization"
 layout: "nsxt"
 page_title: "NSXT: policy_segment_realization"
 description: State of segment realization on hypervisors.

--- a/website/docs/d/policy_segment_security_profile.html.markdown
+++ b/website/docs/d/policy_segment_security_profile.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - Segments"
+subcategory: "Segments"
 layout: "nsxt"
 page_title: "NSXT: policy_segment_security_profile"
 description: Policy SegmentSecurityProfile data source.

--- a/website/docs/d/policy_service.html.markdown
+++ b/website/docs/d/policy_service.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - Firewall"
+subcategory: "Firewall"
 layout: "nsxt"
 page_title: "NSXT: policy_service"
 description: A policy service data source.

--- a/website/docs/d/policy_site.html.markdown
+++ b/website/docs/d/policy_site.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - Fabric"
+subcategory: "Fabric"
 layout: "nsxt"
 page_title: "NSXT: policy_site"
 description: Policy Site data source.

--- a/website/docs/d/policy_spoofguard_profile.html.markdown
+++ b/website/docs/d/policy_spoofguard_profile.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - Segments"
+subcategory: "Segments"
 layout: "nsxt"
 page_title: "NSXT: policy_spoofguard_profile"
 description: Policy SpoofGuardProfile data source.

--- a/website/docs/d/policy_tier0_gateway.html.markdown
+++ b/website/docs/d/policy_tier0_gateway.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - Gateways and Routing"
+subcategory: "Gateways and Routing"
 layout: "nsxt"
 page_title: "NSXT: policy_tier0_gateway"
 description: A policy Tier-0 gateway data source.

--- a/website/docs/d/policy_tier1_gateway.html.markdown
+++ b/website/docs/d/policy_tier1_gateway.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - Gateways and Routing"
+subcategory: "Gateways and Routing"
 layout: "nsxt"
 page_title: "NSXT: policy_tier1_gateway"
 description: A policy Tier-1 gateway data source.

--- a/website/docs/d/policy_transport_zone.html.markdown
+++ b/website/docs/d/policy_transport_zone.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - Fabric"
+subcategory: "Fabric"
 layout: "nsxt"
 page_title: "NSXT: nsxt_policy_transport_zone"
 description: A Policy Transport Zone data source.

--- a/website/docs/d/policy_vm.html.markdown
+++ b/website/docs/d/policy_vm.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - Grouping and Tagging"
+subcategory: "Grouping and Tagging"
 layout: "nsxt"
 page_title: "NSXT: nsxt_policy_vm"
 description: A Discovered Policy Virtual Machine data source.

--- a/website/docs/d/policy_vms.html.markdown
+++ b/website/docs/d/policy_vms.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Beta"
+subcategory: "Grouping and Tagging"
 layout: "nsxt"
 page_title: "NSXT: nsxt_policy_vms"
 description: A Discovered Policy Virtual Machines data source.

--- a/website/docs/d/policy_vni_pool.html.markdown
+++ b/website/docs/d/policy_vni_pool.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - Segments"
+subcategory: "Segments"
 layout: "nsxt"
 page_title: "NSXT: policy_vni_pool"
 description: Policy VNI Pool Config data source.

--- a/website/docs/r/policy_bgp_config.html.markdown
+++ b/website/docs/r/policy_bgp_config.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - Gateways and Routing"
+subcategory: "Gateways and Routing"
 layout: "nsxt"
 page_title: "NSXT: nsxt_policy_bgp_config"
 description: A resource to configure BGP Settings of Tier0 Gateway.

--- a/website/docs/r/policy_bgp_neighbor.html.markdown
+++ b/website/docs/r/policy_bgp_neighbor.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - Gateways and Routing"
+subcategory: "Gateways and Routing"
 layout: "nsxt"
 page_title: "NSXT: nsxt_policy_bgp_neighbor"
 description: A resource to configure a BGP Neighbor.

--- a/website/docs/r/policy_context_profile.html.markdown
+++ b/website/docs/r/policy_context_profile.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - Firewall"
+subcategory: "Firewall"
 layout: "nsxt"
 page_title: "NSXT: nsxt_policy_context_profile"
 description: A resource to configure a Context Profile.

--- a/website/docs/r/policy_context_profile_custom_attribute.html.markdown
+++ b/website/docs/r/policy_context_profile_custom_attribute.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - Firewall"
+subcategory: "Firewall"
 layout: "nsxt"
 page_title: "NSXT: nsxt_policy_context_profile_custom_attribute"
 description: A resource to configure a Context Profile FQDN or URL Custom attribute.

--- a/website/docs/r/policy_dhcp_relay.html.markdown
+++ b/website/docs/r/policy_dhcp_relay.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - DHCP"
+subcategory: "DHCP"
 layout: "nsxt"
 page_title: "NSXT: nsxt_policy_dhcp_relay"
 description: A resource to configure a Dhcp Relay.

--- a/website/docs/r/policy_dhcp_server.html.markdown
+++ b/website/docs/r/policy_dhcp_server.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - DHCP"
+subcategory: "DHCP"
 layout: "nsxt"
 page_title: "NSXT: nsxt_policy_dhcp_server"
 description: A resource to configure a DHCP Servers in NSX-T.

--- a/website/docs/r/policy_dhcp_v4_static_binding.html.markdown
+++ b/website/docs/r/policy_dhcp_v4_static_binding.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - DHCP"
+subcategory: "DHCP"
 layout: "nsxt"
 page_title: "NSXT: nsxt_policy_dhcp_v4_static_binding"
 description: A resource to configure IPv4 DHCP Static Binding.

--- a/website/docs/r/policy_dhcp_v6_static_binding.html.markdown
+++ b/website/docs/r/policy_dhcp_v6_static_binding.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - DHCP"
+subcategory: "DHCP"
 layout: "nsxt"
 page_title: "NSXT: nsxt_policy_dhcp_v6_static_binding"
 description: A resource to configure IPv6 DHCP Static Binding.

--- a/website/docs/r/policy_dns_forwarder_zone.html.markdown
+++ b/website/docs/r/policy_dns_forwarder_zone.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - DNS"
+subcategory: "DNS"
 layout: "nsxt"
 page_title: "NSXT: nsxt_policy_dns_forwarder_zone"
 description: A resource to configure DNS Forwarder Zone.

--- a/website/docs/r/policy_domain.html.markdown
+++ b/website/docs/r/policy_domain.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - Grouping and Tagging"
+subcategory: "Grouping and Tagging"
 layout: "nsxt"
 page_title: "NSXT: nsxt_policy_domain"
 description: A resource to configure a Global manager domain.

--- a/website/docs/r/policy_evpn_config.html.markdown
+++ b/website/docs/r/policy_evpn_config.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - EVPN"
+subcategory: "EVPN"
 layout: "nsxt"
 page_title: "NSXT: nsxt_policy_evpn_config"
 description: A resource to configure EVPN Settings of Tier0 Gateway.
@@ -56,4 +56,4 @@ terraform import nsxt_policy_evpn_config.config1 gwPath
 
 The above command imports EVPN Config named `config1` for NSX Policy Tier0 Gateway with full Policy Path `gwPath`.
 
-~> **NOTE:** Note that import parameter here is non-standard here. Please make sure you use full policy path for the gateway, such as `/infra/tier-0s/mygateway`
+~> **NOTE:** Note that import parameter is non-standard here. Please make sure you use full policy path for the gateway, such as `/infra/tier-0s/mygateway`

--- a/website/docs/r/policy_evpn_tenant.html.markdown
+++ b/website/docs/r/policy_evpn_tenant.html.markdown
@@ -1,8 +1,8 @@
 ---
-subcategory: "Policy - EVPN"
+subcategory: "EVPN"
 layout: "nsxt"
 page_title: "NSXT: nsxt_policy_evpn_tenant"
-description: A resource to configure EVPN Tenant in NSX Policy manager.
+description: A resource to configure EVPN Tenant on NSX Policy manager.
 ---
 
 # nsxt_policy_evpn_tenant

--- a/website/docs/r/policy_evpn_tunnel_endpoint.html.markdown
+++ b/website/docs/r/policy_evpn_tunnel_endpoint.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - EVPN"
+subcategory: "EVPN"
 layout: "nsxt"
 page_title: "NSXT: nsxt_policy_evpn_tunnel_endpoint"
 description: A resource to configure EVPN Tunnel Endpoint in NSX Policy manager.

--- a/website/docs/r/policy_fixed_segment.html.markdown
+++ b/website/docs/r/policy_fixed_segment.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - Segments"
+subcategory: "Segments"
 layout: "nsxt"
 page_title: "NSXT: nsxt_policy_fixed_segment"
 description: A resource to configure a network Segment on specific Tier1 Gateway.
@@ -8,7 +8,7 @@ description: A resource to configure a network Segment on specific Tier1 Gateway
 # nsxt_policy_fixed_segment
 
 This resource provides a method for the management of Fixed Segments (attached to
-specifice Tier-1 Gateway)
+specific Tier-1 Gateway)
 
 This resource is applicable to VMC. For NSX Global Manager and NSX Policy Manager, it
 is recommended to use nsxt_policy_segment resource instead.

--- a/website/docs/r/policy_gateway_community_list.html.markdown
+++ b/website/docs/r/policy_gateway_community_list.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - Gateways and Routing"
+subcategory: "Gateways and Routing"
 layout: "nsxt"
 page_title: "NSXT: nsxt_policy_gateway_community_list"
 description: A resource to configure Community List on Tier0 Gateway.

--- a/website/docs/r/policy_gateway_dns_forwarder.html.markdown
+++ b/website/docs/r/policy_gateway_dns_forwarder.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - DNS"
+subcategory: "DNS"
 layout: "nsxt"
 page_title: "NSXT: nsxt_policy_gateway_dns_forwarder"
 description: A resource to configure DNS Forwarder on Gateway.

--- a/website/docs/r/policy_gateway_policy.html.markdown
+++ b/website/docs/r/policy_gateway_policy.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - Firewall"
+subcategory: "Firewall"
 layout: "nsxt"
 page_title: "NSXT: nsxt_policy_gateway_policy"
 description: A resource to Gateway security policies.

--- a/website/docs/r/policy_gateway_prefix_list.html.markdown
+++ b/website/docs/r/policy_gateway_prefix_list.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - Gateways and Routing"
+subcategory: "Gateways and Routing"
 layout: "nsxt"
 page_title: "NSXT: nsxt_policy_gateway_prefix_list"
 description: A resource to configure a Tier 0 Gateway Prefix Liston NSX Policy manager.

--- a/website/docs/r/policy_gateway_qos_profile.html.markdown
+++ b/website/docs/r/policy_gateway_qos_profile.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - Gateways and Routing"
+subcategory: "Gateways and Routing"
 layout: "nsxt"
 page_title: "NSXT: nsxt_policy_gateway_qos_profile"
 description: A resource to configure a Gateway QoS Profile.

--- a/website/docs/r/policy_gateway_redistribution_config.html.markdown
+++ b/website/docs/r/policy_gateway_redistribution_config.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - Gateways and Routing"
+subcategory: "Gateways and Routing"
 layout: "nsxt"
 page_title: "NSXT: nsxt_policy_gateway_redistribution_config"
 description: A resource to configure Route Redistribution on Tier-0 gateway in NSX Policy manager.

--- a/website/docs/r/policy_gateway_route_map.html.markdown
+++ b/website/docs/r/policy_gateway_route_map.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - Gateways and Routing"
+subcategory: "Gateways and Routing"
 layout: "nsxt"
 page_title: "NSXT: nsxt_policy_gateway_route_map"
 description: A resource to configure Route Map on Tier0 Gateway.

--- a/website/docs/r/policy_gateway_static_route_bfd_peer.html.markdown
+++ b/website/docs/r/policy_gateway_static_route_bfd_peer.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - Gateways and Routing"
+subcategory: "Gateways and Routing"
 layout: "nsxt"
 page_title: "NSXT: nsxt_policy_static_route_bfd_peer"
 description: A resource to configure Static Route BFD Peer on Tier0 Gateway.

--- a/website/docs/r/policy_group.html.markdown
+++ b/website/docs/r/policy_group.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - Grouping and Tagging"
+subcategory: "Grouping and Tagging"
 layout: "nsxt"
 page_title: "NSXT: nsxt_policy_group"
 description: A resource to configure a Group and its members.

--- a/website/docs/r/policy_intrusion_service_policy.html.markdown
+++ b/website/docs/r/policy_intrusion_service_policy.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - Firewall"
+subcategory: "Firewall"
 layout: "nsxt"
 page_title: "NSXT: nsxt_policy_intrusion_service_policy"
 description: A resource to configure Intrusion Service Policy and its rules.

--- a/website/docs/r/policy_intrusion_service_profile.html.markdown
+++ b/website/docs/r/policy_intrusion_service_profile.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - Firewall"
+subcategory: "Firewall"
 layout: "nsxt"
 page_title: "NSXT: nsxt_policy_intrusion_service_profile"
 description: A resource to configure Intrusion Service Profile.

--- a/website/docs/r/policy_ip_address_allocation.html.markdown
+++ b/website/docs/r/policy_ip_address_allocation.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - IPAM"
+subcategory: "IPAM"
 layout: "nsxt"
 page_title: "NSXT: nsxt_policy_ip_address_allocation"
 description: A resource to configure a IP Address allocations.
@@ -8,9 +8,6 @@ description: A resource to configure a IP Address allocations.
 # nsxt_policy_ip_address_allocation
 
 This resource provides a method for the management of a IP Address Allocations.
-Note that IP Address Allocations cannot be updated once created and changing any attributes of
-an existing allocation will re-create it.
-
 This resource is applicable to NSX Policy Manager.
 
 ## Example Usage

--- a/website/docs/r/policy_ip_block.html.markdown
+++ b/website/docs/r/policy_ip_block.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - IPAM"
+subcategory: "IPAM"
 layout: "nsxt"
 page_title: "NSXT: nsxt_policy_ip_block"
 description: A resource to configure IP Block on NSX Policy.

--- a/website/docs/r/policy_ip_discovery_profile.html.markdown
+++ b/website/docs/r/policy_ip_discovery_profile.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - Segments"
+subcategory: "Segments"
 layout: "nsxt"
 page_title: "NSXT: nsxt_policy_ip_discovery_profile"
 description: A resource to configure an IP discovery profile.

--- a/website/docs/r/policy_ip_pool.html.markdown
+++ b/website/docs/r/policy_ip_pool.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - IPAM"
+subcategory: "IPAM"
 layout: "nsxt"
 page_title: "NSXT: nsxt_policy_ip_pool"
 description: A resource to configure IP Pools in NSX Policy.

--- a/website/docs/r/policy_ip_pool_block_subnet.html.markdown
+++ b/website/docs/r/policy_ip_pool_block_subnet.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - IPAM"
+subcategory: "IPAM"
 layout: "nsxt"
 page_title: "NSXT: nsxt_policy_ip_pool_block_subnet"
 description: A resource to configure IP Pool Block Subnets in NSX Policy.

--- a/website/docs/r/policy_ip_pool_static_subnet.html.markdown
+++ b/website/docs/r/policy_ip_pool_static_subnet.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - IPAM"
+subcategory: "IPAM"
 layout: "nsxt"
 page_title: "NSXT: nsxt_policy_ip_pool_static_subnet"
 description: A resource to configure IP Pool Static Subnets in NSX Policy.
@@ -68,7 +68,7 @@ In addition to arguments listed above, the following attributes are exported:
 
 ## Importing
 
-An existing Static can be [imported][docs-import] into this resource, via the following command:
+An existing Subnet can be [imported][docs-import] into this resource, via the following command:
 
 [docs-import]: https://www.terraform.io/cli/import
 

--- a/website/docs/r/policy_ipsec_vpn_tunnel_profile.html.markdown
+++ b/website/docs/r/policy_ipsec_vpn_tunnel_profile.html.markdown
@@ -35,6 +35,7 @@ The following arguments are supported:
 * `nsx_id` - (Optional) The NSX ID of this resource. If set, this ID will be used to create the resource.
 * `digest_algorithms` - (Required) Set of algorithms to be used for message digest during IKE negotiation. Default is `SHA2_256`.
 * `dh_groups` - (Required) Diffie-Hellman group to be used if PFS is enabled. Default is GROUP14.
+* `df_policy` - (Optional) Defragmentation policy, one of `COPY` or `CLEAR`. `COPY` copies the defragmentation bit from the inner IP packet into the outer packet. `CLEAR` ignores the defragmentation bit present in the inner packet. Default is `COPY`.
 * `encryption_algorithms` - (Optional) Set of encryption algorithms to be used during IKE negotiation.
 * `sa_life_time` - (Optional) SA lifetime specifies the expiry time of security association. Default is 3600.
 * `enable_perfect_forward_secrecy` - (Optional) Enable perfect forward secrecy. Default is True.

--- a/website/docs/r/policy_lb_pool.html.markdown
+++ b/website/docs/r/policy_lb_pool.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - Load Balancer"
+subcategory: "Load Balancer"
 layout: "nsxt"
 page_title: "NSXT: nsxt_policy_lb_pool"
 description: A resource to configure Load Balancer Pool.

--- a/website/docs/r/policy_lb_service.html.markdown
+++ b/website/docs/r/policy_lb_service.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - Load Balancer"
+subcategory: "Load Balancer"
 layout: "nsxt"
 page_title: "NSXT: nsxt_policy_lb_service"
 description: A resource to configure a Load Balancer Service.

--- a/website/docs/r/policy_lb_virtual_server.html.markdown
+++ b/website/docs/r/policy_lb_virtual_server.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - Load Balancer"
+subcategory: "Load Balancer"
 layout: "nsxt"
 page_title: "NSXT: nsxt_policy_lb_virtual_server"
 description: A resource to configure a Load Balancer Virtual Server.

--- a/website/docs/r/policy_mac_discovery_profile.html.markdown
+++ b/website/docs/r/policy_mac_discovery_profile.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Beta"
+subcategory: "Segments"
 layout: "nsxt"
 page_title: "NSXT: nsxt_policy_mac_discovery_profile"
 description: A resource to configure a MAC Discovery Profile.

--- a/website/docs/r/policy_nat_rule.html.markdown
+++ b/website/docs/r/policy_nat_rule.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - Gateways and Routing"
+subcategory: "Gateways and Routing"
 layout: "nsxt"
 page_title: "NSXT: nsxt_policy_nat_rule"
 description: A resource to configure NAT Rules in NSX Policy manager.

--- a/website/docs/r/policy_ospf_area.html.markdown
+++ b/website/docs/r/policy_ospf_area.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - OSPF"
+subcategory: "OSPF"
 layout: "nsxt"
 page_title: "NSXT: nsxt_policy_ospf_area"
 description: A resource to configure a OSPF Area.

--- a/website/docs/r/policy_ospf_config.html.markdown
+++ b/website/docs/r/policy_ospf_config.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - Gateways and Routing"
+subcategory: "Gateways and Routing"
 layout: "nsxt"
 page_title: "NSXT: nsxt_policy_ospf_config"
 description: A resource to configure OSPF Settings of Tier0 Gateway on NSX Policy Manager.

--- a/website/docs/r/policy_predefined_gateway_policy.html.markdown
+++ b/website/docs/r/policy_predefined_gateway_policy.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - Firewall"
+subcategory: "Firewall"
 layout: "nsxt"
 page_title: "NSXT: nsxt_policy_predefined_gateway_policy"
 description: A resource to update Predefined Gateway Security Policies.

--- a/website/docs/r/policy_predefined_security_policy.html.markdown
+++ b/website/docs/r/policy_predefined_security_policy.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - Firewall"
+subcategory: "Firewall"
 layout: "nsxt"
 page_title: "NSXT: nsxt_policy_predefined_security_policy"
 description: A resource to update Predefined (Default) Security Security Policies.

--- a/website/docs/r/policy_qos_profile.html.markdown
+++ b/website/docs/r/policy_qos_profile.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - Segments"
+subcategory: "Segments"
 layout: "nsxt"
 page_title: "NSXT: nsxt_policy_qos_profile"
 description: A resource to configure a QoS profile.

--- a/website/docs/r/policy_security_policy.html.markdown
+++ b/website/docs/r/policy_security_policy.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - Firewall"
+subcategory: "Firewall"
 layout: "nsxt"
 page_title: "NSXT: nsxt_policy_security_policy"
 description: A resource to configure a Security Group and its rules.

--- a/website/docs/r/policy_segment.html.markdown
+++ b/website/docs/r/policy_segment.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - Segments"
+subcategory: "Segments"
 layout: "nsxt"
 page_title: "NSXT: nsxt_policy_segment"
 description: A resource to configure a network Segment.

--- a/website/docs/r/policy_segment_security_profile.html.markdown
+++ b/website/docs/r/policy_segment_security_profile.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - Segments"
+subcategory: "Segments"
 layout: "nsxt"
 page_title: "NSXT: nsxt_policy_segment_security_profile"
 description: A resource to configure a Segment Security Profile.

--- a/website/docs/r/policy_service.html.markdown
+++ b/website/docs/r/policy_service.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - Firewall"
+subcategory: "Firewall"
 layout: "nsxt"
 page_title: "NSXT: nsxt_policy_service"
 description: A resource that can be used to configure a networking and security service in NSX Policy.

--- a/website/docs/r/policy_spoof_guard_profile.html.markdown
+++ b/website/docs/r/policy_spoof_guard_profile.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - Segments"
+subcategory: "Segments"
 layout: "nsxt"
 page_title: "NSXT: nsxt_policy_spoof_guard_profile"
 description: A resource to configure SpoofGuard Profile.

--- a/website/docs/r/policy_static_route.html.markdown
+++ b/website/docs/r/policy_static_route.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - Gateways and Routing"
+subcategory: "Gateways and Routing"
 layout: "nsxt"
 page_title: "NSXT: nsxt_policy_static_route"
 description: A resource to configure Static Routes in NSX Policy manager.

--- a/website/docs/r/policy_tier0_gateway.html.markdown
+++ b/website/docs/r/policy_tier0_gateway.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - Gateways and Routing"
+subcategory: "Gateways and Routing"
 layout: "nsxt"
 page_title: "NSXT: nsxt_policy_tier0_gateway"
 description: A resource to configure a Tier-0 gateway on NSX Policy manager.

--- a/website/docs/r/policy_tier0_gateway_ha_vip_config.html.markdown
+++ b/website/docs/r/policy_tier0_gateway_ha_vip_config.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - Gateways and Routing"
+subcategory: "Gateways and Routing"
 layout: "nsxt"
 page_title: "NSXT: nsxt_policy_tier0_gateway_ha_vip_config"
 description: A resource to configure HA Vip config on Tier-0 gateway in NSX Policy manager.

--- a/website/docs/r/policy_tier0_gateway_interface.html.markdown
+++ b/website/docs/r/policy_tier0_gateway_interface.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - Gateways and Routing"
+subcategory: "Gateways and Routing"
 layout: "nsxt"
 page_title: "NSXT: nsxt_policy_tier0_gateway_interface"
 description: A resource to configure an Interface on Tier-0 gateway on NSX Policy manager.

--- a/website/docs/r/policy_tier1_gateway.html.markdown
+++ b/website/docs/r/policy_tier1_gateway.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - Gateways and Routing"
+subcategory: "Gateways and Routing"
 layout: "nsxt"
 page_title: "NSXT: nsxt_policy_tier1_gateway"
 description: A resource to configure a Tier-1 gateway on NSX Policy manager.

--- a/website/docs/r/policy_tier1_gateway_interface.html.markdown
+++ b/website/docs/r/policy_tier1_gateway_interface.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - Gateways and Routing"
+subcategory: "Gateways and Routing"
 layout: "nsxt"
 page_title: "NSXT: nsxt_policy_tier1_gateway_interface"
 description: A resource to configure an Interface on Tier-1 gateway on NSX Policy manager.

--- a/website/docs/r/policy_vlan_segment.html.markdown
+++ b/website/docs/r/policy_vlan_segment.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - Segments"
+subcategory: "Segments"
 layout: "nsxt"
 page_title: "NSXT: nsxt_policy_vlan_segment"
 description: A resource to configure a VLAN backed network Segment.

--- a/website/docs/r/policy_vm_tags.html.markdown
+++ b/website/docs/r/policy_vm_tags.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Policy - Grouping and Tagging"
+subcategory: "Grouping and Tagging"
 layout: "nsxt"
 page_title: "NSXT: nsxt_policy_vm_tags"
 description: A resource to configure tags for a Virtual Machine in NSX Policy.


### PR DESCRIPTION
MP resources moved into Deprecated category, hence there should be no need to repeat the `Policy` keyword in category. In addition, some documentation polishing.