### PR TITLE
Remove context block from non-mutitenancy example

### DIFF
--- a/website/docs/r/policy_segment.html.markdown
+++ b/website/docs/r/policy_segment.html.markdown
@@ -17,9 +17,6 @@ This resource is applicable to NSX Global Manager, NSX Policy Manager and VMC.
 
 ```hcl
 resource "nsxt_policy_segment" "segment1" {
-  context {
-    project_id = data.nsxt_policy_project.demoproj.id
-  }
   display_name        = "segment1"
   description         = "Terraform provisioned Segment"
   transport_zone_path = data.nsxt_policy_transport_zone.tz1.path


### PR DESCRIPTION
On segment resource doc, multitenancy context has been mistakenly added to non-multitenancy example.