### PR TITLE
MTU value can be set to nothing

### DIFF
--- a/nsxt/resource_nsxt_uplink_host_switch_profile.go
+++ b/nsxt/resource_nsxt_uplink_host_switch_profile.go
@@ -192,7 +192,6 @@ func resourceNsxtUplinkHostSwitchProfile() *schema.Resource {
 				Type:         schema.TypeInt,
 				Description:  "Maximum Transmission Unit used for uplinks",
 				Optional:     true,
-				Default:      1700,
 				ValidateFunc: validation.IntAtLeast(1280),
 			},
 			"realized_id": {
@@ -263,7 +262,11 @@ func setUplinkHostSwitchProfileSchema(d *schema.ResourceData, profile model.Poli
 
 	d.Set("overlay_encap", profile.OverlayEncap)
 	d.Set("transport_vlan", profile.TransportVlan)
-	d.Set("mtu", profile.Mtu)
+
+	// Set MTU only when has a value
+	if profile.Mtu != nil {
+		d.Set("mtu", profile.Mtu)
+	}
 }
 
 func resourceNsxtUplinkHostSwitchProfileExists(id string, connector client.Connector, isGlobalManager bool) (bool, error) {
@@ -410,12 +413,14 @@ func uplinkHostSwitchProfileSchemaToModel(d *schema.ResourceData) model.PolicyUp
 		Description:   &description,
 		Tags:          tags,
 		ResourceType:  model.PolicyBaseHostSwitchProfile_RESOURCE_TYPE_POLICYUPLINKHOSTSWITCHPROFILE,
-		Mtu:           &mtu,
 		OverlayEncap:  &overlayEncap,
 		TransportVlan: &transportVlan,
 		Lags:          lags,
 		NamedTeamings: namedTeamings,
 		Teaming:       &teaming,
+	}
+	if mtu != 0 {
+		uplinkHostSwitchProfile.Mtu = &mtu
 	}
 	return uplinkHostSwitchProfile
 }

--- a/nsxt/resource_nsxt_uplink_host_switch_profile_test.go
+++ b/nsxt/resource_nsxt_uplink_host_switch_profile_test.go
@@ -171,7 +171,7 @@ func TestAccResourceNsxtUplinkHostSwitchProfile_basic(t *testing.T) {
 					resource.TestCheckNoResourceAttr(testResourceName, "lag.#"),
 					resource.TestCheckNoResourceAttr(testResourceName, "named_teaming.#"),
 					resource.TestCheckNoResourceAttr(testResourceName, "teaming.0.standby.#"),
-					resource.TestCheckResourceAttr(testResourceName, "mtu", "1700"),
+					resource.TestCheckResourceAttr(testResourceName, "mtu", "0"),
 					resource.TestCheckResourceAttr(testResourceName, "overlay_encap", "GENEVE"),
 					resource.TestCheckResourceAttr(testResourceName, "transport_vlan", "0"),
 				),


### PR DESCRIPTION
For VDS switch type, MTU field should be blank. Therefore it cannot have a default value.