### PR TITLE
Update assigned_by_dhcp documentation

### DIFF
--- a/website/docs/r/policy_host_transport_node_profile.html.markdown
+++ b/website/docs/r/policy_host_transport_node_profile.html.markdown
@@ -51,7 +51,7 @@ The following arguments are supported:
     * `host_switch_profile` - (Optional) Policy paths of host switch profiles to be associated with this host switch.
     * `host_switch_type` - (Optional) Type of HostSwitch. Accepted values - 'NVDS' or 'VDS'. The default value is 'NVDS'.
     * `ip_assignment` - (Required) - Specification for IPs to be used with host switch virtual tunnel endpoints. Should contain exactly one of the below:
-        * `assigned_by_dhcp` - (Optional) Enables DHCP assignment. Should be set to true.
+        * `assigned_by_dhcp` - (Optional) Enables DHCP assignment.
         * `static_ip` - (Optional) IP assignment specification for Static IP List.
             * `ip_addresses` - (Required) List of IPs for transport node host switch virtual tunnel endpoints.
             * `subnet_mask` - (Required) Subnet mask.
@@ -73,7 +73,7 @@ The following arguments are supported:
             * `host_switch_id` - (Optional) The host switch id. This ID will be used to reference a host switch.
             * `host_switch_profile` - (Optional) Policy paths of host switch profiles to be associated with this host switch.
             * `ip_assignment` - (Required) - Specification for IPs to be used with host switch virtual tunnel endpoints. Should contain exatly one of the below:
-                * `assigned_by_dhcp` - (Optional) Enables DHCP assignment. Should be set to true.
+                * `assigned_by_dhcp` - (Optional) Enables DHCP assignment.
                 * `static_ip` - (Optional) IP assignment specification for Static IP List.
                     * `ip_addresses` - (Required) List of IPs for transport node host switch virtual tunnel endpoints.
                     * `subnet_mask` - (Required) Subnet mask.

--- a/website/docs/r/transport_node.html.markdown
+++ b/website/docs/r/transport_node.html.markdown
@@ -78,7 +78,7 @@ The following arguments are supported:
   * `host_switch_profile` - (Optional) Identifiers of host switch profiles to be associated with this host switch.
   * `host_switch_type` - (Optional) Type of HostSwitch. Accepted values - 'NVDS' or 'VDS'. The default value is 'NVDS'.
   * `ip_assignment` - (Required) - Specification for IPs to be used with host switch virtual tunnel endpoints. Should contain exatly one of the below:
-    * `assigned_by_dhcp` - (Optional) Enables DHCP assignment. Should be set to true.
+    * `assigned_by_dhcp` - (Optional) Enables DHCP assignment.
     * `static_ip` - (Optional) IP assignment specification for Static IP List.
       * `ip_addresses` - (Required) List of IPs for transport node host switch virtual tunnel endpoints.
       * `subnet_mask` - (Required) Subnet mask.
@@ -100,7 +100,7 @@ The following arguments are supported:
       * `host_switch_id` - (Optional) The host switch id. This ID will be used to reference a host switch.
       * `host_switch_profile` - (Optional) Identifiers of host switch profiles to be associated with this host switch.
       * `ip_assignment` - (Required) - Specification for IPs to be used with host switch virtual tunnel endpoints. Should contain exatly one of the below:
-        * `assigned_by_dhcp` - (Optional) Enables DHCP assignment. Should be set to true.
+        * `assigned_by_dhcp` - (Optional) Enables DHCP assignment.
         * `static_ip` - (Optional) IP assignment specification for Static IP List.
           * `ip_addresses` - (Required) List of IPs for transport node host switch virtual tunnel endpoints.
           * `subnet_mask` - (Required) Subnet mask.
@@ -237,7 +237,7 @@ The following arguments are supported:
 * `remote_tunnel_endpoint` - (Optional) Configuration for a remote tunnel endpoint.
   * `host_switch_name` - (Required) The host switch name to be used for the remote tunnel endpoint.
   * `ip_assignment` - (Required) - Specification for IPs to be used with host switch virtual tunnel endpoints. Should contain exatly one of the below:
-    * `assigned_by_dhcp` - (Optional) Enables DHCP assignment. Should be set to true.
+    * `assigned_by_dhcp` - (Optional) Enables DHCP assignment.
     * `static_ip` - (Optional) IP assignment specification for Static IP List.
       * `ip_addresses` - (Required) List of IPs for transport node host switch virtual tunnel endpoints.
       * `subnet_mask` - (Required) Subnet mask.


### PR DESCRIPTION
Remove redundant "Should be set to true" comment from documentation.