### PR TITLE
Multitenancy doc - refer Project data source

### DIFF
--- a/website/docs/r/policy_dhcp_server.html.markdown
+++ b/website/docs/r/policy_dhcp_server.html.markdown
@@ -38,7 +38,7 @@ resource "nsxt_policy_dhcp_server" "test" {
   }
   display_name      = "test"
   description       = "Terraform provisioned DhcpServerConfig"
-  edge_cluster_path = data.nsxt_policy_edge_cluster.ec1.path
+  edge_cluster_path = data.nsxt_policy_project.demoproj.site_info.0.edge_cluster_paths.0
   lease_time        = 200
   server_addresses  = ["110.64.0.1/16", "2001::1234:abcd:ffff:c0a8:101/64"]
 }

--- a/website/docs/r/policy_tier1_gateway.html.markdown
+++ b/website/docs/r/policy_tier1_gateway.html.markdown
@@ -51,6 +51,7 @@ resource "nsxt_policy_tier1_gateway" "tier1_gw" {
 ```
 
 ## Global manager example usage
+
 ```hcl
 resource "nsxt_policy_tier1_gateway" "tier1_gw" {
   description  = "Tier-1 provisioned by Terraform"
@@ -90,12 +91,12 @@ resource "nsxt_policy_tier1_gateway" "tier1_gw" {
   description               = "Tier-1 provisioned by Terraform"
   display_name              = "Tier1-gw1"
   nsx_id                    = "predefined_id"
-  edge_cluster_path         = data.nsxt_policy_edge_cluster.EC.path
+  edge_cluster_path         = data.nsxt_policy_project.demoproj.site_info.0.edge_cluster_paths.0
   failover_mode             = "PREEMPTIVE"
   default_rule_logging      = "false"
   enable_firewall           = "true"
   enable_standby_relocation = "false"
-  tier0_path                = data.nsxt_policy_tier0_gateway.T0.path
+  tier0_path                = data.nsxt_policy_project.demoproj.tier0_gateway_paths.0
   route_advertisement_types = ["TIER1_STATIC_ROUTES", "TIER1_CONNECTED"]
   pool_allocation           = "ROUTING"
 


### PR DESCRIPTION
Tenant users have no access to Tier0, Edge Cluster data sources but this data is available in the Project object.