### PR TITLE
Force new object creation when project_id changes

### DIFF
--- a/nsxt/utils.go
+++ b/nsxt/utils.go
@@ -676,6 +676,7 @@ func getContextSchema() *schema.Schema {
 					Type:        schema.TypeString,
 					Description: "Id of the project which the resource belongs to.",
 					Required:    true,
+					ForceNew:    true,
 				},
 			},
 		},


### PR DESCRIPTION
As the ForceNew attribute for the context doesn't apply to the project_id underneath, set this explicitly.