### PR TITLE
Add Principle Identity resource

### DIFF
--- a/nsxt/provider.go
+++ b/nsxt/provider.go
@@ -425,6 +425,7 @@ func Provider() *schema.Provider {
 			"nsxt_manager_cluster":                         resourceNsxtManagerCluster(),
 			"nsxt_policy_uplink_host_switch_profile":       resourceNsxtUplinkHostSwitchProfile(),
 			"nsxt_node_user":                               resourceNsxtUsers(),
+			"nsxt_principle_identity":                      resourceNsxtPrincipleIdentity(),
 			"nsxt_transport_node":                          resourceNsxtTransportNode(),
 			"nsxt_failure_domain":                          resourceNsxtFailureDomain(),
 			"nsxt_cluster_virtual_ip":                      resourceNsxtClusterVirualIP(),

--- a/nsxt/resource_nsxt_policy_role_binding.go
+++ b/nsxt/resource_nsxt_policy_role_binding.go
@@ -14,12 +14,10 @@ import (
 	nsxModel "github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 )
 
-// Only support local user at the moment
 var roleBindingUserTypes = [](string){
 	nsxModel.RoleBinding_TYPE_LOCAL_USER,
 	nsxModel.RoleBinding_TYPE_REMOTE_USER,
 	nsxModel.RoleBinding_TYPE_REMOTE_GROUP,
-	nsxModel.RoleBinding_TYPE_PRINCIPAL_IDENTITY,
 }
 
 var roleBindingIdentitySourceTypes = [](string){

--- a/nsxt/resource_nsxt_policy_role_binding_test.go
+++ b/nsxt/resource_nsxt_policy_role_binding_test.go
@@ -50,13 +50,12 @@ func TestAccResourceNsxtPolicyRoleBinding_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(testResourceName, "identity_source_type", identType),
 					resource.TestCheckResourceAttr(testResourceName, "roles_for_path.#", "2"),
 					resource.TestCheckResourceAttr(testResourceName, "roles_for_path.0.path", "/"),
-					resource.TestCheckResourceAttr(testResourceName, "roles_for_path.0.role.#", "1"),
-					resource.TestCheckResourceAttr(testResourceName, "roles_for_path.0.role.0.role", "auditor"),
+					resource.TestCheckResourceAttr(testResourceName, "roles_for_path.0.roles.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "roles_for_path.0.roles.0", "auditor"),
 					resource.TestCheckResourceAttr(testResourceName, "roles_for_path.1.path", "/orgs/default"),
-					resource.TestCheckResourceAttr(testResourceName, "roles_for_path.1.role.#", "1"),
-					resource.TestCheckResourceAttr(testResourceName, "roles_for_path.1.role.0.role", "org_admin"),
+					resource.TestCheckResourceAttr(testResourceName, "roles_for_path.1.roles.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "roles_for_path.1.roles.0", "org_admin"),
 
-					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
 					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
 				),
 			},
@@ -71,10 +70,9 @@ func TestAccResourceNsxtPolicyRoleBinding_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(testResourceName, "identity_source_type", identType),
 					resource.TestCheckResourceAttr(testResourceName, "roles_for_path.#", "1"),
 					resource.TestCheckResourceAttr(testResourceName, "roles_for_path.0.path", "/"),
-					resource.TestCheckResourceAttr(testResourceName, "roles_for_path.0.role.#", "1"),
-					resource.TestCheckResourceAttr(testResourceName, "roles_for_path.0.role.0.role", "auditor"),
+					resource.TestCheckResourceAttr(testResourceName, "roles_for_path.0.roles.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "roles_for_path.0.roles.0", "auditor"),
 
-					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
 					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
 				),
 			},
@@ -172,19 +170,13 @@ resource "nsxt_policy_user_management_role_binding" "test" {
     identity_source_type = "%s"
 
     roles_for_path {
-        path = "/"
-
-        role {
-            role              = "auditor"
-        }
+        path  = "/"
+        roles = ["auditor"]
     }
 
     roles_for_path {
-        path = "/orgs/default"
-
-        role {
-            role = "org_admin"
-        }
+        path  = "/orgs/default"
+        roles = ["org_admin"]
     }
 }`, attrMap["display_name"], attrMap["description"], user, userType, identType)
 }
@@ -200,11 +192,8 @@ resource "nsxt_policy_user_management_role_binding" "test" {
     identity_source_type = "%s"
 
     roles_for_path {
-        path = "/"
-
-        role {
-            role              = "auditor"
-        }
+        path  = "/"
+        roles = ["auditor"]
     }
 }`, attrMap["display_name"], attrMap["description"], user, userType, identType)
 }

