### PR TITLE
Add User Management Resources

### DIFF
--- a/nsxt/provider.go
+++ b/nsxt/provider.go
@@ -427,6 +427,8 @@ func Provider() *schema.Provider {
 			"nsxt_compute_manager":                         resourceNsxtComputeManager(),
 			"nsxt_manager_cluster":                         resourceNsxtManagerCluster(),
 			"nsxt_policy_uplink_host_switch_profile":       resourceNsxtUplinkHostSwitchProfile(),
+			"nsxt_node_user":                               resourceNsxtUsers(),
+			"nsxt_uplink_host_switch_profile":              resourceNsxtUplinkHostSwitchProfile(),
 			"nsxt_transport_node":                          resourceNsxtTransportNode(),
 			"nsxt_failure_domain":                          resourceNsxtFailureDomain(),
 			"nsxt_cluster_virtual_ip":                      resourceNsxtClusterVirualIP(),

--- a/nsxt/provider.go
+++ b/nsxt/provider.go
@@ -424,6 +424,7 @@ func Provider() *schema.Provider {
 			"nsxt_policy_project":                          resourceNsxtPolicyProject(),
 			"nsxt_policy_transport_zone":                   resourceNsxtPolicyTransportZone(),
 			"nsxt_policy_user_management_role":             resourceNsxtPolicyUserManagementRole(),
+			"nsxt_policy_user_management_role_binding":     resourceNsxtPolicyUserManagementRoleBinding(),
 			"nsxt_edge_cluster":                            resourceNsxtEdgeCluster(),
 			"nsxt_compute_manager":                         resourceNsxtComputeManager(),
 			"nsxt_manager_cluster":                         resourceNsxtManagerCluster(),

--- a/nsxt/provider.go
+++ b/nsxt/provider.go
@@ -423,6 +423,7 @@ func Provider() *schema.Provider {
 			"nsxt_policy_gateway_qos_profile":              resourceNsxtPolicyGatewayQosProfile(),
 			"nsxt_policy_project":                          resourceNsxtPolicyProject(),
 			"nsxt_policy_transport_zone":                   resourceNsxtPolicyTransportZone(),
+			"nsxt_policy_user_management_role":             resourceNsxtPolicyUserManagementRole(),
 			"nsxt_edge_cluster":                            resourceNsxtEdgeCluster(),
 			"nsxt_compute_manager":                         resourceNsxtComputeManager(),
 			"nsxt_manager_cluster":                         resourceNsxtManagerCluster(),

--- a/nsxt/resource_nsxt_node_user.go
+++ b/nsxt/resource_nsxt_node_user.go
@@ -1,0 +1,240 @@
+/* Copyright © 2023 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: MPL-2.0 */
+
+package nsxt
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	nsxModel "github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp/nsx/model"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp/nsx/node"
+)
+
+func resourceNsxtUsers() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceNsxtNodeUserCreate,
+		Read:   resourceNsxtNodeUserRead,
+		Update: resourceNsxtNodeUserUpdate,
+		Delete: resourceNsxtNodeUserDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"full_name": {
+				Type:        schema.TypeString,
+				Description: "Full name for the user",
+				Required:    true,
+			},
+			"last_password_change": {
+				Type:        schema.TypeInt,
+				Description: "Number of days since password was last changed",
+				Computed:    true,
+			},
+			"password": {
+				Type:        schema.TypeString,
+				Description: "Old password for the user",
+				Sensitive:   true,
+				Optional:    true,
+			},
+			"password_change_frequency": {
+				Type:         schema.TypeInt,
+				Description:  "Number of days password is valid before it must be changed",
+				Optional:     true,
+				Default:      90,
+				ValidateFunc: validation.IntBetween(0, 9999),
+			},
+			"password_change_warning": {
+				Type:         schema.TypeInt,
+				Description:  "Number of days before user receives warning message of password expiration",
+				Optional:     true,
+				Default:      7,
+				ValidateFunc: validation.IntBetween(0, 9999),
+			},
+			"password_reset_required": {
+				Type:        schema.TypeBool,
+				Description: "Boolean value that states if a password reset is required",
+				Computed:    true,
+			},
+			"active": {
+				Type:        schema.TypeBool,
+				Description: "Boolean value that states if the user account is activated",
+				Optional:    true,
+				Default:     true,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Description: "User status",
+				Computed:    true,
+			},
+			"user_id": {
+				Type:        schema.TypeInt,
+				Description: "Numeric id for the user",
+				Computed:    true,
+			},
+			"username": {
+				Type:         schema.TypeString,
+				Description:  "User login name",
+				ValidateFunc: validateUsername(),
+				Required:     true,
+			},
+		},
+	}
+}
+
+func validateUsername() schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (s []string, es []error) {
+		v, ok := i.(string)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be string", k))
+			return
+		}
+
+		r := regexp.MustCompile("^[a-zA-Z][a-zA-Z0-9@-_.\\-]*$")
+		if ok := r.MatchString(v); !ok {
+			es = append(es, fmt.Errorf("must be a valid username matching: ^[a-zA-Z][a-zA-Z0-9@-_.\\-]*$"))
+			return
+		}
+
+		if len(v) < 1 || len(v) > 32 {
+			es = append(es, fmt.Errorf("expected length of %s to be in the range (%d - %d), got %s", k, 1, 32, v))
+			return
+		}
+		return
+	}
+}
+
+func resourceNsxtNodeUserCreate(d *schema.ResourceData, m interface{}) error {
+	connector := getPolicyConnector(m)
+	client := node.NewUsersClient(connector)
+
+	fullName := d.Get("full_name").(string)
+	passwordChangeFrequency := int64(d.Get("password_change_frequency").(int))
+	passwordChangeWarning := int64(d.Get("password_change_warning").(int))
+	username := d.Get("username").(string)
+	password := d.Get("password").(string)
+
+	userProp := nsxModel.NodeUserProperties{
+		FullName:                &fullName,
+		PasswordChangeFrequency: &passwordChangeFrequency,
+		PasswordChangeWarning:   &passwordChangeWarning,
+		Username:                &username,
+	}
+	if len(password) > 0 {
+		userProp.Password = &password
+	}
+
+	user, err := client.Createuser(userProp)
+	if err != nil {
+		return handleCreateError("User", username, err)
+	}
+	d.Set("user_id", user.Userid)
+	d.SetId(strconv.Itoa(int(*user.Userid)))
+
+	return resourceNsxtNodeUserRead(d, m)
+}
+
+func resourceNsxtNodeUserRead(d *schema.ResourceData, m interface{}) error {
+	connector := getPolicyConnector(m)
+	client := node.NewUsersClient(connector)
+	id := d.Id()
+	if id == "" {
+		return fmt.Errorf("error obtaining logical object id")
+	}
+	user, err := client.Get(id)
+	if err != nil {
+		return handleReadError(d, "User", id, err)
+	}
+
+	// Password not return on GET
+	d.Set("full_name", user.FullName)
+	d.Set("last_password_change", user.LastPasswordChange)
+	d.Set("password_change_frequency", user.PasswordChangeFrequency)
+	d.Set("password_change_warning", user.PasswordChangeWarning)
+	d.Set("password_reset_required", user.PasswordResetRequired)
+	d.Set("status", user.Status)
+	d.Set("user_id", user.Userid)
+	d.Set("username", user.Username)
+	if *user.Status == nsxModel.NodeUserProperties_STATUS_NOT_ACTIVATED {
+		d.Set("active", false)
+	} else {
+		d.Set("active", true)
+	}
+	return nil
+}
+
+func resourceNsxtNodeUserUpdate(d *schema.ResourceData, m interface{}) error {
+	connector := getPolicyConnector(m)
+	client := node.NewUsersClient(connector)
+	id := d.Id()
+	if id == "" {
+		return fmt.Errorf("error obtaining logical object id")
+	}
+	password := d.Get("password").(string)
+	active := d.Get("active").(bool)
+	status := d.Get("status").(string)
+
+	// Handle user status change first
+	// Password reset can be achieved by deactivating then re-activate the account
+	if status == nsxModel.NodeUserProperties_STATUS_NOT_ACTIVATED && active {
+		if len(password) == 0 {
+			return fmt.Errorf("must specify password to activate Nsxt Node user %s", id)
+		}
+		_, err := client.Activate(id, nsxModel.NodeUserPasswordProperty{Password: &password})
+		if err != nil {
+			return fmt.Errorf("failed to activate Nsxt Node user %s: %s", id, err)
+		}
+	} else if status != nsxModel.NodeUserProperties_STATUS_NOT_ACTIVATED && !active {
+		_, err := client.Deactivate(id)
+		if err != nil {
+			return fmt.Errorf("failed to deactivate Nsxt Node user %s: %s", id, err)
+		}
+	}
+
+	// Update other user properties
+	fullName := d.Get("full_name").(string)
+	passwordChangeFrequency := int64(d.Get("password_change_frequency").(int))
+	passwordChangeWarning := int64(d.Get("password_change_warning").(int))
+	username := d.Get("username").(string)
+	userProp := nsxModel.NodeUserProperties{
+		FullName:                &fullName,
+		PasswordChangeFrequency: &passwordChangeFrequency,
+		PasswordChangeWarning:   &passwordChangeWarning,
+		Username:                &username,
+	}
+	_, err := client.Update(id, userProp)
+	if err != nil {
+		return handleUpdateError("User", id, err)
+	}
+	return resourceNsxtNodeUserRead(d, m)
+}
+
+func resourceNsxtNodeUserDelete(d *schema.ResourceData, m interface{}) error {
+	connector := getPolicyConnector(m)
+	client := node.NewUsersClient(connector)
+	id := d.Id()
+	if id == "" {
+		return fmt.Errorf("error obtaining logical object id")
+	}
+
+	// Workaround a bug where the delete response body is marked as non-json content type by NSX,
+	// triggering SDK to raise it as internal server error.
+	// Error Data is not complying with ApiErrorBindingType, making the conversion result empty.
+	// A second deletion attempt should be deemed as NotFound, which is then treated as successful.
+	var err error
+	for i := 0; i < 2; i++ {
+		err = client.Delete(id)
+		if err == nil {
+			return nil
+		}
+		err = handleDeleteError("User", id, err)
+		time.Sleep(1 * time.Second)
+	}
+
+	return err
+}

