### PR TITLE
Fix rule order bug

### DIFF
--- a/nsxt/policy_common.go
+++ b/nsxt/policy_common.go
@@ -440,6 +440,7 @@ func validatePolicyRuleSequence(d *schema.ResourceData) error {
 func getPolicyRulesFromSchema(d *schema.ResourceData) []model.Rule {
 	rules := d.Get("rule").([]interface{})
 	var ruleList []model.Rule
+	lastSequence := int64(0)
 	for _, rule := range rules {
 		data := rule.(map[string]interface{})
 		displayName := data["display_name"].(string)
@@ -469,6 +470,11 @@ func getPolicyRulesFromSchema(d *schema.ResourceData) []model.Rule {
 		}
 
 		resourceType := "Rule"
+		if sequenceNumber == 0 {
+			sequenceNumber = lastSequence + 1
+		}
+		lastSequence = sequenceNumber
+
 		elem := model.Rule{
 			ResourceType:         &resourceType,
 			Id:                   &id,
@@ -489,10 +495,7 @@ func getPolicyRulesFromSchema(d *schema.ResourceData) []model.Rule {
 			Services:             getPathListFromMap(data, "services"),
 			Scope:                getPathListFromMap(data, "scope"),
 			Profiles:             getPathListFromMap(data, "profiles"),
-		}
-
-		if sequenceNumber > 0 {
-			elem.SequenceNumber = &sequenceNumber
+			SequenceNumber:       &sequenceNumber,
 		}
 
 		ruleList = append(ruleList, elem)

--- a/nsxt/resource_nsxt_policy_security_policy_test.go
+++ b/nsxt/resource_nsxt_policy_security_policy_test.go
@@ -952,38 +952,40 @@ func testAccNsxtPolicySecurityPolicyWithIPCidrRange(name string, destIP string, 
 			destination_groups    = ["%s"]
 			services              = [nsxt_policy_service.icmp.path]
 			action                = "ALLOW"
-		  }
+		}
 
-		  rule {
+		rule {
 			display_name          = "rule3"
 			source_groups         = [nsxt_policy_group.group1.path]
 			destination_groups    = ["%s"]
 			services              = [nsxt_policy_service.icmp.path]
 			action                = "ALLOW"
-		  }
-		  rule {
+			sequence_number       = 50
+		}
+		rule {
 			display_name          = "rule4"
 			source_groups         = ["%s"]
 			destination_groups    = [nsxt_policy_group.group2.path]
 			services              = [nsxt_policy_service.icmp.path]
 			action                = "ALLOW"
-		  }
+		}
   
-		  rule {
+		rule {
 			  display_name          = "rule5"
 			  source_groups         = ["%s"]			
 			  destination_groups    = [nsxt_policy_group.group2.path]
 			  services              = [nsxt_policy_service.icmp.path]
 			  action                = "ALLOW"
-			}
+			  sequence_number       = 105
+                }
   
-			rule {
+		rule {
 			  display_name          = "rule6"
 			  source_groups         = ["%s"]
 			  destination_groups    = [nsxt_policy_group.group2.path]
 			  services              = [nsxt_policy_service.icmp.path]
 			  action                = "ALLOW"
-			}
+		}
 }`, name, destIP, destCidr, destIPRange, sourceIP, sourceCidr, sourceIPRange)
 }
 


### PR DESCRIPTION
NSX can not guarantee rule order unless sequence_number is provided, or `revise` API is called.
This change auto-assigns sequence number to all rules in list, for which it was not provided by the user.
It takes care of provider upgrade by making sure rules without assigned sequence number are updated even if terraform does not detect a change in them.