### PR TITLE
Improve Compute Manager data source

### DIFF
--- a/nsxt/data_source_nsxt_compute_manager_test.go
+++ b/nsxt/data_source_nsxt_compute_manager_test.go
@@ -11,24 +11,44 @@ import (
 )
 
 func TestAccDataSourceNsxtComputeManager_basic(t *testing.T) {
-	ComputeManagerName := getComputeManagerName()
-	testResourceName := "data.nsxt_edge_cluster.test"
+	computeManagerName := getComputeManagerName()
+	testResourceName := "data.nsxt_compute_manager.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccOnlyLocalManager(t)
-			testAccTestMP(t)
 			testAccPreCheck(t)
 			testAccEnvDefined(t, "NSXT_TEST_COMPUTE_MANAGER")
 		},
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNSXComputeManagerReadTemplate(ComputeManagerName),
+				Config: testAccNSXComputeManagerReadTemplate(computeManagerName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(testResourceName, "display_name", ComputeManagerName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", computeManagerName),
 					resource.TestCheckResourceAttrSet(testResourceName, "id"),
-					resource.TestCheckResourceAttrSet(testResourceName, "description"),
+					resource.TestCheckResourceAttrSet(testResourceName, "server"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceNsxtComputeManager_single(t *testing.T) {
+	testResourceName := "data.nsxt_compute_manager.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccOnlyLocalManager(t)
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNSXComputeManagerSingleReadTemplate(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(testResourceName, "display_name"),
+					resource.TestCheckResourceAttrSet(testResourceName, "id"),
 					resource.TestCheckResourceAttrSet(testResourceName, "server"),
 				),
 			},
@@ -41,4 +61,10 @@ func testAccNSXComputeManagerReadTemplate(name string) string {
 data "nsxt_compute_manager" "test" {
   display_name = "%s"
 }`, name)
+}
+
+func testAccNSXComputeManagerSingleReadTemplate() string {
+	return `
+data "nsxt_compute_manager" "test" {
+}`
 }

--- a/website/docs/d/compute_manager.html.markdown
+++ b/website/docs/d/compute_manager.html.markdown
@@ -5,7 +5,7 @@ page_title: "NSXT: compute_manager"
 description: A Compute Manager data source.
 ---
 
-# nsxt_mac_pool
+# nsxt_compute_manager
 
 This data source provides information about a Compute Manager configured on NSX.
 
@@ -13,7 +13,6 @@ This data source provides information about a Compute Manager configured on NSX.
 
 ```hcl
 data "nsxt_compute_manager" "test_vcenter" {
-  display_name = "test-vcenter"
 }
 ```
 
@@ -26,5 +25,5 @@ data "nsxt_compute_manager" "test_vcenter" {
 
 In addition to arguments listed above, the following attributes are exported:
 
-* `description` - The description of the MAC pool.
-* `server` - IP address or hostname of compute manager.
+* `description` - The description of the resource.
+* `server` - IP address or hostname of the resource.


### PR DESCRIPTION
Since usually only one compute manager is configured, it is useful to retrieve its ID without providing any filters. This PR enables this.