--- a/nsxt/resource_nsxt_principal_identity.go
+++ b/nsxt/resource_nsxt_principal_identity.go
@@ -25,6 +25,13 @@ func resourceNsxtPrincipleIdentity() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"tag": getTagsSchemaForceNew(),
+			"is_protected": {
+				Type:        schema.TypeBool,
+				Description: "Indicates whether the entities created by this principal should be protected",
+				Optional:    true,
+				Default:     true,
+				ForceNew:    true,
+			},
 			"name": {
 				Type:         schema.TypeString,
 				Description:  "Name of the principal",
@@ -111,6 +118,7 @@ func resourceNsxtPrincipleIdentityCreate(d *schema.ResourceData, m interface{}) 
 	client := principal_identities.NewWithCertificateClient(connector)
 
 	tags := getMPTagsFromSchema(d)
+	isProtected := d.Get("is_protected").(bool)
 	name := d.Get("name").(string)
 	nodeID := d.Get("node_id").(string)
 	certificatePem := d.Get("certificate_pem").(string)
@@ -118,6 +126,7 @@ func resourceNsxtPrincipleIdentityCreate(d *schema.ResourceData, m interface{}) 
 
 	piObj := mpModel.PrincipalIdentityWithCertificate{
 		Tags:           tags,
+		IsProtected:    &isProtected,
 		Name:           &name,
 		NodeId:         &nodeID,
 		CertificatePem: &certificatePem,
@@ -146,6 +155,7 @@ func resourceNsxtPrincipleIdentityRead(d *schema.ResourceData, m interface{}) er
 	}
 
 	setMPTagsInSchema(d, piObj.Tags)
+	d.Set("is_protected", piObj.IsProtected)
 	d.Set("name", piObj.Name)
 	d.Set("node_id", piObj.NodeId)
 	d.Set("certificate_id", piObj.CertificateId)

--- a/nsxt/resource_nsxt_principal_identity.go
+++ b/nsxt/resource_nsxt_principal_identity.go
@@ -1,0 +1,182 @@
+/* Copyright © 2023 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: MPL-2.0 */
+
+package nsxt
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	mpModel "github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp/nsx/model"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp/nsx/trust_management"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp/nsx/trust_management/principal_identities"
+	policyModel "github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+)
+
+func resourceNsxtPrincipleIdentity() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceNsxtPrincipleIdentityCreate,
+		Read:   resourceNsxtPrincipleIdentityRead,
+		Delete: resourceNsxtPrincipleIdentityDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"tag": getTagsSchemaForceNew(),
+			"name": {
+				Type:         schema.TypeString,
+				Description:  "Name of the principal",
+				ValidateFunc: validatePINameOrNodeID(),
+				Required:     true,
+				ForceNew:     true,
+			},
+			"node_id": {
+				Type:         schema.TypeString,
+				Description:  "Unique node-id of a principal",
+				ValidateFunc: validatePINameOrNodeID(),
+				Required:     true,
+				ForceNew:     true,
+			},
+			"certificate_id": {
+				Type:        schema.TypeString,
+				Description: "Id of the imported certificate pem",
+				Computed:    true,
+				ForceNew:    true,
+			},
+			"certificate_pem": {
+				Type:        schema.TypeString,
+				Description: "PEM encoding of the new certificate",
+				Required:    true,
+				ForceNew:    true,
+			},
+			"roles_for_path": getRolesForPathSchema(true),
+		},
+	}
+}
+
+func validatePINameOrNodeID() schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (s []string, es []error) {
+		v, ok := i.(string)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be string", k))
+			return
+		}
+
+		r := regexp.MustCompile(`^[a-zA-Z0-9]+([-._]?[a-zA-Z0-9]+)*$`)
+		if ok := r.MatchString(v); !ok {
+			es = append(es, fmt.Errorf("%s %s is invalid", k, v))
+			return
+		}
+
+		if len(v) < 1 || len(v) > 255 {
+			es = append(es, fmt.Errorf("expected length of %s to be in the range (%d - %d), got %d", k, 1, 255, len(v)))
+			return
+		}
+		return
+	}
+}
+
+func convertToMPRolesForPath(policyRolesForPath []policyModel.RolesForPath) []mpModel.RolesForPath {
+	mpRolesForPath := make([]mpModel.RolesForPath, len(policyRolesForPath))
+	for i, pRolesForPath := range policyRolesForPath {
+		mpRolesForPath[i].DeletePath = pRolesForPath.DeletePath
+		mpRolesForPath[i].Path = pRolesForPath.Path
+		mpRolesForPath[i].Roles = make([]mpModel.Role, len(pRolesForPath.Roles))
+		for j, pRole := range pRolesForPath.Roles {
+			mpRolesForPath[i].Roles[j].Role = pRole.Role
+			mpRolesForPath[i].Roles[j].RoleDisplayName = pRole.RoleDisplayName
+		}
+	}
+	return mpRolesForPath
+}
+
+func convertToPolicyRolesForPath(mpRolesForPath []mpModel.RolesForPath) []policyModel.RolesForPath {
+	pRolesForPath := make([]policyModel.RolesForPath, len(mpRolesForPath))
+	for i, mRolesForPath := range mpRolesForPath {
+		pRolesForPath[i].DeletePath = mRolesForPath.DeletePath
+		pRolesForPath[i].Path = mRolesForPath.Path
+		pRolesForPath[i].Roles = make([]policyModel.Role, len(mRolesForPath.Roles))
+		for j, mRole := range mRolesForPath.Roles {
+			pRolesForPath[i].Roles[j].Role = mRole.Role
+			pRolesForPath[i].Roles[j].RoleDisplayName = mRole.RoleDisplayName
+		}
+	}
+	return pRolesForPath
+}
+
+func resourceNsxtPrincipleIdentityCreate(d *schema.ResourceData, m interface{}) error {
+	connector := getPolicyConnector(m)
+	client := principal_identities.NewWithCertificateClient(connector)
+
+	tags := getMPTagsFromSchema(d)
+	name := d.Get("name").(string)
+	nodeID := d.Get("node_id").(string)
+	certificatePem := d.Get("certificate_pem").(string)
+	rolesForPaths := convertToMPRolesForPath(getRolesForPathList(d))
+
+	piObj := mpModel.PrincipalIdentityWithCertificate{
+		Tags:           tags,
+		Name:           &name,
+		NodeId:         &nodeID,
+		CertificatePem: &certificatePem,
+		RolesForPaths:  rolesForPaths,
+	}
+
+	pi, err := client.Create(piObj)
+	if err != nil {
+		return handleCreateError("PrincipalIdentity", name, err)
+	}
+	d.SetId(*pi.Id)
+
+	return resourceNsxtPrincipleIdentityRead(d, m)
+}
+
+func resourceNsxtPrincipleIdentityRead(d *schema.ResourceData, m interface{}) error {
+	connector := getPolicyConnector(m)
+	client := trust_management.NewPrincipalIdentitiesClient(connector)
+	id := d.Id()
+	if id == "" {
+		return fmt.Errorf("error obtaining logical object id")
+	}
+	piObj, err := client.Get(id)
+	if err != nil {
+		return handleReadError(d, "PrincipalIdentity", id, err)
+	}
+
+	setMPTagsInSchema(d, piObj.Tags)
+	d.Set("name", piObj.Name)
+	d.Set("node_id", piObj.NodeId)
+	d.Set("certificate_id", piObj.CertificateId)
+	setRolesForPathInSchema(d, convertToPolicyRolesForPath(piObj.RolesForPaths))
+	return nil
+}
+
+func resourceNsxtPrincipleIdentityDelete(d *schema.ResourceData, m interface{}) error {
+	connector := getPolicyConnector(m)
+	piClient := trust_management.NewPrincipalIdentitiesClient(connector)
+	id := d.Id()
+	if id == "" {
+		return fmt.Errorf("error obtaining logical object id")
+	}
+	certID := d.Get("certificate_id").(string)
+	err := piClient.Delete(id)
+	if err != nil {
+		// In case PI is already deleted, do not return here to attempt cert deletion.
+		if handledErr := handleDeleteError("PrincipalIdentity", id, err); handledErr != nil {
+			return handledErr
+		}
+	}
+
+	// Clean up underlying cert imported by NSX if exists
+	if len(certID) > 0 {
+		certClient := trust_management.NewCertificatesClient(connector)
+		err := certClient.Delete(certID)
+		if err != nil {
+			return handleDeleteError("Certificate", certID, err)
+		}
+	}
+
+	return err
+}

