### PR TITLE
On read, extract sensitive data from state

### DIFF
--- a/nsxt/policy_utils.go
+++ b/nsxt/policy_utils.go
@@ -380,3 +380,14 @@ func retryUponPreconditionFailed(readAndUpdate func() error, maxRetryAttempts in
 
 	return err
 }
+
+func getElemOrEmptyMapFromSchema(d *schema.ResourceData, key string) map[string]interface{} {
+	e := d.Get(key)
+	if e != nil {
+		elems := e.([]interface{})
+		if len(elems) > 0 {
+			return elems[0].(map[string]interface{})
+		}
+	}
+	return make(map[string]interface{})
+}


### PR DESCRIPTION
NSX does not return sensitive data (e.g passwords) on GET operation, and therefore TF detects a diff.
But as the schema.Resource object contains the credentials from the state, we can keep these intact and then the value will remain as is and stored again in the state.
This is relevant to the transport_node resource as it contains multiple password attributes, which are as of now placed in empty maps during read - hence state values are ignored.