### PR TITLE
Add VMC Oauth app support

### DIFF
--- a/nsxt/provider.go
+++ b/nsxt/provider.go
@@ -33,7 +33,6 @@ import (
 )
 
 var defaultRetryOnStatusCodes = []int{400, 409, 429, 500, 503, 504}
-var defaultVmcAuthHost = "console.cloud.vmware.com/csp/gateway/am/api/auth/api-tokens/authorize"
 
 // Provider configuration that is shared for policy and MP
 type commonProviderConfig struct {
@@ -160,13 +159,6 @@ func Provider() *schema.Provider {
 				Optional:    true,
 				Description: "URL for VMC authorization service (CSP)",
 				DefaultFunc: schema.EnvDefaultFunc("NSXT_VMC_AUTH_HOST", nil),
-				Deprecated:  "Use vmc_csp_url instead",
-			},
-			"vmc_csp_url": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "VMC Cloud Service Provider URL.",
-				DefaultFunc: schema.EnvDefaultFunc("NSXT_VMC_CSP_URL", "console.cloud.vmware.com"),
 			},
 			"vmc_token": {
 				Type:          schema.TypeString,
@@ -606,7 +598,7 @@ type jwtToken struct {
 }
 
 type vmcAuthInfo struct {
-	authUrl      string
+	authHost     string
 	authMode     string
 	accessToken  string
 	clientID     string
@@ -615,33 +607,26 @@ type vmcAuthInfo struct {
 
 func getVmcAuthInfo(d *schema.ResourceData) *vmcAuthInfo {
 	vmcInfo := vmcAuthInfo{
+		authHost:     d.Get("vmc_auth_host").(string),
 		authMode:     d.Get("vmc_auth_mode").(string),
 		accessToken:  d.Get("vmc_token").(string),
 		clientID:     d.Get("vmc_client_id").(string),
 		clientSecret: d.Get("vmc_client_secret").(string),
 	}
-
-	authHost := d.Get("vmc_auth_host").(string)
-	cspUrl := d.Get("vmc_csp_url").(string)
-	// For backward compatibility, use vmc_auth_host only when it's non-default value
-	if len(authHost) > 0 && authHost != defaultVmcAuthHost {
-		vmcInfo.authUrl = authHost
+	if len(vmcInfo.authHost) > 0 {
 		return &vmcInfo
 	}
 
-	// Fill in csp host + auth url based on auth method
+	// Fill in default auth host + url based on auth method
 	if len(vmcInfo.accessToken) > 0 {
-		vmcInfo.authUrl = cspUrl + "/csp/gateway/am/api/auth/api-tokens/authorize"
+		vmcInfo.authHost = "console.cloud.vmware.com/csp/gateway/am/api/auth/api-tokens/authorize"
 	} else if len(vmcInfo.clientSecret) > 0 && len(vmcInfo.clientID) > 0 {
-		vmcInfo.authUrl = cspUrl + "/csp/gateway/am/api/auth/authorize"
+		vmcInfo.authHost = "console.cloud.vmware.com/csp/gateway/am/api/auth/authorize"
 	}
 	return &vmcInfo
 }
 
 func (v *vmcAuthInfo) IsZero() bool {
-	if len(v.authUrl) == 0 {
-		return true
-	}
 	return len(v.accessToken) == 0 && len(v.clientID) == 0 && len(v.clientSecret) == 0
 }
 
@@ -651,12 +636,12 @@ func (v *vmcAuthInfo) getAPIToken() (string, error) {
 	// Access token
 	if len(v.accessToken) > 0 {
 		payload := strings.NewReader("refresh_token=" + v.accessToken)
-		req, _ = http.NewRequest("POST", "https://"+v.authUrl, payload)
+		req, _ = http.NewRequest("POST", "https://"+v.authHost, payload)
 	}
 	// Oauth app
 	if len(v.clientSecret) > 0 && len(v.clientID) > 0 {
 		payload := strings.NewReader("grant_type=client_credentials")
-		req, _ = http.NewRequest("POST", "https://"+v.authUrl, payload)
+		req, _ = http.NewRequest("POST", "https://"+v.authHost, payload)
 		req.SetBasicAuth(v.clientID, v.clientSecret)
 	}
 	if req == nil {

--- a/nsxt/resource_nsxt_manager_cluster.go
+++ b/nsxt/resource_nsxt_manager_cluster.go
@@ -324,7 +324,7 @@ func getNewNsxtClient(node NsxClusterNode, d *schema.ResourceData, clients inter
 
 func configureNewClient(newClient *nsxtClients, oldClient *nsxtClients, host string, username string, password string) error {
 	newClient.Host = host
-	securityCtx, err := getConfiguredSecurityContext(newClient, "", "", "", username, password)
+	securityCtx, err := getConfiguredSecurityContext(newClient, &vmcAuthInfo{}, username, password)
 	if err != nil {
 		return fmt.Errorf("Failed to configure new client with host %s: %s", host, err)
 	}

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -221,15 +221,15 @@ The following arguments are used to configure the VMware NSX-T Provider:
   partially successful realization as valid state and not fail apply.
 * `vmc_token` - (Optional) Long-lived API token for authenticating with VMware
   Cloud Services APIs. This token will be used to short-lived token that is
-  needed to communicate with NSX Manager in VMC environment. In conflict with 
-  `vmc_client_id` and `vmc_client_secret`.
+  needed to communicate with NSX Manager in VMC environment. Can not be specified 
+  together with `vmc_client_id` and `vmc_client_secret`.
   Note that only subset of policy resources are supported with VMC environment.
 * `vmc_client_id`- (Optional) ID of OAuth App associated with the VMC organization. 
   The combination with `vmc_client_secret` is used to authenticate when calling 
-  VMware Cloud Services APIs. In conflict with `vmc_token`.
+  VMware Cloud Services APIs. Can not be specified together with `vmc_token`.
 * `vmc_client_secret` - (Optional) Secret of OAuth App associated with the VMC 
   organization. The combination with `vmc_client_id` is used to authenticate when 
-  calling VMware Cloud Services APIs. In conflict with `vmc_token`.
+  calling VMware Cloud Services APIs. Can not be specified together with `vmc_token`.
   Note that only subset of policy resources are supported with VMC environment.
 * `vmc_auth_host` - (Optional) URL for VMC authorization service that is used
   to obtain short-lived token for NSX manager access. Defaults to VMC

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -221,7 +221,15 @@ The following arguments are used to configure the VMware NSX-T Provider:
   partially successful realization as valid state and not fail apply.
 * `vmc_token` - (Optional) Long-lived API token for authenticating with VMware
   Cloud Services APIs. This token will be used to short-lived token that is
-  needed to communicate with NSX Manager in VMC environment.
+  needed to communicate with NSX Manager in VMC environment. In conflict with 
+  `vmc_client_id` and `vmc_client_secret`.
+  Note that only subset of policy resources are supported with VMC environment.
+* `vmc_client_id`- (Optional) ID of OAuth App associated with the VMC organization. 
+  The combination with `vmc_client_secret` is used to authenticate when calling 
+  VMware Cloud Services APIs. In conflict with `vmc_token`.
+* `vmc_client_secret` - (Optional) Secret of OAuth App associated with the VMC 
+  organization. The combination with `vmc_client_id` is used to authenticate when 
+  calling VMware Cloud Services APIs. In conflict with `vmc_token`.
   Note that only subset of policy resources are supported with VMC environment.
 * `vmc_auth_host` - (Optional) URL for VMC authorization service that is used
   to obtain short-lived token for NSX manager access. Defaults to VMC


### PR DESCRIPTION
This change adds support of NSX token exchange on VMC using Oauth app, which is a newer method compared to using refresh token.

Implementation mainly referenced [python client for vmc on aws](https://github.com/vmware/python-client-for-vmware-cloud-on-aws/blob/development/pyvmc_fxns.py#L166) and terraform vmc provider.

Testing done:
With Oauth app created in server-to-server mode, assigned with all roles under "VMware Cloud on AWS" category, provider configured as:

```
provider "nsxt" {
  host                 = "<nsx-private-ip>.rp.vmwarevmc.com/vmc/reverse-proxy/api/orgs/<org-id>/sddcs/<ssdc-id>/sks-nsxt-manager"
  allow_unverified_ssl = true
  max_retries          = 2
 
  enforcement_point    = "vmc-enforcementpoint"
  vmc_client_id        = "<oauth-app-id>"
  vmc_client_secret    = "<oauth-app-secret>"
}
``` 

Able to create and delete resources like:
```
resource "nsxt_policy_gateway_qos_profile" "test" {
  display_name        = "test"
  description         = "Terraform provisioned profile"
  burst_size          = 10
  committed_bandwidth = 20
}
```

For regression, verified using access token to create and delete the same resource. The provider is configured as follows:
```
provider "nsxt" {
  host                 = "<nsx-private-ip>.rp.vmwarevmc.com/vmc/reverse-proxy/api/orgs/<org-id>/sddcs/<ssdc-id>/sks-nsxt-manager"
  allow_unverified_ssl = true
  max_retries          = 2
 
  enforcement_point    = "vmc-enforcementpoint"
  vmc_token            = "<access-token>"
}
```

e2e test covers non-vmc cases.

Closes #944 