### PR TITLE
Probe NSX API endpoint in manager cluster

### DIFF
--- a/nsxt/provider.go
+++ b/nsxt/provider.go
@@ -712,13 +712,13 @@ func configurePolicyConnectorData(d *schema.ResourceData, clients *nsxtClients) 
 	}
 
 	if !isVMC {
-		err = configureLicenses(getPolicyConnectorForInit(*clients), clients.CommonConfig.LicenseDiff)
+		err = configureLicenses(getPolicyConnectorForInit(*clients, true), clients.CommonConfig.LicenseDiff)
 		if err != nil {
 			return err
 		}
 	}
 
-	err = initNSXVersion(getPolicyConnectorForInit(*clients))
+	err = initNSXVersion(getPolicyConnectorForInit(*clients, true))
 	if err != nil && isVMC {
 		// In case version API does not work for VMC, we workaround by testing version-specific APIs
 		// TODO - remove this when /node/version API works for all auth methods on VMC
@@ -978,14 +978,14 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 }
 
 func getPolicyConnector(clients interface{}) client.Connector {
-	return getPolicyConnectorWithHeaders(clients, nil, false)
+	return getPolicyConnectorWithHeaders(clients, nil, false, true)
 }
 
-func getPolicyConnectorForInit(clients interface{}) client.Connector {
-	return getPolicyConnectorWithHeaders(clients, nil, true)
+func getPolicyConnectorForInit(clients interface{}, withRetry bool) client.Connector {
+	return getPolicyConnectorWithHeaders(clients, nil, true, withRetry)
 }
 
-func getPolicyConnectorWithHeaders(clients interface{}, customHeaders *map[string]string, initFlow bool) client.Connector {
+func getPolicyConnectorWithHeaders(clients interface{}, customHeaders *map[string]string, initFlow bool, withRetry bool) client.Connector {
 	c := clients.(nsxtClients)
 
 	retryFunc := func(retryContext retry.RetryContext) bool {
@@ -1018,9 +1018,13 @@ func getPolicyConnectorWithHeaders(clients interface{}, customHeaders *map[strin
 		return true
 	}
 
-	connectorOptions := []client.ConnectorOption{client.UsingRest(nil), client.WithHttpClient(c.PolicyHTTPClient), client.WithDecorators(retry.NewRetryDecorator(uint(c.CommonConfig.MaxRetries), retryFunc))}
+	connectorOptions := []client.ConnectorOption{client.UsingRest(nil), client.WithHttpClient(c.PolicyHTTPClient)}
 	var requestProcessors []core.RequestProcessor
 	var responseAcceptors []core.ResponseAcceptor
+
+	if withRetry {
+		connectorOptions = append(connectorOptions, client.WithDecorators(retry.NewRetryDecorator(uint(c.CommonConfig.MaxRetries), retryFunc)))
+	}
 
 	if c.PolicySecurityContext != nil {
 		connectorOptions = append(connectorOptions, client.WithSecurityContext(c.PolicySecurityContext))

--- a/website/docs/r/manager_cluster.html.markdown
+++ b/website/docs/r/manager_cluster.html.markdown
@@ -12,6 +12,8 @@ This resource is supported with NSX 4.1.0 onwards.
 The main node for the cluster is the host in terraform nsxt provider config,
 user will need to specify the nodes that will join the cluster in the resource config.
 Only one instance of nsxt_manager_cluster resource is supported.
+If `api_probing` is enabled, this resource will wait for NSX API endpoints to come up
+before performing cluster joining.
 
 ## Example Usage
 
@@ -38,6 +40,11 @@ The following arguments are supported:
   * `ip_address` - (Required) Ip address of the node.
   * `username` - (Required) The username for login to the node.
   * `password` - (Required) The password for login to the node.
+* `api_probing` - (Optional) Parameters for probing NSX API endpoint connection. Since NSX nodes might have been created during same apply, we might need to wait until the API endpoint becomes available and all required default objects are created.
+  * `enabled` - (Optional) Whether API connectivity check is enabled. Default is `true`.
+  * `delay` - (Optional) Initial delay before we start probing API endpoint in seconds. Default is 0.
+  * `interval` - (Optional) Interval for probing API endpoint in seconds. Default is 10.
+  * `timeout` - (Optional) Timeout for probing the API endpoint in seconds. Default is 1800.
 
 ## Argument Reference
 


### PR DESCRIPTION
In manager cluster resource, probe for NSX connectivity before joining cluster nodes. Parameters for connection probing are specified within `node_connectivity` block.

This option is useful since nsx manager nodes might be spawned within same apply process, in which case it would take a while for NSX API endpoint to become responsive. Rather than using custom provisioner script to ensure connectivity, we give a probe and wait option in manager cluster resource.

Standard retry mechanism will not be present in this connection probing in order to avoid duplication (we expect retry parameters to be very different for regular retry and initial connection probing)