### PR TITLE
Fix release header template

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,10 @@ on:
   push:
     tags:
       - 'v*'
+
+permissions:
+  contents: write
+
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
@@ -33,10 +37,10 @@ jobs:
           PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
       -
         name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2.5.0
+        uses: goreleaser/goreleaser-action@v5
         with:
           version: latest
-          args: release --rm-dist --release-header .goreleaser.tmpl
+          args: release --clean --release-header-tmpl .goreleaser.tmpl
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,10 +31,10 @@ jobs:
       -
         name: Import GPG key
         id: import_gpg
-        uses: crazy-max/ghaction-import-gpg@v2
-        env:
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-          PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5

--- a/nsxt/provider.go
+++ b/nsxt/provider.go
@@ -806,8 +806,8 @@ func (processor logRequestProcessor) Process(req *http.Request) error {
 	}
 
 	// Replace sensitive information in HTTP headers
-	authHeaderRegexp := regexp.MustCompile("(?i)Authorization:.*")
-	cspHeaderRegexp := regexp.MustCompile("(?i)Csp-Auth-Token:.*")
+	authHeaderRegexp := regexp.MustCompile(`(?i)Authorization:.*`)
+	cspHeaderRegexp := regexp.MustCompile(`(?i)Csp-Auth-Token:.*`)
 	replaced := authHeaderRegexp.ReplaceAllString(string(reqDump), "<Omitted Authorization header>")
 	replaced = cspHeaderRegexp.ReplaceAllString(replaced, "<Omitted Csp-Auth-Token header>")
 

--- a/nsxt/resource_nsxt_node_user.go
+++ b/nsxt/resource_nsxt_node_user.go
@@ -95,7 +95,7 @@ func validateUsername() schema.SchemaValidateFunc {
 			return
 		}
 
-		r := regexp.MustCompile("^[a-zA-Z][a-zA-Z0-9@-_.\\-]*$")
+		r := regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9@-_.\-]*$`)
 		if ok := r.MatchString(v); !ok {
 			es = append(es, fmt.Errorf("username %s is invalid", v))
 			return

--- a/nsxt/resource_nsxt_policy_role_binding.go
+++ b/nsxt/resource_nsxt_policy_role_binding.go
@@ -94,7 +94,7 @@ func resourceNsxtPolicyUserManagementRoleBinding() *schema.Resource {
 										Required:    true,
 										ValidateFunc: validation.StringMatch(
 											regexp.MustCompile(
-												"^[_a-z0-9-]+$"),
+												`^[_a-z0-9-]+$`),
 											"Must be a valid role identifier matching: ^[_a-z0-9-]+$"),
 									},
 									"role_display_name": {


### PR DESCRIPTION
This PR is to fix the broken release note header rendering since [v3.2.0](https://github.com/vmware/terraform-provider-nsxt/releases/tag/v3.2.0), due to the command line option in `goreleaser` changed from `--release-header` to `--release-header-tmpl`, where the prior one is now treated as a static file.

Also addresses the following nits in our release action:
- Bumps `ghaction-import-gpg` action to latest to address deprecation warnings of `save-state` and `set-output`
- Uses `--clean` instead of `--rm-dist` per https://goreleaser.com/deprecations/#-rm-dist
- Sets job content write permission per guideline

Takes care of regex quoting of several instances as previously not being captured by PR golang lint jobs.

Testing done:
- Action run under personal repo: https://github.com/wsquan171/terraform-provider-nsxt/actions/runs/6567984764
- Release generated from ^ run: https://github.com/wsquan171/terraform-provider-nsxt/releases/tag/v0.0.2