### PR TITLE
Set edge_node data source member_index attribute

### DIFF
--- a/nsxt/data_source_nsxt_policy_edge_node.go
+++ b/nsxt/data_source_nsxt_policy_edge_node.go
@@ -114,6 +114,7 @@ func dataSourceNsxtPolicyEdgeNodeRead(d *schema.ResourceData, m interface{}) err
 	}
 
 	d.SetId(*obj.Id)
+	d.Set("member_index", obj.MemberIndex)
 	d.Set("display_name", obj.DisplayName)
 	d.Set("description", obj.Description)
 	d.Set("path", obj.Path)


### PR DESCRIPTION
When retrieving an edge node using the data source, set member_index attribute into state.