### PR TITLE
Add LDAP identity source resource

### DIFF
--- a/nsxt/provider.go
+++ b/nsxt/provider.go
@@ -419,6 +419,7 @@ func Provider() *schema.Provider {
 			"nsxt_policy_transport_zone":                   resourceNsxtPolicyTransportZone(),
 			"nsxt_policy_user_management_role":             resourceNsxtPolicyUserManagementRole(),
 			"nsxt_policy_user_management_role_binding":     resourceNsxtPolicyUserManagementRoleBinding(),
+			"nsxt_policy_ldap_identity_source":             resourceNsxtPolicyLdapIdentitySource(),
 			"nsxt_edge_cluster":                            resourceNsxtEdgeCluster(),
 			"nsxt_compute_manager":                         resourceNsxtComputeManager(),
 			"nsxt_manager_cluster":                         resourceNsxtManagerCluster(),

--- a/nsxt/resource_nsxt_policy_ldap_identity_source.go
+++ b/nsxt/resource_nsxt_policy_ldap_identity_source.go
@@ -1,0 +1,333 @@
+/* Copyright © 2023 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: MPL-2.0 */
+
+package nsxt
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/bindings"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/data"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/aaa"
+	nsxModel "github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+)
+
+var ldapServerTypes = [](string){
+	nsxModel.LdapIdentitySource_RESOURCE_TYPE_ACTIVEDIRECTORYIDENTITYSOURCE,
+	nsxModel.LdapIdentitySource_RESOURCE_TYPE_OPENLDAPIDENTITYSOURCE,
+}
+
+func resourceNsxtPolicyLdapIdentitySource() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceNsxtPolicyLdapIdentitySourceCreate,
+		Read:   resourceNsxtPolicyLdapIdentitySourceRead,
+		Update: resourceNsxtPolicyLdapIdentitySourceUpdate,
+		Delete: resourceNsxtPolicyLdapIdentitySourceDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"nsx_id":       getNsxIDSchema(),
+			"display_name": getDataSourceDisplayNameSchema(),
+			"description":  getDataSourceDescriptionSchema(),
+			"revision":     getRevisionSchema(),
+			"tag":          getTagsSchema(),
+			"type": {
+				Type:         schema.TypeString,
+				Description:  "Indicates the type of LDAP server",
+				Required:     true,
+				ValidateFunc: validation.StringInSlice(ldapServerTypes, false),
+			},
+			"domain_name": {
+				Type:        schema.TypeString,
+				Description: "Authentication domain name",
+				Required:    true,
+			},
+			"base_dn": {
+				Type:        schema.TypeString,
+				Description: "DN of subtree for user and group searches",
+				Required:    true,
+			},
+			"alternative_domain_names": {
+				Type:        schema.TypeList,
+				Description: "Additional domains to be directed to this identity source",
+				Optional:    true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"ldap_server": {
+				Type:        schema.TypeList,
+				Description: "LDAP servers for this identity source",
+				Required:    true,
+				MaxItems:    1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"bind_identity": {
+							Type:        schema.TypeString,
+							Description: "Username or DN for LDAP authentication",
+							Optional:    true,
+						},
+						"certificates": {
+							Type:        schema.TypeList,
+							Description: "TLS certificate(s) for LDAP server(s)",
+							Optional:    true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"enabled": {
+							Type:        schema.TypeBool,
+							Description: "If true, this LDAP server is enabled",
+							Optional:    true,
+							Default:     true,
+						},
+						"password": {
+							Type:        schema.TypeString,
+							Description: "The authentication password for login",
+							Optional:    true,
+							Sensitive:   true,
+						},
+						"url": {
+							Type:         schema.TypeString,
+							Description:  "The URL for the LDAP server",
+							Required:     true,
+							ValidateFunc: validateLdapOrLdapsURL(),
+						},
+						"use_starttls": {
+							Type:        schema.TypeBool,
+							Description: "Enable/disable StartTLS",
+							Optional:    true,
+							Default:     false,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func getLdapServersFromSchema(d *schema.ResourceData) []nsxModel.IdentitySourceLdapServer {
+	servers := d.Get("ldap_server").([]interface{})
+	serverList := make([]nsxModel.IdentitySourceLdapServer, 0)
+	for _, server := range servers {
+		data := server.(map[string]interface{})
+		bindIdentity := data["bind_identity"].(string)
+		certificates := interface2StringList(data["certificates"].([]interface{}))
+		enabled := data["enabled"].(bool)
+		password := data["password"].(string)
+		url := data["url"].(string)
+		useStarttls := data["use_starttls"].(bool)
+		elem := nsxModel.IdentitySourceLdapServer{
+			BindIdentity: &bindIdentity,
+			Certificates: certificates,
+			Enabled:      &enabled,
+			Password:     &password,
+			Url:          &url,
+			UseStarttls:  &useStarttls,
+		}
+
+		serverList = append(serverList, elem)
+	}
+	return serverList
+}
+
+// getLdapServerPasswordMap caches password of ldap servers for setting back to schema after read
+func getLdapServerPasswordMap(d *schema.ResourceData) map[string]string {
+	passwordMap := make(map[string]string)
+	servers := d.Get("ldap_server").([]interface{})
+	for _, server := range servers {
+		data := server.(map[string]interface{})
+		password := data["password"].(string)
+		url := data["url"].(string)
+		passwordMap[url] = password
+	}
+
+	return passwordMap
+}
+
+func setLdapServersInSchema(d *schema.ResourceData, nsxLdapServerList []nsxModel.IdentitySourceLdapServer, passwordMap map[string]string) {
+	var ldapServerList []map[string]interface{}
+	for _, ldapServer := range nsxLdapServerList {
+		elem := make(map[string]interface{})
+		elem["bind_identity"] = ldapServer.BindIdentity
+		elem["certificates"] = ldapServer.Certificates
+		elem["enabled"] = ldapServer.Enabled
+		elem["url"] = ldapServer.Url
+		elem["use_starttls"] = ldapServer.UseStarttls
+		if val, ok := passwordMap[*ldapServer.Url]; ok {
+			elem["password"] = val
+		}
+		ldapServerList = append(ldapServerList, elem)
+	}
+	err := d.Set("ldap_server", ldapServerList)
+	if err != nil {
+		log.Printf("[WARNING] Failed to set ldap_server in schema: %v", err)
+	}
+}
+
+func resourceNsxtPolicyLdapIdentitySourceExists(id string, connector client.Connector, isGlobalManager bool) (bool, error) {
+	var err error
+
+	ldapClient := aaa.NewLdapIdentitySourcesClient(connector)
+	_, err = ldapClient.Get(id)
+	if err == nil {
+		return true, nil
+	}
+	if isNotFoundError(err) {
+		return false, nil
+	}
+
+	return false, logAPIError("Error retrieving resource", err)
+}
+
+func resourceNsxtPolicyLdapIdentitySourceProbeAndUpdate(d *schema.ResourceData, m interface{}, id string) error {
+	connector := getPolicyConnector(m)
+	ldapClient := aaa.NewLdapIdentitySourcesClient(connector)
+	converter := bindings.NewTypeConverter()
+	serverType := d.Get("type").(string)
+
+	displayName := d.Get("display_name").(string)
+	description := d.Get("description").(string)
+	revision := int64(d.Get("revision").(int))
+	tags := getPolicyTagsFromSchema(d)
+	domainName := d.Get("domain_name").(string)
+	baseDn := d.Get("base_dn").(string)
+	altDomainNames := getStringListFromSchemaList(d, "alternative_domain_names")
+	ldapServers := getLdapServersFromSchema(d)
+
+	var structValue *data.StructValue
+	obj := nsxModel.LdapIdentitySource{
+		DisplayName:            &displayName,
+		Description:            &description,
+		Revision:               &revision,
+		Tags:                   tags,
+		DomainName:             &domainName,
+		BaseDn:                 &baseDn,
+		AlternativeDomainNames: altDomainNames,
+		LdapServers:            ldapServers,
+		ResourceType:           serverType,
+	}
+	dataValue, errs := converter.ConvertToVapi(obj, nsxModel.LdapIdentitySourceBindingType())
+	if errs != nil {
+		return errs[0]
+	}
+	structValue = dataValue.(*data.StructValue)
+
+	log.Printf("[INFO] Probing LDAP Identity Source with ID %s", id)
+	probeResult, err := ldapClient.Probeidentitysource(structValue)
+	if err != nil {
+		return logAPIError("Error probing LDAP Identity Source", err)
+	}
+	for _, result := range probeResult.Results {
+		if result.Result != nil && *result.Result != nsxModel.IdentitySourceLdapServerProbeResult_RESULT_SUCCESS {
+			probeErrs := make([]string, 0)
+			for _, probeErr := range result.Errors {
+				if probeErr.ErrorType != nil {
+					probeErrs = append(probeErrs, *probeErr.ErrorType)
+				}
+			}
+			return fmt.Errorf("LDAP Identity Source server %s probe failed with errors: %s",
+				*result.Url, strings.Join(probeErrs, ","))
+		}
+	}
+
+	log.Printf("[INFO] PUT LDAP Identity Source with ID %s", id)
+	if _, err = ldapClient.Update(id, structValue); err != nil {
+		return handleUpdateError(serverType, id, err)
+	}
+
+	return nil
+}
+
+func resourceNsxtPolicyLdapIdentitySourceCreate(d *schema.ResourceData, m interface{}) error {
+	// Initialize resource Id and verify this ID is not yet used
+	id, err := getOrGenerateID(d, m, resourceNsxtPolicyLdapIdentitySourceExists)
+	if err != nil {
+		return err
+	}
+
+	if err := resourceNsxtPolicyLdapIdentitySourceProbeAndUpdate(d, m, id); err != nil {
+		return err
+	}
+	d.SetId(id)
+	d.Set("nsx_id", id)
+
+	return resourceNsxtPolicyLdapIdentitySourceRead(d, m)
+}
+
+func resourceNsxtPolicyLdapIdentitySourceRead(d *schema.ResourceData, m interface{}) error {
+	connector := getPolicyConnector(m)
+	converter := bindings.NewTypeConverter()
+
+	id := d.Id()
+	if id == "" {
+		return fmt.Errorf("error obtaining LDAPIdentitySource ID")
+	}
+
+	ldapClient := aaa.NewLdapIdentitySourcesClient(connector)
+	structObj, err := ldapClient.Get(id)
+	if err != nil {
+		return handleReadError(d, "LDAPIdentitySource", id, err)
+	}
+
+	obj, errs := converter.ConvertToGolang(structObj, nsxModel.LdapIdentitySourceBindingType())
+	if errs != nil {
+		return errs[0]
+	}
+
+	ldapObj := obj.(nsxModel.LdapIdentitySource)
+	resourceType := ldapObj.ResourceType
+	if resourceType != nsxModel.LdapIdentitySource_RESOURCE_TYPE_ACTIVEDIRECTORYIDENTITYSOURCE &&
+		resourceType != nsxModel.LdapIdentitySource_RESOURCE_TYPE_OPENLDAPIDENTITYSOURCE {
+		return fmt.Errorf("unrecognized LdapIdentitySource Resource Type %s", resourceType)
+	}
+
+	passwordMap := getLdapServerPasswordMap(d)
+
+	d.Set("nsx_id", id)
+	d.Set("display_name", ldapObj.DisplayName)
+	d.Set("description", ldapObj.Description)
+	d.Set("revision", ldapObj.Revision)
+	setPolicyTagsInSchema(d, ldapObj.Tags)
+	d.Set("type", resourceType)
+	d.Set("domain_name", ldapObj.DomainName)
+	d.Set("base_dn", ldapObj.BaseDn)
+	d.Set("alternative_domain_names", ldapObj.AlternativeDomainNames)
+	setLdapServersInSchema(d, ldapObj.LdapServers, passwordMap)
+	return nil
+}
+
+func resourceNsxtPolicyLdapIdentitySourceUpdate(d *schema.ResourceData, m interface{}) error {
+	id := d.Id()
+	if id == "" {
+		return fmt.Errorf("rrror obtaining LDAPIdentitySource ID")
+	}
+
+	if err := resourceNsxtPolicyLdapIdentitySourceProbeAndUpdate(d, m, id); err != nil {
+		return handleUpdateError("LDAPIdentitySource", id, err)
+	}
+
+	return resourceNsxtPolicyLdapIdentitySourceRead(d, m)
+}
+
+func resourceNsxtPolicyLdapIdentitySourceDelete(d *schema.ResourceData, m interface{}) error {
+	id := d.Id()
+	if id == "" {
+		return fmt.Errorf("error obtaining LDAPIdentitySource ID")
+	}
+
+	connector := getPolicyConnector(m)
+	ldapClient := aaa.NewLdapIdentitySourcesClient(connector)
+	if err := ldapClient.Delete(id); err != nil {
+		return handleDeleteError("LDAPIdentitySource", id, err)
+	}
+
+	return nil
+}

--- a/nsxt/resource_nsxt_policy_ldap_identity_source_test.go
+++ b/nsxt/resource_nsxt_policy_ldap_identity_source_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	nsxModel "github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 )
 
 var accTestPolicyLdapIdentitySourceCreateAttributes = map[string]string{
@@ -24,7 +23,7 @@ var accTestPolicyLdapIdentitySourceUpdateAttributes = map[string]string{
 
 func TestAccResourceNsxtPolicyLdapIdentitySource_basic(t *testing.T) {
 	testResourceName := "nsxt_policy_ldap_identity_source.test"
-	ldapType := nsxModel.LdapIdentitySource_RESOURCE_TYPE_ACTIVEDIRECTORYIDENTITYSOURCE
+	ldapType := activeDirectoryType
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -92,7 +91,7 @@ func TestAccResourceNsxtPolicyLdapIdentitySource_basic(t *testing.T) {
 
 func TestAccResourceNsxtPolicyLdapIdentitySource_import_basic(t *testing.T) {
 	testResourceName := "nsxt_policy_ldap_identity_source.test"
-	ldapType := nsxModel.LdapIdentitySource_RESOURCE_TYPE_ACTIVEDIRECTORYIDENTITYSOURCE
+	ldapType := activeDirectoryType
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {

--- a/nsxt/resource_nsxt_policy_ldap_identity_source_test.go
+++ b/nsxt/resource_nsxt_policy_ldap_identity_source_test.go
@@ -1,0 +1,226 @@
+/* Copyright © 2023 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: MPL-2.0 */
+
+package nsxt
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	nsxModel "github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+)
+
+var accTestPolicyLdapIdentitySourceCreateAttributes = map[string]string{
+	"display_name": getAccTestResourceName(),
+	"description":  "terraform created",
+}
+
+var accTestPolicyLdapIdentitySourceUpdateAttributes = map[string]string{
+	"display_name": getAccTestResourceName(),
+	"description":  "terraform updated",
+}
+
+func TestAccResourceNsxtPolicyLdapIdentitySource_basic(t *testing.T) {
+	testResourceName := "nsxt_policy_ldap_identity_source.test"
+	ldapType := nsxModel.LdapIdentitySource_RESOURCE_TYPE_ACTIVEDIRECTORYIDENTITYSOURCE
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccEnvDefined(t, "NSXT_TEST_LDAP_USER")
+			testAccEnvDefined(t, "NSXT_TEST_LDAP_PASSWORD")
+			testAccEnvDefined(t, "NSXT_TEST_LDAP_URL")
+			testAccEnvDefined(t, "NSXT_TEST_LDAP_CERT")
+			testAccEnvDefined(t, "NSXT_TEST_LDAP_DOMAIN")
+			testAccEnvDefined(t, "NSXT_TEST_LDAP_BASE_DN")
+			testAccOnlyLocalManager(t)
+		},
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyLdapIdentitySourceCheckDestroy(state, accTestPolicyLdapIdentitySourceUpdateAttributes["display_name"])
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyLdapIdentitySourceCreate(
+					ldapType, getTestLdapDomain(), getTestLdapBaseDN(), getTestLdapUser(), getTestLdapPassword(),
+					getTestLdapURL(), getTestLdapCert()),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicyLdapIdentitySourceExists(accTestPolicyLdapIdentitySourceCreateAttributes["display_name"], testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestPolicyLdapIdentitySourceCreateAttributes["display_name"]),
+					resource.TestCheckResourceAttr(testResourceName, "description", accTestPolicyLdapIdentitySourceCreateAttributes["description"]),
+					resource.TestCheckResourceAttr(testResourceName, "type", ldapType),
+					resource.TestCheckResourceAttr(testResourceName, "domain_name", getTestLdapDomain()),
+					resource.TestCheckResourceAttr(testResourceName, "base_dn", getTestLdapBaseDN()),
+					resource.TestCheckResourceAttr(testResourceName, "ldap_server.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "ldap_server.0.bind_identity", getTestLdapUser()),
+					resource.TestCheckResourceAttr(testResourceName, "ldap_server.0.password", getTestLdapPassword()),
+					resource.TestCheckResourceAttr(testResourceName, "ldap_server.0.url", getTestLdapURL()),
+					resource.TestCheckResourceAttr(testResourceName, "ldap_server.0.certificates.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
+
+					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+				),
+			},
+			{
+				Config: testAccNsxtPolicyLdapIdentitySourceUpdate(
+					ldapType, getTestLdapDomain(), getTestLdapBaseDN(), getTestLdapUser(), getTestLdapPassword(),
+					getTestLdapURL(), getTestLdapCert()),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicyLdapIdentitySourceExists(accTestPolicyLdapIdentitySourceUpdateAttributes["display_name"], testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestPolicyLdapIdentitySourceUpdateAttributes["display_name"]),
+					resource.TestCheckResourceAttr(testResourceName, "description", accTestPolicyLdapIdentitySourceUpdateAttributes["description"]),
+					resource.TestCheckResourceAttr(testResourceName, "type", ldapType),
+					resource.TestCheckResourceAttr(testResourceName, "domain_name", getTestLdapDomain()),
+					resource.TestCheckResourceAttr(testResourceName, "base_dn", getTestLdapBaseDN()),
+					resource.TestCheckResourceAttr(testResourceName, "ldap_server.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "ldap_server.0.bind_identity", getTestLdapUser()),
+					resource.TestCheckResourceAttr(testResourceName, "ldap_server.0.password", getTestLdapPassword()),
+					resource.TestCheckResourceAttr(testResourceName, "ldap_server.0.url", getTestLdapURL()),
+					resource.TestCheckResourceAttr(testResourceName, "ldap_server.0.certificates.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "tag.#", "0"),
+
+					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceNsxtPolicyLdapIdentitySource_import_basic(t *testing.T) {
+	testResourceName := "nsxt_policy_ldap_identity_source.test"
+	ldapType := nsxModel.LdapIdentitySource_RESOURCE_TYPE_ACTIVEDIRECTORYIDENTITYSOURCE
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccEnvDefined(t, "NSXT_TEST_LDAP_USER")
+			testAccEnvDefined(t, "NSXT_TEST_LDAP_PASSWORD")
+			testAccEnvDefined(t, "NSXT_TEST_LDAP_URL")
+			testAccEnvDefined(t, "NSXT_TEST_LDAP_CERT")
+			testAccEnvDefined(t, "NSXT_TEST_LDAP_DOMAIN")
+			testAccEnvDefined(t, "NSXT_TEST_LDAP_BASE_DN")
+			testAccOnlyLocalManager(t)
+		},
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyLdapIdentitySourceCheckDestroy(state, accTestPolicyLdapIdentitySourceCreateAttributes["display_name"])
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyLdapIdentitySourceCreate(
+					ldapType, getTestLdapDomain(), getTestLdapBaseDN(), getTestLdapUser(), getTestLdapPassword(),
+					getTestLdapURL(), getTestLdapCert()),
+			},
+			{
+				ResourceName:            testResourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"ldap_server.0.password"},
+			},
+		},
+	})
+}
+
+func testAccNsxtPolicyLdapIdentitySourceExists(displayName string, resourceName string) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+		connector := getPolicyConnector(testAccProvider.Meta().(nsxtClients))
+		rs, ok := state.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("LdapIdentitySource resource %s not found in resources", resourceName)
+		}
+
+		ldapSourceID := rs.Primary.Attributes["id"]
+		if ldapSourceID == "" {
+			return fmt.Errorf("LdapIdentitySource resource ID not set in resources")
+		}
+		exist, err := resourceNsxtPolicyLdapIdentitySourceExists(ldapSourceID, connector, false)
+		if err != nil {
+			return err
+		}
+		if !exist {
+			return fmt.Errorf("LdapIdentitySource %s does not exist", displayName)
+		}
+
+		return nil
+	}
+}
+
+func testAccNsxtPolicyLdapIdentitySourceCheckDestroy(state *terraform.State, displayName string) error {
+	connector := getPolicyConnector(testAccProvider.Meta().(nsxtClients))
+	for _, rs := range state.RootModule().Resources {
+		if rs.Type != "nsxt_policy_ldap_identity_source" {
+			continue
+		}
+
+		ldapSourceID := rs.Primary.Attributes["id"]
+		if ldapSourceID == "" {
+			return fmt.Errorf("LdapIdentitySource resource ID not set in resources")
+		}
+		exist, err := resourceNsxtPolicyLdapIdentitySourceExists(ldapSourceID, connector, false)
+		if err != nil {
+			return err
+		}
+		if exist {
+			return fmt.Errorf("LdapIdentitySource %s still exists", displayName)
+		}
+		return nil
+	}
+	return nil
+}
+
+func testAccNsxtPolicyLdapIdentitySourceCreate(serverType, domainName, baseDn, bindUser, bindPwd, url, cert string) string {
+	attrMap := accTestPolicyLdapIdentitySourceCreateAttributes
+	return fmt.Sprintf(`
+resource "nsxt_policy_ldap_identity_source" "test" {
+    display_name = "%s"
+    description  = "%s"
+    type         = "%s"
+    domain_name  = "%s"
+    base_dn      = "%s"
+
+    ldap_server {
+        bind_identity = "%s"
+        password      = "%s"
+        url           = "%s"
+        certificates  = [
+            <<-EOT
+%s
+            EOT
+            ,
+        ]
+    }
+
+    tag {
+        scope = "scope1"
+        tag = "tag1"
+    }
+}`, attrMap["display_name"], attrMap["description"], serverType, domainName, baseDn, bindUser, bindPwd, url, cert)
+}
+
+func testAccNsxtPolicyLdapIdentitySourceUpdate(serverType, domainName, baseDn, bindUser, bindPwd, url, cert string) string {
+	attrMap := accTestPolicyLdapIdentitySourceUpdateAttributes
+	return fmt.Sprintf(`
+resource "nsxt_policy_ldap_identity_source" "test" {
+    display_name = "%s"
+    description  = "%s"
+    type         = "%s"
+    domain_name  = "%s"
+    base_dn      = "%s"
+
+    ldap_server {
+        bind_identity = "%s"
+        password      = "%s"
+        url           = "%s"
+        certificates  = [
+            <<-EOT
+%s
+            EOT
+            ,
+        ]
+    }
+}`, attrMap["display_name"], attrMap["description"], serverType, domainName, baseDn, bindUser, bindPwd, url, cert)
+}

--- a/nsxt/utils_test.go
+++ b/nsxt/utils_test.go
@@ -190,6 +190,26 @@ func getTestLdapUser() string {
 	return os.Getenv("NSXT_TEST_LDAP_USER")
 }
 
+func getTestLdapPassword() string {
+	return os.Getenv("NSXT_TEST_LDAP_PASSWORD")
+}
+
+func getTestLdapURL() string {
+	return os.Getenv("NSXT_TEST_LDAP_URL")
+}
+
+func getTestLdapCert() string {
+	return os.Getenv("NSXT_TEST_LDAP_CERT")
+}
+
+func getTestLdapDomain() string {
+	return os.Getenv("NSXT_TEST_LDAP_DOMAIN")
+}
+
+func getTestLdapBaseDN() string {
+	return os.Getenv("NSXT_TEST_LDAP_BASE_DN")
+}
+
 func testAccEnvDefined(t *testing.T, envVar string) {
 	if len(os.Getenv(envVar)) == 0 {
 		t.Skipf("This test requires %s environment variable to be set", envVar)

--- a/nsxt/validators.go
+++ b/nsxt/validators.go
@@ -546,3 +546,17 @@ func validatePolicyBGPCommunity(i interface{}, k string) (s []string, es []error
 
 	return
 }
+
+// validateLdapOrLdapsURL( is a SchemaValidateFunc which tests if the url is of type string and a valid LDAP or LDAPs
+func validateLdapOrLdapsURL() schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (s []string, es []error) {
+		_, ok := i.(string)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be string", k))
+			return
+		}
+
+		s, es = validation.IsURLWithScheme([]string{"ldap", "ldaps"})(i, k)
+		return
+	}
+}

--- a/website/docs/r/policy_ldap_identity_source.html.markdown
+++ b/website/docs/r/policy_ldap_identity_source.html.markdown
@@ -1,0 +1,73 @@
+---
+subcategory: "Beta"
+layout: "nsxt"
+page_title: "NSXT: nsxt_policy_ldap_identity_source"
+description: A resource to configure LDAP identity sources.
+---
+
+# nsxt_policy_ldap_identity_source
+
+This resource provides a method for the management of LDAP identity sources.
+
+## Example Usage
+
+```hcl
+resource "nsxt_policy_ldap_identity_source" "test" {
+  display_name = "Airius LDAP"
+  description  = "Airius LDAP Identity Source"
+  type         = "ActiveDirectoryIdentitySource"
+  domain_name  = "airius.com"
+  base_dn      = "DC=airius, DC=com"
+
+  ldap_server {
+    bind_identity = "nsxint@airius.com"
+    password      = "forever big xray tempo"
+    url           = "ldap://ldap-vip01.corp.airius.com"
+    use_starttls  = true
+    certificates = [
+      trimspace(file("cert.pem")),
+    ]
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `display_name` - (Optional) Display name of the resource.
+* `description` - (Optional) Description of the resource.
+* `tag` - (Optional) A list of scope + tag pairs to associate with this resource.
+* `nsx_id` - (Optional) The NSX ID of this resource. If set, this ID will be used to create the resource.
+* `type` - (Required) Indicates the type of the LDAP identity source. Valid options:
+  * `ActiveDirectoryIdentitySource` - This is an Active Directory identity source.
+  * `OpenLdapIdentitySource` - This is an OpenLDAP identity source.
+* `domain_name` - (Required) Authentication domain name. This is the name of the authentication domain. When users log into NSX using an identity of the form "user@domain", NSX uses the domain portion to determine which LDAP identity source to use.
+* `base_dn` - (Required) DN of subtree for user and group searches.
+* `alternative_domain_names` - (Optional) Additional domains to be directed to this identity source. After parsing the "user@domain", the domain portion is used to select the LDAP identity source to use. Additional domains listed here will also be directed to this LDAP identity source. In Active Directory these are sometimes referred to as Alternative UPN Suffixes.
+* `ldap_server` - (Required) List of LDAP servers that provide LDAP service for this identity source. Currently, only one LDAP server is supported.
+    * `bind_identity` - (Optional) Username or DN for LDAP authentication.This user should have privileges to search the LDAP directory for groups and users. This user is also used in some cases (OpenLDAP) to look up an NSX user's distinguished name based on their NSX login name. If omitted, NSX will authenticate to the LDAP server using an LDAP anonymous bind operation. For Active Directory, provide a userPrincipalName (e.g. administrator@airius.com) or the full distinguished nane. For OpenLDAP, provide the distinguished name of the user (e.g. uid=admin, cn=airius, dc=com).
+    * `certificates` - (Optional) TLS certificate(s) for LDAP server(s). If using LDAPS or STARTTLS, provide the X.509 certificate of the LDAP server in PEM format. This property is not required when connecting without TLS encryption and is ignored in that case.
+    * `enabled` - (Optional) Allows the LDAP server to be enabled or disabled. When disabled, this LDAP server will not be used to authenticate users. Default value is `ture`.
+    * `password` - (Optional) A password used when authenticating to the directory.
+    * `url`- (Required) The URL for the LDAP server. Supported URL schemes are LDAP and LDAPS. Either a hostname or an IP address may be given, and the port number is optional and defaults to 389 for the LDAP scheme and 636 for the LDAPS scheme.
+    * `use_starttls` - (Optional) If set to true, Use the StartTLS extended operation to upgrade the connection to TLS before sending any sensitive information. The LDAP server must support the StartTLS extended operation in order for this protocol to operate correctly. This option is ignored if the URL scheme is LDAPS.
+
+## Attributes Reference
+
+In addition to arguments listed above, the following attributes are exported:
+
+* `id` - ID of the resource.
+* `revision` - Indicates current revision number of the object as seen by NSX-T API server. This attribute can be useful for debugging.
+
+
+## Importing
+
+An existing object can be [imported][docs-import] into this resource, via the following command:
+
+[docs-import]: https://www.terraform.io/cli/import
+
+```
+terraform import nsxt_policy_ldap_identity_source.test ID
+```
+The above command imports LDAP identity source named `test` with the identifier `ID`.

--- a/website/docs/r/policy_ldap_identity_source.html.markdown
+++ b/website/docs/r/policy_ldap_identity_source.html.markdown
@@ -15,7 +15,7 @@ This resource provides a method for the management of LDAP identity sources.
 resource "nsxt_policy_ldap_identity_source" "test" {
   display_name = "Airius LDAP"
   description  = "Airius LDAP Identity Source"
-  type         = "ActiveDirectoryIdentitySource"
+  type         = "ActiveDirectory"
   domain_name  = "airius.com"
   base_dn      = "DC=airius, DC=com"
 
@@ -40,8 +40,8 @@ The following arguments are supported:
 * `tag` - (Optional) A list of scope + tag pairs to associate with this resource.
 * `nsx_id` - (Optional) The NSX ID of this resource. If set, this ID will be used to create the resource.
 * `type` - (Required) Indicates the type of the LDAP identity source. Valid options:
-  * `ActiveDirectoryIdentitySource` - This is an Active Directory identity source.
-  * `OpenLdapIdentitySource` - This is an OpenLDAP identity source.
+  * `ActiveDirectory` - This is an Active Directory identity source.
+  * `OpenLdap` - This is an OpenLDAP identity source.
 * `domain_name` - (Required) Authentication domain name. This is the name of the authentication domain. When users log into NSX using an identity of the form "user@domain", NSX uses the domain portion to determine which LDAP identity source to use.
 * `base_dn` - (Required) DN of subtree for user and group searches.
 * `alternative_domain_names` - (Optional) Additional domains to be directed to this identity source. After parsing the "user@domain", the domain portion is used to select the LDAP identity source to use. Additional domains listed here will also be directed to this LDAP identity source. In Active Directory these are sometimes referred to as Alternative UPN Suffixes.


### PR DESCRIPTION
This PR adds policy LDAP identity source resource. Both `ActiveDirectoryIdentitySource` and `OpenLdapIdentitySource` type LDAP are supported. The two resources have different resource type on NSX API, but shares the same attributes.