### PR TITLE
Allow to configure nsx_id for locale service

### DIFF
--- a/nsxt/policy_common.go
+++ b/nsxt/policy_common.go
@@ -36,6 +36,15 @@ func getNsxIDSchema() *schema.Schema {
 	}
 }
 
+func getNestedNsxIDSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeString,
+		Description: "NSX ID for this resource",
+		Optional:    true,
+		ForceNew:    true,
+	}
+}
+
 func getFlexNsxIDSchema(readOnly bool) *schema.Schema {
 	return &schema.Schema{
 		Type:        schema.TypeString,

--- a/nsxt/utils.go
+++ b/nsxt/utils.go
@@ -70,6 +70,24 @@ func getStringListFromSchemaList(d *schema.ResourceData, schemaAttrName string) 
 	return interface2StringList(d.Get(schemaAttrName).([]interface{}))
 }
 
+// helper to construct a map based on curtain attribute in schema set
+// this helper is only relevant for Sets of nested objects (not scalars), and attrName
+// is the object attribute value of which would appear as key in the returned map object.
+// this is useful when Read function needs to make a decision based on intent provided
+// by user in a nested schema
+func getAttrKeyMapFromSchemaSet(schemaSet interface{}, attrName string) map[string]bool {
+
+	keyMap := make(map[string]bool)
+	for _, item := range schemaSet.(*schema.Set).List() {
+		mapItem := item.(map[string]interface{})
+		if value, ok := mapItem[attrName]; ok {
+			keyMap[value.(string)] = true
+		}
+	}
+
+	return keyMap
+}
+
 func intList2int64List(configured []interface{}) []int64 {
 	vs := make([]int64, 0, len(configured))
 	for _, v := range configured {

--- a/nsxt/utils_test.go
+++ b/nsxt/utils_test.go
@@ -191,6 +191,12 @@ func getTestAnotherSiteName() string {
 	return os.Getenv("NSXT_TEST_ANOTHER_SITE_NAME")
 }
 
+func getTestAdvancedTopology() string {
+	// Non-basic testing topology available
+	// For now this is used by tests that have minimum 2 edge nodes per cluster
+	return os.Getenv("NSXT_TEST_ADVANCED_TOPOLOGY")
+}
+
 func getTestCertificateName(isClient bool) string {
 	if isClient {
 		return os.Getenv("NSXT_TEST_CLIENT_CERTIFICATE_NAME")

--- a/website/docs/r/policy_tier0_gateway.html.markdown
+++ b/website/docs/r/policy_tier0_gateway.html.markdown
@@ -92,10 +92,12 @@ resource "nsxt_policy_tier0_gateway" "tier0_gw" {
   failover_mode = "PREEMPTIVE"
 
   locale_service {
+    nsx_id            = "paris"
     edge_cluster_path = data.nsxt_policy_edge_cluster.paris.path
   }
 
   locale_service {
+    nsx_id               = "london"
     edge_cluster_path    = data.nsxt_policy_edge_cluster.london.path
     preferred_edge_paths = [data.nsxt_policy_edge_node.edge1.path]
   }
@@ -122,6 +124,7 @@ The following arguments are supported:
 * `nsx_id` - (Optional) The NSX ID of this resource. If set, this ID will be used to create the policy resource.
 * `edge_cluster_path` - (Optional) The path of the edge cluster where the Tier-0 is placed.For advanced configuration and on Global Manager, use `locale_service` clause instead. Note that for some configurations (such as BGP) setting edge cluster is required.
 * `locale_service` - (Optional) This is required on NSX Global Manager. Multiple locale services can be specified for multiple locations.
+  * `nsx_id` - (Optional) NSX id for the locale service. It is recommended to specify this attribute in order to avoid unnecessary recreation of this object. Should be unique within the gateway.
   * `edge_cluster_path` - (Required) The path of the edge cluster where the Tier-0 is placed.
   * `preferred_edge_paths` - (Optional) Policy paths to edge nodes. Specified edge is used as preferred edge cluster member when failover mode is set to `PREEMPTIVE`.
   * `display_name` - (Optional) Display name for the locale service.

--- a/website/docs/r/policy_tier1_gateway.html.markdown
+++ b/website/docs/r/policy_tier1_gateway.html.markdown
@@ -58,10 +58,12 @@ resource "nsxt_policy_tier1_gateway" "tier1_gw" {
   display_name = "Tier1-gw1"
 
   locale_service {
+    nsx_id            = "paris"
     edge_cluster_path = data.nsxt_policy_edge_cluster.paris.path
   }
 
   locale_service {
+    nsx_id               = "london"
     edge_cluster_path    = data.nsxt_policy_edge_cluster.london.path
     preferred_edge_paths = [data.nsxt_policy_egde_node.edge1.path]
   }
@@ -119,6 +121,7 @@ The following arguments are supported:
   * `project_id` - (Required) The ID of the project which the object belongs to
 * `edge_cluster_path` - (Optional) The path of the edge cluster where the Tier-1 is placed.For advanced configuration, use `locale_service` clause instead. 
 * `locale_service` - (Optional) This argument is required on NSX Global Manager. Multiple locale services can be specified for multiple locations.
+  * `nsx_id` - (Optional) NSX id for the locale service. It is recommended to specify this attribute in order to avoid unnecessary recreation of this object. Should be unique within the gateway.
   * `edge_cluster_path` - (Required) The path of the edge cluster where the Tier-0 is placed.
   * `preferred_edge_paths` - (Optional) Policy paths to edge nodes. Specified edge is used as preferred edge cluster member when failover mode is set to `PREEMPTIVE`.
   * `display_name` - (Optional) Display name for the locale service.


### PR DESCRIPTION
Rather than recreating locale services with every update, allow to change existing locale service by specifying it nsx_id 
When nsx_id is specified for locale service, update will happen in place. When not specified, update on locale service will force new gateway object, thus recreating dependant objects such as service interfaces.