--- a/nsxt/resource_nsxt_principal_identity_test.go
+++ b/nsxt/resource_nsxt_principal_identity_test.go
@@ -1,0 +1,157 @@
+/* Copyright © 2023 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: MPL-2.0 */
+
+package nsxt
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp/nsx/trust_management"
+)
+
+var accTestPrincipleIdentityCreateAttributes = map[string]string{
+	"name":      getAccTestResourceName(),
+	"node_id":   "node-2",
+	"role_path": "/orgs/default",
+	"role":      "org_admin",
+}
+
+func TestAccResourceNsxtPrincipleIdentity_basic(t *testing.T) {
+	testResourceName := "nsxt_principle_identity.test"
+	certPem, _, err := testAccGenerateTLSKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccOnlyLocalManager(t)
+		},
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPrincipleIdentityCheckDestroy(state, accTestPrincipleIdentityCreateAttributes["name"])
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPrincipleIdentityCreate(certPem),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPrincipleIdentityExists(accTestPrincipleIdentityCreateAttributes["name"], testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "name", accTestPrincipleIdentityCreateAttributes["name"]),
+					resource.TestCheckResourceAttr(testResourceName, "node_id", accTestPrincipleIdentityCreateAttributes["node_id"]),
+					resource.TestCheckResourceAttr(testResourceName, "roles_for_path.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "roles_for_path.0.path", accTestPrincipleIdentityCreateAttributes["role_path"]),
+					resource.TestCheckResourceAttr(testResourceName, "roles_for_path.0.role.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "roles_for_path.0.role.0.role", accTestPrincipleIdentityCreateAttributes["role"]),
+
+					resource.TestCheckResourceAttrSet(testResourceName, "certificate_id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "certificate_pem"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceNsxtPrincipleIdentity_import_basic(t *testing.T) {
+	testResourceName := "nsxt_principle_identity.test"
+	certPem, _, err := testAccGenerateTLSKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccOnlyLocalManager(t)
+		},
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPrincipleIdentityCheckDestroy(state, accTestPrincipleIdentityCreateAttributes["name"])
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPrincipleIdentityCreate(certPem),
+			},
+			{
+				ResourceName:            testResourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"certificate_pem"},
+			},
+		},
+	})
+}
+
+func testAccNsxtPrincipleIdentityExists(name string, resourceName string) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+
+		connector := getPolicyConnector(testAccProvider.Meta().(nsxtClients))
+
+		rs, ok := state.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("PrincipleIdentity resource %s not found in resources", resourceName)
+		}
+
+		piID := rs.Primary.Attributes["id"]
+		if piID == "" {
+			return fmt.Errorf("PrincipleIdentity resource ID not set in resources")
+		}
+		tmClient := trust_management.NewPrincipalIdentitiesClient(connector)
+		_, err := tmClient.Get(piID)
+		if err != nil {
+			if isNotFoundError(err) {
+				return fmt.Errorf("PrincipleIdentity %s does not exist", name)
+			}
+		}
+
+		return err
+	}
+}
+
+func testAccNsxtPrincipleIdentityCheckDestroy(state *terraform.State, name string) error {
+	connector := getPolicyConnector(testAccProvider.Meta().(nsxtClients))
+	for _, rs := range state.RootModule().Resources {
+
+		if rs.Type != "nsxt_principle_identity" {
+			continue
+		}
+
+		piID := rs.Primary.Attributes["id"]
+		if piID == "" {
+			return fmt.Errorf("PrincipleIdentity resource ID not set in resources")
+		}
+		tmClient := trust_management.NewPrincipalIdentitiesClient(connector)
+		_, err := tmClient.Get(piID)
+		if err != nil {
+			if isNotFoundError(err) {
+				return nil
+			}
+			return err
+		}
+		return fmt.Errorf("PrincipleIdentity %s still exists", name)
+	}
+	return nil
+}
+
+func testAccNsxtPrincipleIdentityCreate(certPem string) string {
+	attrMap := accTestPrincipleIdentityCreateAttributes
+	return fmt.Sprintf(`
+resource "nsxt_principle_identity" "test" {
+    certificate_pem = <<-EOT
+%s
+    EOT
+    name            = "%s"
+    node_id         = "%s"
+
+    roles_for_path {
+        path = "%s"
+
+        role {
+            role = "%s"
+        }
+    }
+}`, certPem, attrMap["name"], attrMap["node_id"], attrMap["role_path"], attrMap["role"])
+}

