### PR TITLE
Add support of overwriting role binding of local user

### DIFF
--- a/nsxt/resource_nsxt_policy_role_binding.go
+++ b/nsxt/resource_nsxt_policy_role_binding.go
@@ -26,6 +26,9 @@ var roleBindingIdentitySourceTypes = [](string){
 	nsxModel.RoleBinding_IDENTITY_SOURCE_TYPE_CSP,
 }
 
+var defaultRolePath = "/"
+var defaultRoleName = "auditor"
+
 func resourceNsxtPolicyUserManagementRoleBinding() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceNsxtPolicyUserManagementRoleBindingCreate,
@@ -69,6 +72,12 @@ func resourceNsxtPolicyUserManagementRoleBinding() *schema.Resource {
 				ValidateFunc: validation.StringInSlice(roleBindingIdentitySourceTypes, false),
 			},
 			"roles_for_path": getRolesForPathSchema(false),
+			"overwrite_local_user": {
+				Type:        schema.TypeBool,
+				Description: "Allow overwriting auto-created role binding on NSX for local users",
+				Optional:    true,
+				Default:     false,
+			},
 		},
 	}
 }
@@ -102,6 +111,15 @@ func getRolesForPathSchema(forceNew bool) *schema.Schema {
 
 type rolesForPath map[string]rolesPerPath
 type rolesPerPath map[string]bool
+
+func (r rolesPerPath) getAnyRole() *string {
+	for k, v := range r {
+		if v {
+			return &k
+		}
+	}
+	return nil
+}
 
 func getRolesForPathFromSchema(d *schema.ResourceData) rolesForPath {
 	rolesForPathMap := make(rolesForPath)
@@ -138,7 +156,7 @@ func setRolesForPathInSchema(d *schema.ResourceData, nsxRolesForPathList []nsxMo
 	}
 }
 
-func getRolesForPathList(d *schema.ResourceData) []nsxModel.RolesForPath {
+func getRolesForPathList(d *schema.ResourceData, rolesToRemove rolesForPath) []nsxModel.RolesForPath {
 	boolTrue := true
 	rolesPerPathMap := getRolesForPathFromSchema(d)
 	nsxRolesForPaths := make([]nsxModel.RolesForPath, 0)
@@ -158,7 +176,24 @@ func getRolesForPathList(d *schema.ResourceData) []nsxModel.RolesForPath {
 		})
 	}
 
-	// Handle deletion of entire paths
+	// Remove roles explicitly marked for removal.
+	// This is only expected for overwriting local users' role bindings
+	pathRemoved := make(map[string]bool)
+	for path, rolesMap := range rolesToRemove {
+		if _, ok := rolesPerPathMap[path]; ok {
+			// This path is also in TF definition
+			// Roles in it will be overwritten
+			continue
+		}
+		nsxRolesForPaths = append(nsxRolesForPaths, nsxModel.RolesForPath{
+			Path:       &path,
+			DeletePath: &boolTrue,
+			Roles:      []nsxModel.Role{{Role: rolesMap.getAnyRole()}},
+		})
+		pathRemoved[path] = true
+	}
+
+	// Handle deletion of entire paths on change
 	if d.HasChange("roles_for_path") {
 		o, _ := d.GetChange("roles_for_path")
 		oldRoles := o.([]interface{})
@@ -166,6 +201,9 @@ func getRolesForPathList(d *schema.ResourceData) []nsxModel.RolesForPath {
 			data := oldRole.(map[string]interface{})
 			path := data["path"].(string)
 			if _, ok := rolesPerPathMap[path]; ok {
+				continue
+			}
+			if _, ok := pathRemoved[path]; ok {
 				continue
 			}
 			// Add one role in the list to make NSX happy
@@ -178,12 +216,13 @@ func getRolesForPathList(d *schema.ResourceData) []nsxModel.RolesForPath {
 				DeletePath: &boolTrue,
 				Roles:      []nsxModel.Role{{Role: &roles[0]}},
 			})
+			pathRemoved[path] = true
 		}
 	}
 	return nsxRolesForPaths
 }
 
