### PR TITLE
Change password for BGP neighbor only on demand

### DIFF
--- a/nsxt/resource_nsxt_policy_bgp_neighbor.go
+++ b/nsxt/resource_nsxt_policy_bgp_neighbor.go
@@ -290,11 +290,14 @@ func resourceNsxtPolicyBgpNeighborResourceDataToStruct(d *schema.ResourceData, i
 		KeepAliveTime:       &keepAliveTime,
 		MaximumHopLimit:     &maximumHopLimit,
 		NeighborAddress:     &neighborAddress,
-		Password:            &password,
 		RemoteAsNum:         &remoteAsNum,
 		RouteFiltering:      rFilters,
 		SourceAddresses:     sourceAddresses,
 		Id:                  &id,
+	}
+
+	if d.HasChange("password") {
+		neighborStruct.Password = &password
 	}
 
 	return neighborStruct, nil


### PR DESCRIPTION
Since password is not sent back from NSX for security reasons, it will not be present in state after import.
In this scenario, we need to avoid the password from being cleared next time an update is triggered on the imported resource. Hence we only update the password if a change in this field s detected. Note that user can leave the password blank in configuration of the imported resource.