--- a/nsxt/resource_nsxt_principal_identity_test.go
+++ b/nsxt/resource_nsxt_principal_identity_test.go
@@ -46,8 +46,8 @@ func TestAccResourceNsxtPrincipleIdentity_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(testResourceName, "node_id", accTestPrincipleIdentityCreateAttributes["node_id"]),
 					resource.TestCheckResourceAttr(testResourceName, "roles_for_path.#", "1"),
 					resource.TestCheckResourceAttr(testResourceName, "roles_for_path.0.path", accTestPrincipleIdentityCreateAttributes["role_path"]),
-					resource.TestCheckResourceAttr(testResourceName, "roles_for_path.0.role.#", "1"),
-					resource.TestCheckResourceAttr(testResourceName, "roles_for_path.0.role.0.role", accTestPrincipleIdentityCreateAttributes["role"]),
+					resource.TestCheckResourceAttr(testResourceName, "roles_for_path.0.roles.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "roles_for_path.0.roles.0", accTestPrincipleIdentityCreateAttributes["role"]),
 
 					resource.TestCheckResourceAttrSet(testResourceName, "certificate_id"),
 					resource.TestCheckResourceAttrSet(testResourceName, "certificate_pem"),
@@ -150,11 +150,8 @@ resource "nsxt_principle_identity" "test" {
     node_id         = "%s"
 
     roles_for_path {
-        path = "%s"
-
-        role {
-            role = "%s"
-        }
+        path  = "%s"
+        roles = ["%s"]
     }
 }`, certPem, attrMap["is_protected"], attrMap["name"], attrMap["node_id"], attrMap["role_path"], attrMap["role"])
 }

--- a/nsxt/resource_nsxt_principal_identity_test.go
+++ b/nsxt/resource_nsxt_principal_identity_test.go
@@ -13,10 +13,11 @@ import (
 )
 
 var accTestPrincipleIdentityCreateAttributes = map[string]string{
-	"name":      getAccTestResourceName(),
-	"node_id":   "node-2",
-	"role_path": "/orgs/default",
-	"role":      "org_admin",
+	"is_protected": "false",
+	"name":         getAccTestResourceName(),
+	"node_id":      "node-2",
+	"role_path":    "/orgs/default",
+	"role":         "org_admin",
 }
 
 func TestAccResourceNsxtPrincipleIdentity_basic(t *testing.T) {
@@ -40,6 +41,7 @@ func TestAccResourceNsxtPrincipleIdentity_basic(t *testing.T) {
 				Config: testAccNsxtPrincipleIdentityCreate(certPem),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNsxtPrincipleIdentityExists(accTestPrincipleIdentityCreateAttributes["name"], testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "is_protected", accTestPrincipleIdentityCreateAttributes["is_protected"]),
 					resource.TestCheckResourceAttr(testResourceName, "name", accTestPrincipleIdentityCreateAttributes["name"]),
 					resource.TestCheckResourceAttr(testResourceName, "node_id", accTestPrincipleIdentityCreateAttributes["node_id"]),
 					resource.TestCheckResourceAttr(testResourceName, "roles_for_path.#", "1"),
@@ -143,6 +145,7 @@ resource "nsxt_principle_identity" "test" {
     certificate_pem = <<-EOT
 %s
     EOT
+    is_protected    = %s
     name            = "%s"
     node_id         = "%s"
 
@@ -153,5 +156,5 @@ resource "nsxt_principle_identity" "test" {
             role = "%s"
         }
     }
-}`, certPem, attrMap["name"], attrMap["node_id"], attrMap["role_path"], attrMap["role"])
+}`, certPem, attrMap["is_protected"], attrMap["name"], attrMap["node_id"], attrMap["role_path"], attrMap["role"])
 }

--- a/nsxt/utils_test.go
+++ b/nsxt/utils_test.go
@@ -4,7 +4,15 @@
 package nsxt
 
 import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	cryptorand "crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
 	"fmt"
+	"math/big"
 	"math/rand"
 	"net/http"
 	"os"
@@ -670,4 +678,46 @@ func testAccResourceNsxtPolicyImportIDRetriever(resourceID string) func(*terrafo
 		}
 		return path, nil
 	}
+}
+
+func testAccGenerateTLSKeyPair() (string, string, error) {
+	// Ref: https://go.dev/src/crypto/tls/generate_cert.go
+	var publicPem, privatePem string
+	priv, err := ecdsa.GenerateKey(elliptic.P384(), cryptorand.Reader)
+	if err != nil {
+		return publicPem, privatePem, err
+	}
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			Organization: []string{"Acme Co"},
+		},
+		NotBefore: time.Now(),
+		NotAfter:  time.Now().Add(time.Hour * 24 * 180),
+
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+
+	derBytes, err := x509.CreateCertificate(cryptorand.Reader, &template, &template, &priv.PublicKey, priv)
+	if err != nil {
+		return publicPem, privatePem, err
+	}
+	buf := &bytes.Buffer{}
+
+	if err := pem.Encode(buf, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes}); err != nil {
+		return publicPem, privatePem, err
+	}
+	publicPem = buf.String()
+	buf.Reset()
+	privBytes, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		return publicPem, privatePem, err
+	}
+	if err := pem.Encode(buf, &pem.Block{Type: "PRIVATE KEY", Bytes: privBytes}); err != nil {
+		return publicPem, privatePem, err
+	}
+	privatePem = buf.String()
+	return publicPem, privatePem, nil
 }

--- a/website/docs/r/policy_user_management_role_binding.html.markdown
+++ b/website/docs/r/policy_user_management_role_binding.html.markdown
@@ -19,20 +19,13 @@ resource "nsxt_policy_user_management_role_binding" "test" {
   identity_source_type = "LDAP"
 
   roles_for_path {
-    path = "/"
-    role {
-      role = "auditor"
-    }
+    path  = "/"
+    roles = ["auditor"]
   }
 
   roles_for_path {
-    path = "/orgs/default"
-    role {
-      role = "org_admin"
-    }
-    role {
-      role = "vpc_admin"
-    }
+    path  = "/orgs/default"
+    roles = ["org_admin", "vpc_admin"]
   }
 }
 ```
