### PR TITLE
Validate order of rules is consistent with seq

### DIFF
--- a/nsxt/resource_nsxt_policy_gateway_policy.go
+++ b/nsxt/resource_nsxt_policy_gateway_policy.go
@@ -64,6 +64,10 @@ func getUpdatedRuleChildren(d *schema.ResourceData) ([]*data.StructValue, error)
 	}
 
 	oldRules, newRules := d.GetChange("rule")
+	err1 := validatePolicyRuleSequence(d)
+	if err1 != nil {
+		return policyChildren, err1
+	}
 	rules := getPolicyRulesFromSchema(d)
 	newRulesCount := len(newRules.([]interface{}))
 	oldRulesCount := len(oldRules.([]interface{}))

--- a/nsxt/resource_nsxt_policy_predefined_gateway_policy.go
+++ b/nsxt/resource_nsxt_policy_predefined_gateway_policy.go
@@ -314,6 +314,10 @@ func updatePolicyPredefinedGatewayPolicy(id string, d *schema.ResourceData, m in
 	var childRules []*data.StructValue
 	if d.HasChange("rule") {
 		oldRules, _ := d.GetChange("rule")
+		err1 := validatePolicyRuleSequence(d)
+		if err1 != nil {
+			return err1
+		}
 		rules := getPolicyRulesFromSchema(d)
 
 		existingRules := make(map[string]bool)

--- a/nsxt/resource_nsxt_policy_predefined_security_policy.go
+++ b/nsxt/resource_nsxt_policy_predefined_security_policy.go
@@ -236,6 +236,10 @@ func updatePolicyPredefinedSecurityPolicy(id string, d *schema.ResourceData, m i
 	var childRules []*data.StructValue
 	if d.HasChange("rule") {
 		oldRules, _ := d.GetChange("rule")
+		err1 := validatePolicyRuleSequence(d)
+		if err1 != nil {
+			return err1
+		}
 		rules := getPolicyRulesFromSchema(d)
 
 		existingRules := make(map[string]bool)

--- a/nsxt/resource_nsxt_policy_security_policy_test.go
+++ b/nsxt/resource_nsxt_policy_security_policy_test.go
@@ -226,6 +226,7 @@ func TestAccResourceNsxtPolicySecurityPolicy_withDependencies(t *testing.T) {
 					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
 					resource.TestCheckResourceAttr(testResourceName, "rule.#", "2"),
 					resource.TestCheckResourceAttr(testResourceName, "rule.0.display_name", "rule1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.0.sequence_number", "20"),
 					resource.TestCheckResourceAttr(testResourceName, "rule.0.direction", defaultDirection),
 					resource.TestCheckResourceAttr(testResourceName, "rule.0.ip_version", defaultProtocol),
 					resource.TestCheckResourceAttr(testResourceName, "rule.0.action", defaultAction),
@@ -236,6 +237,7 @@ func TestAccResourceNsxtPolicySecurityPolicy_withDependencies(t *testing.T) {
 					resource.TestCheckResourceAttr(testResourceName, "rule.0.services.#", "2"),
 					resource.TestCheckResourceAttr(testResourceName, "rule.1.display_name", "rule2"),
 					resource.TestCheckResourceAttr(testResourceName, "rule.1.direction", defaultDirection),
+					resource.TestCheckResourceAttr(testResourceName, "rule.1.sequence_number", "30"),
 					resource.TestCheckResourceAttr(testResourceName, "rule.1.ip_version", defaultProtocol),
 					resource.TestCheckResourceAttr(testResourceName, "rule.1.action", defaultAction),
 					resource.TestCheckResourceAttr(testResourceName, "rule.1.source_groups.#", "2"),
@@ -872,6 +874,7 @@ resource "nsxt_policy_security_policy" "test" {
 
   rule {
     display_name          = "rule1"
+    sequence_number       = 20
     source_groups         = [nsxt_policy_group.group1.path]
     destination_groups    = [nsxt_policy_group.group2.path]
     sources_excluded      = true
@@ -881,6 +884,7 @@ resource "nsxt_policy_security_policy" "test" {
 
   rule {
     display_name          = "rule2"
+    sequence_number       = 30
     source_groups         = [nsxt_policy_group.group1.path, nsxt_policy_group.group2.path]
     sources_excluded      = false
     destinations_excluded = false

--- a/website/docs/r/policy_gateway_policy.html.markdown
+++ b/website/docs/r/policy_gateway_policy.html.markdown
@@ -157,6 +157,7 @@ The following arguments are supported:
   * `log_label` - (Optional) Additional information (string) which will be propagated to the rule syslog.
   * `tag` - (Optional) A list of scope + tag pairs to associate with this Rule.
   * `action` - (Optional) The action for the Rule. Must be one of: `ALLOW`, `DROP` or `REJECT`. Defaults to `ALLOW`.
+  * `sequence_number` - (Optional) It is recommended not to specify sequence number for rules, and rely on NSX to auto-assign them. If you choose to specify sequence numbers, you must make sure the numbers are consistent with order of the rules in configuration. To avoid confusion, either specify sequence numbers in all rules, or none at all.
 
 ## Attributes Reference
 

--- a/website/docs/r/policy_security_policy.html.markdown
+++ b/website/docs/r/policy_security_policy.html.markdown
@@ -174,6 +174,7 @@ The following arguments are supported:
   * `services` - (Optional) Set of service paths to match.
   * `log_label` - (Optional) Additional information (string) which will be propagated to the rule syslog.
   * `tag` - (Optional) A list of scope + tag pairs to associate with this Rule.
+  * `sequence_number` - (Optional) It is recommended not to specify sequence number for rules, and rely on NSX to auto-assign them. If you choose to specify sequence numbers, you must make sure the numbers are consistent with order of the rules in configuration. To avoid confusion, either specify sequence numbers in all rules, or none at all.
 
 
 ## Attributes Reference


### PR DESCRIPTION
In security policy and gateway policy, user can specify sequence numbers for the rules. This change validates their consistency with rule order upon apply and throws an error if validation fails. Before this change, inconsistent sequence number in rules would be applied and cause a permanent non-empty diff.