### PR TITLE
Documentation fixes

### DIFF
--- a/website/docs/d/certificate.html.markdown
+++ b/website/docs/d/certificate.html.markdown
@@ -22,7 +22,6 @@ data "nsxt_certificate" "CA" {
 ## Argument Reference
 
 * `id` - (Optional) The ID of Certificate to retrieve.
-
 * `display_name` - (Optional) The Display Name of the Certificate to retrieve.
 
 ## Attributes Reference

--- a/website/docs/d/edge_cluster.html.markdown
+++ b/website/docs/d/edge_cluster.html.markdown
@@ -20,7 +20,6 @@ data "nsxt_edge_cluster" "edge_cluster1" {
 ## Argument Reference
 
 * `id` - (Optional) The ID of Edge Cluster to retrieve.
-
 * `display_name` - (Optional) The Display Name prefix of the Edge Cluster to retrieve.
 
 ## Attributes Reference
@@ -28,7 +27,5 @@ data "nsxt_edge_cluster" "edge_cluster1" {
 In addition to arguments listed above, the following attributes are exported:
 
 * `description` - The description of the edge cluster.
-
 * `deployment_type` - This field could show deployment_type of members. It would return UNKNOWN if there is no members, and return VIRTUAL_MACHINE|PHYSICAL_MACHINE if all Edge members are VIRTUAL_MACHINE|PHYSICAL_MACHINE.
-
 * `member_node_type` - An Edge cluster is homogeneous collection of NSX transport nodes used for north/south connectivity between NSX logical networking and physical networking. Hence all transport nodes of the cluster must be of same type. This field shows the type of transport node,

--- a/website/docs/d/firewall_section.html.markdown
+++ b/website/docs/d/firewall_section.html.markdown
@@ -20,7 +20,6 @@ data "nsxt_firewall_section" "block_all" {
 ## Argument Reference
 
 * `id` - (Optional) The ID of resource to retrieve
-
 * `display_name` - (Optional) The Display Name of resource to retrieve.
 
 ## Attributes Reference

--- a/website/docs/d/ip_pool.html.markdown
+++ b/website/docs/d/ip_pool.html.markdown
@@ -20,7 +20,6 @@ data "nsxt_ip_pool" "ip_pool" {
 ## Argument Reference
 
 * `id` - (Optional) The ID of IP pool to retrieve
-
 * `display_name` - (Optional) The Display Name of the IP pool to retrieve.
 
 ## Attributes Reference

--- a/website/docs/d/logical_tier0_router.html.markdown
+++ b/website/docs/d/logical_tier0_router.html.markdown
@@ -20,7 +20,6 @@ data "nsxt_logical_tier0_router" "tier0_router" {
 ## Argument Reference
 
 * `id` - (Optional) The ID of Logical Router to retrieve.
-
 * `display_name` - (Optional) The Display Name prefix of Logical Router to retrieve.
 
 ## Attributes Reference
@@ -28,7 +27,5 @@ data "nsxt_logical_tier0_router" "tier0_router" {
 In addition to arguments listed above, the following attributes are exported:
 
 * `description` - The description of the Logical Router.
-
 * `edge_cluster_id` - The id of the Edge Cluster where this Logical Router is placed.
-
 * `high_availability_mode` - The high availability mode of this Logical Router.

--- a/website/docs/d/logical_tier1_router.html.markdown
+++ b/website/docs/d/logical_tier1_router.html.markdown
@@ -20,7 +20,6 @@ data "nsxt_logical_tier1_router" "tier1_router" {
 ## Argument Reference
 
 * `id` - (Optional) The ID of Logical Router to retrieve.
-
 * `display_name` - (Optional) The Display Name prefix of Logical Router to retrieve.
 
 ## Attributes Reference
@@ -28,5 +27,4 @@ data "nsxt_logical_tier1_router" "tier1_router" {
 In addition to arguments listed above, the following attributes are exported:
 
 * `description` - The description of the Logical Router.
-
 * `edge_cluster_id` - The id of the Edge cluster where this Logical Router is placed.

--- a/website/docs/d/mac_pool.html.markdown
+++ b/website/docs/d/mac_pool.html.markdown
@@ -20,7 +20,6 @@ data "nsxt_mac_pool" "mac_pool" {
 ## Argument Reference
 
 * `id` - (Optional) The ID of MAC pool to retrieve
-
 * `display_name` - (Optional) The Display Name of the MAC pool to retrieve.
 
 ## Attributes Reference

--- a/website/docs/d/management_cluster.html.markdown
+++ b/website/docs/d/management_cluster.html.markdown
@@ -18,5 +18,4 @@ data "nsxt_management_cluster" "cluster" {}
 ## Attributes Reference
 
 * `id` - Unique identifier of this cluster.
-
 * `node_sha256_thumbprint` - SHA256 of certificate thumbprint of this manager node.

--- a/website/docs/d/ns_group.html.markdown
+++ b/website/docs/d/ns_group.html.markdown
@@ -20,7 +20,6 @@ data "nsxt_ns_group" "ns_group_1" {
 ## Argument Reference
 
 * `id` - (Optional) The ID of NS group to retrieve
-
 * `display_name` - (Optional) The Display Name of the NS group to retrieve.
 
 ## Attributes Reference

--- a/website/docs/d/ns_service.html.markdown
+++ b/website/docs/d/ns_service.html.markdown
@@ -20,7 +20,6 @@ data "nsxt_ns_service" "ns_service_dns" {
 ## Argument Reference
 
 * `id` - (Optional) The ID of NS service to retrieve
-
 * `display_name` - (Optional) The Display Name of the NS service to retrieve.
 
 ## Attributes Reference

--- a/website/docs/d/policy_bfd_profile.html.markdown
+++ b/website/docs/d/policy_bfd_profile.html.markdown
@@ -21,7 +21,6 @@ data "nsxt_policy_bfd_profile" "test" {
 ## Argument Reference
 
 * `id` - (Optional) The ID of Profile to retrieve. If ID is specified, no additional argument should be configured.
-
 * `display_name` - (Optional) The Display Name prefix of the Profile to retrieve.
 
 ## Attributes Reference
@@ -29,5 +28,4 @@ data "nsxt_policy_bfd_profile" "test" {
 In addition to arguments listed above, the following attributes are exported:
 
 * `description` - The description of the resource.
-
 * `path` - The NSX path of the policy resource.

--- a/website/docs/d/policy_bridge_profile.html.markdown
+++ b/website/docs/d/policy_bridge_profile.html.markdown
@@ -21,7 +21,6 @@ data "nsxt_policy_bridge_profile" "test" {
 ## Argument Reference
 
 * `id` - (Optional) The ID of Profile to retrieve. If ID is specified, no additional argument should be configured.
-
 * `display_name` - (Optional) The Display Name prefix of the Profile to retrieve.
 
 ## Attributes Reference
@@ -29,5 +28,4 @@ data "nsxt_policy_bridge_profile" "test" {
 In addition to arguments listed above, the following attributes are exported:
 
 * `description` - The description of the resource.
-
 * `path` - The NSX path of the policy resource.

--- a/website/docs/d/policy_certificate.html.markdown
+++ b/website/docs/d/policy_certificate.html.markdown
@@ -22,7 +22,6 @@ data "nsxt_policy_certificate" "test" {
 ## Argument Reference
 
 * `id` - (Optional) The ID of Certificate to retrieve.
-
 * `display_name` - (Optional) The Display Name prefix of the Certificate to retrieve.
 
 ## Attributes Reference
@@ -30,5 +29,4 @@ data "nsxt_policy_certificate" "test" {
 In addition to arguments listed above, the following attributes are exported:
 
 * `description` - The description of the resource.
-
 * `path` - The NSX path of the policy resource.

--- a/website/docs/d/policy_dhcp_server.html.markdown
+++ b/website/docs/d/policy_dhcp_server.html.markdown
@@ -22,7 +22,6 @@ data "nsxt_policy_dhcp_server" "test" {
 ## Argument Reference
 
 * `id` - (Optional) The ID of DHCP Server to retrieve. If ID is specified, no additional argument should be configured.
-
 * `display_name` - (Optional) The Display Name prefix of DHCP server to retrieve.
 
 ## Attributes Reference
@@ -30,5 +29,4 @@ data "nsxt_policy_dhcp_server" "test" {
 In addition to arguments listed above, the following attributes are exported:
 
 * `description` - The description of the resource.
-
 * `path` - The NSX path of the policy resource.

--- a/website/docs/d/policy_edge_cluster.html.markdown
+++ b/website/docs/d/policy_edge_cluster.html.markdown
@@ -35,9 +35,7 @@ data "nsxt_policy_edge_cluster" "gm_ec" {
 ## Argument Reference
 
 * `id` - (Optional) The ID of the edge cluster to retrieve.
-
 * `display_name` - (Optional) The Display Name prefix of the edge cluster to retrieve.
-
 * `site_path` - (Optional) The path of the site which the Edge Cluster belongs to, this configuration is required for global manager only. `path` field of the existing `nsxt_policy_site` can be used here. If a single edge cluster is configured on site, `id` and `display_name` can be omitted in configuration, otherwise either of these is required to specify the desired cluster.
 
 ## Attributes Reference
@@ -45,5 +43,4 @@ data "nsxt_policy_edge_cluster" "gm_ec" {
 In addition to arguments listed above, the following attributes are exported:
 
 * `description` - The description of the resource.
-
 * `path` - The NSX path of the policy resource.

--- a/website/docs/d/policy_edge_node.html.markdown
+++ b/website/docs/d/policy_edge_node.html.markdown
@@ -27,11 +27,8 @@ data "nsxt_policy_edge_node" "node1" {
 ## Argument Reference
 
 * `edge_cluster_path` - (Required) The path of edge cluster where to which this node belongs.
-
 * `id` - (Optional) The ID of the edge node to retrieve.
-
 * `display_name` - (Optional) The Display Name prefix of the edge node to retrieve.
-
 * `member_index` - (Optional) Member index of the node in edge cluster.
 
 ## Attributes Reference
@@ -39,5 +36,4 @@ data "nsxt_policy_edge_node" "node1" {
 In addition to arguments listed above, the following attributes are exported:
 
 * `description` - The description of the resource.
-
 * `path` - The NSX path of the policy resource.

--- a/website/docs/d/policy_gateway_qos_profile.html.markdown
+++ b/website/docs/d/policy_gateway_qos_profile.html.markdown
@@ -22,7 +22,6 @@ data "nsxt_policy_gateway_qos_profile" "test" {
 ## Argument Reference
 
 * `id` - (Optional) The ID of GatewayQosProfile to retrieve.
-
 * `display_name` - (Optional) The Display Name prefix of the Gateway QoS Profile to retrieve.
 
 ## Attributes Reference
@@ -30,5 +29,4 @@ data "nsxt_policy_gateway_qos_profile" "test" {
 In addition to arguments listed above, the following attributes are exported:
 
 * `description` - The description of the resource.
-
 * `path` - The NSX path of the policy resource.

--- a/website/docs/d/policy_group.html.markdown
+++ b/website/docs/d/policy_group.html.markdown
@@ -22,9 +22,7 @@ data "nsxt_policy_group" "test" {
 ## Argument Reference
 
 * `id` - (Optional) The ID of Group to retrieve.
-
 * `display_name` - (Optional) The Display Name prefix of the Group to retrieve.
-
 * `domain` - (Optional) The domain this Group belongs to. For VMware Cloud on AWS use `cgw`. For Global Manager, please use site id for this field. If not specified, this field is default to `default`. 
 
 ## Attributes Reference
@@ -32,5 +30,4 @@ data "nsxt_policy_group" "test" {
 In addition to arguments listed above, the following attributes are exported:
 
 * `description` - The description of the resource.
-
 * `path` - The NSX path of the policy resource.

--- a/website/docs/d/policy_intrusion_service_profile.html.markdown
+++ b/website/docs/d/policy_intrusion_service_profile.html.markdown
@@ -21,7 +21,6 @@ data "nsxt_policy_intrusion_service_profile" "test" {
 ## Argument Reference
 
 * `id` - (Optional) The ID of Profile to retrieve. If ID is specified, no additional argument should be configured.
-
 * `display_name` - (Optional) The Display Name prefix of the Profile to retrieve.
 
 ## Attributes Reference
@@ -29,5 +28,4 @@ data "nsxt_policy_intrusion_service_profile" "test" {
 In addition to arguments listed above, the following attributes are exported:
 
 * `description` - The description of the resource.
-
 * `path` - The NSX path of the policy resource.

--- a/website/docs/d/policy_ip_discovery_profile.html.markdown
+++ b/website/docs/d/policy_ip_discovery_profile.html.markdown
@@ -22,7 +22,6 @@ data "nsxt_policy_ip_discovery_profile" "test" {
 ## Argument Reference
 
 * `id` - (Optional) The ID of Profile to retrieve.
-
 * `display_name` - (Optional) The Display Name prefix of the Profile to retrieve.
 
 ## Attributes Reference
@@ -30,5 +29,4 @@ data "nsxt_policy_ip_discovery_profile" "test" {
 In addition to arguments listed above, the following attributes are exported:
 
 * `description` - The description of the resource.
-
 * `path` - The NSX path of the policy resource.

--- a/website/docs/d/policy_ipv6_dad_profile.html.markdown
+++ b/website/docs/d/policy_ipv6_dad_profile.html.markdown
@@ -22,7 +22,6 @@ data "nsxt_policy_ipv6_dad_profile" "test" {
 ## Argument Reference
 
 * `id` - (Optional) The ID of Profile to retrieve.
-
 * `display_name` - (Optional) The Display Name prefix of the Profile to retrieve.
 
 ## Attributes Reference
@@ -30,5 +29,4 @@ data "nsxt_policy_ipv6_dad_profile" "test" {
 In addition to arguments listed above, the following attributes are exported:
 
 * `description` - The description of the resource.
-
 * `path` - The NSX path of the policy resource.

--- a/website/docs/d/policy_ipv6_ndra_profile.html.markdown
+++ b/website/docs/d/policy_ipv6_ndra_profile.html.markdown
@@ -22,7 +22,6 @@ data "nsxt_policy_ipv6_ndra_profile" "test" {
 ## Argument Reference
 
 * `id` - (Optional) The ID of Profile to retrieve.
-
 * `display_name` - (Optional) The Display Name prefix of the Profile to retrieve.
 
 ## Attributes Reference
@@ -30,5 +29,4 @@ data "nsxt_policy_ipv6_ndra_profile" "test" {
 In addition to arguments listed above, the following attributes are exported:
 
 * `description` - The description of the resource.
-
 * `path` - The NSX path of the policy resource.

--- a/website/docs/d/policy_lb_client_ssl_profile.html.markdown
+++ b/website/docs/d/policy_lb_client_ssl_profile.html.markdown
@@ -22,7 +22,6 @@ data "nsxt_policy_lb_client_ssl_profile" "test" {
 ## Argument Reference
 
 * `id` - (Optional) The ID of Profile to retrieve.
-
 * `display_name` - (Optional) The Display Name prefix of the Profile to retrieve.
 
 ## Attributes Reference
@@ -30,5 +29,4 @@ data "nsxt_policy_lb_client_ssl_profile" "test" {
 In addition to arguments listed above, the following attributes are exported:
 
 * `description` - The description of the resource.
-
 * `path` - The NSX path of the policy resource.

--- a/website/docs/d/policy_lb_server_ssl_profile.html.markdown
+++ b/website/docs/d/policy_lb_server_ssl_profile.html.markdown
@@ -22,7 +22,6 @@ data "nsxt_policy_lb_server_ssl_profile" "test" {
 ## Argument Reference
 
 * `id` - (Optional) The ID of Profile to retrieve.
-
 * `display_name` - (Optional) The Display Name prefix of the Profile to retrieve.
 
 ## Attributes Reference
@@ -30,5 +29,4 @@ data "nsxt_policy_lb_server_ssl_profile" "test" {
 In addition to arguments listed above, the following attributes are exported:
 
 * `description` - The description of the resource.
-
 * `path` - The NSX path of the policy resource.

--- a/website/docs/d/policy_lb_service.html.markdown
+++ b/website/docs/d/policy_lb_service.html.markdown
@@ -22,7 +22,6 @@ data "nsxt_policy_lb_service" "test" {
 ## Argument Reference
 
 * `id` - (Optional) The ID of Service to retrieve.
-
 * `display_name` - (Optional) The Display Name prefix of the Service to retrieve.
 
 ## Attributes Reference
@@ -30,5 +29,4 @@ data "nsxt_policy_lb_service" "test" {
 In addition to arguments listed above, the following attributes are exported:
 
 * `description` - The description of the resource.
-
 * `path` - The NSX path of the policy resource.

--- a/website/docs/d/policy_mac_discovery_profile.html.markdown
+++ b/website/docs/d/policy_mac_discovery_profile.html.markdown
@@ -22,7 +22,6 @@ data "nsxt_policy_mac_discovery_profile" "test" {
 ## Argument Reference
 
 * `id` - (Optional) The ID of Profile to retrieve.
-
 * `display_name` - (Optional) The Display Name prefix of Profile to retrieve.
 
 ## Attributes Reference
@@ -30,5 +29,4 @@ data "nsxt_policy_mac_discovery_profile" "test" {
 In addition to arguments listed above, the following attributes are exported:
 
 * `description` - The description of the resource.
-
 * `path` - The NSX path of the policy resource.

--- a/website/docs/d/policy_qos_profile.html.markdown
+++ b/website/docs/d/policy_qos_profile.html.markdown
@@ -22,7 +22,6 @@ data "nsxt_policy_qos_profile" "test" {
 ## Argument Reference
 
 * `id` - (Optional) The ID of Profile to retrieve.
-
 * `display_name` - (Optional) The Display Name prefix of the Profile to retrieve.
 
 ## Attributes Reference
@@ -30,5 +29,4 @@ data "nsxt_policy_qos_profile" "test" {
 In addition to arguments listed above, the following attributes are exported:
 
 * `description` - The description of the resource.
-
 * `path` - The NSX path of the policy resource.

--- a/website/docs/d/policy_segment.html.markdown
+++ b/website/docs/d/policy_segment.html.markdown
@@ -21,7 +21,6 @@ data "nsxt_policy_segment" "test" {
 ## Argument Reference
 
 * `id` - (Optional) The ID of Segment to retrieve. If ID is specified, no additional argument should be configured.
-
 * `display_name` - (Optional) The Display Name prefix of the Segment to retrieve.
 
 ## Attributes Reference
@@ -29,5 +28,4 @@ data "nsxt_policy_segment" "test" {
 In addition to arguments listed above, the following attributes are exported:
 
 * `description` - The description of the resource.
-
 * `path` - The NSX path of the policy resource.

--- a/website/docs/d/policy_segment_realization.html.markdown
+++ b/website/docs/d/policy_segment_realization.html.markdown
@@ -19,7 +19,7 @@ This data source is applicable to NSX Policy Manager.
 ```hcl
 resource "nsxt_policy_segment" "s1" {
   display_name        = "segment1"
-  transport_zone_path = data.nsxt_transport_zone.tz1.path
+  transport_zone_path = data.nsxt_policy_transport_zone.tz1.path
 }
 
 data "nsxt_policy_segment_realization" "s1" {

--- a/website/docs/d/policy_segment_security_profile.html.markdown
+++ b/website/docs/d/policy_segment_security_profile.html.markdown
@@ -22,7 +22,6 @@ data "nsxt_policy_segment_security_profile" "test" {
 ## Argument Reference
 
 * `id` - (Optional) The ID of SegmentSecurityProfile to retrieve.
-
 * `display_name` - (Optional) The Display Name prefix of the SegmentSecurityProfile to retrieve.
 
 ## Attributes Reference
@@ -30,5 +29,4 @@ data "nsxt_policy_segment_security_profile" "test" {
 In addition to arguments listed above, the following attributes are exported:
 
 * `description` - The description of the resource.
-
 * `path` - The NSX path of the policy resource.

--- a/website/docs/d/policy_service.html.markdown
+++ b/website/docs/d/policy_service.html.markdown
@@ -20,7 +20,6 @@ data "nsxt_policy_service" "dns_service" {
 ## Argument Reference
 
 * `id` - (Optional) The ID of service to retrieve.
-
 * `display_name` - (Optional) The Display Name prefix of the service to retrieve.
 
 ## Attributes Reference
@@ -28,5 +27,4 @@ data "nsxt_policy_service" "dns_service" {
 In addition to arguments listed above, the following attributes are exported:
 
 * `description` - The description of the resource.
-
 * `path` - The NSX path of the policy resource.

--- a/website/docs/d/policy_site.html.markdown
+++ b/website/docs/d/policy_site.html.markdown
@@ -22,7 +22,6 @@ data "nsxt_policy_site" "paris" {
 ## Argument Reference
 
 * `id` - (Optional) The ID of Site to retrieve.
-
 * `display_name` - (Optional) The Display Name prefix of the Site to retrieve.
 
 
@@ -31,5 +30,4 @@ data "nsxt_policy_site" "paris" {
 In addition to arguments listed above, the following attributes are exported:
 
 * `description` - The description of the resource.
-
 * `path` - The NSX path of the policy resource. This attribute can serve as `site_path` field of `nsxt_policy_transport_zone` data source.

--- a/website/docs/d/policy_spoofguard_profile.html.markdown
+++ b/website/docs/d/policy_spoofguard_profile.html.markdown
@@ -22,7 +22,6 @@ data "nsxt_policy_spoofguard_profile" "test" {
 ## Argument Reference
 
 * `id` - (Optional) The ID of SpoofGuardProfile to retrieve.
-
 * `display_name` - (Optional) The Display Name prefix of the SpoofGuardProfile to retrieve.
 
 ## Attributes Reference
@@ -30,5 +29,4 @@ data "nsxt_policy_spoofguard_profile" "test" {
 In addition to arguments listed above, the following attributes are exported:
 
 * `description` - The description of the resource.
-
 * `path` - The NSX path of the policy resource.

--- a/website/docs/d/policy_tier0_gateway.html.markdown
+++ b/website/docs/d/policy_tier0_gateway.html.markdown
@@ -22,7 +22,6 @@ data "nsxt_policy_tier0_gateway" "tier0_gw_gateway" {
 ## Argument Reference
 
 * `id` - (Optional) The ID of Tier-0 gateway to retrieve.
-
 * `display_name` - (Optional) The Display Name prefix of the Tier-0 gateway to retrieve.
 
 ## Attributes Reference
@@ -30,7 +29,5 @@ data "nsxt_policy_tier0_gateway" "tier0_gw_gateway" {
 In addition to arguments listed above, the following attributes are exported:
 
 * `description` - The description of the resource.
-
 * `edge_cluster_path` - The path of the Edge cluster where this Tier-0 gateway is placed. This attribute is not set for NSX Global Manager, where gateway can spawn across multiple sites.
-
 * `path` - The NSX path of the policy resource.

--- a/website/docs/d/policy_tier1_gateway.html.markdown
+++ b/website/docs/d/policy_tier1_gateway.html.markdown
@@ -22,7 +22,6 @@ data "nsxt_policy_tier1_gateway" "tier1_router" {
 ## Argument Reference
 
 * `id` - (Optional) The ID of Tier-1 gateway to retrieve.
-
 * `display_name` - (Optional) The Display Name prefix of the Tier-1 gateway to retrieve.
 
 ## Attributes Reference
@@ -30,7 +29,5 @@ data "nsxt_policy_tier1_gateway" "tier1_router" {
 In addition to arguments listed above, the following attributes are exported:
 
 * `description` - The description of the resource.
-
 * `edge_cluster_path` - The path of the Edge cluster where this Tier-1 gateway is placed.
-
 * `path` - The NSX path of the policy resource.

--- a/website/docs/d/switching_profile.html.markdown
+++ b/website/docs/d/switching_profile.html.markdown
@@ -20,7 +20,6 @@ data "nsxt_switching_profile" "qos_profile" {
 ## Argument Reference
 
 * `id` - (Optional) The ID of Switching Profile to retrieve.
-
 * `display_name` - (Optional) The Display Name of the Switching Profile to retrieve.
 
 ## Attributes Reference
@@ -28,5 +27,4 @@ data "nsxt_switching_profile" "qos_profile" {
 In addition to arguments listed above, the following attributes are exported:
 
 * `resource_type` - The resource type representing the specific type of this switching profile.
-
 * `description` - The description of the switching profile.

--- a/website/docs/d/transport_zone.html.markdown
+++ b/website/docs/d/transport_zone.html.markdown
@@ -20,7 +20,6 @@ data "nsxt_transport_zone" "overlay_transport_zone" {
 ## Argument Reference
 
 * `id` - (Optional) The ID of Transport Zone to retrieve.
-
 * `display_name` - (Optional) The Display Name prefix of the Transport Zone to retrieve.
 
 ## Attributes Reference
@@ -28,7 +27,5 @@ data "nsxt_transport_zone" "overlay_transport_zone" {
 In addition to arguments listed above, the following attributes are exported:
 
 * `description` - The description of the Transport Zone.
-
 * `host_switch_name` - The name of the N-VDS (host switch) on all Transport Nodes in this Transport Zone that will be used to run NSX network traffic.
-
 * `transport_type` - The transport type of this transport zone (OVERLAY or VLAN).


### PR DESCRIPTION
Changed doublespaced bullets in data source docs to make documentation more uniform.
Also use correct data source in segment_realization example.