@@ -53,7 +46,7 @@ The following arguments are supported:
 * `identity_source_id` - (Optional) The ID of the external identity source that holds the referenced external entity. Currently, only external `LDAP` and `OIDC` servers are allowed.
 * `roles_for_path` - (Required) A list of The roles that are associated with the user, limiting them to a path. In case the path is '/', the roles apply everywhere.
     * `path` - (Required) Path of the entity in parent hierarchy.
-    * `role` - (Required) A list of identifiers for the roles to associate with the given user limited to a path.
+    * `roles` - (Required) A list of identifiers for the roles to associate with the given user limited to a path.
 
 ## Attributes Reference
 

--- a/website/docs/r/policy_user_management_role_binding.html.markdown
+++ b/website/docs/r/policy_user_management_role_binding.html.markdown
@@ -49,7 +49,6 @@ The following arguments are supported:
     * `remote_user` - This is a user which is external to NSX. 
     * `remote_group` - This is a group of users which is external to NSX.
     * `local_user` - This is a user local to NSX. These are linux users. Note: Role bindings for local users are owned by NSX. Creation and deletion is not allowed for local users' binding. For updates, import existing bindings first.
-    * `principal_identity` - This is a principal identity user.
 * `identity_source_type` - (Optional) Identity source type. Applicable only to `remote_user` and `remote_group` user types. Valid options are: `VIDM`, `LDAP`, `OIDC`, `CSP`. Defaults to `VIDM` when applicable.
 * `identity_source_id` - (Optional) The ID of the external identity source that holds the referenced external entity. Currently, only external `LDAP` and `OIDC` servers are allowed.
 * `roles_for_path` - (Required) A list of The roles that are associated with the user, limiting them to a path. In case the path is '/', the roles apply everywhere.

