### PR TITLE
Support on-demand connection init in the provider

### DIFF
--- a/nsxt/provider.go
+++ b/nsxt/provider.go
@@ -210,6 +210,12 @@ func Provider() *schema.Provider {
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("NSXT_CA", nil),
 			},
+			"on_demand_connection": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Avoid initializing NSX connection on startup",
+				DefaultFunc: schema.EnvDefaultFunc("NSXT_ON_DEMAND_CONNECTION", false),
+			},
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
@@ -407,12 +413,18 @@ func Provider() *schema.Provider {
 }
 
 func configureNsxtClient(d *schema.ResourceData, clients *nsxtClients) error {
+	onDemandConn := d.Get("on_demand_connection").(bool)
 	clientAuthCertFile := d.Get("client_auth_cert_file").(string)
 	clientAuthKeyFile := d.Get("client_auth_key_file").(string)
 	clientAuthCert := d.Get("client_auth_cert").(string)
 	clientAuthKey := d.Get("client_auth_key").(string)
 	vmcToken := d.Get("vmc_token").(string)
 	vmcAuthMode := d.Get("vmc_auth_mode").(string)
+
+	if onDemandConn {
+		// On demand connection option is not supported with old SDK
+		return nil
+	}
 
 	if (len(vmcToken) > 0) || (vmcAuthMode == "Basic") {
 		// VMC can operate without token with basic auth, however MP API is not
@@ -605,6 +617,7 @@ func getConnectorTLSConfig(d *schema.ResourceData) (*tls.Config, error) {
 }
 
 func configurePolicyConnectorData(d *schema.ResourceData, clients *nsxtClients) error {
+	onDemandConn := d.Get("on_demand_connection").(bool)
 	host := d.Get("host").(string)
 	username := d.Get("username").(string)
 	password := d.Get("password").(string)
@@ -616,6 +629,19 @@ func configurePolicyConnectorData(d *schema.ResourceData, clients *nsxtClients) 
 	policyEnforcementPoint := d.Get("enforcement_point").(string)
 	policyGlobalManager := d.Get("global_manager").(bool)
 	vmcAuthMode := d.Get("vmc_auth_mode").(string)
+
+	isVMC := false
+	if (len(vmcAccessToken) > 0) || (vmcAuthMode == "Basic") {
+		isVMC = true
+		if onDemandConn {
+			return fmt.Errorf("on demand connection option is not supported with VMC")
+		}
+	}
+
+	if d.HasChange("license_keys") && onDemandConn {
+		// TODO - remove this constraint when license is rewritten with new SDK
+		return fmt.Errorf("on demand connection option is not supported with license feature")
+	}
 
 	if host == "" {
 		return fmt.Errorf("host must be provided")
@@ -683,7 +709,12 @@ func configurePolicyConnectorData(d *schema.ResourceData, clients *nsxtClients) 
 	clients.PolicyEnforcementPoint = policyEnforcementPoint
 	clients.PolicyGlobalManager = policyGlobalManager
 
-	if (len(vmcAccessToken) > 0) || (vmcAuthMode == "Basic") {
+	if onDemandConn {
+		// version init will happen on demand
+		return nil
+	}
+
+	if isVMC {
 		// Special treatment for VMC since MP API is not available there
 		initNSXVersionVMC(*clients)
 		return nil
@@ -936,6 +967,11 @@ func getPolicyConnectorWithHeaders(clients interface{}, customHeaders *map[strin
 		connectorOptions = append(connectorOptions, client.WithRequestProcessors(requestProcessors...))
 	}
 	connector := client.NewConnector(c.Host, connectorOptions...)
+
+	// Init NSX version if not done yet
+	if nsxVersion == "" {
+		initNSXVersion(connector)
+	}
 	return connector
 }
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -236,7 +236,12 @@ The following arguments are used to configure the VMware NSX-T Provider:
 * `global_manager` - (Optional) True if this is a global manager endpoint.
   False by default.
 * `license_keys` - (Optional) List of NSX-T license keys. License keys are applied
-  during plan and will not be deleted if they are removed from the configuration.
+  during plan or apply commands.
+* `on_demand_connection` - (Optional) Avoid verification on NSX connectivity on provider
+  startup. Instead, initialize the connection on demand. This setting can not be turned on
+  for VMC environments, and is not supported with deprecated NSX manager resources and
+  data sources. Note - this setting is useful when NSX manager is not yet available at 
+  time of provider evaluation, and not recommended to be turned on otherwise.
 
 ## NSX Logical Networking
 


### PR DESCRIPTION
When the new `on_demand_connection` provider flag is set to true, provider will not verify connection and pull NSX version on provider startup. Instead, those operations will be done for each provider instance when terraform objects are evaluated.
This setting is useful when NSX appliance is being deployed via same apply process, and not yet responsive when the provider is initialized. This setting is not supported for VMC and not compatible with deprecated objects implemented via the old SDK. It is also temporarily incompatible with license feature (this will be fixed in follow up PR)