### PR TITLE
Allow to configure timeout for ip allocation

### DIFF
--- a/nsxt/policy_utils.go
+++ b/nsxt/policy_utils.go
@@ -305,7 +305,7 @@ func commaSeparatedStringToStringList(commaString string) []string {
 	return strList
 }
 
-func nsxtPolicyWaitForRealizationStateConf(connector client.Connector, d *schema.ResourceData, realizedEntityPath string) *resource.StateChangeConf {
+func nsxtPolicyWaitForRealizationStateConf(connector client.Connector, d *schema.ResourceData, realizedEntityPath string, timeout int) *resource.StateChangeConf {
 	client := realized_state.NewRealizedEntitiesClient(connector)
 	pendingStates := []string{"UNKNOWN", "UNREALIZED"}
 	targetStates := []string{"REALIZED", "ERROR"}
@@ -327,7 +327,7 @@ func nsxtPolicyWaitForRealizationStateConf(connector client.Connector, d *schema
 			}
 			return nil, "", realizationError
 		},
-		Timeout:    d.Timeout(schema.TimeoutCreate),
+		Timeout:    time.Duration(timeout) * time.Second,
 		MinTimeout: 1 * time.Second,
 		Delay:      1 * time.Second,
 	}


### PR DESCRIPTION
In IP address allocation resource, allow to configure timeout for IP realization.