--- a/website/docs/r/principle_identity.html.markdown
+++ b/website/docs/r/principle_identity.html.markdown
@@ -31,6 +31,7 @@ resource "nsxt_principle_identity" "test" {
 The following arguments are supported:
 
 * `tag` - (Optional) A list of scope + tag pairs to associate with this resource.
+* `is_protected` - (optional) Indicates whether the entities created by this principal should be protected.
 * `name` - (Required) Name of the principal.
 * `node_id` - (Required) Unique node-id of a principal. This is used primarily in the case where a cluster of nodes is used to make calls to the NSX Manager and the same `name` is used so that the nodes can access and modify the same data while still accessing NSX through their individual secret (certificate or JWT). In all other cases this can be any string.
 * `certificate_pem` - (Required) PEM encoding of the certificate to be associated with this principle identity.

--- a/website/docs/r/principle_identity.html.markdown
+++ b/website/docs/r/principle_identity.html.markdown
@@ -17,11 +17,8 @@ resource "nsxt_principle_identity" "test" {
   node_id         = "node-2"
   certificate_pem = trimspace(file("cert.pem"))
   roles_for_path {
-    path = "/orgs/default"
-
-    role {
-      role = "org_admin"
-    }
+    path  = "/orgs/default"
+    roles = ["org_admin"]
   }
 }
 ```
@@ -37,7 +34,7 @@ The following arguments are supported:
 * `certificate_pem` - (Required) PEM encoding of the certificate to be associated with this principle identity.
 * `roles_for_path` - (Required) A list of The roles that are associated with the user, limiting them to a path. In case the path is '/', the roles apply everywhere.
     * `path` - (Required) Path of the entity in parent hierarchy.
-    * `role` - (Required) A list of identifiers for the roles to associate with the given user limited to a path.
+    * `roles` - (Required) A list of identifiers for the roles to associate with the given user limited to a path.
 
 Once a Principle Identity is created, it can't be modified. Modification of above arguments will cause the current PI on NSX to be deleted and recreated. Certificate updates is also handled in the same way. 
 

--- a/website/docs/r/principle_identity.html.markdown
+++ b/website/docs/r/principle_identity.html.markdown
@@ -1,0 +1,59 @@
+---
+subcategory: "Beta"
+layout: "nsxt"
+page_title: "NSXT: nsxt_principle_identity"
+description: A resource to configure principle identities.
+---
+
+# nsxt_principle_identity
+
+This resource provides a method for the management of Principle Identities.
+
+## Example Usage
+
+```hcl
+resource "nsxt_principle_identity" "test" {
+  name            = "open-stack"
+  node_id         = "node-2"
+  certificate_pem = trimspace(file("cert.pem"))
+  roles_for_path {
+    path = "/orgs/default"
+
+    role {
+      role = "org_admin"
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `tag` - (Optional) A list of scope + tag pairs to associate with this resource.
+* `name` - (Required) Name of the principal.
+* `node_id` - (Required) Unique node-id of a principal. This is used primarily in the case where a cluster of nodes is used to make calls to the NSX Manager and the same `name` is used so that the nodes can access and modify the same data while still accessing NSX through their individual secret (certificate or JWT). In all other cases this can be any string.
+* `certificate_pem` - (Required) PEM encoding of the certificate to be associated with this principle identity.
+* `roles_for_path` - (Required) A list of The roles that are associated with the user, limiting them to a path. In case the path is '/', the roles apply everywhere.
+    * `path` - (Required) Path of the entity in parent hierarchy.
+    * `role` - (Required) A list of identifiers for the roles to associate with the given user limited to a path.
+
+Once a Principle Identity is created, it can't be modified. Modification of above arguments will cause the current PI on NSX to be deleted and recreated. Certificate updates is also handled in the same way. 
+
+## Attributes Reference
+
+In addition to arguments listed above, the following attributes are exported:
+
+* `certificate_id` - NSX certificate ID of the imported `certificate_pem`.
+
+
+## Importing
+
+An existing object can be [imported][docs-import] into this resource, via the following command:
+
+[docs-import]: https://www.terraform.io/cli/import
+
+```
+terraform import nsxt_principle_identity.test PRINCIPLE_IDENTITY_ID
+```
+The above command imports Principle Identity named `test` with the identifier `PRINCIPLE_IDENTITY_ID`.


### PR DESCRIPTION
This PR adds support of Principle Identity resource. A principle identity is identified as a pair of PI `name` and `cert`. If an API is called with SSL client cert matching with a registered PI, the caller is recognized as the PI, granted with its roles and associated privileges.

Currently, the only non-deprecated API on NSX are:
- `createWithPem`: PI's cert pem is in-lined as part of PI creation call. The inlined pem has to be unique / new to NSX. NSX then creates a certificate in the background, and populates the MP cert id in `certificate_id` in response. This cert, however, will not be removed by NSX upon PI deletion.
- `updateCert`: If a PI's cert has expired, it can be updated by using this API call to replace the current `certificate_id` with another cert that is already in the system. The issue is:
  - NSX UI no longer shows MP API for cert management. This means if user imports their own cert on UI they have no way to find the underlying ID. Even if figured out, the cert belongs to internal PI `nsx_policy` and will cause trouble to be used for PI
  - our tf provider currently only supports cert as a data source
  - Other metadatas (`tags`, `display_name`, `description`) can also be updated with this API if and only if the `certificate_id` is changed and valid
- `delete`

As a result, PI is in general immutable. This is also reflected on NSX UI. In this implementation, I decided to:
- Make all fields `ForceNew`
- Leave out `display_name`, `description` and `revision`. As they're either not used or won't be reflected even on UI.
- Use `createWithPem` for PI creation and leave out `updateCert` to avoid res ownership issues and confusion. Cert updates are handled as PI recreation
- Deletes the NSX-imported pem when the PI is deleted.

Also made some changes to role binding resource to reuse some common arguments. Added TLS cert generation for test.

Principle Identity is also removed from role binding resource, as bindings created for PI is immutable from that API as well.