### PR TITLE
BGP config: support local_as_num and tags for VRFs.

### DIFF
--- a/nsxt/resource_nsxt_policy_bgp_config.go
+++ b/nsxt/resource_nsxt_policy_bgp_config.go
@@ -101,6 +101,11 @@ func resourceNsxtPolicyBgpConfigToStruct(d *schema.ResourceData, isVRF bool) (*m
 		Ecmp:              &ecmp,
 		Enabled:           &enabled,
 		RouteAggregations: aggregationStructs,
+		Tags:              tags,
+	}
+
+	if len(localAsNum) > 0 {
+		routeStruct.LocalAsNum = &localAsNum
 	}
 
 	// For BGP on VRF, only limited attributes can be set
@@ -126,11 +131,7 @@ func resourceNsxtPolicyBgpConfigToStruct(d *schema.ResourceData, isVRF bool) (*m
 			Timer: &restartTimerStruct,
 		}
 
-		routeStruct.Tags = tags
 		routeStruct.InterSrIbgp = &interSrIbgp
-		if len(localAsNum) > 0 {
-			routeStruct.LocalAsNum = &localAsNum
-		}
 		routeStruct.MultipathRelax = &multipathRelax
 		routeStruct.GracefulRestartConfig = &restartConfigStruct
 	}

--- a/nsxt/resource_nsxt_policy_tier0_gateway.go
+++ b/nsxt/resource_nsxt_policy_tier0_gateway.go
@@ -629,12 +629,11 @@ func resourceNsxtPolicyTier0GatewayBGPConfigSchemaToStruct(cfg interface{}, isVr
 		Revision:          &revision,
 	}
 
+	if len(localAsNum) > 0 {
+		routeStruct.LocalAsNum = &localAsNum
+	}
+
 	if isVrf {
-		// backend complains if the below config appears on VRF gateway.
-		// We print a warning if property differs from default
-		if localAsNum != "" {
-			log.Printf("[WARNING] BGP setting local_as_num is not applicable for VRF gateway %s, and will be ignored", gwID)
-		}
 		if (restartMode != model.BgpGracefulRestartConfig_MODE_HELPER_ONLY) || (restartTimer != int64(policyBGPGracefulRestartStaleRouteTimerDefault)) || (staleTimer != int64(policyBGPGracefulRestartStaleRouteTimerDefault)) {
 			log.Printf("[WARNING] BGP graceful restart settings are not applicable for VRF gateway %s, and will be ignored", gwID)
 		}

--- a/website/docs/r/policy_bgp_config.html.markdown
+++ b/website/docs/r/policy_bgp_config.html.markdown
@@ -59,7 +59,7 @@ The following arguments are supported:
 * `ecmp` - (Optional) A boolean flag to enable/disable ECMP. Default is `true`.
 * `enabled` - (Optional) A boolean flag to enable/disable BGP. Default is `true`.
 * `inter_sr_ibgp` - (Optional) A boolean flag to enable/disable inter SR IBGP configuration. Default is `true`.
-* `local_as_num` - (Optional) BGP AS number in ASPLAIN/ASDOT Format. This attribute is required for non-VRF configurations.
+* `local_as_num` - (Optional) BGP AS number in ASPLAIN/ASDOT Format. This attribute is optional for VRF-Lite gateways, and is required otherwise.
 * `multipath_relax` - (Optional) A boolean flag to enable/disable multipath relax for BGP. Default is `true`.
 * `graceful_restart_mode` - (Optional) Setting to control BGP graceful restart mode, one of `DISABLE`, `GR_AND_HELPER`, `HELPER_ONLY`.
 * `graceful_restart_timer` - (Optional) BGP graceful restart timer. Default is `180`.

--- a/website/docs/r/policy_tier0_gateway.html.markdown
+++ b/website/docs/r/policy_tier0_gateway.html.markdown
@@ -145,7 +145,7 @@ The following arguments are supported:
   * `ecmp` - (Optional) A boolean flag to enable/disable ECMP. Default is `true`.
   * `enabled` - (Optional) A boolean flag to enable/disable BGP. Default is `true`.
   * `inter_sr_ibgp` - (Optional) A boolean flag to enable/disable inter SR IBGP configuration. Default is `true`. This setting is not applicable to VRF-Lite Gateway.
-  * `local_as_num` - (Optional) BGP AS number in ASPLAIN/ASDOT Format. This setting is not applicable to VRF-Lite Gateway, and is required otherwise.
+  * `local_as_num` - (Optional) BGP AS number in ASPLAIN/ASDOT Format. This setting is optional for VRF-Lite Gateways, and is required otherwise.
   * `multipath_relax` - (Optional) A boolean flag to enable/disable multipath relax for BGP. Default is `true`. This setting is not applicable to VRF-Lite Gateway.
   * `graceful_restart_mode` - (Optional) Setting to control BGP graceful restart mode, one of `DISABLE`, `GR_AND_HELPER`, `HELPER_ONLY`. This setting is not applicable to VRF-Lite Gateway.
   * `graceful_restart_timer` - (Optional) BGP graceful restart timer. Default is `180`. This setting is not applicable to VRF-Lite Gateway.


### PR DESCRIPTION
These two attributes can also be specified for BGP configuration on VRFs. The terraform provider currently only sets them for BGP config for Tier-0 routers.