### PR TITLE
Rename 'principle' to 'principal' around the code

### DIFF
--- a/nsxt/provider.go
+++ b/nsxt/provider.go
@@ -429,7 +429,7 @@ func Provider() *schema.Provider {
 			"nsxt_manager_cluster":                         resourceNsxtManagerCluster(),
 			"nsxt_policy_uplink_host_switch_profile":       resourceNsxtUplinkHostSwitchProfile(),
 			"nsxt_node_user":                               resourceNsxtUsers(),
-			"nsxt_principle_identity":                      resourceNsxtPrincipleIdentity(),
+			"nsxt_principal_identity":                      resourceNsxtPrincipalIdentity(),
 			"nsxt_edge_transport_node":                     resourceNsxtEdgeTransportNode(),
 			"nsxt_failure_domain":                          resourceNsxtFailureDomain(),
 			"nsxt_cluster_virtual_ip":                      resourceNsxtClusterVirualIP(),

--- a/nsxt/resource_nsxt_principal_identity.go
+++ b/nsxt/resource_nsxt_principal_identity.go
@@ -14,11 +14,11 @@ import (
 	policyModel "github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 )
 
-func resourceNsxtPrincipleIdentity() *schema.Resource {
+func resourceNsxtPrincipalIdentity() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceNsxtPrincipleIdentityCreate,
-		Read:   resourceNsxtPrincipleIdentityRead,
-		Delete: resourceNsxtPrincipleIdentityDelete,
+		Create: resourceNsxtPrincipalIdentityCreate,
+		Read:   resourceNsxtPrincipalIdentityRead,
+		Delete: resourceNsxtPrincipalIdentityDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -113,7 +113,7 @@ func convertToPolicyRolesForPath(mpRolesForPath []mpModel.RolesForPath) []policy
 	return pRolesForPath
 }
 
-func resourceNsxtPrincipleIdentityCreate(d *schema.ResourceData, m interface{}) error {
+func resourceNsxtPrincipalIdentityCreate(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
 	client := principal_identities.NewWithCertificateClient(connector)
 
@@ -139,10 +139,10 @@ func resourceNsxtPrincipleIdentityCreate(d *schema.ResourceData, m interface{}) 
 	}
 	d.SetId(*pi.Id)
 
-	return resourceNsxtPrincipleIdentityRead(d, m)
+	return resourceNsxtPrincipalIdentityRead(d, m)
 }
 
-func resourceNsxtPrincipleIdentityRead(d *schema.ResourceData, m interface{}) error {
+func resourceNsxtPrincipalIdentityRead(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
 	client := trust_management.NewPrincipalIdentitiesClient(connector)
 	id := d.Id()
@@ -163,7 +163,7 @@ func resourceNsxtPrincipleIdentityRead(d *schema.ResourceData, m interface{}) er
 	return nil
 }
 
-func resourceNsxtPrincipleIdentityDelete(d *schema.ResourceData, m interface{}) error {
+func resourceNsxtPrincipalIdentityDelete(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
 	piClient := trust_management.NewPrincipalIdentitiesClient(connector)
 	id := d.Id()

--- a/nsxt/resource_nsxt_principal_identity_test.go
+++ b/nsxt/resource_nsxt_principal_identity_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp/nsx/trust_management"
 )
 
-var accTestPrincipleIdentityCreateAttributes = map[string]string{
+var accTestPrincipalIdentityCreateAttributes = map[string]string{
 	"is_protected": "false",
 	"name":         getAccTestResourceName(),
 	"node_id":      "node-2",
@@ -20,8 +20,8 @@ var accTestPrincipleIdentityCreateAttributes = map[string]string{
 	"role":         "org_admin",
 }
 
-func TestAccResourceNsxtPrincipleIdentity_basic(t *testing.T) {
-	testResourceName := "nsxt_principle_identity.test"
+func TestAccResourceNsxtPrincipalIdentity_basic(t *testing.T) {
+	testResourceName := "nsxt_principal_identity.test"
 	certPem, _, err := testAccGenerateTLSKeyPair()
 	if err != nil {
 		t.Fatal(err)
@@ -35,20 +35,20 @@ func TestAccResourceNsxtPrincipleIdentity_basic(t *testing.T) {
 		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNsxtPrincipleIdentityCheckDestroy(state, accTestPrincipleIdentityCreateAttributes["name"])
+			return testAccNsxtPrincipalIdentityCheckDestroy(state, accTestPrincipalIdentityCreateAttributes["name"])
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNsxtPrincipleIdentityCreate(certPem),
+				Config: testAccNsxtPrincipalIdentityCreate(certPem),
 				Check: resource.ComposeTestCheckFunc(
-					testAccNsxtPrincipleIdentityExists(accTestPrincipleIdentityCreateAttributes["name"], testResourceName),
-					resource.TestCheckResourceAttr(testResourceName, "is_protected", accTestPrincipleIdentityCreateAttributes["is_protected"]),
-					resource.TestCheckResourceAttr(testResourceName, "name", accTestPrincipleIdentityCreateAttributes["name"]),
-					resource.TestCheckResourceAttr(testResourceName, "node_id", accTestPrincipleIdentityCreateAttributes["node_id"]),
+					testAccNsxtPrincipalIdentityExists(accTestPrincipalIdentityCreateAttributes["name"], testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "is_protected", accTestPrincipalIdentityCreateAttributes["is_protected"]),
+					resource.TestCheckResourceAttr(testResourceName, "name", accTestPrincipalIdentityCreateAttributes["name"]),
+					resource.TestCheckResourceAttr(testResourceName, "node_id", accTestPrincipalIdentityCreateAttributes["node_id"]),
 					resource.TestCheckResourceAttr(testResourceName, "roles_for_path.#", "1"),
-					resource.TestCheckResourceAttr(testResourceName, "roles_for_path.0.path", accTestPrincipleIdentityCreateAttributes["role_path"]),
+					resource.TestCheckResourceAttr(testResourceName, "roles_for_path.0.path", accTestPrincipalIdentityCreateAttributes["role_path"]),
 					resource.TestCheckResourceAttr(testResourceName, "roles_for_path.0.roles.#", "1"),
-					resource.TestCheckResourceAttr(testResourceName, "roles_for_path.0.roles.0", accTestPrincipleIdentityCreateAttributes["role"]),
+					resource.TestCheckResourceAttr(testResourceName, "roles_for_path.0.roles.0", accTestPrincipalIdentityCreateAttributes["role"]),
 
 					resource.TestCheckResourceAttrSet(testResourceName, "certificate_id"),
 					resource.TestCheckResourceAttrSet(testResourceName, "certificate_pem"),
@@ -58,8 +58,8 @@ func TestAccResourceNsxtPrincipleIdentity_basic(t *testing.T) {
 	})
 }
 
-func TestAccResourceNsxtPrincipleIdentity_import_basic(t *testing.T) {
-	testResourceName := "nsxt_principle_identity.test"
+func TestAccResourceNsxtPrincipalIdentity_import_basic(t *testing.T) {
+	testResourceName := "nsxt_principal_identity.test"
 	certPem, _, err := testAccGenerateTLSKeyPair()
 	if err != nil {
 		t.Fatal(err)
@@ -73,11 +73,11 @@ func TestAccResourceNsxtPrincipleIdentity_import_basic(t *testing.T) {
 		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNsxtPrincipleIdentityCheckDestroy(state, accTestPrincipleIdentityCreateAttributes["name"])
+			return testAccNsxtPrincipalIdentityCheckDestroy(state, accTestPrincipalIdentityCreateAttributes["name"])
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNsxtPrincipleIdentityCreate(certPem),
+				Config: testAccNsxtPrincipalIdentityCreate(certPem),
 			},
 			{
 				ResourceName:            testResourceName,
@@ -89,25 +89,25 @@ func TestAccResourceNsxtPrincipleIdentity_import_basic(t *testing.T) {
 	})
 }
 
-func testAccNsxtPrincipleIdentityExists(name string, resourceName string) resource.TestCheckFunc {
+func testAccNsxtPrincipalIdentityExists(name string, resourceName string) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
 
 		connector := getPolicyConnector(testAccProvider.Meta().(nsxtClients))
 
 		rs, ok := state.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("PrincipleIdentity resource %s not found in resources", resourceName)
+			return fmt.Errorf("PrincipalIdentity resource %s not found in resources", resourceName)
 		}
 
 		piID := rs.Primary.Attributes["id"]
 		if piID == "" {
-			return fmt.Errorf("PrincipleIdentity resource ID not set in resources")
+			return fmt.Errorf("PrincipalIdentity resource ID not set in resources")
 		}
 		tmClient := trust_management.NewPrincipalIdentitiesClient(connector)
 		_, err := tmClient.Get(piID)
 		if err != nil {
 			if isNotFoundError(err) {
-				return fmt.Errorf("PrincipleIdentity %s does not exist", name)
+				return fmt.Errorf("PrincipalIdentity %s does not exist", name)
 			}
 		}
 
@@ -115,17 +115,17 @@ func testAccNsxtPrincipleIdentityExists(name string, resourceName string) resour
 	}
 }
 
-func testAccNsxtPrincipleIdentityCheckDestroy(state *terraform.State, name string) error {
+func testAccNsxtPrincipalIdentityCheckDestroy(state *terraform.State, name string) error {
 	connector := getPolicyConnector(testAccProvider.Meta().(nsxtClients))
 	for _, rs := range state.RootModule().Resources {
 
-		if rs.Type != "nsxt_principle_identity" {
+		if rs.Type != "nsxt_principal_identity" {
 			continue
 		}
 
 		piID := rs.Primary.Attributes["id"]
 		if piID == "" {
-			return fmt.Errorf("PrincipleIdentity resource ID not set in resources")
+			return fmt.Errorf("PrincipalIdentity resource ID not set in resources")
 		}
 		tmClient := trust_management.NewPrincipalIdentitiesClient(connector)
 		_, err := tmClient.Get(piID)
@@ -135,15 +135,15 @@ func testAccNsxtPrincipleIdentityCheckDestroy(state *terraform.State, name strin
 			}
 			return err
 		}
-		return fmt.Errorf("PrincipleIdentity %s still exists", name)
+		return fmt.Errorf("PrincipalIdentity %s still exists", name)
 	}
 	return nil
 }
 
-func testAccNsxtPrincipleIdentityCreate(certPem string) string {
-	attrMap := accTestPrincipleIdentityCreateAttributes
+func testAccNsxtPrincipalIdentityCreate(certPem string) string {
+	attrMap := accTestPrincipalIdentityCreateAttributes
 	return fmt.Sprintf(`
-resource "nsxt_principle_identity" "test" {
+resource "nsxt_principal_identity" "test" {
     certificate_pem = <<-EOT
 %s
     EOT

--- a/website/docs/r/principal_identity.html.markdown
+++ b/website/docs/r/principal_identity.html.markdown
@@ -1,20 +1,20 @@
 ---
 subcategory: "Beta"
 layout: "nsxt"
-page_title: "NSXT: nsxt_principle_identity"
-description: A resource to configure principle identities.
+page_title: "NSXT: nsxt_principal_identity"
+description: A resource to configure principal identities.
 ---
 
-# nsxt_principle_identity
+# nsxt_principal_identity
 
-This resource provides a method for the management of Principle Identities.
+This resource provides a method for the management of Principal Identities.
 
 ~> **NOTE:** This resource requires NSX version 4.0.0 or higher.
 
 ## Example Usage
 
 ```hcl
-resource "nsxt_principle_identity" "test" {
+resource "nsxt_principal_identity" "test" {
   name            = "open-stack"
   node_id         = "node-2"
   certificate_pem = trimspace(file("cert.pem"))
@@ -33,12 +33,12 @@ The following arguments are supported:
 * `is_protected` - (optional) Indicates whether the entities created by this principal should be protected.
 * `name` - (Required) Name of the principal.
 * `node_id` - (Required) Unique node-id of a principal. This is used primarily in the case where a cluster of nodes is used to make calls to the NSX Manager and the same `name` is used so that the nodes can access and modify the same data while still accessing NSX through their individual secret (certificate or JWT). In all other cases this can be any string.
-* `certificate_pem` - (Required) PEM encoding of the certificate to be associated with this principle identity.
+* `certificate_pem` - (Required) PEM encoding of the certificate to be associated with this principal identity.
 * `roles_for_path` - (Required) A list of The roles that are associated with the user, limiting them to a path. In case the path is '/', the roles apply everywhere.
     * `path` - (Required) Path of the entity in parent hierarchy.
     * `roles` - (Required) A list of identifiers for the roles to associate with the given user limited to a path.
 
-Once a Principle Identity is created, it can't be modified. Modification of above arguments will cause the current PI on NSX to be deleted and recreated. Certificate updates is also handled in the same way. 
+Once a Principal Identity is created, it can't be modified. Modification of above arguments will cause the current PI on NSX to be deleted and recreated. Certificate updates is also handled in the same way. 
 
 ## Attributes Reference
 
@@ -73,6 +73,6 @@ An existing object can be [imported][docs-import] into this resource, via the fo
 [docs-import]: https://www.terraform.io/cli/import
 
 ```
-terraform import nsxt_principle_identity.test PRINCIPLE_IDENTITY_ID
+terraform import nsxt_principal_identity.test PRINCIPAL_IDENTITY_ID
 ```
-The above command imports Principle Identity named `test` with the identifier `PRINCIPLE_IDENTITY_ID`.
+The above command imports Principal Identity named `test` with the identifier `PRINCIPAL_IDENTITY_ID`.


### PR DESCRIPTION
Those two words are used around the code and in filenames for the same resource. Standardized this to 'principal' all over for consistency.