### PR TITLE
Rename testAccTestMP() to testAccTestDeprecated()

### DIFF
--- a/nsxt/data_source_nsxt_compute_collection_test.go
+++ b/nsxt/data_source_nsxt_compute_collection_test.go
@@ -15,7 +15,7 @@ func TestAccDataSourceNsxtComputeCollection_basic(t *testing.T) {
 	testResourceName := "data.nsxt_compute_collection.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/nsxt/data_source_nsxt_compute_manager_test.go
+++ b/nsxt/data_source_nsxt_compute_manager_test.go
@@ -17,7 +17,6 @@ func TestAccDataSourceNsxtComputeManager_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccOnlyLocalManager(t)
-			testAccTestMP(t)
 			testAccPreCheck(t)
 			testAccEnvDefined(t, "NSXT_TEST_COMPUTE_MANAGER")
 		},

--- a/nsxt/data_source_nsxt_edge_cluster_test.go
+++ b/nsxt/data_source_nsxt_edge_cluster_test.go
@@ -15,7 +15,7 @@ func TestAccDataSourceNsxtEdgeCluster_basic(t *testing.T) {
 	testResourceName := "data.nsxt_edge_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/nsxt/data_source_nsxt_firewall_section_test.go
+++ b/nsxt/data_source_nsxt_firewall_section_test.go
@@ -18,7 +18,7 @@ func TestAccDataSourceNsxtFirewallSection_basic(t *testing.T) {
 	testResourceName := "data.nsxt_firewall_section.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccDataSourceNsxtFirewallSectionDeleteByName(name)

--- a/nsxt/data_source_nsxt_ip_pool_test.go
+++ b/nsxt/data_source_nsxt_ip_pool_test.go
@@ -18,7 +18,7 @@ func TestAccDataSourceNsxtIPPool_basic(t *testing.T) {
 	testResourceName := "data.nsxt_ip_pool.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/nsxt/data_source_nsxt_logical_tier0_router_test.go
+++ b/nsxt/data_source_nsxt_logical_tier0_router_test.go
@@ -15,7 +15,7 @@ func TestAccDataSourceNsxtLogicalTier0Router_basic(t *testing.T) {
 	testResourceName := "data.nsxt_logical_tier0_router.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/nsxt/data_source_nsxt_logical_tier1_router_test.go
+++ b/nsxt/data_source_nsxt_logical_tier1_router_test.go
@@ -18,7 +18,7 @@ func TestAccDataSourceNsxtLogicalTier1Router_basic(t *testing.T) {
 	testResourceName := "data.nsxt_logical_tier1_router.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccDataSourceNsxtTier1RouterDeleteByName(routerName)

--- a/nsxt/data_source_nsxt_mac_pool_test.go
+++ b/nsxt/data_source_nsxt_mac_pool_test.go
@@ -15,7 +15,7 @@ func TestAccDataSourceNsxtMacPool_basic(t *testing.T) {
 	testResourceName := "data.nsxt_mac_pool.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/nsxt/data_source_nsxt_management_cluster_test.go
+++ b/nsxt/data_source_nsxt_management_cluster_test.go
@@ -13,7 +13,7 @@ func TestAccDataSourceNsxtManagementCluster_basic(t *testing.T) {
 	testResourceName := "data.nsxt_management_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/nsxt/data_source_nsxt_ns_group_test.go
+++ b/nsxt/data_source_nsxt_ns_group_test.go
@@ -18,7 +18,7 @@ func TestAccDataSourceNsxtNsGroup_basic(t *testing.T) {
 	testResourceName := "data.nsxt_ns_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccDataSourceNsxtNsGroupDeleteByName(groupName)

--- a/nsxt/data_source_nsxt_ns_groups_test.go
+++ b/nsxt/data_source_nsxt_ns_groups_test.go
@@ -21,7 +21,7 @@ func TestAccDataSourceNsxtNsGroups_basic(t *testing.T) {
 	checkResourceName := "nsxt_ns_group.check"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccDataSourceNsxtNsGroupDeleteByName(groupName)

--- a/nsxt/data_source_nsxt_ns_service_test.go
+++ b/nsxt/data_source_nsxt_ns_service_test.go
@@ -18,7 +18,7 @@ func TestAccDataSourceNsxtNsService_basic(t *testing.T) {
 	testResourceName := "data.nsxt_ns_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccDataSourceNsxtNsServiceDeleteByName(serviceName)
@@ -45,7 +45,7 @@ func TestAccDataSourceNsxtNsService_systemOwned(t *testing.T) {
 	testResourceName := "data.nsxt_ns_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/nsxt/data_source_nsxt_ns_services_test.go
+++ b/nsxt/data_source_nsxt_ns_services_test.go
@@ -21,7 +21,7 @@ func TestAccDataSourceNsxtNsServices_basic(t *testing.T) {
 	checkResourceName := "nsxt_ns_group.check"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccDataSourceNsxtNsServiceDeleteByName(serviceName)

--- a/nsxt/data_source_nsxt_switching_profile_test.go
+++ b/nsxt/data_source_nsxt_switching_profile_test.go
@@ -19,7 +19,7 @@ func TestAccDataSourceNsxtSwitchingProfile_basic(t *testing.T) {
 	testResourceName := "data.nsxt_switching_profile.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccDataSourceNsxtSwitchingProfileDeleteByName(profileName)

--- a/nsxt/data_source_nsxt_transport_zone_test.go
+++ b/nsxt/data_source_nsxt_transport_zone_test.go
@@ -15,7 +15,7 @@ func TestAccDataSourceNsxtTransportZone_basic(t *testing.T) {
 	testResourceName := "data.nsxt_transport_zone.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/nsxt/resource_nsxt_algorithm_type_ns_service_test.go
+++ b/nsxt/resource_nsxt_algorithm_type_ns_service_test.go
@@ -20,7 +20,7 @@ func TestAccResourceNsxtAlgorithmTypeNsService_basic(t *testing.T) {
 	updatedDestPort := "21"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXAlgServiceCheckDestroy(state, updateServiceName)
@@ -58,7 +58,7 @@ func TestAccResourceNsxtAlgorithmTypeNsService_importBasic(t *testing.T) {
 	serviceName := getAccTestResourceName()
 	testResourceName := "nsxt_algorithm_type_ns_service.test"
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXAlgServiceCheckDestroy(state, serviceName)

--- a/nsxt/resource_nsxt_dhcp_relay_profile_test.go
+++ b/nsxt/resource_nsxt_dhcp_relay_profile_test.go
@@ -18,7 +18,7 @@ func TestAccResourceNsxtDhcpRelayProfile_basic(t *testing.T) {
 	testResourceName := "nsxt_dhcp_relay_profile.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXDhcpRelayProfileCheckDestroy(state, updatePrfName)
@@ -53,7 +53,7 @@ func TestAccResourceNsxtDhcpRelayProfile_importBasic(t *testing.T) {
 	testResourceName := "nsxt_dhcp_relay_profile.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXDhcpRelayProfileCheckDestroy(state, prfName)

--- a/nsxt/resource_nsxt_dhcp_relay_service_test.go
+++ b/nsxt/resource_nsxt_dhcp_relay_service_test.go
@@ -18,7 +18,7 @@ func TestAccResourceNsxtDhcpRelayService_basic(t *testing.T) {
 	testResourceName := "nsxt_dhcp_relay_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXDhcpRelayServiceCheckDestroy(state, prfName)
@@ -51,7 +51,7 @@ func TestAccResourceNsxtDhcpRelayService_importBasic(t *testing.T) {
 	testResourceName := "nsxt_dhcp_relay_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXDhcpRelayServiceCheckDestroy(state, prfName)

--- a/nsxt/resource_nsxt_dhcp_server_ip_pool_test.go
+++ b/nsxt/resource_nsxt_dhcp_server_ip_pool_test.go
@@ -27,7 +27,7 @@ func TestAccResourceNsxtDhcpServerIPPool_basic(t *testing.T) {
 	updatedLeaseTime := "1000000"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXDhcpServerIPPoolCheckDestroy(state, updatedName)
@@ -94,7 +94,7 @@ func TestAccResourceNsxtDhcpServerIPPool_noOpts(t *testing.T) {
 	end2 := "1.1.1.160"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXDhcpServerIPPoolCheckDestroy(state, updatedName)
@@ -140,7 +140,7 @@ func TestAccResourceNsxtDhcpServerIPPool_Import(t *testing.T) {
 	edgeClusterName := getEdgeClusterName()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXNATRuleCheckDestroy(state, name)

--- a/nsxt/resource_nsxt_dhcp_server_profile_test.go
+++ b/nsxt/resource_nsxt_dhcp_server_profile_test.go
@@ -19,7 +19,7 @@ func TestAccResourceNsxtDhcpServerProfile_basic(t *testing.T) {
 	edgeClusterName := getEdgeClusterName()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXDhcpServerProfileCheckDestroy(state, updatePrfName)
@@ -55,7 +55,7 @@ func TestAccResourceNsxtDhcpServerProfile_importBasic(t *testing.T) {
 	edgeClusterName := getEdgeClusterName()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXDhcpServerProfileCheckDestroy(state, prfName)

--- a/nsxt/resource_nsxt_ether_type_ns_service_test.go
+++ b/nsxt/resource_nsxt_ether_type_ns_service_test.go
@@ -18,7 +18,7 @@ func TestAccResourceNsxtEtherTypeNsService_basic(t *testing.T) {
 	testResourceName := "nsxt_ether_type_ns_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXEtherServiceCheckDestroy(state, updateServiceName)
@@ -53,7 +53,7 @@ func TestAccResourceNsxtEtherTypeNsService_importBasic(t *testing.T) {
 	testResourceName := "nsxt_ether_type_ns_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXEtherServiceCheckDestroy(state, serviceName)

--- a/nsxt/resource_nsxt_firewall_section_test.go
+++ b/nsxt/resource_nsxt_firewall_section_test.go
@@ -21,7 +21,7 @@ func TestAccResourceNsxtFirewallSection_basic(t *testing.T) {
 	tos := ""
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXFirewallSectionCheckDestroy(state, updateSectionName)
@@ -75,7 +75,7 @@ target_id   = "${nsxt_ns_group.grp2.id}"
 }`
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXFirewallSectionCheckDestroy(state, sectionName)
@@ -121,7 +121,7 @@ func TestAccResourceNsxtFirewallSection_withRules(t *testing.T) {
 	ruleTos := ""
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXFirewallSectionCheckDestroy(state, sectionName)
@@ -170,7 +170,7 @@ func TestAccResourceNsxtFirewallSection_withRulesAndTags(t *testing.T) {
 	tos := ""
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXFirewallSectionCheckDestroy(state, sectionName)
@@ -233,7 +233,7 @@ applied_to {
 }`
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXFirewallSectionCheckDestroy(state, sectionName)
@@ -277,7 +277,7 @@ func TestAccResourceNsxtFirewallSection_ordered(t *testing.T) {
 	testResourceNames := [4]string{"nsxt_firewall_section.test1", "nsxt_firewall_section.test2", "nsxt_firewall_section.test3", "nsxt_firewall_section.test4"}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			for i := 0; i <= 3; i++ {
@@ -336,7 +336,7 @@ func TestAccResourceNsxtFirewallSection_edge(t *testing.T) {
 		PreCheck: func() {
 			testAccOnlyLocalManager(t)
 			testAccPreCheck(t)
-			testAccTestMP(t)
+			testAccTestDeprecated(t)
 			testAccNSXVersion(t, "2.4.0")
 		},
 		Providers: testAccProviders,
@@ -383,7 +383,7 @@ func TestAccResourceNsxtFirewallSection_importBasic(t *testing.T) {
 	tos := string("")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXFirewallSectionCheckDestroy(state, sectionName)
@@ -409,7 +409,7 @@ func TestAccResourceNsxtFirewallSection_importWithRules(t *testing.T) {
 	tos := string("")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXFirewallSectionCheckDestroy(state, sectionName)
@@ -437,7 +437,7 @@ target_id = "${nsxt_ns_group.grp1.id}"
 }`
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXFirewallSectionCheckDestroy(state, sectionName)

--- a/nsxt/resource_nsxt_icmp_type_ns_service_test.go
+++ b/nsxt/resource_nsxt_icmp_type_ns_service_test.go
@@ -18,7 +18,7 @@ func TestAccResourceNsxtIcmpTypeNsService_basic(t *testing.T) {
 	testResourceName := "nsxt_icmp_type_ns_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXIcmpServiceCheckDestroy(state, updateServiceName)
@@ -57,7 +57,7 @@ func TestAccResourceNsxtIcmpTypeNsService_importBasic(t *testing.T) {
 	testResourceName := "nsxt_icmp_type_ns_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXIcmpServiceCheckDestroy(state, serviceName)

--- a/nsxt/resource_nsxt_igmp_type_ns_service_test.go
+++ b/nsxt/resource_nsxt_igmp_type_ns_service_test.go
@@ -18,7 +18,7 @@ func TestAccResourceNsxtIgmpTypeNsService_basic(t *testing.T) {
 	testResourceName := "nsxt_igmp_type_ns_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXIgmpServiceCheckDestroy(state, updateServiceName)
@@ -51,7 +51,7 @@ func TestAccResourceNsxtIgmpTypeNsService_importBasic(t *testing.T) {
 	testResourceName := "nsxt_igmp_type_ns_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXIgmpServiceCheckDestroy(state, serviceName)

--- a/nsxt/resource_nsxt_ip_block_subnet_test.go
+++ b/nsxt/resource_nsxt_ip_block_subnet_test.go
@@ -20,7 +20,7 @@ func TestAccResourceNsxtIpBlockSubnet_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccOnlyLocalManager(t)
-			testAccTestMP(t)
+			testAccTestDeprecated(t)
 			testAccPreCheck(t)
 			testAccNSXVersion(t, "2.4.0")
 		},
@@ -71,7 +71,7 @@ func TestAccResourceNsxtIpBlockSubnet_importBasic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccOnlyLocalManager(t)
-			testAccTestMP(t)
+			testAccTestDeprecated(t)
 			testAccPreCheck(t)
 			testAccNSXVersion(t, "2.4.0")
 		},

--- a/nsxt/resource_nsxt_ip_block_test.go
+++ b/nsxt/resource_nsxt_ip_block_test.go
@@ -19,7 +19,7 @@ func TestAccResourceNsxtIpBlock_basic(t *testing.T) {
 	cidr1 := "1.1.1.0/24"
 	cidr2 := "2.2.2.0/24"
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXIpBlockCheckDestroy(state, updateName)
@@ -65,7 +65,7 @@ func TestAccResourceNsxtIpBlock_importBasic(t *testing.T) {
 	testResourceName := "nsxt_ip_block.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXIpBlockCheckDestroy(state, name)

--- a/nsxt/resource_nsxt_ip_discovery_switching_profile_test.go
+++ b/nsxt/resource_nsxt_ip_discovery_switching_profile_test.go
@@ -18,7 +18,7 @@ func TestAccResourceNsxtIpDiscoverySwitchingProfile_basic(t *testing.T) {
 	testResourceName := "nsxt_ip_discovery_switching_profile.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXIpDiscoverySwitchingProfileCheckDestroy(state, updatedName)
@@ -65,7 +65,7 @@ func TestAccResourceNsxtIpDiscoverySwitchingProfile_importBasic(t *testing.T) {
 	name := getAccTestResourceName()
 	testResourceName := "nsxt_ip_discovery_switching_profile.test"
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXIpDiscoverySwitchingProfileCheckDestroy(state, name)

--- a/nsxt/resource_nsxt_ip_pool_allocation_ip_address_test.go
+++ b/nsxt/resource_nsxt_ip_pool_allocation_ip_address_test.go
@@ -25,7 +25,7 @@ func TestAccResourceNsxtIPPoolAllocationIPAddress_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccOnlyLocalManager(t)
-			testAccTestMP(t)
+			testAccTestDeprecated(t)
 			testAccPreCheck(t)
 			testAccEnvDefined(t, "NSXT_TEST_IP_POOL")
 		},
@@ -51,7 +51,7 @@ func TestAccResourceNsxtIPPoolAllocationIPAddress_import(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccTestMP(t)
+			testAccTestDeprecated(t)
 			testAccEnvDefined(t, "NSXT_TEST_IP_POOL")
 			testAccOnlyLocalManager(t)
 		},

--- a/nsxt/resource_nsxt_ip_pool_test.go
+++ b/nsxt/resource_nsxt_ip_pool_test.go
@@ -18,7 +18,7 @@ func TestAccResourceNsxtIpPool_basic(t *testing.T) {
 	testResourceName := "nsxt_ip_pool.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXIpPoolCheckDestroy(state, updateName)
@@ -58,7 +58,7 @@ func TestAccResourceNsxtIpPool_importBasic(t *testing.T) {
 	testResourceName := "nsxt_ip_pool.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXIpPoolCheckDestroy(state, name)

--- a/nsxt/resource_nsxt_ip_protocol_ns_service_test.go
+++ b/nsxt/resource_nsxt_ip_protocol_ns_service_test.go
@@ -18,7 +18,7 @@ func TestAccResourceNsxtIpProtocolNsService_basic(t *testing.T) {
 	testResourceName := "nsxt_ip_protocol_ns_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXIpProtocolServiceCheckDestroy(state, updateServiceName)
@@ -53,7 +53,7 @@ func TestAccResourceNsxtIpProtocolNsService_importBasic(t *testing.T) {
 	testResourceName := "nsxt_ip_protocol_ns_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXIpProtocolServiceCheckDestroy(state, serviceName)

--- a/nsxt/resource_nsxt_ip_set_test.go
+++ b/nsxt/resource_nsxt_ip_set_test.go
@@ -18,7 +18,7 @@ func TestAccResourceNsxtIpSet_basic(t *testing.T) {
 	testResourceName := "nsxt_ip_set.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXIpSetCheckDestroy(state, updateName)
@@ -53,7 +53,7 @@ func TestAccResourceNsxtIpSet_noName(t *testing.T) {
 	testResourceName := "nsxt_ip_set.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXIpSetCheckDestroy(state, name)
@@ -88,7 +88,7 @@ func TestAccResourceNsxtIpSet_importBasic(t *testing.T) {
 	testResourceName := "nsxt_ip_set.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXIpSetCheckDestroy(state, name)

--- a/nsxt/resource_nsxt_l4_port_set_ns_service_test.go
+++ b/nsxt/resource_nsxt_l4_port_set_ns_service_test.go
@@ -18,7 +18,7 @@ func TestAccResourceNsxtL4PortNsService_basic(t *testing.T) {
 	testResourceName := "nsxt_l4_port_set_ns_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXL4ServiceCheckDestroy(state, updateServiceName)
@@ -53,7 +53,7 @@ func TestAccResourceNsxtL4PortNsService_importBasic(t *testing.T) {
 	testResourceName := "nsxt_l4_port_set_ns_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXL4ServiceCheckDestroy(state, serviceName)

--- a/nsxt/resource_nsxt_lb_client_ssl_profile_test.go
+++ b/nsxt/resource_nsxt_lb_client_ssl_profile_test.go
@@ -20,7 +20,7 @@ func TestAccResourceNsxtLbClientSSLProfile_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccOnlyLocalManager(t)
-			testAccTestMP(t)
+			testAccTestDeprecated(t)
 			testAccPreCheck(t)
 			testAccNSXVersion(t, "2.3.0")
 		},
@@ -69,7 +69,7 @@ func TestAccResourceNsxtLbClientSSLProfile_importBasic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccOnlyLocalManager(t)
-			testAccTestMP(t)
+			testAccTestDeprecated(t)
 			testAccPreCheck(t)
 			testAccNSXVersion(t, "2.3.0")
 		},

--- a/nsxt/resource_nsxt_lb_cookie_persistence_profile_test.go
+++ b/nsxt/resource_nsxt_lb_cookie_persistence_profile_test.go
@@ -24,7 +24,7 @@ func TestAccResourceNsxtLbCookiePersistenceProfile_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccOnlyLocalManager(t)
-			testAccTestMP(t)
+			testAccTestDeprecated(t)
 			testAccPreCheck(t)
 			testAccNSXVersion(t, "2.3.0")
 		},
@@ -78,7 +78,7 @@ func TestAccResourceNsxtLbCookiePersistenceProfile_insertMode(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccOnlyLocalManager(t)
-			testAccTestMP(t)
+			testAccTestDeprecated(t)
 			testAccPreCheck(t)
 			testAccNSXVersion(t, "2.3.0")
 		},
@@ -137,7 +137,7 @@ func TestAccResourceNsxtLbCookiePersistenceProfile_importBasic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccOnlyLocalManager(t)
-			testAccTestMP(t)
+			testAccTestDeprecated(t)
 			testAccPreCheck(t)
 			testAccNSXVersion(t, "2.3.0")
 		},

--- a/nsxt/resource_nsxt_lb_fast_tcp_application_profile_test.go
+++ b/nsxt/resource_nsxt_lb_fast_tcp_application_profile_test.go
@@ -26,7 +26,7 @@ func TestAccResourceNsxtLbFastTCPApplicationProfile_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccOnlyLocalManager(t)
-			testAccTestMP(t)
+			testAccTestDeprecated(t)
 			testAccPreCheck(t)
 			testAccNSXVersion(t, "2.3.0")
 		},
@@ -68,7 +68,7 @@ func TestAccResourceNsxtLbFastTCPApplicationProfile_importBasic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccOnlyLocalManager(t)
-			testAccTestMP(t)
+			testAccTestDeprecated(t)
 			testAccPreCheck(t)
 			testAccNSXVersion(t, "2.3.0")
 		},

--- a/nsxt/resource_nsxt_lb_fast_udp_application_profile_test.go
+++ b/nsxt/resource_nsxt_lb_fast_udp_application_profile_test.go
@@ -24,7 +24,7 @@ func TestAccResourceNsxtLbFastUDPApplicationProfile_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccOnlyLocalManager(t)
-			testAccTestMP(t)
+			testAccTestDeprecated(t)
 			testAccPreCheck(t)
 			testAccNSXVersion(t, "2.3.0")
 		},
@@ -64,7 +64,7 @@ func TestAccResourceNsxtLbFastUDPApplicationProfile_importBasic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccOnlyLocalManager(t)
-			testAccTestMP(t)
+			testAccTestDeprecated(t)
 			testAccPreCheck(t)
 			testAccNSXVersion(t, "2.3.0")
 		},

--- a/nsxt/resource_nsxt_lb_http_application_profile_test.go
+++ b/nsxt/resource_nsxt_lb_http_application_profile_test.go
@@ -37,7 +37,7 @@ func TestAccResourceNsxtLbHTTPApplicationProfile_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccOnlyLocalManager(t)
-			testAccTestMP(t)
+			testAccTestDeprecated(t)
 			testAccPreCheck(t)
 			testAccNSXVersion(t, "2.3.0")
 		},
@@ -82,7 +82,7 @@ func TestAccResourceNsxtLbHTTPApplicationProfile_importBasic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccOnlyLocalManager(t)
-			testAccTestMP(t)
+			testAccTestDeprecated(t)
 			testAccPreCheck(t)
 			testAccNSXVersion(t, "2.3.0")
 		},

--- a/nsxt/resource_nsxt_lb_http_forwarding_rule_test.go
+++ b/nsxt/resource_nsxt_lb_http_forwarding_rule_test.go
@@ -23,7 +23,7 @@ func TestAccResourceNsxtLbHttpForwardingRule_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccOnlyLocalManager(t)
-			testAccTestMP(t)
+			testAccTestDeprecated(t)
 			testAccPreCheck(t)
 			testAccNSXVersion(t, "2.3.0")
 		},
@@ -154,7 +154,7 @@ func TestAccResourceNsxtLbHttpForwardingRule_importBasic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccOnlyLocalManager(t)
-			testAccTestMP(t)
+			testAccTestDeprecated(t)
 			testAccPreCheck(t)
 			testAccNSXVersion(t, "2.3.0")
 		},

--- a/nsxt/resource_nsxt_lb_http_request_rewrite_rule_test.go
+++ b/nsxt/resource_nsxt_lb_http_request_rewrite_rule_test.go
@@ -21,7 +21,7 @@ func TestAccResourceNsxtLbHttpRequestRewriteRule_basic(t *testing.T) {
 	updatedMatchType := "ENDS_WITH"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbHTTPRequestRewriteRuleCheckDestroy(state, name)
@@ -175,7 +175,7 @@ func TestAccResourceNsxtLbHttpRequestRewriteRule_importBasic(t *testing.T) {
 	name := getAccTestResourceName()
 	resourceName := "nsxt_lb_http_request_rewrite_rule.test"
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbHTTPRequestRewriteRuleCheckDestroy(state, name)

--- a/nsxt/resource_nsxt_lb_http_response_rewrite_rule_test.go
+++ b/nsxt/resource_nsxt_lb_http_response_rewrite_rule_test.go
@@ -21,7 +21,7 @@ func TestAccResourceNsxtLbHttpResponseRewriteRule_basic(t *testing.T) {
 	updatedMatchType := "REGEX"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbHTTPResponseRewriteRuleCheckDestroy(state, name)
@@ -141,7 +141,7 @@ func TestAccResourceNsxtLbHttpResponseRewriteRule_importBasic(t *testing.T) {
 	name := getAccTestResourceName()
 	resourceName := "nsxt_lb_http_response_rewrite_rule.test"
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbHTTPResponseRewriteRuleCheckDestroy(state, name)

--- a/nsxt/resource_nsxt_lb_http_virtual_server_test.go
+++ b/nsxt/resource_nsxt_lb_http_virtual_server_test.go
@@ -31,7 +31,7 @@ func TestAccResourceNsxtLbHttpVirtualServer_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccOnlyLocalManager(t)
-			testAccTestMP(t)
+			testAccTestDeprecated(t)
 			testAccPreCheck(t)
 			testAccNSXVersion(t, "2.3.0")
 		},
@@ -93,7 +93,7 @@ func TestAccResourceNsxtLbHttpVirtualServer_withRules(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccOnlyLocalManager(t)
-			testAccTestMP(t)
+			testAccTestDeprecated(t)
 			testAccPreCheck(t)
 			testAccNSXVersion(t, "2.3.0")
 		},
@@ -133,7 +133,7 @@ func TestAccResourceNsxtLbHttpVirtualServer_withSSL(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccOnlyLocalManager(t)
-			testAccTestMP(t)
+			testAccTestDeprecated(t)
 			testAccPreCheck(t)
 			testAccNSXVersion(t, "2.3.0")
 		},
@@ -208,7 +208,7 @@ func TestAccResourceNsxtLbHttpVirtualServer_importBasic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccOnlyLocalManager(t)
-			testAccTestMP(t)
+			testAccTestDeprecated(t)
 			testAccPreCheck(t)
 			testAccNSXVersion(t, "2.3.0")
 		},

--- a/nsxt/resource_nsxt_lb_icmp_monitor_test.go
+++ b/nsxt/resource_nsxt_lb_icmp_monitor_test.go
@@ -27,7 +27,7 @@ func TestAccResourceNsxtLbIcmpMonitor_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccOnlyLocalManager(t)
-			testAccTestMP(t)
+			testAccTestDeprecated(t)
 			testAccPreCheck(t)
 			testAccNSXVersion(t, "2.3.0")
 		},
@@ -76,7 +76,7 @@ func TestAccResourceNsxtLbIcmpMonitor_importBasic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccOnlyLocalManager(t)
-			testAccTestMP(t)
+			testAccTestDeprecated(t)
 			testAccPreCheck(t)
 			testAccNSXVersion(t, "2.3.0")
 		},

--- a/nsxt/resource_nsxt_lb_l4_monitor_test.go
+++ b/nsxt/resource_nsxt_lb_l4_monitor_test.go
@@ -44,7 +44,7 @@ func testAccResourceNsxtLbL4MonitorBasic(t *testing.T, protocol string) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccOnlyLocalManager(t)
-			testAccTestMP(t)
+			testAccTestDeprecated(t)
 			testAccPreCheck(t)
 			testAccNSXVersion(t, "2.3.0")
 		},
@@ -95,7 +95,7 @@ func testAccResourceNsxtLbL4MonitorImport(t *testing.T, protocol string) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccOnlyLocalManager(t)
-			testAccTestMP(t)
+			testAccTestDeprecated(t)
 			testAccPreCheck(t)
 			testAccNSXVersion(t, "2.3.0")
 		},

--- a/nsxt/resource_nsxt_lb_l4_virtual_server_test.go
+++ b/nsxt/resource_nsxt_lb_l4_virtual_server_test.go
@@ -32,7 +32,7 @@ func testAccResourceNsxtLbL4VirtualServer(t *testing.T, protocol string) {
 	updatedMemberPort := "10098"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbL4VirtualServerCheckDestroy(state, protocol, name)
@@ -100,7 +100,7 @@ func testAccResourceNsxtLbL4VirtualServerImport(t *testing.T, protocol string) {
 	name := getAccTestResourceName()
 	resourceName := fmt.Sprintf("nsxt_lb_%s_virtual_server.test", protocol)
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbL4VirtualServerCheckDestroy(state, protocol, name)

--- a/nsxt/resource_nsxt_lb_l7_monitor_test.go
+++ b/nsxt/resource_nsxt_lb_l7_monitor_test.go
@@ -43,7 +43,7 @@ func testAccResourceNsxtLbL7MonitorBasic(t *testing.T, protocol string) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccOnlyLocalManager(t)
-			testAccTestMP(t)
+			testAccTestDeprecated(t)
 			testAccPreCheck(t)
 			testAccNSXVersion(t, "2.3.0")
 		},
@@ -93,7 +93,7 @@ func TestAccResourceNsxtLbHTTPSMonitor_withAuth(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccOnlyLocalManager(t)
-			testAccTestMP(t)
+			testAccTestDeprecated(t)
 			testAccPreCheck(t)
 			testAccNSXVersion(t, "2.3.0")
 		},
@@ -131,7 +131,7 @@ func testAccResourceNsxtLbL7MonitorImport(t *testing.T, protocol string) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccOnlyLocalManager(t)
-			testAccTestMP(t)
+			testAccTestDeprecated(t)
 			testAccPreCheck(t)
 			testAccNSXVersion(t, "2.3.0")
 		},

--- a/nsxt/resource_nsxt_lb_passive_monitor_test.go
+++ b/nsxt/resource_nsxt_lb_passive_monitor_test.go
@@ -23,7 +23,7 @@ func TestAccResourceNsxtLbPassiveMonitor_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccOnlyLocalManager(t)
-			testAccTestMP(t)
+			testAccTestDeprecated(t)
 			testAccPreCheck(t)
 			testAccNSXVersion(t, "2.3.0")
 		},
@@ -64,7 +64,7 @@ func TestAccResourceNsxtLbPassiveMonitor_importBasic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccOnlyLocalManager(t)
-			testAccTestMP(t)
+			testAccTestDeprecated(t)
 			testAccPreCheck(t)
 			testAccNSXVersion(t, "2.3.0")
 		},

--- a/nsxt/resource_nsxt_lb_pool_test.go
+++ b/nsxt/resource_nsxt_lb_pool_test.go
@@ -26,7 +26,7 @@ func TestAccResourceNsxtLbPool_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccOnlyLocalManager(t)
-			testAccTestMP(t)
+			testAccTestDeprecated(t)
 			testAccPreCheck(t)
 			testAccNSXVersion(t, "2.3.0")
 		},
@@ -72,7 +72,7 @@ func TestAccResourceNsxtLbPool_withMonitors(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccOnlyLocalManager(t)
-			testAccTestMP(t)
+			testAccTestDeprecated(t)
 			testAccPreCheck(t)
 			testAccNSXVersion(t, "2.3.0")
 		},
@@ -124,7 +124,7 @@ func TestAccResourceNsxtLbPool_withIpSnat(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccOnlyLocalManager(t)
-			testAccTestMP(t)
+			testAccTestDeprecated(t)
 			testAccPreCheck(t)
 			testAccNSXVersion(t, "2.3.0")
 		},
@@ -179,7 +179,7 @@ func TestAccResourceNsxtLbPool_withMember(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccOnlyLocalManager(t)
-			testAccTestMP(t)
+			testAccTestDeprecated(t)
 			testAccPreCheck(t)
 			testAccNSXVersion(t, "2.3.0")
 		},
@@ -233,7 +233,7 @@ func TestAccResourceNsxtLbPool_withMemberGroup(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccOnlyLocalManager(t)
-			testAccTestMP(t)
+			testAccTestDeprecated(t)
 			testAccPreCheck(t)
 			testAccNSXVersion(t, "2.3.0")
 		},
@@ -288,7 +288,7 @@ func TestAccResourceNsxtLbPool_importBasic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccOnlyLocalManager(t)
-			testAccTestMP(t)
+			testAccTestDeprecated(t)
 			testAccPreCheck(t)
 			testAccNSXVersion(t, "2.3.0")
 		},

--- a/nsxt/resource_nsxt_lb_server_ssl_profile_test.go
+++ b/nsxt/resource_nsxt_lb_server_ssl_profile_test.go
@@ -20,7 +20,7 @@ func TestAccResourceNsxtLbServerSSLProfile_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccOnlyLocalManager(t)
-			testAccTestMP(t)
+			testAccTestDeprecated(t)
 			testAccPreCheck(t)
 			testAccNSXVersion(t, "2.3.0")
 		},
@@ -65,7 +65,7 @@ func TestAccResourceNsxtLbServerSSLProfile_importBasic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccOnlyLocalManager(t)
-			testAccTestMP(t)
+			testAccTestDeprecated(t)
 			testAccPreCheck(t)
 			testAccNSXVersion(t, "2.3.0")
 		},

--- a/nsxt/resource_nsxt_lb_service_test.go
+++ b/nsxt/resource_nsxt_lb_service_test.go
@@ -17,7 +17,7 @@ func TestAccResourceNsxtLbService_basic(t *testing.T) {
 	testResourceName := "nsxt_lb_service.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbServiceCheckDestroy(state, name)
@@ -60,7 +60,7 @@ func TestAccResourceNsxtLbService_withServers(t *testing.T) {
 	updatedLogLevel := "INFO"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbServiceCheckDestroy(state, name)
@@ -99,7 +99,7 @@ func TestAccResourceNsxtLbService_importBasic(t *testing.T) {
 	testResourceName := "nsxt_lb_service.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbServiceCheckDestroy(state, name)

--- a/nsxt/resource_nsxt_lb_source_ip_persistence_profile_test.go
+++ b/nsxt/resource_nsxt_lb_source_ip_persistence_profile_test.go
@@ -20,7 +20,7 @@ func TestAccResourceNsxtLbSourceIpPersistenceProfile_basic(t *testing.T) {
 	updatedTimeout := "200"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbSourceIPPersistenceProfileCheckDestroy(state, updatedName)
@@ -60,7 +60,7 @@ func TestAccResourceNsxtLbSourceIpPersistenceProfile_importBasic(t *testing.T) {
 	name := getAccTestResourceName()
 	testResourceName := "nsxt_lb_source_ip_persistence_profile.test"
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLbSourceIPPersistenceProfileCheckDestroy(state, name)

--- a/nsxt/resource_nsxt_logical_dhcp_port_test.go
+++ b/nsxt/resource_nsxt_logical_dhcp_port_test.go
@@ -19,7 +19,7 @@ func TestAccResourceNsxtLogicalDhcpPort_basic(t *testing.T) {
 	edgeClusterName := getEdgeClusterName()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLogicalPortCheckDestroy(state, updatePortName)
@@ -60,7 +60,7 @@ func TestAccResourceNsxtLogicalDhcpPort_importBasic(t *testing.T) {
 	edgeClusterName := getEdgeClusterName()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLogicalPortCheckDestroy(state, portName)

--- a/nsxt/resource_nsxt_logical_dhcp_server_test.go
+++ b/nsxt/resource_nsxt_logical_dhcp_server_test.go
@@ -26,7 +26,7 @@ func TestAccResourceNsxtLogicalDhcpServer_basic(t *testing.T) {
 	ip5 := "1.1.1.23"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLogicalDhcpServerCheckDestroy(state, updatePrfName)
@@ -85,7 +85,7 @@ func TestAccResourceNsxtLogicalDhcpServer_noOpts(t *testing.T) {
 	ip4 := "1.1.1.22"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLogicalDhcpServerCheckDestroy(state, prfName)
@@ -131,7 +131,7 @@ func TestAccResourceNsxtLogicalDhcpServer_importBasic(t *testing.T) {
 	edgeClusterName := getEdgeClusterName()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLogicalDhcpServerCheckDestroy(state, prfName)

--- a/nsxt/resource_nsxt_logical_port_test.go
+++ b/nsxt/resource_nsxt_logical_port_test.go
@@ -19,7 +19,7 @@ func TestAccResourceNsxtLogicalPort_basic(t *testing.T) {
 	transportZoneName := getOverlayTransportZoneName()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLogicalPortCheckDestroy(state, updatePortName)
@@ -58,7 +58,7 @@ func TestAccResourceNsxtLogicalPort_withProfiles(t *testing.T) {
 	profileType := "QosSwitchingProfile"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			// Verify that the LP was deleted
@@ -106,7 +106,7 @@ func TestAccResourceNsxtLogicalPort_withNSGroup(t *testing.T) {
 	transportZoneName := getOverlayTransportZoneName()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLogicalPortCheckDestroy(state, portName)
@@ -135,7 +135,7 @@ func TestAccResourceNsxtLogicalPort_importBasic(t *testing.T) {
 	transportZoneName := getOverlayTransportZoneName()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLogicalPortCheckDestroy(state, portName)

--- a/nsxt/resource_nsxt_logical_router_centralized_service_port_test.go
+++ b/nsxt/resource_nsxt_logical_router_centralized_service_port_test.go
@@ -23,7 +23,7 @@ func TestAccResourceNsxtLogicalRouterCentralizedServicePort_basic(t *testing.T) 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccOnlyLocalManager(t)
-			testAccTestMP(t)
+			testAccTestDeprecated(t)
 			testAccPreCheck(t)
 			testAccNSXVersion(t, "2.3.0")
 		},
@@ -73,7 +73,7 @@ func TestAccResourceNsxtLogicalRouterCentralizedServicePort_onTier0(t *testing.T
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccOnlyLocalManager(t)
-			testAccTestMP(t)
+			testAccTestDeprecated(t)
 			testAccPreCheck(t)
 			testAccNSXVersion(t, "2.3.0")
 		},
@@ -122,7 +122,7 @@ func TestAccResourceNsxtLogicalRouterCentralizedServicePort_importBasic(t *testi
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccOnlyLocalManager(t)
-			testAccTestMP(t)
+			testAccTestDeprecated(t)
 			testAccPreCheck(t)
 			testAccNSXVersion(t, "2.3.0")
 		},
@@ -152,7 +152,7 @@ func TestAccResourceNsxtLogicalRouterCentralizedServicePort_onTier1(t *testing.T
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccOnlyLocalManager(t)
-			testAccTestMP(t)
+			testAccTestDeprecated(t)
 			testAccPreCheck(t)
 			testAccNSXVersion(t, "2.3.0")
 		},

--- a/nsxt/resource_nsxt_logical_router_downlink_port_test.go
+++ b/nsxt/resource_nsxt_logical_router_downlink_port_test.go
@@ -20,7 +20,7 @@ func TestAccResourceNsxtLogicalRouterDownlinkPort_basic(t *testing.T) {
 	edgeClusterName := getEdgeClusterName()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLogicalRouterDownlinkPortCheckDestroy(state, updatePortName)
@@ -74,7 +74,7 @@ func TestAccResourceNsxtLogicalRouterDownlinkPort_withRelay(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLogicalRouterDownlinkPortCheckDestroy(state, updatePortName)
@@ -119,7 +119,7 @@ func TestAccResourceNsxtLogicalRouterDownlinkPort_importBasic(t *testing.T) {
 	edgeClusterName := getEdgeClusterName()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLogicalRouterDownlinkPortCheckDestroy(state, portName)

--- a/nsxt/resource_nsxt_logical_router_link_port_on_tier0_test.go
+++ b/nsxt/resource_nsxt_logical_router_link_port_on_tier0_test.go
@@ -19,7 +19,7 @@ func TestAccResourceNsxtLogicalRouterLinkPortOnTier0_basic(t *testing.T) {
 	testResourceName := "nsxt_logical_router_link_port_on_tier0.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLogicalRouterLinkPortOnTier0CheckDestroy(state, updateName)
@@ -53,7 +53,7 @@ func TestAccResourceNsxtLogicalRouterLinkPortOnTier0_importBasic(t *testing.T) {
 	testResourceName := "nsxt_logical_router_link_port_on_tier0.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLogicalRouterLinkPortOnTier0CheckDestroy(state, name)

--- a/nsxt/resource_nsxt_logical_router_link_port_on_tier1_test.go
+++ b/nsxt/resource_nsxt_logical_router_link_port_on_tier1_test.go
@@ -20,7 +20,7 @@ func TestAccResourceNsxtLogicalRouterLinkPortOnTier1_basic(t *testing.T) {
 	testResourceName := "nsxt_logical_router_link_port_on_tier1.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLogicalRouterLinkPortOnTier1CheckDestroy(state, updateName)
@@ -59,7 +59,7 @@ func TestAccResourceNsxtLogicalRouterLinkPortOnTier1_importBasic(t *testing.T) {
 	testResourceName := "nsxt_logical_router_link_port_on_tier1.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLogicalRouterLinkPortOnTier1CheckDestroy(state, name)

--- a/nsxt/resource_nsxt_logical_switch_test.go
+++ b/nsxt/resource_nsxt_logical_switch_test.go
@@ -23,7 +23,7 @@ func TestAccResourceNsxtLogicalSwitch_basic(t *testing.T) {
 	transportZoneName := getOverlayTransportZoneName()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLogicalSwitchCheckDestroy(state, updateSwitchName, "nsxt_logical_switch")
@@ -75,7 +75,7 @@ func TestAccResourceNsxtLogicalSwitch_vlan(t *testing.T) {
 	replicationMode := ""
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLogicalSwitchCheckDestroy(state, updateSwitchName, "nsxt_logical_switch")
@@ -115,7 +115,7 @@ func TestAccResourceNsxtLogicalSwitch_withProfiles(t *testing.T) {
 	profileType := "SwitchSecuritySwitchingProfile"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			// Verify that the LS was deleted
@@ -166,7 +166,7 @@ func TestAccResourceNsxtLogicalSwitch_withMacPool(t *testing.T) {
 	replicationMode := "MTEP"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLogicalSwitchCheckDestroy(state, switchName, "nsxt_logical_switch")
@@ -201,7 +201,7 @@ func TestAccResourceNsxtLogicalSwitch_importBasic(t *testing.T) {
 	transportZoneName := getOverlayTransportZoneName()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLogicalSwitchCheckDestroy(state, switchName, "nsxt_logical_switch")

--- a/nsxt/resource_nsxt_logical_tier0_router_test.go
+++ b/nsxt/resource_nsxt_logical_tier0_router_test.go
@@ -20,7 +20,7 @@ func TestAccResourceNsxtLogicalTier0Router_basic(t *testing.T) {
 	edgeClusterName := getEdgeClusterName()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLogicalTier0RouterCheckDestroy(state, updateName)
@@ -57,7 +57,7 @@ func TestAccResourceNsxtLogicalTier0Router_active(t *testing.T) {
 	edgeClusterName := getEdgeClusterName()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLogicalTier0RouterCheckDestroy(state, name)
@@ -94,7 +94,7 @@ func TestAccResourceNsxtLogicalTier0Router_importBasic(t *testing.T) {
 	edgeClusterName := getEdgeClusterName()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLogicalTier0RouterCheckDestroy(state, name)

--- a/nsxt/resource_nsxt_logical_tier1_router_test.go
+++ b/nsxt/resource_nsxt_logical_tier1_router_test.go
@@ -20,7 +20,7 @@ func TestAccResourceNsxtLogicalTier1Router_basic(t *testing.T) {
 	edgeClusterName := getEdgeClusterName()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLogicalTier1RouterCheckDestroy(state, updateName)
@@ -69,7 +69,7 @@ func TestAccResourceNsxtLogicalTier1Router_importBasic(t *testing.T) {
 	edgeClusterName := getEdgeClusterName()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLogicalTier1RouterCheckDestroy(state, name)

--- a/nsxt/resource_nsxt_mac_management_switching_profile_test.go
+++ b/nsxt/resource_nsxt_mac_management_switching_profile_test.go
@@ -20,7 +20,7 @@ func TestAccResourceNsxtMacManagementSwitchingProfile_basic(t *testing.T) {
 	updatedLimit := "101"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXMacManagementSwitchingProfileCheckDestroy(state, updatedName)
@@ -70,7 +70,7 @@ func TestAccResourceNsxtMacManagementSwitchingProfile_importBasic(t *testing.T) 
 	name := getAccTestResourceName()
 	testResourceName := "nsxt_mac_management_switching_profile.test"
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXMacManagementSwitchingProfileCheckDestroy(state, name)

--- a/nsxt/resource_nsxt_nat_rule_test.go
+++ b/nsxt/resource_nsxt_nat_rule_test.go
@@ -20,7 +20,7 @@ func TestAccResourceNsxtNatRule_snat(t *testing.T) {
 	edgeClusterName := getEdgeClusterName()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXNATRuleCheckDestroy(state, updateRuleName)
@@ -71,7 +71,7 @@ func TestAccResourceNsxtNatRule_snatImport(t *testing.T) {
 	edgeClusterName := getEdgeClusterName()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXNATRuleCheckDestroy(state, ruleName)
@@ -95,7 +95,7 @@ func TestAccResourceNsxtNatRule_dnat(t *testing.T) {
 	edgeClusterName := getEdgeClusterName()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXNATRuleCheckDestroy(state, ruleName)
@@ -142,7 +142,7 @@ func TestAccResourceNsxtNatRule_dnatImport(t *testing.T) {
 	edgeClusterName := getEdgeClusterName()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXNATRuleCheckDestroy(state, ruleName)
@@ -168,7 +168,7 @@ func TestAccResourceNsxtNatRule_noNnat(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccOnlyLocalManager(t)
-			testAccTestMP(t)
+			testAccTestDeprecated(t)
 			testAccPreCheck(t)
 			testAccNSXVersionLessThan(t, "3.0.0")
 		},

--- a/nsxt/resource_nsxt_ns_group_test.go
+++ b/nsxt/resource_nsxt_ns_group_test.go
@@ -20,7 +20,7 @@ func TestAccResourceNsxtNSGroup_basic(t *testing.T) {
 	testResourceName := "nsxt_ns_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXNSGroupCheckDestroy(state, updateGrpName)
@@ -56,7 +56,7 @@ func TestAccResourceNsxtNSGroup_nested(t *testing.T) {
 	testResourceName := "nsxt_ns_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXNSGroupCheckDestroy(state, updateGrpName)
@@ -90,7 +90,7 @@ func TestAccResourceNsxtNSGroup_withCriteria(t *testing.T) {
 	transportZoneName := getOverlayTransportZoneName()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXNSGroupCheckDestroy(state, grpName)
@@ -125,7 +125,7 @@ func TestAccResourceNsxtNSGroup_importBasic(t *testing.T) {
 	testResourceName := "nsxt_ns_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXNSGroupCheckDestroy(state, grpName)
@@ -148,7 +148,7 @@ func TestAccResourceNsxtNSGroup_importWithCriteria(t *testing.T) {
 	testResourceName := "nsxt_ns_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXNSGroupCheckDestroy(state, grpName)

--- a/nsxt/resource_nsxt_ns_service_group_test.go
+++ b/nsxt/resource_nsxt_ns_service_group_test.go
@@ -18,7 +18,7 @@ func TestAccResourceNsxtNsServiceGroup_basic(t *testing.T) {
 	testResourceName := "nsxt_ns_service_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXServiceGroupCheckDestroy(state, updateServiceName)
@@ -53,7 +53,7 @@ func TestAccResourceNsxtNsServiceGroup_importBasic(t *testing.T) {
 	testResourceName := "nsxt_ns_service_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXServiceGroupCheckDestroy(state, serviceName)

--- a/nsxt/resource_nsxt_qos_switching_profile_test.go
+++ b/nsxt/resource_nsxt_qos_switching_profile_test.go
@@ -22,7 +22,7 @@ func TestAccResourceNsxtQosSwitchingProfile_basic(t *testing.T) {
 	updatedPeak := "400"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXQosSwitchingProfileCheckDestroy(state, updatedName)
@@ -85,7 +85,7 @@ func TestAccResourceNsxtQosSwitchingProfile_importBasic(t *testing.T) {
 	name := getAccTestResourceName()
 	testResourceName := "nsxt_qos_switching_profile.test"
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXQosSwitchingProfileCheckDestroy(state, name)

--- a/nsxt/resource_nsxt_spoofguard_switching_profile_test.go
+++ b/nsxt/resource_nsxt_spoofguard_switching_profile_test.go
@@ -18,7 +18,7 @@ func TestAccResourceNsxtSpoofGuardSwitchingProfile_basic(t *testing.T) {
 	testResourceName := "nsxt_spoofguard_switching_profile.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXSpoofguardSwitchingProfileCheckDestroy(state, updatedName)
@@ -59,7 +59,7 @@ func TestAccResourceNsxtSpoofGuardSwitchingProfile_importBasic(t *testing.T) {
 	name := getAccTestResourceName()
 	testResourceName := "nsxt_spoofguard_switching_profile.test"
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXSpoofguardSwitchingProfileCheckDestroy(state, name)

--- a/nsxt/resource_nsxt_static_route_test.go
+++ b/nsxt/resource_nsxt_static_route_test.go
@@ -30,7 +30,7 @@ func testAccResourceNsxtStaticRoute(t *testing.T, tier string) {
 	transportZoneName := getOverlayTransportZoneName()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXStaticRouteCheckDestroy(state, updateName)
@@ -81,7 +81,7 @@ func testAccResourceNsxtStaticRouteImport(t *testing.T, tier string) {
 	transportZoneName := getOverlayTransportZoneName()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestMP(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXStaticRouteCheckDestroy(state, name)

--- a/nsxt/resource_nsxt_switch_security_switching_profile_test.go
+++ b/nsxt/resource_nsxt_switch_security_switching_profile_test.go
@@ -20,7 +20,7 @@ func TestAccResourceNsxtSwitchSecuritySwitchingProfile_basic(t *testing.T) {
 	updatedLimit := "400"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t); testAccTestMP(t); testAccOnlyLocalManager(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccTestDeprecated(t); testAccOnlyLocalManager(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXSwitchSecuritySwitchingProfileCheckDestroy(state, updatedName)
@@ -81,7 +81,7 @@ func TestAccResourceNsxtSwitchSecuritySwitchingProfile_importBasic(t *testing.T)
 	name := getAccTestResourceName()
 	testResourceName := "nsxt_switch_security_switching_profile.test"
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t); testAccTestMP(t); testAccOnlyLocalManager(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccTestDeprecated(t); testAccOnlyLocalManager(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXSwitchSecuritySwitchingProfileCheckDestroy(state, name)

--- a/nsxt/resource_nsxt_vlan_logical_switch_test.go
+++ b/nsxt/resource_nsxt_vlan_logical_switch_test.go
@@ -23,7 +23,7 @@ func TestAccResourceNsxtVlanLogicalSwitch_basic(t *testing.T) {
 	updatedvlan := "2"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t); testAccTestMP(t); testAccOnlyLocalManager(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccTestDeprecated(t); testAccOnlyLocalManager(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLogicalSwitchCheckDestroy(state, updateSwitchName, "nsxt_vlan_logical_switch")
@@ -64,7 +64,7 @@ func TestAccResourceNsxtVlanLogicalSwitch_withProfiles(t *testing.T) {
 	profileType := "SwitchSecuritySwitchingProfile"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t); testAccTestMP(t); testAccOnlyLocalManager(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccTestDeprecated(t); testAccOnlyLocalManager(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			// Verify that the LS was deleted
@@ -114,7 +114,7 @@ func TestAccResourceNsxtVlanLogicalSwitch_withMacPool(t *testing.T) {
 	novlan := "0"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t); testAccTestMP(t); testAccOnlyLocalManager(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccTestDeprecated(t); testAccOnlyLocalManager(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLogicalSwitchCheckDestroy(state, switchName, "nsxt_vlan_logical_switch")
@@ -147,7 +147,7 @@ func TestAccResourceNsxtVlanLogicalSwitch_importBasic(t *testing.T) {
 	transportZoneName := getVlanTransportZoneName()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t); testAccTestMP(t); testAccOnlyLocalManager(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccTestDeprecated(t); testAccOnlyLocalManager(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXLogicalSwitchCheckDestroy(state, switchName, "nsxt_vlan_logical_switch")

--- a/nsxt/resource_nsxt_vm_tags_test.go
+++ b/nsxt/resource_nsxt_vm_tags_test.go
@@ -20,7 +20,7 @@ func TestAccResourceNsxtVMTags_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccTestMP(t)
+			testAccTestDeprecated(t)
 			testAccEnvDefined(t, "NSXT_TEST_VM_ID")
 			testAccOnlyLocalManager(t)
 		},
@@ -59,7 +59,7 @@ func TestAccResourceNsxtVMTags_import_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccTestMP(t)
+			testAccTestDeprecated(t)
 			testAccEnvDefined(t, "NSXT_TEST_VM_ID")
 			testAccOnlyLocalManager(t)
 		},

--- a/nsxt/utils_test.go
+++ b/nsxt/utils_test.go
@@ -271,7 +271,7 @@ func testAccNSXGlobalManagerSitePrecheck(t *testing.T) {
 	}
 }
 
-func testAccTestMP(t *testing.T) {
+func testAccTestDeprecated(t *testing.T) {
 	if os.Getenv("NSXT_TEST_MP") != "true" && os.Getenv("NSXT_TEST_MP") != "1" {
 		t.Skipf("To run MP test suite, please enable NSXT_TEST_MP in your environment.")
 	}


### PR DESCRIPTION
Plus remove this check from fabric resources.