### PR TITLE
Allow multiple switches per node

### DIFF
--- a/nsxt/resource_nsxt_transport_node.go
+++ b/nsxt/resource_nsxt_transport_node.go
@@ -558,7 +558,6 @@ func getPublicCloudGatewayNodeSchema() *schema.Schema {
 func getPreconfiguredHostSwitchSchema() *schema.Schema {
 	return &schema.Schema{
 		Type:        schema.TypeList,
-		MaxItems:    1,
 		Optional:    true,
 		Description: "Preconfigured host switch",
 		Elem: &schema.Resource{
@@ -582,7 +581,6 @@ func getPreconfiguredHostSwitchSchema() *schema.Schema {
 func getStandardHostSwitchSchema() *schema.Schema {
 	return &schema.Schema{
 		Type:        schema.TypeList,
-		MaxItems:    1,
 		Optional:    true,
 		Description: "Standard host switch specification",
 		ExactlyOneOf: []string{


### PR DESCRIPTION
This limitation doesn't exist in NSX and therefore we can remove MaxItems: 1

Fixes #1005 