### PR TITLE
Handle path parse errors

### DIFF
--- a/nsxt/policy_utils.go
+++ b/nsxt/policy_utils.go
@@ -196,6 +196,15 @@ func nsxtDomainResourceImporter(d *schema.ResourceData, m interface{}) ([]*schem
 	return []*schema.ResourceData{d}, nil
 }
 
+func getParameterFromPolicyPath(startDelimiter, endDelimiter, policyPath string) (string, error) {
+	startIndex := strings.Index(policyPath, startDelimiter)
+	endIndex := strings.Index(policyPath, endDelimiter)
+	if startIndex < 0 || endIndex < 0 || (startIndex+len(startDelimiter)) > endIndex {
+		return "", fmt.Errorf("failed to parse policy path %s, delimited by '%s' and '%s'", policyPath, startDelimiter, endDelimiter)
+	}
+	return policyPath[startIndex+len(startDelimiter) : endIndex], nil
+}
+
 func nsxtPolicyPathResourceImporter(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
 	rd, err := nsxtPolicyPathResourceImporterHelper(d, m)
 	if errors.Is(err, ErrNotAPolicyPath) {

--- a/nsxt/resource_nsxt_policy_dhcp_v4_static_binding.go
+++ b/nsxt/resource_nsxt_policy_dhcp_v4_static_binding.go
@@ -328,7 +328,11 @@ func nsxtSegmentResourceImporter(d *schema.ResourceData, m interface{}) ([]*sche
 	s := strings.Split(importID, "/")
 	rd, err := nsxtPolicyPathResourceImporterHelper(d, m)
 	if err == nil {
-		d.Set("segment_path", importID[0:strings.Index(importID, "/dhcp-static-binding-configs/")])
+		segmentPath, err := getParameterFromPolicyPath("", "/dhcp-static-binding-configs/", importID)
+		if err != nil {
+			return nil, err
+		}
+		d.Set("segment_path", segmentPath)
 		return rd, nil
 	} else if !errors.Is(err, ErrNotAPolicyPath) {
 		return rd, err

--- a/nsxt/resource_nsxt_policy_fixed_segment.go
+++ b/nsxt/resource_nsxt_policy_fixed_segment.go
@@ -45,7 +45,11 @@ func nsxtGatewayResourceImporter(d *schema.ResourceData, m interface{}) ([]*sche
 	importID := d.Id()
 	rd, err := nsxtPolicyPathResourceImporterHelper(d, m)
 	if err == nil {
-		d.Set("connectivity_path", importID[0:strings.Index(importID, "/segments/")])
+		connectivityPath, err := getParameterFromPolicyPath("", "/segments/", importID)
+		if err != nil {
+			return nil, err
+		}
+		d.Set("connectivity_path", connectivityPath)
 		return rd, nil
 	} else if !errors.Is(err, ErrNotAPolicyPath) {
 		return rd, err

--- a/nsxt/resource_nsxt_policy_ip_address_allocation.go
+++ b/nsxt/resource_nsxt_policy_ip_address_allocation.go
@@ -230,7 +230,11 @@ func resourceNsxtPolicyIPAddressAllocationImport(d *schema.ResourceData, m inter
 	s := strings.Split(importID, "/")
 	rd, err := nsxtPolicyPathResourceImporterHelper(d, m)
 	if err == nil {
-		d.Set("pool_path", importID[0:strings.Index(importID, "/ip-allocations/")])
+		poolPath, err := getParameterFromPolicyPath("", "/ip-allocations/", importID)
+		if err != nil {
+			return nil, err
+		}
+		d.Set("pool_path", poolPath)
 		return rd, nil
 	} else if !errors.Is(err, ErrNotAPolicyPath) {
 		return rd, err

--- a/nsxt/resource_nsxt_policy_ip_address_allocation.go
+++ b/nsxt/resource_nsxt_policy_ip_address_allocation.go
@@ -4,6 +4,7 @@
 package nsxt
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -227,6 +228,14 @@ func resourceNsxtPolicyIPAddressAllocationDelete(d *schema.ResourceData, m inter
 func resourceNsxtPolicyIPAddressAllocationImport(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
 	importID := d.Id()
 	s := strings.Split(importID, "/")
+	rd, err := nsxtPolicyPathResourceImporterHelper(d, m)
+	if err == nil {
+		d.Set("pool_path", importID[0:strings.Index(importID, "/ip-allocations/")])
+		return rd, nil
+	} else if !errors.Is(err, ErrNotAPolicyPath) {
+		return rd, err
+	}
+
 	if len(s) != 2 {
 		return nil, fmt.Errorf("Please provide <ip-pool-id>/<allocation-id> as an input")
 	}

--- a/nsxt/resource_nsxt_policy_ip_address_allocation_test.go
+++ b/nsxt/resource_nsxt_policy_ip_address_allocation_test.go
@@ -165,6 +165,32 @@ func TestAccResourceNsxtPolicyIPAddressAllocation_importBasic(t *testing.T) {
 	})
 }
 
+func TestAccResourceNsxtPolicyIPAddressAllocation_importBasic_multitenancy(t *testing.T) {
+	name := accTestPolicyIPAddressAllocationUpdateAttributes["display_name"]
+	testResourceName := "nsxt_policy_ip_address_allocation.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t); testAccOnlyMultitenancy(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyIPAddressAllocationCheckDestroy(state, name)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyIPAddressAllocationTemplate(true, true),
+			},
+			{
+				ResourceName:      testResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccResourceNsxtPolicyImportIDRetriever(testResourceName),
+			},
+			{
+				Config: testAccNsxtPolicyIPAddressAllocationDependenciesTemplate(true),
+			},
+		},
+	})
+}
 func testAccNSXPolicyIPAddressAllocationImporterGetID(s *terraform.State) (string, error) {
 	rs, ok := s.RootModule().Resources["nsxt_policy_ip_address_allocation.test"]
 	if !ok {

--- a/nsxt/resource_nsxt_policy_ip_pool_block_subnet.go
+++ b/nsxt/resource_nsxt_policy_ip_pool_block_subnet.go
@@ -260,7 +260,11 @@ func resourceNsxtPolicyIPPoolSubnetImport(d *schema.ResourceData, m interface{})
 	s := strings.Split(importID, "/")
 	rd, err := nsxtPolicyPathResourceImporterHelper(d, m)
 	if err == nil {
-		d.Set("pool_path", importID[0:strings.Index(importID, "/ip-subnets/")])
+		poolPath, err := getParameterFromPolicyPath("", "/ip-subnets/", importID)
+		if err != nil {
+			return nil, err
+		}
+		d.Set("pool_path", poolPath)
 		return rd, nil
 	} else if !errors.Is(err, ErrNotAPolicyPath) {
 		return rd, err

--- a/nsxt/resource_nsxt_policy_nat_rule.go
+++ b/nsxt/resource_nsxt_policy_nat_rule.go
@@ -422,8 +422,15 @@ func resourceNsxtPolicyNATRuleImport(d *schema.ResourceData, m interface{}) ([]*
 	s := strings.Split(importID, "/")
 	rd, err := nsxtPolicyPathResourceImporterHelper(d, m)
 	if err == nil {
-		d.Set("gateway_path", importID[0:strings.Index(importID, "/nat/")])
-		natType := importID[strings.Index(importID, "/nat/")+5 : strings.Index(importID, "/nat-rules/")]
+		gwPath, err := getParameterFromPolicyPath("", "/nat/", importID)
+		if err != nil {
+			return nil, err
+		}
+		d.Set("gateway_path", gwPath)
+		natType, err := getParameterFromPolicyPath("/nat/", "/nat-rules/", importID)
+		if err != nil {
+			return nil, err
+		}
 		if natType == model.PolicyNat_NAT_TYPE_USER {
 			// Value will be overwritten by resourceNsxtPolicyNATRuleRead()
 			d.Set("action", model.PolicyNatRule_ACTION_DNAT)

--- a/nsxt/resource_nsxt_policy_static_route.go
+++ b/nsxt/resource_nsxt_policy_static_route.go
@@ -337,7 +337,11 @@ func resourceNsxtPolicyStaticRouteImport(d *schema.ResourceData, m interface{}) 
 	s := strings.Split(importID, "/")
 	rd, err := nsxtPolicyPathResourceImporterHelper(d, m)
 	if err == nil {
-		d.Set("gateway_path", importID[0:strings.Index(importID, "/static-routes")])
+		gwPath, err := getParameterFromPolicyPath("", "/static-routes", importID)
+		if err != nil {
+			return nil, err
+		}
+		d.Set("gateway_path", gwPath)
 		return rd, nil
 	} else if !errors.Is(err, ErrNotAPolicyPath) {
 		return rd, err

--- a/nsxt/resource_nsxt_policy_tier1_gateway_interface.go
+++ b/nsxt/resource_nsxt_policy_tier1_gateway_interface.go
@@ -319,7 +319,11 @@ func resourceNsxtPolicyTier1GatewayInterfaceImport(d *schema.ResourceData, m int
 	s := strings.Split(importID, "/")
 	rd, err := nsxtPolicyPathResourceImporterHelper(d, m)
 	if err == nil {
-		d.Set("gateway_path", importID[0:strings.Index(importID, "/locale-services/")])
+		gwPath, err := getParameterFromPolicyPath("", "/locale-services/", importID)
+		if err != nil {
+			return nil, err
+		}
+		d.Set("gateway_path", gwPath)
 		for i, e := range s {
 			if e == "locale-services" {
 				d.Set("locale_service_id", s[i+1])

--- a/website/docs/r/policy_ip_address_allocation.html.markdown
+++ b/website/docs/r/policy_ip_address_allocation.html.markdown
@@ -113,5 +113,10 @@ An existing IP Allocation can be [imported][docs-import] into this resource, via
 ```
 terraform import nsxt_policy_ip_address_allocation.test POOL-ID/ID
 ```
-
 The above command imports IpAddressAllocation named `test` with the NSX IpAddressAllocation ID `ID` in IP Pool `POOL-ID`.
+
+```
+terraform import nsxt_policy_ip_address_allocation.test POLICY_PATH
+```
+The above command imports IpAddressAllocation named `test` with the NSX policy path `POLICY_PATH`.
+Note: for multitenancy projects only the later form is usable.


### PR DESCRIPTION
When importing using policy path, the provider could crash due to
invalid input. Change to terminate gracefully with an error.
