### PR TITLE
Verify that project_id contains a value

### DIFF
--- a/nsxt/utils.go
+++ b/nsxt/utils.go
@@ -692,10 +692,11 @@ func getContextSchema() *schema.Schema {
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"project_id": {
-					Type:        schema.TypeString,
-					Description: "Id of the project which the resource belongs to.",
-					Required:    true,
-					ForceNew:    true,
+					Type:         schema.TypeString,
+					Description:  "Id of the project which the resource belongs to.",
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
 				},
 			},
 		},


### PR DESCRIPTION
Empty project id is meaningless and also crashes the provider.