### PR TITLE
Validate rule sequence numbers on create only

### DIFF
--- a/nsxt/resource_nsxt_policy_predefined_gateway_policy.go
+++ b/nsxt/resource_nsxt_policy_predefined_gateway_policy.go
@@ -314,10 +314,6 @@ func updatePolicyPredefinedGatewayPolicy(id string, d *schema.ResourceData, m in
 	var childRules []*data.StructValue
 	if d.HasChange("rule") {
 		oldRules, _ := d.GetChange("rule")
-		err1 := validatePolicyRuleSequence(d)
-		if err1 != nil {
-			return err1
-		}
 		rules := getPolicyRulesFromSchema(d)
 
 		existingRules := make(map[string]bool)

--- a/nsxt/resource_nsxt_policy_predefined_security_policy.go
+++ b/nsxt/resource_nsxt_policy_predefined_security_policy.go
@@ -236,10 +236,6 @@ func updatePolicyPredefinedSecurityPolicy(id string, d *schema.ResourceData, m i
 	var childRules []*data.StructValue
 	if d.HasChange("rule") {
 		oldRules, _ := d.GetChange("rule")
-		err1 := validatePolicyRuleSequence(d)
-		if err1 != nil {
-			return err1
-		}
 		rules := getPolicyRulesFromSchema(d)
 
 		existingRules := make(map[string]bool)

--- a/nsxt/resource_nsxt_policy_security_policy.go
+++ b/nsxt/resource_nsxt_policy_security_policy.go
@@ -87,14 +87,13 @@ func policySecurityPolicyBuildAndPatch(d *schema.ResourceData, m interface{}, co
 	}
 	log.Printf("[INFO] Creating Security Policy with ID %s", id)
 
-	if !createFlow {
+	if createFlow {
+		if err := validatePolicyRuleSequence(d); err != nil {
+			return err
+		}
+	} else {
 		// This is update flow
 		obj.Revision = &revision
-	}
-
-	err := validatePolicyRuleSequence(d)
-	if err != nil {
-		return err
 	}
 
 	policyChildren, err := getUpdatedRuleChildren(d)


### PR DESCRIPTION
Since sequence number is Computed in rule, bad sequence numbers may be stuck in state as a result of configurations with previous provider version.
Rather than throwing an error, the provider will auto-correct the sequence number while also logging this event.
For create flow, we leave sequence number validation since state for new object is clean.