### PR TITLE
Fix error handling for MP SDK resources

### DIFF
--- a/nsxt/resource_nsxt_compute_manager.go
+++ b/nsxt/resource_nsxt_compute_manager.go
@@ -240,8 +240,7 @@ func resourceNsxtComputeManagerCreate(d *schema.ResourceData, m interface{}) err
 	setAsOidcProvider := d.Get("set_as_oidc_provider").(bool)
 	credential, err := getCredentialValues(d)
 	if err != nil {
-		// id isn't known yet
-		handleCreateError("ComputeManager", "", err)
+		return handleCreateError("ComputeManager", displayName, err)
 	}
 
 	obj := model.ComputeManager{
@@ -259,16 +258,11 @@ func resourceNsxtComputeManagerCreate(d *schema.ResourceData, m interface{}) err
 		SetAsOidcProvider:     &setAsOidcProvider,
 	}
 
+	log.Printf("[INFO] Creating Compute Manager %s", displayName)
 	obj, err = client.Create(obj)
 	if err != nil {
-		id := ""
-		if obj.Id != nil {
-			id = *obj.Id
-		}
-		return handleCreateError("Compute Manager", id, err)
+		return handleCreateError("Compute Manager", displayName, err)
 	}
-
-	log.Printf("[INFO] Creating Compute Manager with ID %s", *obj.Id)
 
 	d.SetId(*obj.Id)
 	return resourceNsxtComputeManagerRead(d, m)
@@ -381,7 +375,7 @@ func resourceNsxtComputeManagerRead(d *schema.ResourceData, m interface{}) error
 
 	obj, err := client.Get(id)
 	if err != nil {
-		return fmt.Errorf("error during Compute Manager read: %v", err)
+		return handleReadError(d, "ComputeManager", id, err)
 	}
 
 	d.Set("revision", obj.Revision)
@@ -488,8 +482,7 @@ func resourceNsxtComputeManagerUpdate(d *schema.ResourceData, m interface{}) err
 	setAsOidcProvider := d.Get("set_as_oidc_provider").(bool)
 	credential, err := getCredentialValues(d)
 	if err != nil {
-		// id isn't known yet
-		handleCreateError("ComputeManager", "", err)
+		return handleUpdateError("ComputeManager", id, err)
 	}
 
 	obj := model.ComputeManager{
@@ -509,7 +502,7 @@ func resourceNsxtComputeManagerUpdate(d *schema.ResourceData, m interface{}) err
 
 	_, err = client.Update(id, obj)
 	if err != nil {
-		return fmt.Errorf("error during Compute Manager %s update: %v", id, err)
+		return handleUpdateError("ComputeManager", id, err)
 	}
 
 	return resourceNsxtComputeManagerRead(d, m)
@@ -527,7 +520,7 @@ func resourceNsxtComputeManagerDelete(d *schema.ResourceData, m interface{}) err
 
 	err := client.Delete(id)
 	if err != nil {
-		return fmt.Errorf("error during Compute Manager delete: %v", err)
+		return handleDeleteError("ComputeManager", id, err)
 	}
 	return nil
 }

--- a/nsxt/resource_nsxt_edge_cluster.go
+++ b/nsxt/resource_nsxt_edge_cluster.go
@@ -117,16 +117,11 @@ func resourceNsxtEdgeClusterCreate(d *schema.ResourceData, m interface{}) error 
 		Members:                members,
 	}
 
+	log.Printf("[INFO] Creating Edge Cluster with name %s", displayName)
 	obj, err := client.Create(obj)
 	if err != nil {
-		id := ""
-		if obj.Id != nil {
-			id = *obj.Id
-		}
-		return handleCreateError("Edge Cluster", id, err)
+		return handleCreateError("Edge Cluster", displayName, err)
 	}
-
-	log.Printf("[INFO] Creating Edge Cluster with ID %s", *obj.Id)
 
 	d.SetId(*obj.Id)
 	return resourceNsxtEdgeClusterRead(d, m)
@@ -175,7 +170,7 @@ func resourceNsxtEdgeClusterRead(d *schema.ResourceData, m interface{}) error {
 	client := nsx.NewEdgeClustersClient(connector)
 	obj, err := client.Get(id)
 	if err != nil {
-		return fmt.Errorf("error during Edge Cluster read: %v", err)
+		return handleReadError(d, "EdgeCluster", id, err)
 	}
 
 	d.Set("revision", obj.Revision)
@@ -253,7 +248,7 @@ func resourceNsxtEdgeClusterUpdate(d *schema.ResourceData, m interface{}) error 
 
 	_, err := client.Update(id, obj)
 	if err != nil {
-		return fmt.Errorf("error during Edge Cluster %s update: %v", id, err)
+		return handleUpdateError("EdgeCluster", id, err)
 	}
 
 	return resourceNsxtEdgeClusterRead(d, m)
@@ -271,7 +266,7 @@ func resourceNsxtEdgeClusterDelete(d *schema.ResourceData, m interface{}) error 
 
 	err := client.Delete(id)
 	if err != nil {
-		return fmt.Errorf("error during Edge Cluster delete: %v", err)
+		return handleDeleteError("EdgeCluster", id, err)
 	}
 	return nil
 }

--- a/nsxt/resource_nsxt_failure_domain.go
+++ b/nsxt/resource_nsxt_failure_domain.go
@@ -56,7 +56,7 @@ func resourceNsxtFailureDomainRead(d *schema.ResourceData, m interface{}) error 
 	client := nsx.NewFailureDomainsClient(connector)
 	obj, err := client.Get(id)
 	if err != nil {
-		return fmt.Errorf("error during FailureDomain read: %v", err)
+		return handleReadError(d, "FailureDomain", id, err)
 	}
 
 	d.Set("display_name", obj.DisplayName)
@@ -67,7 +67,7 @@ func resourceNsxtFailureDomainRead(d *schema.ResourceData, m interface{}) error 
 	preferPtr := obj.PreferredActiveEdgeServices
 	preferStr := "no_preference"
 	if preferPtr != nil {
-		if *preferPtr == true {
+		if *preferPtr {
 			preferStr = "active"
 		} else {
 			preferStr = "standby"
@@ -106,15 +106,12 @@ func resourceNsxtFailureDomainCreate(d *schema.ResourceData, m interface{}) erro
 	client := nsx.NewFailureDomainsClient(connector)
 
 	failureDomain := failureDomainSchemaToModel(d)
+	displayName := d.Get("display_name").(string)
+	log.Printf("[INFO] Creating Failure Domain %s", displayName)
 	obj, err := client.Create(failureDomain)
 	if err != nil {
-		id := ""
-		if obj.Id != nil {
-			id = *obj.Id
-		}
-		return handleCreateError("Failure Domain", id, err)
+		return handleCreateError("Failure Domain", displayName, err)
 	}
-	log.Printf("[INFO] FailureDomain with ID %s created", *obj.Id)
 	d.SetId(*obj.Id)
 
 	return resourceNsxtFailureDomainRead(d, m)
@@ -135,7 +132,7 @@ func resourceNsxtFailureDomainUpdate(d *schema.ResourceData, m interface{}) erro
 
 	_, err := client.Update(id, failureDomain)
 	if err != nil {
-		return handleCreateError("FailureDomain", id, err)
+		return handleUpdateError("FailureDomain", id, err)
 	}
 
 	return resourceNsxtFailureDomainRead(d, m)


### PR DESCRIPTION
Make sure all new fabric resources use error handling helpers, and those helpers work for error spec defined in all SDK services