### PR TITLE
Replace panic(err) with t.Error(err)

### DIFF
--- a/nsxt/data_source_nsxt_firewall_section_test.go
+++ b/nsxt/data_source_nsxt_firewall_section_test.go
@@ -27,7 +27,7 @@ func TestAccDataSourceNsxtFirewallSection_basic(t *testing.T) {
 			{
 				PreConfig: func() {
 					if err := testAccDataSourceNsxtFirewallSectionCreate(name); err != nil {
-						panic(err)
+						t.Error(err)
 					}
 				},
 				Config: testAccNSXFirewallSectionReadTemplate(name),

--- a/nsxt/data_source_nsxt_logical_tier1_router_test.go
+++ b/nsxt/data_source_nsxt_logical_tier1_router_test.go
@@ -27,7 +27,7 @@ func TestAccDataSourceNsxtLogicalTier1Router_basic(t *testing.T) {
 			{
 				PreConfig: func() {
 					if err := testAccDataSourceNsxtTier1RouterCreate(routerName); err != nil {
-						panic(err)
+						t.Error(err)
 					}
 				},
 				Config: testAccNSXTier1RouterReadTemplate(routerName),

--- a/nsxt/data_source_nsxt_ns_group_test.go
+++ b/nsxt/data_source_nsxt_ns_group_test.go
@@ -27,7 +27,7 @@ func TestAccDataSourceNsxtNsGroup_basic(t *testing.T) {
 			{
 				PreConfig: func() {
 					if err := testAccDataSourceNsxtNsGroupCreate(groupName); err != nil {
-						panic(err)
+						t.Error(err)
 					}
 				},
 				Config: testAccNSXNsGroupReadTemplate(groupName),

--- a/nsxt/data_source_nsxt_ns_groups_test.go
+++ b/nsxt/data_source_nsxt_ns_groups_test.go
@@ -30,7 +30,7 @@ func TestAccDataSourceNsxtNsGroups_basic(t *testing.T) {
 			{
 				PreConfig: func() {
 					if err := testAccDataSourceNsxtNsGroupCreate(groupName); err != nil {
-						panic(err)
+						t.Error(err)
 					}
 				},
 				Config: testAccNSXNsGroupsReadTemplate(groupName),

--- a/nsxt/data_source_nsxt_ns_service_test.go
+++ b/nsxt/data_source_nsxt_ns_service_test.go
@@ -27,7 +27,7 @@ func TestAccDataSourceNsxtNsService_basic(t *testing.T) {
 			{
 				PreConfig: func() {
 					if err := testAccDataSourceNsxtNsServiceCreate(serviceName); err != nil {
-						panic(err)
+						t.Error(err)
 					}
 				},
 				Config: testAccNSXNsServiceReadTemplate(serviceName),

--- a/nsxt/data_source_nsxt_ns_services_test.go
+++ b/nsxt/data_source_nsxt_ns_services_test.go
@@ -30,7 +30,7 @@ func TestAccDataSourceNsxtNsServices_basic(t *testing.T) {
 			{
 				PreConfig: func() {
 					if err := testAccDataSourceNsxtNsServiceCreate(serviceName); err != nil {
-						panic(err)
+						t.Error(err)
 					}
 				},
 				Config: testAccNSXNsServicesReadTemplate(serviceName),

--- a/nsxt/data_source_nsxt_policy_bfd_profile_test.go
+++ b/nsxt/data_source_nsxt_policy_bfd_profile_test.go
@@ -30,7 +30,7 @@ func TestAccDataSourceNsxtPolicyBfdProfile_basic(t *testing.T) {
 			{
 				PreConfig: func() {
 					if err := testAccDataSourceNsxtPolicyBfdProfileCreate(name); err != nil {
-						panic(err)
+						t.Error(err)
 					}
 				},
 				Config: testAccNsxtPolicyBfdProfileReadTemplate(name),

--- a/nsxt/data_source_nsxt_policy_bridge_profile_test.go
+++ b/nsxt/data_source_nsxt_policy_bridge_profile_test.go
@@ -28,7 +28,7 @@ func TestAccDataSourceNsxtPolicyBridgeProfile_basic(t *testing.T) {
 			{
 				PreConfig: func() {
 					if err := testAccDataSourceNsxtPolicyBridgeProfileCreate(name); err != nil {
-						panic(err)
+						t.Error(err)
 					}
 				},
 				Config: testAccNsxtPolicyBridgeProfileReadTemplate(name),

--- a/nsxt/data_source_nsxt_policy_gateway_qos_profile_test.go
+++ b/nsxt/data_source_nsxt_policy_gateway_qos_profile_test.go
@@ -44,7 +44,7 @@ func testAccDataSourceNsxtPolicyGatewayQosProfileBasic(t *testing.T, withContext
 			{
 				PreConfig: func() {
 					if err := testAccDataSourceNsxtPolicyGatewayQosProfileCreate(name); err != nil {
-						panic(err)
+						t.Error(err)
 					}
 				},
 				Config: testAccNsxtPolicyGatewayQosProfileReadTemplate(name, withContext),

--- a/nsxt/data_source_nsxt_policy_group_test.go
+++ b/nsxt/data_source_nsxt_policy_group_test.go
@@ -42,7 +42,7 @@ func testAccDataSourceNsxtPolicyGroupBasic(t *testing.T, withContext bool, preCh
 			{
 				PreConfig: func() {
 					if err := testAccDataSourceNsxtPolicyGroupCreate(domain, name); err != nil {
-						panic(err)
+						t.Error(err)
 					}
 				},
 				Config: testAccNsxtPolicyGroupReadTemplate(domain, name, withContext),
@@ -76,7 +76,7 @@ func TestAccDataSourceNsxtPolicyGroup_withSite(t *testing.T) {
 			{
 				PreConfig: func() {
 					if err := testAccDataSourceNsxtPolicyGroupCreate(domain, name); err != nil {
-						panic(err)
+						t.Error(err)
 					}
 				},
 				Config: testAccNsxtPolicyGroupReadTemplate(domain, name, false),

--- a/nsxt/data_source_nsxt_policy_ip_block_test.go
+++ b/nsxt/data_source_nsxt_policy_ip_block_test.go
@@ -43,7 +43,7 @@ func testAccDataSourceNsxtPolicyIPBlockBasic(t *testing.T, withContext bool, pre
 			{
 				PreConfig: func() {
 					if err := testAccDataSourceNsxtPolicyIPBlockCreate(name); err != nil {
-						panic(err)
+						t.Error(err)
 					}
 				},
 				Config: testAccNsxtPolicyIPBlockReadTemplate(name, withContext),

--- a/nsxt/data_source_nsxt_policy_ip_pool_test.go
+++ b/nsxt/data_source_nsxt_policy_ip_pool_test.go
@@ -42,7 +42,7 @@ func testAccDataSourceNsxtPolicyIPPoolBasic(t *testing.T, withContext bool, preC
 			{
 				PreConfig: func() {
 					if err := testAccDataSourceNsxtPolicyIPPoolCreate(name); err != nil {
-						panic(err)
+						t.Error(err)
 					}
 				},
 				Config: testAccNsxtPolicyIPPoolReadTemplate(name, withContext),

--- a/nsxt/data_source_nsxt_policy_ipv6_dad_profile_test.go
+++ b/nsxt/data_source_nsxt_policy_ipv6_dad_profile_test.go
@@ -41,7 +41,7 @@ func testAccDataSourceNsxtPolicyIpv6DadProfileBasic(t *testing.T, withContext bo
 			{
 				PreConfig: func() {
 					if err := testAccDataSourceNsxtPolicyIpv6DadProfileCreate(name); err != nil {
-						panic(err)
+						t.Error(err)
 					}
 				},
 				Config: testAccNsxtPolicyIpv6DadProfileReadTemplate(name, withContext),

--- a/nsxt/data_source_nsxt_policy_ipv6_ndra_profile_test.go
+++ b/nsxt/data_source_nsxt_policy_ipv6_ndra_profile_test.go
@@ -41,7 +41,7 @@ func testAccDataSourceNsxtPolicyIpv6NdraProfileBasic(t *testing.T, withContext b
 			{
 				PreConfig: func() {
 					if err := testAccDataSourceNsxtPolicyIpv6NdraProfileCreate(name); err != nil {
-						panic(err)
+						t.Error(err)
 					}
 				},
 				Config: testAccNsxtPolicyIpv6NdraProfileReadTemplate(name, withContext),

--- a/nsxt/data_source_nsxt_policy_lb_app_profile_test.go
+++ b/nsxt/data_source_nsxt_policy_lb_app_profile_test.go
@@ -29,7 +29,7 @@ func TestAccDataSourceNsxtPolicyLBAppProfile_basic(t *testing.T) {
 			{
 				PreConfig: func() {
 					if err := testAccDataSourceNsxtPolicyLBAppProfileCreate(name); err != nil {
-						panic(err)
+						t.Error(err)
 					}
 				},
 				Config: testAccNsxtPolicyLBAppProfileReadTemplate(name),

--- a/nsxt/data_source_nsxt_policy_lb_client_ssl_profile_test.go
+++ b/nsxt/data_source_nsxt_policy_lb_client_ssl_profile_test.go
@@ -27,7 +27,7 @@ func TestAccDataSourceNsxtPolicyLBClientSslProfile_basic(t *testing.T) {
 			{
 				PreConfig: func() {
 					if err := testAccDataSourceNsxtPolicyLBClientSslProfileCreate(name); err != nil {
-						panic(err)
+						t.Error(err)
 					}
 				},
 				Config: testAccNsxtPolicyLBClientSslProfileReadTemplate(name),

--- a/nsxt/data_source_nsxt_policy_lb_monitor_test.go
+++ b/nsxt/data_source_nsxt_policy_lb_monitor_test.go
@@ -29,7 +29,7 @@ func TestAccDataSourceNsxtPolicyLBMonitor_basic(t *testing.T) {
 			{
 				PreConfig: func() {
 					if err := testAccDataSourceNsxtPolicyLBMonitorCreate(name); err != nil {
-						panic(err)
+						t.Error(err)
 					}
 				},
 				Config: testAccNsxtPolicyLBMonitorReadTemplate(name),

--- a/nsxt/data_source_nsxt_policy_lb_server_ssl_profile_test.go
+++ b/nsxt/data_source_nsxt_policy_lb_server_ssl_profile_test.go
@@ -27,7 +27,7 @@ func TestAccDataSourceNsxtPolicyLBServerSslProfile_basic(t *testing.T) {
 			{
 				PreConfig: func() {
 					if err := testAccDataSourceNsxtPolicyLBServerSslProfileCreate(name); err != nil {
-						panic(err)
+						t.Error(err)
 					}
 				},
 				Config: testAccNsxtPolicyLBServerSslProfileReadTemplate(name),

--- a/nsxt/data_source_nsxt_policy_project_test.go
+++ b/nsxt/data_source_nsxt_policy_project_test.go
@@ -31,7 +31,7 @@ func TestAccDataSourceNsxtPolicyProject_basic(t *testing.T) {
 			{
 				PreConfig: func() {
 					if err := testAccDataSourceNsxtPolicyProjectCreate(name); err != nil {
-						panic(err)
+						t.Error(err)
 					}
 				},
 				Config: testAccNsxtPolicyProjectReadTemplate(name),

--- a/nsxt/data_source_nsxt_policy_qos_profile_test.go
+++ b/nsxt/data_source_nsxt_policy_qos_profile_test.go
@@ -41,7 +41,7 @@ func testAccDataSourceNsxtPolicyQosProfileBasic(t *testing.T, withContext bool, 
 			{
 				PreConfig: func() {
 					if err := testAccDataSourceNsxtPolicyQosProfileCreate(name); err != nil {
-						panic(err)
+						t.Error(err)
 					}
 				},
 				Config: testAccNsxtPolicyQosProfileReadTemplate(name, withContext),

--- a/nsxt/data_source_nsxt_policy_realization_info_test.go
+++ b/nsxt/data_source_nsxt_policy_realization_info_test.go
@@ -41,7 +41,7 @@ func testAccDataSourceNsxtPolicyRealizationInfoTier1DataSource(t *testing.T, wit
 			{
 				PreConfig: func() {
 					if err := testAccDataSourceNsxtPolicyTier1GatewayCreate(resourceName); err != nil {
-						panic(err)
+						t.Error(err)
 					}
 				},
 				Config: testAccNsxtPolicyRealizationInfoReadDataSourceTemplate(resourceDataType, resourceName, entityType, withContext),
@@ -86,7 +86,7 @@ func testAccDataSourceNsxtPolicyRealizationInfoTier1DataSourceEntity(t *testing.
 			{
 				PreConfig: func() {
 					if err := testAccDataSourceNsxtPolicyTier1GatewayCreate(resourceName); err != nil {
-						panic(err)
+						t.Error(err)
 					}
 				},
 				Config: testAccNsxtPolicyRealizationInfoReadDataSourceTemplate(resourceDataType, resourceName, entityType, withContext),

--- a/nsxt/data_source_nsxt_policy_segment_test.go
+++ b/nsxt/data_source_nsxt_policy_segment_test.go
@@ -42,7 +42,7 @@ func testAccDataSourceNsxtPolicySegmentBasic(t *testing.T, withContext bool, pre
 			{
 				PreConfig: func() {
 					if err := testAccDataSourceNsxtPolicySegmentCreate(name); err != nil {
-						panic(err)
+						t.Error(err)
 					}
 				},
 				Config: testAccNsxtPolicySegmentReadTemplate(name, withContext),

--- a/nsxt/data_source_nsxt_policy_tier0_gateway_test.go
+++ b/nsxt/data_source_nsxt_policy_tier0_gateway_test.go
@@ -30,7 +30,7 @@ func TestAccDataSourceNsxtPolicyTier0Gateway_basic(t *testing.T) {
 			{
 				PreConfig: func() {
 					if err := testAccDataSourceNsxtPolicyTier0GatewayCreate(name); err != nil {
-						panic(err)
+						t.Error(err)
 					}
 				},
 				Config: testAccNsxtPolicyTier0GatewayReadTemplate(name),

--- a/nsxt/data_source_nsxt_policy_tier1_gateway_test.go
+++ b/nsxt/data_source_nsxt_policy_tier1_gateway_test.go
@@ -41,7 +41,7 @@ func testAccDataSourceNsxtPolicyTier1GatewayBasic(t *testing.T, withContext bool
 			{
 				PreConfig: func() {
 					if err := testAccDataSourceNsxtPolicyTier1GatewayCreate(routerName); err != nil {
-						panic(err)
+						t.Error(err)
 					}
 				},
 				Config: testAccNsxtPolicyTier1ReadTemplate(routerName, withContext),

--- a/nsxt/data_source_nsxt_policy_vni_pool_test.go
+++ b/nsxt/data_source_nsxt_policy_vni_pool_test.go
@@ -29,7 +29,7 @@ func TestAccDataSourceNsxtPolicyVniPoolConfig_basic(t *testing.T) {
 			{
 				PreConfig: func() {
 					if err := testAccDataSourceNsxtPolicyVniPoolConfigCreate(); err != nil {
-						panic(err)
+						t.Error(err)
 					}
 				},
 				Config: testAccNsxtPolicyVniPoolConfigReadTemplate(),

--- a/nsxt/data_source_nsxt_switching_profile_test.go
+++ b/nsxt/data_source_nsxt_switching_profile_test.go
@@ -28,7 +28,7 @@ func TestAccDataSourceNsxtSwitchingProfile_basic(t *testing.T) {
 			{
 				PreConfig: func() {
 					if err := testAccDataSourceNsxtSwitchingProfileCreate(profileName, profileType); err != nil {
-						panic(err)
+						t.Error(err)
 					}
 				},
 				Config: testAccNSXSwitchingProfileReadTemplate(profileName),

--- a/nsxt/resource_nsxt_logical_port_test.go
+++ b/nsxt/resource_nsxt_logical_port_test.go
@@ -74,7 +74,7 @@ func TestAccResourceNsxtLogicalPort_withProfiles(t *testing.T) {
 				PreConfig: func() {
 					// Create a custom switching profile
 					if err := testAccDataSourceNsxtSwitchingProfileCreate(customProfileName, profileType); err != nil {
-						panic(err)
+						t.Error(err)
 					}
 				},
 				// Create a logical port to use the custom switching profile

--- a/nsxt/resource_nsxt_logical_switch_test.go
+++ b/nsxt/resource_nsxt_logical_switch_test.go
@@ -131,7 +131,7 @@ func TestAccResourceNsxtLogicalSwitch_withProfiles(t *testing.T) {
 				PreConfig: func() {
 					// Create a custom switching profile
 					if err := testAccDataSourceNsxtSwitchingProfileCreate(customProfileName, profileType); err != nil {
-						panic(err)
+						t.Error(err)
 					}
 				},
 				// Create a logical switch to use the custom switching profile

--- a/nsxt/resource_nsxt_policy_evpn_config_test.go
+++ b/nsxt/resource_nsxt_policy_evpn_config_test.go
@@ -24,7 +24,7 @@ func TestAccResourceNsxtPolicyEvpnConfig_inline(t *testing.T) {
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			if err := testAccDataSourceNsxtPolicyVniPoolConfigDelete(); err != nil {
-				panic(err)
+				t.Error(err)
 			}
 			return testAccNsxtPolicyEvpnConfigCheckDestroy(state, displayName)
 		},
@@ -32,7 +32,7 @@ func TestAccResourceNsxtPolicyEvpnConfig_inline(t *testing.T) {
 			{
 				PreConfig: func() {
 					if err := testAccDataSourceNsxtPolicyVniPoolConfigCreate(); err != nil {
-						panic(err)
+						t.Error(err)
 					}
 				},
 				Config: testAccNsxtPolicyEvpnConfigInline(displayName, description, true),
@@ -80,7 +80,7 @@ func TestAccResourceNsxtPolicyEvpnConfig_routeServer(t *testing.T) {
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			if err := testAccDataSourceNsxtPolicyVniPoolConfigDelete(); err != nil {
-				panic(err)
+				t.Error(err)
 			}
 			return testAccNsxtPolicyEvpnConfigCheckDestroy(state, displayName)
 		},
@@ -88,7 +88,7 @@ func TestAccResourceNsxtPolicyEvpnConfig_routeServer(t *testing.T) {
 			{
 				PreConfig: func() {
 					if err := testAccDataSourceNsxtPolicyVniPoolConfigCreate(); err != nil {
-						panic(err)
+						t.Error(err)
 					}
 				},
 				Config: testAccNsxtPolicyEvpnConfigRouteServer(displayName, description),
@@ -134,7 +134,7 @@ func TestAccResourceNsxtPolicyEvpnConfig_importBasic(t *testing.T) {
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			if err := testAccDataSourceNsxtPolicyVniPoolConfigDelete(); err != nil {
-				panic(err)
+				t.Error(err)
 			}
 			return testAccNsxtPolicyEvpnConfigCheckDestroy(state, name)
 		},
@@ -142,7 +142,7 @@ func TestAccResourceNsxtPolicyEvpnConfig_importBasic(t *testing.T) {
 			{
 				PreConfig: func() {
 					if err := testAccDataSourceNsxtPolicyVniPoolConfigCreate(); err != nil {
-						panic(err)
+						t.Error(err)
 					}
 				},
 				Config: testAccNsxtPolicyEvpnConfigInline(name, "", false),

--- a/nsxt/resource_nsxt_policy_evpn_tenant_test.go
+++ b/nsxt/resource_nsxt_policy_evpn_tenant_test.go
@@ -29,7 +29,7 @@ func TestAccResourceNsxtPolicyEvpnTenant_basic(t *testing.T) {
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			if err := testAccDataSourceNsxtPolicyVniPoolConfigDelete(); err != nil {
-				panic(err)
+				t.Error(err)
 			}
 			return testAccNsxtPolicyEvpnTenantCheckDestroy(state, accTestPolicyEvpnTenantUpdateAttributes["display_name"])
 		},
@@ -37,7 +37,7 @@ func TestAccResourceNsxtPolicyEvpnTenant_basic(t *testing.T) {
 			{
 				PreConfig: func() {
 					if err := testAccDataSourceNsxtPolicyVniPoolConfigCreate(); err != nil {
-						panic(err)
+						t.Error(err)
 					}
 				},
 				Config: testAccNsxtPolicyEvpnTenantCreate(),
@@ -83,7 +83,7 @@ func TestAccResourceNsxtPolicyEvpnTenant_importBasic(t *testing.T) {
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			if err := testAccDataSourceNsxtPolicyVniPoolConfigDelete(); err != nil {
-				panic(err)
+				t.Error(err)
 			}
 			return testAccNsxtPolicyEvpnTenantCheckDestroy(state, accTestPolicyEvpnTenantUpdateAttributes["display_name"])
 		},
@@ -91,7 +91,7 @@ func TestAccResourceNsxtPolicyEvpnTenant_importBasic(t *testing.T) {
 			{
 				PreConfig: func() {
 					if err := testAccDataSourceNsxtPolicyVniPoolConfigCreate(); err != nil {
-						panic(err)
+						t.Error(err)
 					}
 				},
 				Config: testAccNsxtPolicyEvpnTenantUpdate(),

--- a/nsxt/resource_nsxt_policy_evpn_tunnel_endpoint_test.go
+++ b/nsxt/resource_nsxt_policy_evpn_tunnel_endpoint_test.go
@@ -35,7 +35,7 @@ func TestAccResourceNsxtPolicyEvpnTunnelEndpoint_basic(t *testing.T) {
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			if err := testAccDataSourceNsxtPolicyVniPoolConfigDelete(); err != nil {
-				panic(err)
+				t.Error(err)
 			}
 			return testAccNsxtPolicyEvpnTunnelEndpointCheckDestroy(state, accTestPolicyEvpnTunnelEndpointUpdateAttributes["display_name"])
 		},
@@ -43,7 +43,7 @@ func TestAccResourceNsxtPolicyEvpnTunnelEndpoint_basic(t *testing.T) {
 			{
 				PreConfig: func() {
 					if err := testAccDataSourceNsxtPolicyVniPoolConfigCreate(); err != nil {
-						panic(err)
+						t.Error(err)
 					}
 				},
 				Config: testAccNsxtPolicyEvpnTunnelEndpointBasic(true),
@@ -88,7 +88,7 @@ func TestAccResourceNsxtPolicyEvpnTunnelEndpoint_importBasic(t *testing.T) {
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			if err := testAccDataSourceNsxtPolicyVniPoolConfigDelete(); err != nil {
-				panic(err)
+				t.Error(err)
 			}
 			return testAccNsxtPolicyEvpnTunnelEndpointCheckDestroy(state, name)
 		},
@@ -96,7 +96,7 @@ func TestAccResourceNsxtPolicyEvpnTunnelEndpoint_importBasic(t *testing.T) {
 			{
 				PreConfig: func() {
 					if err := testAccDataSourceNsxtPolicyVniPoolConfigCreate(); err != nil {
-						panic(err)
+						t.Error(err)
 					}
 				},
 				Config: testAccNsxtPolicyEvpnTunnelEndpointBasic(false),

--- a/nsxt/resource_nsxt_policy_segment_test.go
+++ b/nsxt/resource_nsxt_policy_segment_test.go
@@ -283,7 +283,7 @@ func TestAccResourceNsxtPolicySegment_withProfiles(t *testing.T) {
 			{
 				PreConfig: func() {
 					if err := testAccDataSourceNsxtPolicyQosProfileCreate(testAccSegmentQosProfileName); err != nil {
-						panic(err)
+						t.Error(err)
 					}
 				},
 				Config: testAccNsxtPolicySegmentWithProfilesTemplate(tzName, name),
@@ -350,7 +350,7 @@ func TestAccResourceNsxtPolicySegment_withBridge(t *testing.T) {
 			{
 				PreConfig: func() {
 					if err := testAccDataSourceNsxtPolicyBridgeProfileCreate(testAccSegmentBridgeProfileName); err != nil {
-						panic(err)
+						t.Error(err)
 					}
 				},
 				Config: testAccNsxtPolicySegmentWithBridgeTemplate(tzName, vlanTzName, name, vlan),

--- a/nsxt/resource_nsxt_policy_tier1_gateway_gm_test.go
+++ b/nsxt/resource_nsxt_policy_tier1_gateway_gm_test.go
@@ -99,7 +99,7 @@ func TestAccResourceNsxtPolicyTier1Gateway_globalManagerWithQos(t *testing.T) {
 			{
 				PreConfig: func() {
 					if err := testAccDataSourceNsxtPolicyGatewayQosProfileCreate(profileName); err != nil {
-						panic(err)
+						t.Error(err)
 					}
 				},
 				Config: testAccNsxtPolicyTier1GMCreateWithQosTemplate(true, profileName),

--- a/nsxt/resource_nsxt_policy_tier1_gateway_test.go
+++ b/nsxt/resource_nsxt_policy_tier1_gateway_test.go
@@ -332,7 +332,7 @@ func TestAccResourceNsxtPolicyTier1Gateway_withQos(t *testing.T) {
 			{
 				PreConfig: func() {
 					if err := testAccDataSourceNsxtPolicyGatewayQosProfileCreate(profileName); err != nil {
-						panic(err)
+						t.Error(err)
 					}
 				},
 				Config: testAccNsxtPolicyTier1TemplateWithQos(name, profileName),
@@ -421,7 +421,7 @@ func TestAccResourceNsxtPolicyTier1Gateway_withTier0(t *testing.T) {
 			{
 				PreConfig: func() {
 					if err := testAccDataSourceNsxtPolicyTier0GatewayCreate(tier0Name); err != nil {
-						panic(err)
+						t.Error(err)
 					}
 				},
 				Config: testAccNsxtPolicyTier1CreateWithTier0Template(name, tier0Name, failoverMode),

--- a/nsxt/resource_nsxt_vlan_logical_switch_test.go
+++ b/nsxt/resource_nsxt_vlan_logical_switch_test.go
@@ -80,7 +80,7 @@ func TestAccResourceNsxtVlanLogicalSwitch_withProfiles(t *testing.T) {
 				PreConfig: func() {
 					// Create a custom switching profile
 					if err := testAccDataSourceNsxtSwitchingProfileCreate(customProfileName, profileType); err != nil {
-						panic(err)
+						t.Error(err)
 					}
 				},
 				// Create a logical switch to use the custom switching profile


### PR DESCRIPTION
Some tests have panic() calls in their PreConfig stage. That halts then entire test suite execution.
Using t.Error() will let test execution resume while marking the test as failed.