### PR TITLE
Add support for configuring cluster virtual IP

### DIFF
--- a/nsxt/provider.go
+++ b/nsxt/provider.go
@@ -427,6 +427,7 @@ func Provider() *schema.Provider {
 			"nsxt_uplink_host_switch_profile":              resourceNsxtUplinkHostSwitchProfile(),
 			"nsxt_transport_node":                          resourceNsxtTransportNode(),
 			"nsxt_failure_domain":                          resourceNsxtFailureDomain(),
+			"nsxt_cluster_virtual_ip":                      resourceNsxtClusterVirualIP(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/nsxt/resource_nsxt_cluster_virtual_ip.go
+++ b/nsxt/resource_nsxt_cluster_virtual_ip.go
@@ -1,0 +1,130 @@
+/* Copyright © 2023 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: MPL-2.0 */
+
+package nsxt
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp/nsx/cluster"
+	nsxModel "github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp/nsx/model"
+)
+
+var ClusterVirtualIPForceType = []string{
+	nsxModel.ClusterVirtualIpProperties_FORCE_TRUE,
+	nsxModel.ClusterVirtualIpProperties_FORCE_FALSE,
+}
+
+var DefaultIPv4VirtualAddress = "0.0.0.0"
+
+var DefaultIPv6VirtualAddress = "::"
+
+func resourceNsxtClusterVirualIP() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceNsxtClusterVirualIPCreate,
+		Read:   resourceNsxtClusterVirualIPRead,
+		Update: resourceNsxtClusterVirualIPUpdate,
+		Delete: resourceNsxtClusterVirualIPDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"force": {
+				Type:        schema.TypeBool,
+				Description: "On enable it ignores duplicate address detection and DNS lookup validation check",
+				Optional:    true,
+				Default:     true,
+			},
+			"ip_address": {
+				Type:         schema.TypeString,
+				Description:  "Virtual IPv4 address",
+				Optional:     true,
+				ValidateFunc: validation.IsIPv4Address,
+				Default:      DefaultIPv4VirtualAddress,
+			},
+			"ipv6_address": {
+				Type:         schema.TypeString,
+				Description:  "Virtual IPv6 address",
+				Optional:     true,
+				ValidateFunc: validation.IsIPv6Address,
+				Default:      DefaultIPv6VirtualAddress,
+			},
+		},
+	}
+}
+
+func resourceNsxtClusterVirualIPCreate(d *schema.ResourceData, m interface{}) error {
+	// Create and update workflow are mostly the same for virtual IP resource
+	// except that create workflow sets the ID of this resource
+	id := d.Id()
+	if id == "" {
+		id = newUUID()
+	}
+	d.SetId(id)
+	err := setClusterVirtualIP(d, m)
+	if err != nil {
+		return err
+	}
+	return resourceNsxtClusterVirualIPRead(d, m)
+}
+
+func resourceNsxtClusterVirualIPRead(d *schema.ResourceData, m interface{}) error {
+	connector := getPolicyConnector(m)
+	client := cluster.NewApiVirtualIpClient(connector)
+
+	obj, err := client.Get()
+	if err != nil {
+		return err
+	}
+
+	// For some reason the Get() function of ApiVirtulIPClient will only return ip address information
+	// so skip setting force here
+	d.Set("ip_address", obj.IpAddress)
+	d.Set("ipv6_address", obj.Ip6Address)
+
+	return nil
+}
+
+func setClusterVirtualIP(d *schema.ResourceData, m interface{}) error {
+	connector := getPolicyConnector(m)
+	client := cluster.NewApiVirtualIpClient(connector)
+	force := d.Get("force").(bool)
+	ipAddress := d.Get("ip_address").(string)
+	ipv6Address := d.Get("ipv6_address").(string)
+	var forceStr string
+	if force {
+		forceStr = nsxModel.ClusterVirtualIpProperties_FORCE_TRUE
+	} else {
+		forceStr = nsxModel.ClusterVirtualIpProperties_FORCE_FALSE
+	}
+	_, err := client.Setvirtualip(&forceStr, &ipv6Address, &ipAddress)
+	if err != nil {
+		return fmt.Errorf("Failed to set cluster virtual ip: %s", err)
+	}
+	return nil
+}
+
+func resourceNsxtClusterVirualIPUpdate(d *schema.ResourceData, m interface{}) error {
+	err := setClusterVirtualIP(d, m)
+	if err != nil {
+		return err
+	}
+	return resourceNsxtClusterVirualIPRead(d, m)
+}
+
+func resourceNsxtClusterVirualIPDelete(d *schema.ResourceData, m interface{}) error {
+	connector := getPolicyConnector(m)
+	client := cluster.NewApiVirtualIpClient(connector)
+	_, err := client.Clearvirtualip()
+	if err != nil {
+		return fmt.Errorf("Failed to clear cluster virtual IPv4 address: %s", err)
+	}
+	_, err = client.Clearvirtualip6()
+	if err != nil {
+		return fmt.Errorf("Failed to clear cluster virtual IPv6 address: %s", err)
+	}
+	return nil
+}

--- a/website/docs/r/cluster_virtual_ip.html.markdown
+++ b/website/docs/r/cluster_virtual_ip.html.markdown
@@ -1,0 +1,34 @@
+---
+subcategory: "Fabric"
+layout: "nsxt"
+page_title: "NSXT: nsxt_cluster_virtual_ip"
+description: A resource to configure virtual IP of NSXT cluster.
+---
+
+# nsxt_cluster_virtual_ip
+
+This resource provides a method for configuring the virtual IP of NSXT cluster.
+This resource is supported with NSX 4.1.0 onwards.
+Only one instance of nsxt_cluster_virtual_ip resource is supported.
+
+## Example Usage
+
+```hcl
+resource "nsxt_cluster_virtual_ip" "test" {
+  ip_address   = "10.0.0.251"
+  ipv6_address = "fd01:1:2:2918:250:56ff:fe8b:7e4d"
+  force        = "true"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `force` - (Optional) A flag to determine if need to ignore duplicate address detection and DNS lookup validation check. Value can be `true` or `false`. Default value is `false`.
+* `ip_address` - (Optional) Virtual IP Address of the cluster. Must be in the same subnet as the manager nodes. Default value is `0.0.0.0`.
+* `ipv6_address` - (Optional) Virtual IPv6 Address of the cluster. To set ipv6 virtual IP address, IPv6 interface needs to be configured on manager nodes. Default value is `::`.
+
+## Importing
+
+Importing is not supported for this resource.

--- a/website/docs/r/manager_cluster.html.markdown
+++ b/website/docs/r/manager_cluster.html.markdown
@@ -11,6 +11,7 @@ This resource provides a method for creating an NSXT cluster with several nodes
 This resource is supported with NSX 4.1.0 onwards.
 The main node for the cluster is the host in terraform nsxt provider config,
 user will need to specify the nodes that will join the cluster in the resource config.
+Only one instance of nsxt_manager_cluster resource is supported.
 
 ## Example Usage
 


### PR DESCRIPTION
An implementation for resource nsxt_cluster_virtual_ip to configure NSXT cluster virtual IPv4 and IPv6 address.

The virtual IP property can be part of nsxt_manager_cluster resource or an independent resource like in this PR, if we decide to implement it as part of nsxt_manage_cluster resource we can still use this PR as a reference.