### PR TITLE
Add discover node data source

### DIFF
--- a/nsxt/data_source_discover_node.go
+++ b/nsxt/data_source_discover_node.go
@@ -1,0 +1,70 @@
+/* Copyright © 2024 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: MPL-2.0 */
+
+package nsxt
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp/nsx/fabric"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp/nsx/model"
+)
+
+func dataSourceNsxtDiscoverNode() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceNsxtDiscoverNodeRead,
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Description: "External id of the discovered node, ex. a mo-ref from VC",
+				Optional:    true,
+				Computed:    true,
+			},
+			"ip_address": {
+				Type:         schema.TypeString,
+				Description:  "IP Address of the the discovered node.",
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validateCidrOrIPOrRange(),
+			},
+		},
+	}
+}
+
+func dataSourceNsxtDiscoverNodeRead(d *schema.ResourceData, m interface{}) error {
+	connector := getPolicyConnector(m)
+	discoverNodeClient := fabric.NewDiscoveredNodesClient(connector)
+
+	objID := d.Get("id").(string)
+	ipAddress := d.Get("ip_address").(string)
+
+	var obj model.DiscoveredNode
+	if objID != "" {
+		// Get by ID
+		objGet, err := discoverNodeClient.Get(objID)
+		if isNotFoundError(err) {
+			return fmt.Errorf("Discover Node %s was not found", objID)
+		}
+		if err != nil {
+			return fmt.Errorf("Error while reading Discover Node %s: %v", objID, err)
+		}
+		obj = objGet
+	} else if ipAddress == "" {
+		return fmt.Errorf("Error obtaining Discover Node external ID or IP address during read")
+	} else {
+		// Get by IP address
+		objList, err := discoverNodeClient.List(nil, nil, nil, nil, nil, nil, &ipAddress, nil, nil, nil, nil, nil, nil, nil)
+		if isNotFoundError(err) {
+			return fmt.Errorf("Discover Node with IP %s was not found", ipAddress)
+		}
+		if err != nil {
+			return fmt.Errorf("Error while reading Discover Node: %v", err)
+		}
+		obj = objList.Results[0]
+	}
+
+	d.SetId(*obj.ExternalId)
+	d.Set("ip_address", obj.IpAddresses[0])
+	return nil
+}