--- a/nsxt/resource_nsxt_node_user.go
+++ b/nsxt/resource_nsxt_node_user.go
@@ -38,7 +38,7 @@ func resourceNsxtUsers() *schema.Resource {
 			},
 			"password": {
 				Type:        schema.TypeString,
-				Description: "Old password for the user",
+				Description: "Password for the user",
 				Sensitive:   true,
 				Optional:    true,
 			},

--- a/nsxt/resource_nsxt_node_user.go
+++ b/nsxt/resource_nsxt_node_user.go
@@ -97,12 +97,12 @@ func validateUsername() schema.SchemaValidateFunc {
 
 		r := regexp.MustCompile("^[a-zA-Z][a-zA-Z0-9@-_.\\-]*$")
 		if ok := r.MatchString(v); !ok {
-			es = append(es, fmt.Errorf("must be a valid username matching: ^[a-zA-Z][a-zA-Z0-9@-_.\\-]*$"))
+			es = append(es, fmt.Errorf("username %s is invalid", v))
 			return
 		}
 
 		if len(v) < 1 || len(v) > 32 {
-			es = append(es, fmt.Errorf("expected length of %s to be in the range (%d - %d), got %s", k, 1, 32, v))
+			es = append(es, fmt.Errorf("expected length of %s to be in the range (%d - %d), got %d", k, 1, 32, len(v)))
 			return
 		}
 		return

--- a/nsxt/resource_nsxt_node_user_test.go
+++ b/nsxt/resource_nsxt_node_user_test.go
@@ -1,0 +1,192 @@
+/* Copyright © 2023 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: MPL-2.0 */
+
+package nsxt
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	nsxModel "github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp/nsx/model"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp/nsx/node"
+)
+
+var accTestNodeUserCreateAttributes = map[string]string{
+	"full_name":                 getAccTestRandomString(10),
+	"password":                  "Q5&WfLqv9Zd5",
+	"active":                    "true",
+	"password_change_frequency": "180",
+	"password_change_warning":   "30",
+}
+
+var accTestNodeUserUpdateAttributes = map[string]string{
+	"full_name":                 getAccTestRandomString(10),
+	"password":                  "Q5&WfLqv9Zd5",
+	"active":                    "false",
+	"password_change_frequency": "75",
+	"password_change_warning":   "20",
+}
+
+func TestAccResourceNsxtNodeUser_basic(t *testing.T) {
+	testResourceName := "nsxt_node_user.test"
+	testUsername := getAccTestRandomString(10)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccOnlyLocalManager(t)
+		},
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNodeUserCheckDestroy(state, testUsername)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNodeUserCreate(testUsername),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNodeUserExists(testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "full_name", accTestNodeUserCreateAttributes["full_name"]),
+					resource.TestCheckResourceAttr(testResourceName, "active", accTestNodeUserCreateAttributes["active"]),
+					resource.TestCheckResourceAttr(testResourceName, "password_change_frequency", accTestNodeUserCreateAttributes["password_change_frequency"]),
+					resource.TestCheckResourceAttr(testResourceName, "password_change_warning", accTestNodeUserCreateAttributes["password_change_warning"]),
+					resource.TestCheckResourceAttr(testResourceName, "username", testUsername),
+					resource.TestCheckResourceAttr(testResourceName, "status", nsxModel.NodeUserProperties_STATUS_ACTIVE),
+					resource.TestCheckResourceAttrSet(testResourceName, "password_reset_required"),
+					resource.TestCheckResourceAttrSet(testResourceName, "last_password_change"),
+					resource.TestCheckResourceAttrSet(testResourceName, "user_id"),
+				),
+			},
+			{
+				Config: testAccNodeUserUpdate(testUsername),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNodeUserExists(testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "full_name", accTestNodeUserUpdateAttributes["full_name"]),
+					resource.TestCheckResourceAttr(testResourceName, "active", accTestNodeUserUpdateAttributes["active"]),
+					resource.TestCheckResourceAttr(testResourceName, "password_change_frequency", accTestNodeUserUpdateAttributes["password_change_frequency"]),
+					resource.TestCheckResourceAttr(testResourceName, "password_change_warning", accTestNodeUserUpdateAttributes["password_change_warning"]),
+					resource.TestCheckResourceAttr(testResourceName, "username", testUsername),
+					resource.TestCheckResourceAttr(testResourceName, "status", nsxModel.NodeUserProperties_STATUS_NOT_ACTIVATED),
+					resource.TestCheckResourceAttrSet(testResourceName, "password_reset_required"),
+					resource.TestCheckResourceAttrSet(testResourceName, "last_password_change"),
+					resource.TestCheckResourceAttrSet(testResourceName, "user_id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceNsxtNodeUser_import_basic(t *testing.T) {
+	testResourceName := "nsxt_node_user.test"
+	testUsername := getAccTestRandomString(10)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccOnlyLocalManager(t)
+		},
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNodeUserCheckDestroy(state, testUsername)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNodeUserCreate(testUsername),
+			},
+			{
+				ResourceName:            testResourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateIdFunc:       testAccNodeUserImporterGetID,
+				ImportStateVerifyIgnore: []string{"password"},
+			},
+		},
+	})
+}
+
+func testAccNodeUserExists(resourceName string) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+
+		connector := getPolicyConnector(testAccProvider.Meta().(nsxtClients))
+
+		rs, ok := state.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("User resource %s not found in resources", resourceName)
+		}
+
+		userID := rs.Primary.Attributes["id"]
+		if userID == "" {
+			return fmt.Errorf("User ID not set in resources")
+		}
+		client := node.NewUsersClient(connector)
+		_, err := client.Get(userID)
+		if err != nil {
+			if isNotFoundError(err) {
+				return fmt.Errorf("User %s does not exist", userID)
+			}
+			return err
+		}
+
+		return nil
+	}
+}
+
+func testAccNodeUserCheckDestroy(state *terraform.State, username string) error {
+	connector := getPolicyConnector(testAccProvider.Meta().(nsxtClients))
+	for _, rs := range state.RootModule().Resources {
+
+		if rs.Type != "nsxt_node_user" {
+			continue
+		}
+
+		userID := rs.Primary.Attributes["id"]
+		client := node.NewUsersClient(connector)
+		_, err := client.Get(userID)
+		if err != nil {
+			if isNotFoundError(err) {
+				return nil
+			}
+		}
+
+		return fmt.Errorf("user %s still exists", username)
+	}
+	return nil
+}
+
+func testAccNodeUserImporterGetID(s *terraform.State) (string, error) {
+	rs, ok := s.RootModule().Resources["nsxt_node_user.test"]
+	if !ok {
+		return "", fmt.Errorf("User %s not found in resources", "nsxt_node_user.test")
+	}
+	resourceID := rs.Primary.ID
+	if resourceID == "" {
+		return "", fmt.Errorf("User ID not set in resources")
+	}
+	return resourceID, nil
+}
+
+func testAccNodeUserCreate(username string) string {
+	attrMap := accTestNodeUserCreateAttributes
+	return fmt.Sprintf(`
+resource "nsxt_node_user" "test" {
+  active = %s
+  full_name = "%s"
+  password = "%s"
+  username = "%s"
+  password_change_frequency = %s
+  password_change_warning = %s
+}`, attrMap["active"], attrMap["full_name"], attrMap["password"], username, attrMap["password_change_frequency"], attrMap["password_change_warning"])
+}
+
+func testAccNodeUserUpdate(username string) string {
+	attrMap := accTestNodeUserUpdateAttributes
+	return fmt.Sprintf(`
+resource "nsxt_node_user" "test" {
+  active = %s
+  full_name = "%s"
+  username = "%s"
+  password_change_frequency = %s
+  password_change_warning = %s
+}`, attrMap["active"], attrMap["full_name"], username, attrMap["password_change_frequency"], attrMap["password_change_warning"])
+}

