### PR TITLE
Fix Tier0Gateway redistribution for NSX v4.1.1

### DIFF
--- a/nsxt/resource_nsxt_policy_tier0_gateway_test.go
+++ b/nsxt/resource_nsxt_policy_tier0_gateway_test.go
@@ -841,8 +841,13 @@ resource "nsxt_policy_tier0_gateway_interface" "parent-loopback" {
 
 func testAccNsxtPolicyTier0CreateWithRedistribution(name string) string {
 	return fmt.Sprintf(`
+data "nsxt_policy_edge_cluster" "EC" {
+  display_name = "%s"
+}
+
 resource "nsxt_policy_tier0_gateway" "test" {
   display_name = "%s"
+  edge_cluster_path = data.nsxt_policy_edge_cluster.EC.path
   redistribution_config {
     enabled  = false
     ospf_enabled = false
@@ -855,13 +860,18 @@ resource "nsxt_policy_tier0_gateway" "test" {
 
 data "nsxt_policy_realization_info" "realization_info" {
   path = nsxt_policy_tier0_gateway.test.path
-}`, name)
+}`, getEdgeClusterName(), name)
 }
 
 func testAccNsxtPolicyTier0UpdateWithRedistribution(name string) string {
 	return fmt.Sprintf(`
+data "nsxt_policy_edge_cluster" "EC" {
+  display_name = "%s"
+}
+
 resource "nsxt_policy_tier0_gateway" "test" {
   display_name = "%s"
+  edge_cluster_path = data.nsxt_policy_edge_cluster.EC.path
   redistribution_config {
     enabled  = false
     ospf_enabled = false
@@ -877,7 +887,7 @@ resource "nsxt_policy_tier0_gateway" "test" {
 
 data "nsxt_policy_realization_info" "realization_info" {
   path = nsxt_policy_tier0_gateway.test.path
-}`, name)
+}`, getEdgeClusterName(), name)
 }
 
 func testAccNsxtPolicyTier0Update2WithRedistribution(name string) string {


### PR DESCRIPTION
TestAccResourceNsxtPolicyTier0Gateway_redistribution test fails with the following error:

    resource_nsxt_policy_tier0_gateway_test.go:204: Step 2/3 error: Error running apply: exit status 1

        Error: A valid edge_cluster_path is required when BGP is enabled

          with nsxt_policy_tier0_gateway.test,
          on terraform_plugin_test.tf line 3, in resource "nsxt_policy_tier0_gateway" "test":
           3: resource "nsxt_policy_tier0_gateway" "test" {

To resolve, added the edge cluster configuration.