--- a/nsxt/provider.go
+++ b/nsxt/provider.go
@@ -295,6 +295,7 @@ func Provider() *schema.Provider {
 			"nsxt_manager_cluster_node":               dataSourceNsxtManagerClusterNode(),
 			"nsxt_policy_host_transport_node_profile": dataSourceNsxtPolicyHostTransportNodeProfile(),
 			"nsxt_transport_node":                     dataSourceNsxtEdgeTransportNode(),
+			"nsxt_discover_node":                      dataSourceNsxtDiscoverNode(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{

--- a/website/docs/d/discover_node.html.markdown
+++ b/website/docs/d/discover_node.html.markdown
@@ -1,0 +1,23 @@
+---
+subcategory: "Fabric"
+layout: "nsxt"
+page_title: "NSXT: discover_node"
+description: An Discover Node data source.
+---
+
+# nsxt_discover_node
+
+This data source provides information about Discover Node configured in NSX. A Discover Node can be used to create a Host Transport Node.
+
+## Example Usage
+
+```hcl
+data "nsxt_discover_node" "test" {
+  ip_address = "10.43.251.142"
+}
+```
+
+## Argument Reference
+
+* `id` - (Optional) External id of the discovered node, ex. a mo-ref from VC.
+* `ip_address` - (Optional) IP Address of the discovered node.

--- a/website/docs/r/policy_host_transport_node.html.markdown
+++ b/website/docs/r/policy_host_transport_node.html.markdown
@@ -14,33 +14,30 @@ This resource is supported with NSX 4.1.0 onwards.
 
 ```hcl
 resource "nsxt_policy_host_transport_node" "test" {
-  description  = "Terraform-deployed host transport node"
-  display_name = "tf_host_transport_node"
-
-  node_deployment_info {
-    ip_addresses = ["10.168.186.150"]
-
-    host_credential {
-      username   = "user1"
-      password   = "password1"
-      thumbprint = "thumbprint1"
-    }
-  }
+  description        = "Terraform-deployed host transport node"
+  display_name       = "tf_host_transport_node"
+  discovered_node_id = data.nsxt_discover_node.dn.id
 
   standard_host_switch {
-    host_switch_profile = [data.nsxt_policy_uplink_host_switch_profile.hsw_profile1.path]
+    host_switch_id      = "50 0b 31 a4 b8 af 35 df-40 56 b6 f9 aa d3 ee 12"
+    host_switch_profile = [data.nsxt_policy_uplink_host_switch_profile.uplink_host_switch_profile.path]
 
     ip_assignment {
       assigned_by_dhcp = true
     }
 
     transport_zone_endpoint {
-      transport_zone = data.nsxt_transport_zone.tz1.path
+      transport_zone = data.nsxt_policy_transport_zone.overlay_transport_zone.path
     }
 
-    pnic {
-      device_name = "fp-eth0"
-      uplink_name = "uplink1"
+    uplink {
+      uplink_name     = "uplink-1"
+      vds_uplink_name = "uplink1"
+    }
+
+    uplink {
+      uplink_name     = "uplink-2"
+      vds_uplink_name = "uplink2"
     }
   }
 
@@ -60,14 +57,7 @@ The following arguments are supported:
 * `tag` - (Optional) A list of scope + tag pairs to associate with this resource.
 * `site_path` - (Optional) The path of the site which the Host Transport Node belongs to. `path` field of the existing `nsxt_policy_site` can be used here. Defaults to default site path.
 * `enforcement_point` - (Optional) The ID of enforcement point under given `site_path` to manage the Host Transport Node. Defaults to default enforcement point.
-* `discovered_node_id` - (Optional)  Discovered node id to create Host Transport Node. Specify discovered node id to create Host Transport Node for Discovered Node. This field is required during Host Transport Node create from vCenter server managing the ESXi type HostNode.
-* `node_deployment_info` - (Optional)
-  * `fqdn` - (Optional) Fully qualified domain name of the fabric node.
-  * `ip_addresses` - (Required) IP Addresses of the Node, version 4 or 6.
-  * `host_credential` - (Optional) Host login credentials.
-      * `password` - (Required) The authentication password of the host node.
-      * `thumbprint` - (Required) ESXi thumbprint or SSH key fingerprint of the host node.
-      * `username` - (Required) The username of the account on the host node.
+* `discovered_node_id` - (Required)  Discovered node id to create Host Transport Node. Specify discovered node id to create Host Transport Node for Discovered Node. This field is required during Host Transport Node create from vCenter server managing the ESXi type HostNode.
 * `standard_host_switch` - (Required) Standard host switch specification.
   * `host_switch_id` - (Optional) The host switch id. This ID will be used to reference a host switch.
   * `host_switch_mode` - (Optional) Operational mode of a HostSwitch. Accepted values - 'STANDARD', 'ENS', 'ENS_INTERRUPT' or 'LEGACY'. The default value is 'STANDARD'.


### PR DESCRIPTION
1. Add Discover Node data source.

2. Remove node_deployment_info from Host Transport Node. Considering we only support Host Transport Node create from vCenter server managing the ESXi type HostNode and in this case, discovered_node_id is required, so no need to provide node_deployment_info.
Additionally, this could fix the issue that using node_deployment_info with VDS type host switch, which is the only host switch type supported, will receive error from NSX:
```
Failed to create HostTransportNode 9756979d-0165-4cc6-93dc-0c30bb6da065:
VDS Configuration is specified for host 9756979d-0165-4cc6-93dc-0c30bb6da065
and its not managed by a vCenter. Please correct TransportNode configuration
or connect the host to a VCenter. (code 9549)
```
