### PR TITLE
Rename nsxt_uplink_host_switch_profile

### DIFF
--- a/nsxt/provider.go
+++ b/nsxt/provider.go
@@ -424,7 +424,6 @@ func Provider() *schema.Provider {
 			"nsxt_manager_cluster":                         resourceNsxtManagerCluster(),
 			"nsxt_policy_uplink_host_switch_profile":       resourceNsxtUplinkHostSwitchProfile(),
 			"nsxt_node_user":                               resourceNsxtUsers(),
-			"nsxt_uplink_host_switch_profile":              resourceNsxtUplinkHostSwitchProfile(),
 			"nsxt_transport_node":                          resourceNsxtTransportNode(),
 			"nsxt_failure_domain":                          resourceNsxtFailureDomain(),
 			"nsxt_cluster_virtual_ip":                      resourceNsxtClusterVirualIP(),

--- a/website/docs/d/transport_node_realization.html.markdown
+++ b/website/docs/d/transport_node_realization.html.markdown
@@ -25,7 +25,7 @@ resource "nsxt_transport_node" "test" {
       transport_zone         = data.nsxt_transport_zone.tz1.id
       transport_zone_profile = ["52035bb3-ab02-4a08-9884-18631312e50a"]
     }
-    host_switch_profile = [nsxt_uplink_host_switch_profile.hsw_profile1.id]
+    host_switch_profile = [nsxt_policy_uplink_host_switch_profile.hsw_profile1.id]
     is_migrate_pnics    = false
     pnic {
       device_name = "fp-eth0"

--- a/website/docs/r/policy_host_transport_node.html.markdown
+++ b/website/docs/r/policy_host_transport_node.html.markdown
@@ -35,7 +35,7 @@ resource "nsxt_policy_host_transport_node" "test" {
   standard_host_switch {
     host_switch_mode    = "STANDARD"
     host_switch_type    = "NVDS"
-    host_switch_profile = [data.nsxt_uplink_host_switch_profile.hsw_profile1.path]
+    host_switch_profile = [data.nsxt_policy_uplink_host_switch_profile.hsw_profile1.path]
 
     ip_assignment {
       assigned_by_dhcp = true

--- a/website/docs/r/policy_host_transport_node_profile.html.markdown
+++ b/website/docs/r/policy_host_transport_node_profile.html.markdown
@@ -24,7 +24,7 @@ resource "nsxt_policy_host_transport_node_profile" "test" {
     transport_zone_endpoint {
       transport_zone = data.nsxt_transport_zone.tz1.id
     }
-    host_switch_profile = [nsxt_uplink_host_switch_profile.hsw_profile1.path]
+    host_switch_profile = [nsxt_policy_uplink_host_switch_profile.hsw_profile1.path]
     is_migrate_pnics    = false
     pnic {
       device_name = "fp-eth0"

--- a/website/docs/r/policy_uplink_host_switch_profile.html.markdown
+++ b/website/docs/r/policy_uplink_host_switch_profile.html.markdown
@@ -118,13 +118,13 @@ An existing object can be [imported][docs-import] into this resource, via the fo
 [docs-import]: https://www.terraform.io/cli/import
 
 ```
-terraform import nsxt_uplink_host_switch_profile.uplink_host_switch_profile UUID
+terraform import nsxt_policy_uplink_host_switch_profile.uplink_host_switch_profile UUID
 ```
 
 The above command imports UplinkHostSwitchProfile named `uplink_host_switch_profile` with the NSX ID `UUID`.
 
 
 ```
-terraform import nsxt_uplink_host_switch_profile.uplink_host_switch_profile POLICY_PATH
+terraform import nsxt_policy_uplink_host_switch_profile.uplink_host_switch_profile POLICY_PATH
 ```
 The above command imports the uplink host switch profile named `uplink_host_switch_profile` with policy path `POLICY_PATH`.

--- a/website/docs/r/transport_node.html.markdown
+++ b/website/docs/r/transport_node.html.markdown
@@ -26,7 +26,7 @@ resource "nsxt_transport_node" "test" {
       transport_zone         = data.nsxt_transport_zone.tz1.id
       transport_zone_profile = ["52035bb3-ab02-4a08-9884-18631312e50a"]
     }
-    host_switch_profile = [nsxt_uplink_host_switch_profile.hsw_profile1.id]
+    host_switch_profile = [nsxt_policy_uplink_host_switch_profile.hsw_profile1.id]
     is_migrate_pnics    = false
     pnic {
       device_name = "fp-eth0"


### PR DESCRIPTION
Previous PR renamed this resource to
nsxt_policy_uplink_host_switch_profile but left a few places which were unchanged.