### PR TITLE
Fix searching by special chars in data sources

### DIFF
--- a/nsxt/data_source_nsxt_policy_service_test.go
+++ b/nsxt/data_source_nsxt_policy_service_test.go
@@ -91,6 +91,26 @@ func TestAccDataSourceNsxtPolicyService_spaces(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceNsxtPolicyService_specialChars(t *testing.T) {
+	serviceName := "IKE (Key Exchange)"
+	testResourceName := "data.nsxt_policy_service.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyServiceReadTemplate(serviceName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(testResourceName, "display_name", serviceName),
+					resource.TestCheckResourceAttr(testResourceName, "description", serviceName),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccDataSourceNsxtPolicyService_multitenancy(t *testing.T) {
 	serviceName := getAccTestResourceName()
 	testResourceName := "data.nsxt_policy_service.test"

--- a/nsxt/policy_search.go
+++ b/nsxt/policy_search.go
@@ -114,7 +114,7 @@ func policyDataSourceResourceReadWithValidation(d *schema.ResourceData, connecto
 }
 
 func listPolicyResourcesByNameAndType(connector client.Connector, context utl.SessionContext, displayName string, resourceType string, additionalQuery *string) ([]*data.StructValue, error) {
-	query := fmt.Sprintf("resource_type:%s AND display_name:%s* AND marked_for_delete:false", resourceType, displayName)
+	query := fmt.Sprintf("resource_type:%s AND display_name:%s* AND marked_for_delete:false", resourceType, escapeSpecialCharacters(displayName))
 	switch context.ClientType {
 	case utl.Local:
 		return searchLMPolicyResources(connector, *buildPolicyResourcesQuery(&query, additionalQuery))
@@ -129,7 +129,7 @@ func listPolicyResourcesByNameAndType(connector client.Connector, context utl.Se
 
 func escapeSpecialCharacters(str string) string {
 	// we replace special characters that can be encountered in object IDs
-	specials := "()[]"
+	specials := "()[]+-=&|><!{}^~*?:"
 	if !strings.ContainsAny(str, specials) {
 		return str
 	}


### PR DESCRIPTION
For data sources that rely on search API, functionality was broken when searched string contained special characters. This change fixes the issue by escaping special characters according to search API spec.
Signed-off-by: Anna Khmelnitsky <akhmelnitsky@vmware.com>