### PR TITLE
Mark transport zone as computed in segments

### DIFF
--- a/nsxt/segment_common.go
+++ b/nsxt/segment_common.go
@@ -312,6 +312,7 @@ func getPolicyCommonSegmentSchema(vlanRequired bool, isFixed bool) map[string]*s
 			Description:  "Policy path to the transport zone",
 			Optional:     true,
 			ForceNew:     true,
+			Computed:     true,
 			ValidateFunc: validatePolicyPath(),
 		},
 		"vlan_ids": {


### PR DESCRIPTION
With multitenancy and in VMC, tz is auto-assigned