### PR TITLE
Support tenant user creds in T0 and edge cluster

### DIFF
--- a/nsxt/data_source_nsxt_policy_edge_cluster.go
+++ b/nsxt/data_source_nsxt_policy_edge_cluster.go
@@ -4,12 +4,7 @@
 package nsxt
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/sites/enforcement_points"
-	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 )
 
 func dataSourceNsxtPolicyEdgeCluster() *schema.Resource {
@@ -35,9 +30,6 @@ func dataSourceNsxtPolicyEdgeClusterRead(d *schema.ResourceData, m interface{}) 
 	// Read an edge cluster by name or id
 	objSitePath := d.Get("site_path").(string)
 
-	objID := d.Get("id").(string)
-	objName := d.Get("display_name").(string)
-
 	if !isPolicyGlobalManager(m) && objSitePath != "" {
 		return globalManagerOnlyError()
 	}
@@ -58,53 +50,9 @@ func dataSourceNsxtPolicyEdgeClusterRead(d *schema.ResourceData, m interface{}) 
 
 	// Local manager
 	connector := getPolicyConnector(m)
-	client := enforcement_points.NewEdgeClustersClient(connector)
-	var obj model.PolicyEdgeCluster
-	if objID != "" {
-		// Get by id
-		objGet, err := client.Get(defaultSite, getPolicyEnforcementPoint(m), objID)
-
-		if err != nil {
-			return handleDataSourceReadError(d, "Edge Cluster", objID, err)
-		}
-		obj = objGet
-	} else if objName == "" {
-		return fmt.Errorf("Error obtaining edge cluster ID or name during read")
-	} else {
-		// Get by full name/prefix
-		includeMarkForDeleteObjectsParam := false
-		objList, err := client.List(defaultSite, getPolicyEnforcementPoint(m), nil, &includeMarkForDeleteObjectsParam, nil, nil, nil, nil)
-		if err != nil {
-			return handleListError("Edge Cluster", err)
-		}
-		// go over the list to find the correct one (prefer a perfect match. If not - prefix match)
-		var perfectMatch []model.PolicyEdgeCluster
-		var prefixMatch []model.PolicyEdgeCluster
-		for _, objInList := range objList.Results {
-			if strings.HasPrefix(*objInList.DisplayName, objName) {
-				prefixMatch = append(prefixMatch, objInList)
-			}
-			if *objInList.DisplayName == objName {
-				perfectMatch = append(perfectMatch, objInList)
-			}
-		}
-		if len(perfectMatch) > 0 {
-			if len(perfectMatch) > 1 {
-				return fmt.Errorf("Found multiple edge clusters with name '%s'", objName)
-			}
-			obj = perfectMatch[0]
-		} else if len(prefixMatch) > 0 {
-			if len(prefixMatch) > 1 {
-				return fmt.Errorf("Found multiple edge clusters with name starting with '%s'", objName)
-			}
-			obj = prefixMatch[0]
-		} else {
-			return fmt.Errorf("edge cluster '%s' was not found", objName)
-		}
+	_, err := policyDataSourceResourceRead(d, connector, getSessionContext(d, m), "PolicyEdgeCluster", nil)
+	if err != nil {
+		return err
 	}
-	d.SetId(*obj.Id)
-	d.Set("display_name", obj.DisplayName)
-	d.Set("description", obj.Description)
-	d.Set("path", obj.Path)
 	return nil
 }


### PR DESCRIPTION
Tenant user should be able to pull T0 gateway and edge cluster that are shared with the project, using corresponding data sources. Get API would not be available for tenant user, so this change switches data source implementation to search API.