-func getRoleBindingObject(d *schema.ResourceData) *nsxModel.RoleBinding {
+func getRoleBindingObject(d *schema.ResourceData, removeRoles rolesForPath) *nsxModel.RoleBinding {
 	boolTrue := true
 	displayName := d.Get("display_name").(string)
 	description := d.Get("description").(string)
@@ -192,36 +231,135 @@ func getRoleBindingObject(d *schema.ResourceData) *nsxModel.RoleBinding {
 	identitySrcID := d.Get("identity_source_id").(string)
 	identitySrcType := d.Get("identity_source_type").(string)
 	roleBindingType := d.Get("type").(string)
-	nsxRolesForPaths := getRolesForPathList(d)
+	nsxRolesForPaths := getRolesForPathList(d, removeRoles)
 
 	obj := nsxModel.RoleBinding{
-		DisplayName:        &displayName,
-		Description:        &description,
-		Tags:               tags,
-		Name:               &name,
-		IdentitySourceId:   &identitySrcID,
-		IdentitySourceType: &identitySrcType,
-		Type_:              &roleBindingType,
-		ReadRolesForPaths:  &boolTrue,
-		RolesForPaths:      nsxRolesForPaths,
+		DisplayName:       &displayName,
+		Description:       &description,
+		Tags:              tags,
+		Name:              &name,
+		Type_:             &roleBindingType,
+		ReadRolesForPaths: &boolTrue,
+		RolesForPaths:     nsxRolesForPaths,
+	}
+	if len(identitySrcID) > 0 {
+		obj.IdentitySourceId = &identitySrcID
+	}
+	if len(identitySrcType) > 0 {
+		obj.IdentitySourceType = &identitySrcType
 	}
 	return &obj
 }
 
+func getExistingRoleBinding(rbClient aaa.RoleBindingsClient, username, userType string) (*nsxModel.RoleBinding, error) {
+	// Pagination should be unnecessary since filtered with name
+	rbList, err := rbClient.List(nil, nil, nil, nil, &username, nil, nil, nil, nil, nil, nil, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list RoleBinding for %s", username)
+	}
+
+	var rbObj *nsxModel.RoleBinding
+	for i, roleBinding := range rbList.Results {
+		if *roleBinding.Name == username && *roleBinding.Type_ == userType {
+			rbObj = &rbList.Results[i]
+			break
+		}
+	}
+	if rbObj == nil {
+		return nil, fmt.Errorf("failed to match RoleBinding id for %s", username)
+	}
+	return rbObj, nil
+}
+
+func overwriteRoleBinding(d *schema.ResourceData, m interface{}, existingRoleBinding *nsxModel.RoleBinding) error {
+	connector := getPolicyConnector(m)
+	rbClient := aaa.NewRoleBindingsClient(connector)
+	id := d.Id()
+
+	existingRoles := make(rolesForPath)
+	for _, roles := range existingRoleBinding.RolesForPaths {
+		if len(roles.Roles) == 0 {
+			continue
+		}
+		existingRoles[*roles.Path] = make(rolesPerPath)
+		existingRoles[*roles.Path][*roles.Roles[0].Role] = true
+	}
+
+	log.Printf("[INFO] Overwriting RoleBinding with ID %s", id)
+	obj := getRoleBindingObject(d, existingRoles)
+	_, err := rbClient.Update(id, *obj)
+	if err != nil {
+		return handleUpdateError("RoleBinding", id, err)
+	}
+
+	return resourceNsxtPolicyUserManagementRoleBindingRead(d, m)
+}
+
+func revertRoleBinding(d *schema.ResourceData, m interface{}) error {
+	connector := getPolicyConnector(m)
+	rbClient := aaa.NewRoleBindingsClient(connector)
+
+	id := d.Id()
+	boolTrue := true
+	currRoles := getRolesForPathFromSchema(d)
+	nsxRolesForPaths := make([]nsxModel.RolesForPath, 0)
+	for path, roleMap := range currRoles {
+		if path == defaultRolePath {
+			continue
+		}
+		nsxRolesForPaths = append(nsxRolesForPaths, nsxModel.RolesForPath{
+			Path:       &path,
+			DeletePath: &boolTrue,
+			Roles:      []nsxModel.Role{{Role: roleMap.getAnyRole()}},
+		})
+	}
+
+	// Add the auditor role
+	nsxRolesForPaths = append(nsxRolesForPaths, nsxModel.RolesForPath{
+		Path:  &defaultRolePath,
+		Roles: []nsxModel.Role{{Role: &defaultRoleName}},
+	})
+	name := d.Get("name").(string)
+	roleBindingType := d.Get("type").(string)
+	obj := nsxModel.RoleBinding{
+		Name:              &name,
+		Type_:             &roleBindingType,
+		RolesForPaths:     nsxRolesForPaths,
+		ReadRolesForPaths: &boolTrue,
+	}
+
+	log.Printf("[INFO] Reverting RoleBinding ID %s to %s", id, defaultRoleName)
+	if _, err := rbClient.Update(id, obj); err != nil {
+		return handleUpdateError("RoleBinding", id, err)
+	}
+	return nil
+}
+
 func resourceNsxtPolicyUserManagementRoleBindingCreate(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
+	rbClient := aaa.NewRoleBindingsClient(connector)
 
 	roleBindingType := d.Get("type").(string)
+	overwriteLocaluser := d.Get("overwrite_local_user").(bool)
 	username := d.Get("name").(string)
 	if roleBindingType == nsxModel.RoleBinding_TYPE_LOCAL_USER {
-		return fmt.Errorf("creation of RoleBinding for %s is not allowed as it's created by NSX. "+
-			"import the binding first", roleBindingType)
+		if !overwriteLocaluser {
+			return fmt.Errorf(
+				"RoleBinding for %s owned by NSX. Import the binding, or set overwrite_local_user",
+				roleBindingType)
+		}
+		rbObj, err := getExistingRoleBinding(rbClient, username, nsxModel.RoleBinding_TYPE_LOCAL_USER)
+		if err != nil {
+			return err
+		}
+		d.SetId(*rbObj.Id)
+		return overwriteRoleBinding(d, m, rbObj)
 	}
 
 	// Create the resource using POST
 	log.Printf("[INFO] Creating RoleBinding for %s %s", roleBindingType, username)
-	obj := getRoleBindingObject(d)
-	rbClient := aaa.NewRoleBindingsClient(connector)
+	obj := getRoleBindingObject(d, rolesForPath{})
+
 	rbObj, err := rbClient.Create(*obj)
 	if err != nil {
 		return handleCreateError("RoleBinding", username, err)
@@ -253,9 +391,13 @@ func resourceNsxtPolicyUserManagementRoleBindingRead(d *schema.ResourceData, m i
 	setPolicyTagsInSchema(d, obj.Tags)
 	d.Set("revision", obj.Revision)
 	d.Set("name", obj.Name)
-	d.Set("identity_source_id", obj.IdentitySourceId)
-	d.Set("identity_source_type", obj.IdentitySourceType)
 	d.Set("type", obj.Type_)
+	if obj.IdentitySourceId != nil {
+		d.Set("identity_source_id", obj.IdentitySourceId)
+	}
+	if obj.IdentitySourceType != nil {
+		d.Set("identity_source_type", obj.IdentitySourceType)
+	}
 	if obj.UserId != nil {
 		d.Set("user_id", obj.UserId)
 	}
@@ -274,7 +416,7 @@ func resourceNsxtPolicyUserManagementRoleBindingUpdate(d *schema.ResourceData, m
 	log.Printf("[INFO] Updateing RoleBinding with ID %s", id)
 	connector := getPolicyConnector(m)
 	rbClient := aaa.NewRoleBindingsClient(connector)
-	obj := getRoleBindingObject(d)
+	obj := getRoleBindingObject(d, rolesForPath{})
 	_, err := rbClient.Update(id, *obj)
 	if err != nil {
 		return handleCreateError("RoleBinding", id, err)
@@ -294,6 +436,9 @@ func resourceNsxtPolicyUserManagementRoleBindingDelete(d *schema.ResourceData, m
 	}
 	roleBindingType := d.Get("type").(string)
 	if roleBindingType == nsxModel.RoleBinding_TYPE_LOCAL_USER {
+		if d.Get("overwrite_local_user").(bool) {
+			return revertRoleBinding(d, m)
+		}
 		return fmt.Errorf("role binding for %s %s can not be deleted", roleBindingType, id)
 	}
 

--- a/nsxt/resource_nsxt_policy_role_binding_test.go
+++ b/nsxt/resource_nsxt_policy_role_binding_test.go
@@ -171,12 +171,12 @@ resource "nsxt_policy_user_management_role_binding" "test" {
 
     roles_for_path {
         path  = "/"
-        roles = ["auditor"]
+        roles = ["auditor", "security_engineer"]
     }
 
     roles_for_path {
         path  = "/orgs/default"
-        roles = ["org_admin"]
+        roles = ["org_admin", "network_engineer"]
     }
 }`, attrMap["display_name"], attrMap["description"], user, userType, identType)
 }

--- a/nsxt/resource_nsxt_principal_identity.go
+++ b/nsxt/resource_nsxt_principal_identity.go
@@ -122,7 +122,7 @@ func resourceNsxtPrincipleIdentityCreate(d *schema.ResourceData, m interface{}) 
 	name := d.Get("name").(string)
 	nodeID := d.Get("node_id").(string)
 	certificatePem := d.Get("certificate_pem").(string)
-	rolesForPaths := convertToMPRolesForPath(getRolesForPathList(d))
+	rolesForPaths := convertToMPRolesForPath(getRolesForPathList(d, rolesForPath{}))
 
 	piObj := mpModel.PrincipalIdentityWithCertificate{
 		Tags:           tags,

--- a/website/docs/r/policy_user_management_role_binding.html.markdown
+++ b/website/docs/r/policy_user_management_role_binding.html.markdown
@@ -47,7 +47,7 @@ The following arguments are supported:
 * `roles_for_path` - (Required) A list of The roles that are associated with the user, limiting them to a path. In case the path is '/', the roles apply everywhere.
     * `path` - (Required) Path of the entity in parent hierarchy.
     * `roles` - (Required) A list of identifiers for the roles to associate with the given user limited to a path.
-* `overwrite_local_user` - (Optional) Flag to allow overwriting existing role bindings for local user with terraform definition. On deletion, the user's role will be reverted to auditor only. Any exising configuration will be lost.
+* `overwrite_local_user` - (Optional) Flag to allow overwriting existing role bindings for local user with terraform definition. On deletion, the user's role will be reverted to auditor only. Any existing configuration will be lost.
 
 ## Attributes Reference
 

--- a/website/docs/r/policy_user_management_role_binding.html.markdown
+++ b/website/docs/r/policy_user_management_role_binding.html.markdown
@@ -41,12 +41,13 @@ The following arguments are supported:
 * `type` - (Required) Indicates the type of the user. Valid options:
     * `remote_user` - This is a user which is external to NSX. 
     * `remote_group` - This is a group of users which is external to NSX.
-    * `local_user` - This is a user local to NSX. These are linux users. Note: Role bindings for local users are owned by NSX. Creation and deletion is not allowed for local users' binding. For updates, import existing bindings first.
+    * `local_user` - This is a user local to NSX. These are linux users. Note: Role bindings for local users are owned by NSX. Creation and deletion is not allowed for local users' binding. For updates, import existing bindings first. Alternatively, set `overwrite_local_user` to overwrite current role bindings with the one defined in terraform.
 * `identity_source_type` - (Optional) Identity source type. Applicable only to `remote_user` and `remote_group` user types. Valid options are: `VIDM`, `LDAP`, `OIDC`, `CSP`. Defaults to `VIDM` when applicable.
 * `identity_source_id` - (Optional) The ID of the external identity source that holds the referenced external entity. Currently, only external `LDAP` and `OIDC` servers are allowed.
 * `roles_for_path` - (Required) A list of The roles that are associated with the user, limiting them to a path. In case the path is '/', the roles apply everywhere.
     * `path` - (Required) Path of the entity in parent hierarchy.
     * `roles` - (Required) A list of identifiers for the roles to associate with the given user limited to a path.
+* `overwrite_local_user` - (Optional) Flag to allow overwriting existing role bindings for local user with terraform definition. On deletion, the user's role will be reverted to auditor only. Any exising configuration will be lost.
 
 ## Attributes Reference
 
@@ -56,6 +57,25 @@ In addition to arguments listed above, the following attributes are exported:
 * `revision` - Indicates current revision number of the object as seen by NSX-T API server. This attribute can be useful for debugging.
 * `user_id` - Local user's numeric id. Only applicable to `local_user`.
 
+# Build-in NSX roles
+
+`roles_for_path.roles` accepts user created roles as well as roles native to NSX. For reference, the following is a list of native roles as of NSX 4.1.2
+- `network_engineer`: Network Admin
+- `support_bundle_collector`: Support Bundle Collector
+- `security_op`: Security Operator
+- `lb_auditor`: LB Operator
+- `netx_partner_admin`: NETX Partner Admin
+- `project_admin`: Project Admin
+- `auditor`: Auditor
+- `network_op`: Network Operator
+- `enterprise_admin`: Enterprise Admin
+- `lb_admin`: LB Admin
+- `gi_partner_admin`: GI Partner Admin
+- `vpn_admin`: VPN Admin
+- `vpc_admin`: VPC Admin
+- `security_engineer`: Security Admin
+
+The permission matrix for above roles is available on [NSX documentation](https://docs.vmware.com/en/VMware-NSX/4.1/administration/GUID-26C44DE8-1854-4B06-B6DA-A2FD426CDF44.html)
 
 ## Importing
 

--- a/website/docs/r/principle_identity.html.markdown
+++ b/website/docs/r/principle_identity.html.markdown
@@ -44,6 +44,25 @@ In addition to arguments listed above, the following attributes are exported:
 
 * `certificate_id` - NSX certificate ID of the imported `certificate_pem`.
 
+# Build-in NSX roles
+
+`roles_for_path.roles` accepts user created roles as well as roles native to NSX. For reference, the following is a list of native roles as of NSX 4.1.2
+- `network_engineer`: Network Admin
+- `support_bundle_collector`: Support Bundle Collector
+- `security_op`: Security Operator
+- `lb_auditor`: LB Operator
+- `netx_partner_admin`: NETX Partner Admin
+- `project_admin`: Project Admin
+- `auditor`: Auditor
+- `network_op`: Network Operator
+- `enterprise_admin`: Enterprise Admin
+- `lb_admin`: LB Admin
+- `gi_partner_admin`: GI Partner Admin
+- `vpn_admin`: VPN Admin
+- `vpc_admin`: VPC Admin
+- `security_engineer`: Security Admin
+
+The permission matrix for above roles is available on [NSX documentation](https://docs.vmware.com/en/VMware-NSX/4.1/administration/GUID-26C44DE8-1854-4B06-B6DA-A2FD426CDF44.html)
 
 ## Importing
 


### PR DESCRIPTION
This PR adds`overwrite_local_user` to role binding resource. When set to true, allows `Create` and `Delete` of role bindings of local users. On create, existing role bindings which comes with local user creation will be overwritten per terraform definition. On delete, the role binding will be reverted back to auditor only.

Also refactors `roles_for_path` as a set instead of list. This affects both principle identity and role binding resource, but no further doc change is needed.

Added build-in roles on NSX to doc for easier referenced. Linked NSX doc for actual permission matrix.