--- a/nsxt/resource_nsxt_policy_role.go
+++ b/nsxt/resource_nsxt_policy_role.go
@@ -1,0 +1,266 @@
+/* Copyright © 2023 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: MPL-2.0 */
+
+package nsxt
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/aaa"
+	nsxModel "github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+)
+
+var featurePermissionTypes = [](string){
+	nsxModel.FeaturePermission_PERMISSION_CRUD,
+	nsxModel.FeaturePermission_PERMISSION_READ,
+	nsxModel.FeaturePermission_PERMISSION_EXECUTE,
+}
+
+func resourceNsxtPolicyUserManagementRole() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceNsxtPolicyUserManagementRoleCreate,
+		Read:   resourceNsxtPolicyUserManagementRoleRead,
+		Update: resourceNsxtPolicyUserManagementRoleUpdate,
+		Delete: resourceNsxtPolicyUserManagementRoleDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"display_name": getDataSourceDisplayNameSchema(),
+			"description":  getDataSourceDescriptionSchema(),
+			"revision":     getRevisionSchema(),
+			"tag":          getTagsSchema(),
+			"role": {
+				Type:        schema.TypeString,
+				Description: "Short identifier for the role. Must be all lower case with no spaces",
+				Required:    true,
+				ValidateFunc: validation.StringMatch(
+					regexp.MustCompile(
+						"^[_a-z0-9-]+$"),
+					"Must be a valid role identifier matching: ^[_a-z0-9-]+$"),
+			},
+			"feature": {
+				Type:        schema.TypeList,
+				Description: "List of permissions for features",
+				Required:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"feature": {
+							Type:        schema.TypeString,
+							Description: "Feature Id",
+							Required:    true,
+						},
+						"feature_description": {
+							Type:        schema.TypeString,
+							Description: "Feature Description",
+							Computed:    true,
+						},
+						"feature_name": {
+							Type:        schema.TypeString,
+							Description: "Feature Name",
+							Computed:    true,
+						},
+						"permission": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(featurePermissionTypes, false),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceNsxtPolicyUserManagementRoleExists(id string, connector client.Connector) (bool, error) {
+	var err error
+	roleClient := aaa.NewRolesClient(connector)
+	_, err = roleClient.Get(id)
+	if err == nil {
+		return true, nil
+	}
+
+	if isNotFoundError(err) {
+		return false, nil
+	}
+
+	return false, logAPIError("Error retrieving resource", err)
+}
+
+func getFeaturePermissionFromSchema(d *schema.ResourceData) []nsxModel.FeaturePermission {
+	features := d.Get("feature").([]interface{})
+	featurePermissions := make([]nsxModel.FeaturePermission, 0, len(features))
+	for _, feature := range features {
+		data := feature.(map[string]interface{})
+		featureID := data["feature"].(string)
+		featureDescription := data["feature_description"].(string)
+		featureName := data["feature_name"].(string)
+		permission := data["permission"].(string)
+		featurePermissions = append(featurePermissions, nsxModel.FeaturePermission{
+			Feature:            &featureID,
+			FeatureDescription: &featureDescription,
+			FeatureName:        &featureName,
+			Permission:         &permission,
+		})
+	}
+
+	return featurePermissions
+}
+
+func setFeaturePermissionInSchema(d *schema.ResourceData, permissions []nsxModel.FeaturePermission) {
+	var permissionList []map[string]interface{}
+	for _, permission := range permissions {
+		// NSX returns the complete feature set on GET
+		// Bypass ineffective items from the list
+		if permission.IsInternal != nil && *permission.IsInternal {
+			// Internal permissions is not effective for roles
+			continue
+		}
+		if permission.Permission != nil && *permission.Permission == nsxModel.FeaturePermission_PERMISSION_NONE {
+			// Permissions are none by default. None-valued permissions are not allowed either in schema.
+			continue
+		}
+
+		elem := make(map[string]interface{})
+		elem["feature"] = permission.Feature
+		elem["feature_description"] = permission.FeatureDescription
+		elem["feature_name"] = permission.FeatureName
+		elem["permission"] = permission.Permission
+		permissionList = append(permissionList, elem)
+	}
+	err := d.Set("feature", permissionList)
+	if err != nil {
+		log.Printf("[WARNING] Failed to set feature in schema: %v", err)
+	}
+}
+
+func policyUserManagementRolePatch(id string, d *schema.ResourceData, m interface{}) error {
+	connector := getPolicyConnector(m)
+
+	displayName := d.Get("display_name").(string)
+	description := d.Get("description").(string)
+	tags := getPolicyTagsFromSchema(d)
+	role := d.Get("role").(string)
+	features := getFeaturePermissionFromSchema(d)
+
+	// Validate feature set first
+	validateObj := nsxModel.FeaturePermissionArray{
+		FeaturePermissions: features,
+	}
+	roleClient := aaa.NewRolesClient(connector)
+	reco, err := roleClient.Validate(validateObj)
+	if err != nil {
+		log.Printf("[ERROR] Error validating RoleWithFeatures with ID %s", id)
+		return err
+	}
+	if len(reco.Results) > 0 {
+		missingPerm := make([]string, 0, len(reco.Results))
+		for _, permission := range reco.Results {
+			missingPerm = append(missingPerm, *permission.TargetFeature)
+			log.Printf("[ERROR] RoleWithFeatures ID %s requires %s set to %v for %v",
+				id, *permission.TargetFeature, permission.RecommendedPermissions, permission.SrcFeatures)
+		}
+		return fmt.Errorf("RoleWithFeatures ID %s missing dependent permissions %v",
+			id, missingPerm)
+	}
+
+	obj := nsxModel.RoleWithFeatures{
+		DisplayName: &displayName,
+		Description: &description,
+		Tags:        tags,
+		Role:        &role,
+		Features:    features,
+	}
+	_, err = roleClient.Update(id, obj)
+	return err
+}
+
+func resourceNsxtPolicyUserManagementRoleCreate(d *schema.ResourceData, m interface{}) error {
+	connector := getPolicyConnector(m)
+
+	id := d.Get("role").(string)
+	exists, err := resourceNsxtPolicyUserManagementRoleExists(id, connector)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return fmt.Errorf("resource with ID %s already exists", id)
+	}
+
+	// Create the resource using PUT
+	log.Printf("[INFO] Creating RoleWithFeatures with ID %s", id)
+	err = policyUserManagementRolePatch(id, d, m)
+	if err != nil {
+		return handleCreateError("RoleWithFeatures", id, err)
+	}
+
+	d.SetId(id)
+
+	return resourceNsxtPolicyUserManagementRoleRead(d, m)
+}
+
+func resourceNsxtPolicyUserManagementRoleRead(d *schema.ResourceData, m interface{}) error {
+	connector := getPolicyConnector(m)
+	roleClient := aaa.NewRolesClient(connector)
+
+	id := d.Id()
+	if id == "" {
+		err := fmt.Errorf("error obtaining RoleWithFeatures ID")
+		return err
+	}
+
+	obj, err := roleClient.Get(id)
+	if err != nil {
+		return handleReadError(d, "RoleWithFeatures", id, err)
+	}
+
+	d.Set("display_name", obj.DisplayName)
+	d.Set("description", obj.Description)
+	setPolicyTagsInSchema(d, obj.Tags)
+	d.Set("revision", obj.Revision)
+	d.Set("role", obj.Role)
+	setFeaturePermissionInSchema(d, obj.Features)
+
+	return nil
+}
+
+func resourceNsxtPolicyUserManagementRoleUpdate(d *schema.ResourceData, m interface{}) error {
+	id := d.Id()
+	if id == "" {
+		err := fmt.Errorf("error obtaining RoleWithFeatures ID")
+		return err
+	}
+
+	log.Printf("[INFO] Updateing RoleWithFeatures with ID %s", id)
+	err := policyUserManagementRolePatch(id, d, m)
+	if err != nil {
+		return handleUpdateError("RoleWithFeatures", id, err)
+	}
+
+	return resourceNsxtPolicyUserManagementRoleRead(d, m)
+}
+
+func resourceNsxtPolicyUserManagementRoleDelete(d *schema.ResourceData, m interface{}) error {
+	connector := getPolicyConnector(m)
+	roleClient := aaa.NewRolesClient(connector)
+
+	id := d.Id()
+	if id == "" {
+		err := fmt.Errorf("error obtaining RoleWithFeatures ID")
+		return err
+	}
+
+	log.Printf("[INFO] Deleting RoleWithFeatures with ID %s", id)
+	err := roleClient.Delete(id)
+	if err != nil {
+		return handleDeleteError("RoleWithFeatures", id, err)
+	}
+
+	return nil
+}

