### PR TITLE
Hide sensitive info in HTTP logs

### DIFF
--- a/nsxt/provider.go
+++ b/nsxt/provider.go
@@ -796,7 +796,14 @@ func (processor logRequestProcessor) Process(req *http.Request) error {
 	if err != nil {
 		log.Fatal(err)
 	}
-	log.Printf("Issuing request towards NSX:\n%s", reqDump)
+
+	// Replace sensitive information in HTTP headers
+	authHeaderRegexp := regexp.MustCompile("(?i)Authorization:.*")
+	cspHeaderRegexp := regexp.MustCompile("(?i)Csp-Auth-Token:.*")
+	replaced := authHeaderRegexp.ReplaceAllString(string(reqDump), "<Omitted Authorization header>")
+	replaced = cspHeaderRegexp.ReplaceAllString(replaced, "<Omitted Csp-Auth-Token header>")
+
+	log.Printf("Issuing request towards NSX:\n%s", replaced)
 	return nil
 }
 


### PR DESCRIPTION
Prevent auth and csp auth tokens from being dumped into logs
Signed-off-by: Anna Khmelnitsky <akhmelnitsky@vmware.com>