### PR TITLE
Increase timeout for IP allocation realization

### DIFF
--- a/nsxt/resource_nsxt_policy_ip_address_allocation_test.go
+++ b/nsxt/resource_nsxt_policy_ip_address_allocation_test.go
@@ -316,7 +316,8 @@ resource "nsxt_policy_ip_address_allocation" "test" {
 }
 
 data "nsxt_policy_realization_info" "realization_info" {
-  path = nsxt_policy_ip_address_allocation.test.path
+  timeout = 6000
+  path    = nsxt_policy_ip_address_allocation.test.path
 }`, attrMap["display_name"], attrMap["description"])
 }
 


### PR DESCRIPTION
Tests fail occasionally due to timing out while waiting for realization of the IP allocation.

Set higher timeout than the default to avoid this failure.