--- a/nsxt/resource_nsxt_policy_role.go
+++ b/nsxt/resource_nsxt_policy_role.go
@@ -99,14 +99,10 @@ func getFeaturePermissionFromSchema(d *schema.ResourceData) []nsxModel.FeaturePe
 	for _, feature := range features {
 		data := feature.(map[string]interface{})
 		featureID := data["feature"].(string)
-		featureDescription := data["feature_description"].(string)
-		featureName := data["feature_name"].(string)
 		permission := data["permission"].(string)
 		featurePermissions = append(featurePermissions, nsxModel.FeaturePermission{
-			Feature:            &featureID,
-			FeatureDescription: &featureDescription,
-			FeatureName:        &featureName,
-			Permission:         &permission,
+			Feature:    &featureID,
+			Permission: &permission,
 		})
 	}
 
@@ -140,7 +136,7 @@ func setFeaturePermissionInSchema(d *schema.ResourceData, permissions []nsxModel
 	}
 }
 
-func policyUserManagementRolePatch(id string, d *schema.ResourceData, m interface{}) error {
+func policyUserManagementRoleUpdate(id string, d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
 
 	displayName := d.Get("display_name").(string)
@@ -148,6 +144,7 @@ func policyUserManagementRolePatch(id string, d *schema.ResourceData, m interfac
 	tags := getPolicyTagsFromSchema(d)
 	role := d.Get("role").(string)
 	features := getFeaturePermissionFromSchema(d)
+	revision := int64(d.Get("revision").(int))
 
 	// Validate feature set first
 	validateObj := nsxModel.FeaturePermissionArray{
@@ -176,6 +173,7 @@ func policyUserManagementRolePatch(id string, d *schema.ResourceData, m interfac
 		Tags:        tags,
 		Role:        &role,
 		Features:    features,
+		Revision:    &revision,
 	}
 	_, err = roleClient.Update(id, obj)
 	return err
@@ -195,7 +193,7 @@ func resourceNsxtPolicyUserManagementRoleCreate(d *schema.ResourceData, m interf
 
 	// Create the resource using PUT
 	log.Printf("[INFO] Creating RoleWithFeatures with ID %s", id)
-	err = policyUserManagementRolePatch(id, d, m)
+	err = policyUserManagementRoleUpdate(id, d, m)
 	if err != nil {
 		return handleCreateError("RoleWithFeatures", id, err)
 	}
@@ -238,7 +236,7 @@ func resourceNsxtPolicyUserManagementRoleUpdate(d *schema.ResourceData, m interf
 	}
 
 	log.Printf("[INFO] Updateing RoleWithFeatures with ID %s", id)
-	err := policyUserManagementRolePatch(id, d, m)
+	err := policyUserManagementRoleUpdate(id, d, m)
 	if err != nil {
 		return handleUpdateError("RoleWithFeatures", id, err)
 	}

--- a/nsxt/resource_nsxt_policy_role_binding.go
+++ b/nsxt/resource_nsxt_policy_role_binding.go
@@ -40,7 +40,6 @@ func resourceNsxtPolicyUserManagementRoleBinding() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"nsx_id":       getNsxIDSchema(),
 			"display_name": getDataSourceDisplayNameSchema(),
 			"description":  getDataSourceDescriptionSchema(),
 			"revision":     getRevisionSchema(),
@@ -243,7 +242,6 @@ func resourceNsxtPolicyUserManagementRoleBindingCreate(d *schema.ResourceData, m
 
 	id := *rbObj.Id
 	d.SetId(id)
-	d.Set("nsx_id", id)
 
 	return resourceNsxtPolicyUserManagementRoleBindingRead(d, m)
 }
@@ -266,7 +264,6 @@ func resourceNsxtPolicyUserManagementRoleBindingRead(d *schema.ResourceData, m i
 	d.Set("display_name", obj.DisplayName)
 	d.Set("description", obj.Description)
 	setPolicyTagsInSchema(d, obj.Tags)
-	d.Set("nsx_id", id)
 	d.Set("revision", obj.Revision)
 	d.Set("name", obj.Name)
 	d.Set("identity_source_id", obj.IdentitySourceId)

--- a/nsxt/resource_nsxt_policy_role_binding.go
+++ b/nsxt/resource_nsxt_policy_role_binding.go
@@ -1,0 +1,323 @@
+/* Copyright © 2023 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: MPL-2.0 */
+
+package nsxt
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/aaa"
+	nsxModel "github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+)
+
+// Only support local user at the moment
+var roleBindingUserTypes = [](string){
+	nsxModel.RoleBinding_TYPE_LOCAL_USER,
+	nsxModel.RoleBinding_TYPE_REMOTE_USER,
+	nsxModel.RoleBinding_TYPE_REMOTE_GROUP,
+	nsxModel.RoleBinding_TYPE_PRINCIPAL_IDENTITY,
+}
+
+var roleBindingIdentitySourceTypes = [](string){
+	nsxModel.RoleBinding_IDENTITY_SOURCE_TYPE_VIDM,
+	nsxModel.RoleBinding_IDENTITY_SOURCE_TYPE_LDAP,
+	nsxModel.RoleBinding_IDENTITY_SOURCE_TYPE_OIDC,
+	nsxModel.RoleBinding_IDENTITY_SOURCE_TYPE_CSP,
+}
+
+func resourceNsxtPolicyUserManagementRoleBinding() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceNsxtPolicyUserManagementRoleBindingCreate,
+		Read:   resourceNsxtPolicyUserManagementRoleBindingRead,
+		Update: resourceNsxtPolicyUserManagementRoleBindingUpdate,
+		Delete: resourceNsxtPolicyUserManagementRoleBindingDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"nsx_id":       getNsxIDSchema(),
+			"display_name": getDataSourceDisplayNameSchema(),
+			"description":  getDataSourceDescriptionSchema(),
+			"revision":     getRevisionSchema(),
+			"tag":          getTagsSchema(),
+			"name": {
+				Type:        schema.TypeString,
+				Description: "User/Group's name",
+				Required:    true,
+			},
+			"type": {
+				Type:         schema.TypeString,
+				Description:  "Indicates the type of the user",
+				Required:     true,
+				ValidateFunc: validation.StringInSlice(roleBindingUserTypes, false),
+			},
+			"user_id": {
+				Type:        schema.TypeString,
+				Description: "Local user's numeric id",
+				Computed:    true,
+			},
+			"identity_source_id": {
+				Type:        schema.TypeString,
+				Description: "ID of the external identity source",
+				Optional:    true,
+			},
+			"identity_source_type": {
+				Type:         schema.TypeString,
+				Description:  "ID of the external identity source",
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice(roleBindingIdentitySourceTypes, false),
+			},
+			"roles_for_path": {
+				Type:        schema.TypeList,
+				Description: "List of roles that are associated with the user, limiting them to a path",
+				Required:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"path": {
+							Type:        schema.TypeString,
+							Description: "Path of the entity in parent hierarchy.",
+							Required:    true,
+						},
+						"role": {
+							Type:        schema.TypeList,
+							Description: "Applicable roles",
+							Required:    true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"role": {
+										Type:        schema.TypeString,
+										Description: "Short identifier for the role",
+										Required:    true,
+										ValidateFunc: validation.StringMatch(
+											regexp.MustCompile(
+												"^[_a-z0-9-]+$"),
+											"Must be a valid role identifier matching: ^[_a-z0-9-]+$"),
+									},
+									"role_display_name": {
+										Type:        schema.TypeString,
+										Description: "Display name for role",
+										Computed:    true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+type rolesForPath map[string]rolesPerPath
+type rolesPerPath map[string]bool
+
+func getRolesForPathFromSchema(d *schema.ResourceData) rolesForPath {
+	rolesForPathMap := make(rolesForPath)
+	rolesForPathInput := d.Get("roles_for_path").([]interface{})
+	for _, rolesPerPathInput := range rolesForPathInput {
+		data := rolesPerPathInput.(map[string]interface{})
+		path := data["path"].(string)
+		roles := data["role"].([]interface{})
+		rolesPerPathMap := make(rolesPerPath)
+		for _, role := range roles {
+			roleData := role.(map[string]interface{})
+			roleInput := roleData["role"].(string)
+			rolesPerPathMap[roleInput] = true
+		}
+		rolesForPathMap[path] = rolesPerPathMap
+	}
+
+	return rolesForPathMap
+}
+
+func setRolesForPathInSchema(d *schema.ResourceData, nsxRolesForPathList []nsxModel.RolesForPath) {
+	var rolesForPathList []map[string]interface{}
+	for _, nsxRolesForPath := range nsxRolesForPathList {
+		elem := make(map[string]interface{})
+		elem["path"] = nsxRolesForPath.Path
+		var roles []map[string]interface{}
+		for _, nsxRole := range nsxRolesForPath.Roles {
+			rElem := make(map[string]interface{})
+			rElem["role"] = nsxRole.Role
+			rElem["role_display_name"] = nsxRole.RoleDisplayName
+			roles = append(roles, rElem)
+		}
+		elem["role"] = roles
+		rolesForPathList = append(rolesForPathList, elem)
+	}
+	err := d.Set("roles_for_path", rolesForPathList)
+	if err != nil {
+		log.Printf("[WARNING] Failed to set roles_for_path in schema: %v", err)
+	}
+}
+
+func getRoleBindingObject(d *schema.ResourceData) *nsxModel.RoleBinding {
+	boolTrue := true
+	displayName := d.Get("display_name").(string)
+	description := d.Get("description").(string)
+	tags := getPolicyTagsFromSchema(d)
+	name := d.Get("name").(string)
+	identitySrcID := d.Get("identity_source_id").(string)
+	identitySrcType := d.Get("identity_source_type").(string)
+	roleBindingType := d.Get("type").(string)
+	rolesPerPathMap := getRolesForPathFromSchema(d)
+	nsxRolesForPaths := make([]nsxModel.RolesForPath, 0)
+
+	for k, v := range rolesPerPathMap {
+		path := k
+		nsxRoles := make([]nsxModel.Role, 0, len(v))
+		for k := range v {
+			roleID := k
+			nsxRoles = append(nsxRoles, nsxModel.Role{
+				Role: &roleID,
+			})
+		}
+		nsxRolesForPaths = append(nsxRolesForPaths, nsxModel.RolesForPath{
+			Path:  &path,
+			Roles: nsxRoles,
+		})
+	}
+
+	// Handle deletion of entire paths
+	if d.HasChange("roles_for_path") {
+		o, _ := d.GetChange("roles_for_path")
+		oldRoles := o.([]interface{})
+		for _, oldRole := range oldRoles {
+			data := oldRole.(map[string]interface{})
+			path := data["path"].(string)
+			if _, ok := rolesPerPathMap[path]; ok {
+				continue
+			}
+			// Add one role in the list to make NSX happy
+			roles := data["role"].([]interface{})
+			if len(roles) == 0 {
+				continue
+			}
+			roleData := roles[0].(map[string]interface{})
+			roleID := roleData["role"].(string)
+			nsxRolesForPaths = append(nsxRolesForPaths, nsxModel.RolesForPath{
+				Path:       &path,
+				DeletePath: &boolTrue,
+				Roles:      []nsxModel.Role{{Role: &roleID}},
+			})
+		}
+	}
+
+	obj := nsxModel.RoleBinding{
+		DisplayName:        &displayName,
+		Description:        &description,
+		Tags:               tags,
+		Name:               &name,
+		IdentitySourceId:   &identitySrcID,
+		IdentitySourceType: &identitySrcType,
+		Type_:              &roleBindingType,
+		ReadRolesForPaths:  &boolTrue,
+		RolesForPaths:      nsxRolesForPaths,
+	}
+	return &obj
+}
+
+func resourceNsxtPolicyUserManagementRoleBindingCreate(d *schema.ResourceData, m interface{}) error {
+	connector := getPolicyConnector(m)
+
+	roleBindingType := d.Get("type").(string)
+	username := d.Get("name").(string)
+	if roleBindingType == nsxModel.RoleBinding_TYPE_LOCAL_USER {
+		return fmt.Errorf("creation of RoleBinding for %s is not allowed as it's created by NSX. "+
+			"import the binding first", roleBindingType)
+	}
+
+	// Create the resource using POST
+	log.Printf("[INFO] Creating RoleBinding for %s %s", roleBindingType, username)
+	obj := getRoleBindingObject(d)
+	rbClient := aaa.NewRoleBindingsClient(connector)
+	rbObj, err := rbClient.Create(*obj)
+	if err != nil {
+		return handleCreateError("RoleBinding", username, err)
+	}
+
+	id := *rbObj.Id
+	d.SetId(id)
+	d.Set("nsx_id", id)
+
+	return resourceNsxtPolicyUserManagementRoleBindingRead(d, m)
+}
+
+func resourceNsxtPolicyUserManagementRoleBindingRead(d *schema.ResourceData, m interface{}) error {
+	connector := getPolicyConnector(m)
+	rbClient := aaa.NewRoleBindingsClient(connector)
+
+	id := d.Id()
+	if id == "" {
+		err := fmt.Errorf("error obtaining RoleBinding ID")
+		return err
+	}
+
+	obj, err := rbClient.Get(id, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	if err != nil {
+		return handleReadError(d, "RoleBinding", id, err)
+	}
+
+	d.Set("display_name", obj.DisplayName)
+	d.Set("description", obj.Description)
+	setPolicyTagsInSchema(d, obj.Tags)
+	d.Set("nsx_id", id)
+	d.Set("revision", obj.Revision)
+	d.Set("name", obj.Name)
+	d.Set("identity_source_id", obj.IdentitySourceId)
+	d.Set("identity_source_type", obj.IdentitySourceType)
+	d.Set("type", obj.Type_)
+	if obj.UserId != nil {
+		d.Set("user_id", obj.UserId)
+	}
+	setRolesForPathInSchema(d, obj.RolesForPaths)
+
+	return nil
+}
+
+func resourceNsxtPolicyUserManagementRoleBindingUpdate(d *schema.ResourceData, m interface{}) error {
+	id := d.Id()
+	if id == "" {
+		err := fmt.Errorf("error obtaining RoleBinding ID")
+		return err
+	}
+
+	log.Printf("[INFO] Updateing RoleBinding with ID %s", id)
+	connector := getPolicyConnector(m)
+	rbClient := aaa.NewRoleBindingsClient(connector)
+	obj := getRoleBindingObject(d)
+	_, err := rbClient.Update(id, *obj)
+	if err != nil {
+		return handleCreateError("RoleBinding", id, err)
+	}
+
+	return resourceNsxtPolicyUserManagementRoleBindingRead(d, m)
+}
+
+func resourceNsxtPolicyUserManagementRoleBindingDelete(d *schema.ResourceData, m interface{}) error {
+	connector := getPolicyConnector(m)
+	rbClient := aaa.NewRoleBindingsClient(connector)
+
+	id := d.Id()
+	if id == "" {
+		err := fmt.Errorf("error obtaining RoleBinding ID")
+		return err
+	}
+	roleBindingType := d.Get("type").(string)
+	if roleBindingType == nsxModel.RoleBinding_TYPE_LOCAL_USER {
+		return fmt.Errorf("role binding for %s %s can not be deleted", roleBindingType, id)
+	}
+
+	log.Printf("[INFO] Deleting RoleBinding with ID %s", id)
+	err := rbClient.Delete(id, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	if err != nil {
+		return handleDeleteError("RoleBinding", id, err)
+	}
+
+	return nil
+}

--- a/nsxt/resource_nsxt_policy_role_binding_test.go
+++ b/nsxt/resource_nsxt_policy_role_binding_test.go
@@ -1,0 +1,210 @@
+/* Copyright © 2023 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: MPL-2.0 */
+
+package nsxt
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/aaa"
+	nsxModel "github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+)
+
+var accTestPolicyRoleBindingCreateAttributes = map[string]string{
+	"display_name": getAccTestResourceName(),
+	"description":  "terraform created",
+}
+
+var accTestPolicyRoleBindingUpdateAttributes = map[string]string{
+	"display_name": getAccTestResourceName(),
+	"description":  "terraform updated",
+}
+
+func TestAccResourceNsxtPolicyRoleBinding_basic(t *testing.T) {
+	testResourceName := "nsxt_policy_user_management_role_binding.test"
+	identType := nsxModel.RoleBinding_IDENTITY_SOURCE_TYPE_LDAP
+	userType := nsxModel.RoleBinding_TYPE_REMOTE_USER
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccEnvDefined(t, "NSXT_TEST_LDAP_USER")
+			testAccOnlyLocalManager(t)
+		},
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyRoleBindingCheckDestroy(state, accTestPolicyRoleUpdateAttributes["display_name"])
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyRoleBindingCreate(getTestLdapUser(), userType, identType),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicyRoleBindingExists(accTestPolicyRoleBindingCreateAttributes["display_name"], testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestPolicyRoleBindingCreateAttributes["display_name"]),
+					resource.TestCheckResourceAttr(testResourceName, "description", accTestPolicyRoleBindingCreateAttributes["description"]),
+					resource.TestCheckResourceAttr(testResourceName, "name", getTestLdapUser()),
+					resource.TestCheckResourceAttr(testResourceName, "type", userType),
+					resource.TestCheckResourceAttr(testResourceName, "identity_source_type", identType),
+					resource.TestCheckResourceAttr(testResourceName, "roles_for_path.#", "2"),
+					resource.TestCheckResourceAttr(testResourceName, "roles_for_path.0.path", "/"),
+					resource.TestCheckResourceAttr(testResourceName, "roles_for_path.0.role.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "roles_for_path.0.role.0.role", "auditor"),
+					resource.TestCheckResourceAttr(testResourceName, "roles_for_path.1.path", "/orgs/default"),
+					resource.TestCheckResourceAttr(testResourceName, "roles_for_path.1.role.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "roles_for_path.1.role.0.role", "org_admin"),
+
+					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+				),
+			},
+			{
+				Config: testAccNsxtPolicyRoleBindingUpdate(getTestLdapUser(), userType, identType),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicyRoleBindingExists(accTestPolicyRoleBindingUpdateAttributes["display_name"], testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestPolicyRoleBindingUpdateAttributes["display_name"]),
+					resource.TestCheckResourceAttr(testResourceName, "description", accTestPolicyRoleBindingUpdateAttributes["description"]),
+					resource.TestCheckResourceAttr(testResourceName, "name", getTestLdapUser()),
+					resource.TestCheckResourceAttr(testResourceName, "type", userType),
+					resource.TestCheckResourceAttr(testResourceName, "identity_source_type", identType),
+					resource.TestCheckResourceAttr(testResourceName, "roles_for_path.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "roles_for_path.0.path", "/"),
+					resource.TestCheckResourceAttr(testResourceName, "roles_for_path.0.role.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "roles_for_path.0.role.0.role", "auditor"),
+
+					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceNsxtPolicyRoleBinding_import_basic(t *testing.T) {
+	testResourceName := "nsxt_policy_user_management_role_binding.test"
+	identType := nsxModel.RoleBinding_IDENTITY_SOURCE_TYPE_LDAP
+	userType := nsxModel.RoleBinding_TYPE_REMOTE_USER
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccEnvDefined(t, "NSXT_TEST_LDAP_USER")
+			testAccOnlyLocalManager(t)
+		},
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyRoleBindingCheckDestroy(state, accTestPolicyRoleUpdateAttributes["display_name"])
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyRoleBindingCreate(getTestLdapUser(), userType, identType),
+			},
+			{
+				ResourceName:      testResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccNsxtPolicyRoleBindingExists(displayName string, resourceName string) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+
+		connector := getPolicyConnector(testAccProvider.Meta().(nsxtClients))
+
+		rs, ok := state.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("RoleBinding resource %s not found in resources", resourceName)
+		}
+
+		rbID := rs.Primary.Attributes["id"]
+		if rbID == "" {
+			return fmt.Errorf("RoleBinding resource ID not set in resources")
+		}
+		rbClient := aaa.NewRoleBindingsClient(connector)
+		_, err := rbClient.Get(rbID, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		if err != nil {
+			if isNotFoundError(err) {
+				return fmt.Errorf("RoleBinding %s does not exist", rbID)
+			}
+		}
+
+		return err
+	}
+}
+
+func testAccNsxtPolicyRoleBindingCheckDestroy(state *terraform.State, displayName string) error {
+	connector := getPolicyConnector(testAccProvider.Meta().(nsxtClients))
+	for _, rs := range state.RootModule().Resources {
+
+		if rs.Type != "nsxt_policy_user_management_role_binding" {
+			continue
+		}
+
+		rbID := rs.Primary.Attributes["id"]
+		if rbID == "" {
+			return fmt.Errorf("RoleBinding resource ID not set in resources")
+		}
+		rbClient := aaa.NewRoleBindingsClient(connector)
+		_, err := rbClient.Get(rbID, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		if err != nil {
+			if isNotFoundError(err) {
+				return nil
+			}
+			return err
+		}
+		return fmt.Errorf("RoleBinding %s still exists", displayName)
+	}
+	return nil
+}
+
+func testAccNsxtPolicyRoleBindingCreate(user, userType, identType string) string {
+	attrMap := accTestPolicyRoleBindingCreateAttributes
+	return fmt.Sprintf(`
+resource "nsxt_policy_user_management_role_binding" "test" {
+    display_name         = "%s"
+    description          = "%s"
+    name                 = "%s"
+    type                 = "%s"
+    identity_source_type = "%s"
+
+    roles_for_path {
+        path = "/"
+
+        role {
+            role              = "auditor"
+        }
+    }
+
+    roles_for_path {
+        path = "/orgs/default"
+
+        role {
+            role = "org_admin"
+        }
+    }
+}`, attrMap["display_name"], attrMap["description"], user, userType, identType)
+}
+
+func testAccNsxtPolicyRoleBindingUpdate(user, userType, identType string) string {
+	attrMap := accTestPolicyRoleBindingUpdateAttributes
+	return fmt.Sprintf(`
+resource "nsxt_policy_user_management_role_binding" "test" {
+    display_name         = "%s"
+    description          = "%s"
+    name                 = "%s"
+    type                 = "%s"
+    identity_source_type = "%s"
+
+    roles_for_path {
+        path = "/"
+
+        role {
+            role              = "auditor"
+        }
+    }
+}`, attrMap["display_name"], attrMap["description"], user, userType, identType)
+}

--- a/nsxt/resource_nsxt_policy_role_test.go
+++ b/nsxt/resource_nsxt_policy_role_test.go
@@ -1,0 +1,200 @@
+/* Copyright © 2023 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: MPL-2.0 */
+
+package nsxt
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+var accTestPolicyRoleCreateAttributes = map[string]string{
+	"display_name": getAccTestResourceName(),
+	"description":  "terraform created",
+}
+
+var accTestPolicyRoleUpdateAttributes = map[string]string{
+	"display_name": getAccTestResourceName(),
+	"description":  "terraform updated",
+}
+
+func TestAccResourceNsxtPolicyRole_basic(t *testing.T) {
+	testResourceName := "nsxt_policy_user_management_role.test_role"
+	roleName := getAccTestResourceName()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccOnlyLocalManager(t)
+		},
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyRoleCheckDestroy(state, accTestPolicyRoleUpdateAttributes["display_name"])
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyRoleCreate(roleName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicyRoleExists(accTestPolicyRoleCreateAttributes["display_name"], testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestPolicyRoleCreateAttributes["display_name"]),
+					resource.TestCheckResourceAttr(testResourceName, "description", accTestPolicyRoleCreateAttributes["description"]),
+					resource.TestCheckResourceAttr(testResourceName, "role", roleName),
+					resource.TestCheckResourceAttr(testResourceName, "feature.#", "3"),
+					resource.TestCheckResourceAttr(testResourceName, "feature.0.feature", "policy_grouping"),
+					resource.TestCheckResourceAttr(testResourceName, "feature.1.feature", "vm_vm_info"),
+					resource.TestCheckResourceAttr(testResourceName, "feature.2.feature", "policy_services"),
+					resource.TestCheckResourceAttr(testResourceName, "feature.0.permission", "read"),
+					resource.TestCheckResourceAttr(testResourceName, "feature.1.permission", "read"),
+					resource.TestCheckResourceAttr(testResourceName, "feature.2.permission", "read"),
+
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+					resource.TestCheckResourceAttrSet(testResourceName, "feature.0.feature_description"),
+					resource.TestCheckResourceAttrSet(testResourceName, "feature.1.feature_description"),
+					resource.TestCheckResourceAttrSet(testResourceName, "feature.2.feature_description"),
+					resource.TestCheckResourceAttrSet(testResourceName, "feature.0.feature_name"),
+					resource.TestCheckResourceAttrSet(testResourceName, "feature.1.feature_name"),
+					resource.TestCheckResourceAttrSet(testResourceName, "feature.2.feature_name"),
+				),
+			},
+			{
+				Config: testAccNsxtPolicyRoleUpdate(roleName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicyRoleExists(accTestPolicyRoleUpdateAttributes["display_name"], testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestPolicyRoleUpdateAttributes["display_name"]),
+					resource.TestCheckResourceAttr(testResourceName, "description", accTestPolicyRoleUpdateAttributes["description"]),
+					resource.TestCheckResourceAttr(testResourceName, "role", roleName),
+					resource.TestCheckResourceAttr(testResourceName, "feature.#", "2"),
+					resource.TestCheckResourceAttr(testResourceName, "feature.0.feature", "policy_grouping"),
+					resource.TestCheckResourceAttr(testResourceName, "feature.1.feature", "vm_vm_info"),
+					resource.TestCheckResourceAttr(testResourceName, "feature.0.permission", "crud"),
+					resource.TestCheckResourceAttr(testResourceName, "feature.1.permission", "crud"),
+
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+					resource.TestCheckResourceAttrSet(testResourceName, "feature.0.feature_description"),
+					resource.TestCheckResourceAttrSet(testResourceName, "feature.1.feature_description"),
+					resource.TestCheckResourceAttrSet(testResourceName, "feature.0.feature_name"),
+					resource.TestCheckResourceAttrSet(testResourceName, "feature.1.feature_name"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceNsxtPolicyRole_import_basic(t *testing.T) {
+	testResourceName := "nsxt_policy_user_management_role.test_role"
+	roleName := getAccTestResourceName()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccOnlyLocalManager(t)
+		},
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyRoleCheckDestroy(state, accTestPolicyRoleCreateAttributes["display_name"])
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyRoleCreate(roleName),
+			},
+			{
+				ResourceName:      testResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccNsxtPolicyRoleExists(displayName string, resourceName string) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+
+		connector := getPolicyConnector(testAccProvider.Meta().(nsxtClients))
+
+		rs, ok := state.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Role resource %s not found in resources", resourceName)
+		}
+
+		roleID := rs.Primary.Attributes["id"]
+		if roleID == "" {
+			return fmt.Errorf("Role resource ID not set in resources")
+		}
+		exists, err := resourceNsxtPolicyUserManagementRoleExists(roleID, connector)
+		if err != nil {
+			return err
+		}
+		if !exists {
+			return fmt.Errorf("Role %s does not exist", roleID)
+		}
+
+		return nil
+	}
+}
+
+func testAccNsxtPolicyRoleCheckDestroy(state *terraform.State, displayName string) error {
+	connector := getPolicyConnector(testAccProvider.Meta().(nsxtClients))
+	for _, rs := range state.RootModule().Resources {
+
+		if rs.Type != "nsxt_policy_user_management_role" {
+			continue
+		}
+
+		roleID := rs.Primary.Attributes["id"]
+		exists, err := resourceNsxtPolicyUserManagementRoleExists(roleID, connector)
+		if err != nil {
+			return err
+		}
+
+		if exists {
+			return fmt.Errorf("Role %s still exists", displayName)
+		}
+	}
+	return nil
+}
+
+func testAccNsxtPolicyRoleCreate(role string) string {
+	attrMap := accTestPolicyRoleCreateAttributes
+	return fmt.Sprintf(`
+resource "nsxt_policy_user_management_role" "test_role" {
+  display_name = "%s"
+  description = "%s"
+  role = "%s"
+  feature {
+    feature = "policy_grouping"
+    permission = "read"
+  }
+
+  feature {
+    feature = "vm_vm_info"
+    permission = "read"
+  }
+
+  feature {
+    feature = "policy_services"
+    permission = "read"
+  }
+}`, attrMap["display_name"], attrMap["description"], role)
+}
+
+func testAccNsxtPolicyRoleUpdate(role string) string {
+	attrMap := accTestPolicyRoleUpdateAttributes
+	return fmt.Sprintf(`
+resource "nsxt_policy_user_management_role" "test_role" {
+  display_name = "%s"
+  description = "%s"
+  role = "%s"
+  feature {
+    feature = "policy_grouping"
+    permission = "crud"
+  }
+
+  feature {
+    feature = "vm_vm_info"
+    permission = "crud"
+  }
+}`, attrMap["display_name"], attrMap["description"], role)
+}

--- a/nsxt/utils_test.go
+++ b/nsxt/utils_test.go
@@ -185,6 +185,10 @@ func getTestLBServiceName() string {
 	return os.Getenv("NSXT_TEST_LB_SERVICE_NAME")
 }
 
+func getTestLdapUser() string {
+	return os.Getenv("NSXT_TEST_LDAP_USER")
+}
+
 func testAccEnvDefined(t *testing.T, envVar string) {
 	if len(os.Getenv(envVar)) == 0 {
 		t.Skipf("This test requires %s environment variable to be set", envVar)

--- a/website/docs/r/node_user.html.markdown
+++ b/website/docs/r/node_user.html.markdown
@@ -1,0 +1,51 @@
+---
+subcategory: "Beta"
+layout: "nsxt"
+page_title: "NSXT: nsxt_node_user"
+description: A resource to configure Node Users.
+---
+
+# nsxt_node_user
+
+This resource provides a method for the management of NSX node users. These node user accounts can log in to the NSX web-based user interface or access API.
+
+
+## Example Usage
+
+```hcl
+resource "nsxt_node_user" "test_user" {
+  active                    = true
+  full_name                 = "John Doe"
+  password                  = "Str0ng_Pwd!Wins$"
+  username                  = "johndoe123"
+  password_change_frequency = 180
+  password_change_warning   = 30
+}
+```
+
+## Argument Reference
+
+* `active` - (Optional) If this account should be activated or deactivated. Default value is `true`.
+* `full_name` - (Required) The full name of this user.
+* `password` - (Optional) Password of this user. Password must be specified for creating `ACTIVE` accounts. Password updates will only take effect after deactivating the account, then reactivating it.
+* `username` - (Required) User login name.
+* `password_change_frequency` - (Optional) Number of days password is valid before it must be changed. This can be set to 0 to indicate no password change is required or a positive integer up to 9999. By default local user passwords must be changed every 90 days.
+* `password_change_warning` - (Optional) Number of days before user receives warning message of password expiration.
+
+## Attributes Reference
+
+In addition to arguments listed above, the following attributes are exported:
+
+* `last_password_change` - Number of days since password was last changed.
+* `password_reset_required` - Boolean value that states if a password reset is required.
+* `status` - Status of the user. This value can be `ACTIVE` indicating authentication attempts will be successful if the correct credentials are specified. The value can also be `PASSWORD_EXPIRED` indicating authentication attempts will fail because the user's password has expired and must be changed. Or, this value can be `NOT_ACTIVATED` indicating the user's password has not yet been set and must be set before the user can authenticate.
+* `user_id` - Numeric id for the user.
+## Importing
+
+An existing Node User can be [imported][docs-import] into this resource, via the following command:
+
+[docs-import]: https://www.terraform.io/cli/import
+```
+terraform import nsxt_node_user.user1 USER_ID
+```
+The above command imports the User `user1` with the Numeric id (`USER_ID`) of the user.

--- a/website/docs/r/policy_user_management_role.html.markdown
+++ b/website/docs/r/policy_user_management_role.html.markdown
@@ -1,0 +1,64 @@
+---
+subcategory: "Beta"
+layout: "nsxt"
+page_title: "NSXT: nsxt_policy_user_management_role"
+description: A resource to configure user management Roles.
+---
+
+# nsxt_policy_user_management_role
+
+This resource provides a method for the management of Roles.
+
+## Example Usage
+
+```hcl
+resource "nsxt_policy_user_management_role" "test_role" {
+  display_name = "test_role"
+  description  = "Terraform provisioned role"
+  role         = "test_role"
+
+  feature {
+    feature    = "policy_grouping"
+    permission = "crud"
+  }
+
+  feature {
+    feature    = "vm_vm_info"
+    permission = "crud"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `display_name` - (Optional) Display name of the resource.
+* `description` - (Optional) Description of the resource.
+* `tag` - (Optional) A list of scope + tag pairs to associate with this resource.
+* `role` - (Required) Short identifier for the role. Must be all lower case with no spaces.	This will also be the NSX ID of this resource.
+* `feature` - (Required) A list of permissions for features to be granted with this role.
+    * `feature` - (Required) The ID of feature to grant permission.
+    * `permission` - (Required) Type of permission to grant. Valid values are `crud`, `read`, `execute`.
+
+## Attributes Reference
+
+In addition to arguments listed above, the following attributes are exported:
+
+* `id` - ID of the resource.
+* `revision` - Indicates current revision number of the object as seen by NSX-T API server. This attribute can be useful for debugging.
+* `feature` - The permissions for features in the list will also have the following attributes exported:
+  * `feature_description` - Description of the feature.
+  * `feature_name` - Name of the feature.
+
+
+## Importing
+
+An existing object can be [imported][docs-import] into this resource, via the following command:
+
+[docs-import]: https://www.terraform.io/cli/import
+
+```
+terraform import nsxt_policy_user_management_role.test ROLE_ID
+```
+The above command imports Role named `test` with the role identifier `ROLE_ID`.

--- a/website/docs/r/policy_user_management_role_binding.html.markdown
+++ b/website/docs/r/policy_user_management_role_binding.html.markdown
@@ -1,0 +1,77 @@
+---
+subcategory: "Beta"
+layout: "nsxt"
+page_title: "NSXT: nsxt_policy_user_management_role_binding"
+description: A resource to configure user management Role Bindings.
+---
+
+# nsxt_policy_user_management_role_binding
+
+This resource provides a method for the management of Role Bindings of users.
+
+## Example Usage
+
+```hcl
+resource "nsxt_policy_user_management_role_binding" "test" {
+  display_name         = "johndoe@abc.com"
+  name                 = "johndoe@abc.com"
+  type                 = "remote_user"
+  identity_source_type = "LDAP"
+
+  roles_for_path {
+    path = "/"
+    role {
+      role = "auditor"
+    }
+  }
+
+  roles_for_path {
+    path = "/orgs/default"
+    role {
+      role = "org_admin"
+    }
+    role {
+      role = "vpc_admin"
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `display_name` - (Optional) Display name of the resource.
+* `description` - (Optional) Description of the resource.
+* `tag` - (Optional) A list of scope + tag pairs to associate with this resource.
+* `name` - (Required) User/Group's name.
+* `type` - (Required) Indicates the type of the user. Valid options:
+    * `remote_user` - This is a user which is external to NSX. 
+    * `remote_group` - This is a group of users which is external to NSX.
+    * `local_user` - This is a user local to NSX. These are linux users. Note: Role bindings for local users are owned by NSX. Creation and deletion is not allowed for local users' binding. For updates, import existing bindings first.
+    * `principal_identity` - This is a principal identity user.
+* `identity_source_type` - (Optional) Identity source type. Applicable only to `remote_user` and `remote_group` user types. Valid options are: `VIDM`, `LDAP`, `OIDC`, `CSP`. Defaults to `VIDM` when applicable.
+* `identity_source_id` - (Optional) The ID of the external identity source that holds the referenced external entity. Currently, only external `LDAP` and `OIDC` servers are allowed.
+* `roles_for_path` - (Required) A list of The roles that are associated with the user, limiting them to a path. In case the path is '/', the roles apply everywhere.
+    * `path` - (Required) Path of the entity in parent hierarchy.
+    * `role` - (Required) A list of identifiers for the roles to associate with the given user limited to a path.
+
+## Attributes Reference
+
+In addition to arguments listed above, the following attributes are exported:
+
+* `id` - ID of the resource.
+* `revision` - Indicates current revision number of the object as seen by NSX-T API server. This attribute can be useful for debugging.
+* `user_id` - Local user's numeric id. Only applicable to `local_user`.
+
+
+## Importing
+
+An existing object can be [imported][docs-import] into this resource, via the following command:
+
+[docs-import]: https://www.terraform.io/cli/import
+
+```
+terraform import nsxt_policy_user_management_role_binding.test ROLE_BINDING_ID
+```
+The above command imports Role named `test` with the role binding identifier `ROLE_BINDING_ID`.


### PR DESCRIPTION
This PR adds the following 3 resources related to user management:
- Local users (`/api/v1/node/users`)
- Roles (`policy/api/v1/aaa/roles`)
- Role bindings (`policy/api/v1/aaa/role-bindings`)

#### Users ####
- As password is not returned on GET, and it's possible for terraform created users to change the password out of terraform, password updates from config is not checked. Password resets could be done by deactivating then reactivate the same account.
- SSH keys (`api/v1/node/users/{userid}/ssh-keys`) and auth policy (`/api/v1/node/aaa/auth-policy`) not included

#### Roles ####
- Role validation API doesn't return error on invalid set of feature permissions. Instead, a list of "recommended" permissions will be returned. An error is raised reporting such missing permissions if the list is not empty.
- Multi-tenancy API endpoints supports GET only, thus not included.

#### Role Bindings ####
- For local users, role bindings is owned by NSX and created upon user creation. Role Binding Create and Delete is not allowed. Such role bindings must be imported into terraform for modifications.
- To remove an entire `path` of a set of roles from a binding, the path needs to be marked for delete in the `PUT` call, with non-empty role in the list. A random role is picked from old state for the call to make NSX API validation pass.
- Full CRUD for remote user bindings are tested with LDAP.
- Acc test requires env `NSXT_TEST_LDAP_USER` to be set to a valid LDAP user, and NSX is enabled with LDAP identity source.

Partially resolve #943