### PR TITLE
Make domain name unique to address test failures

### DIFF
--- a/nsxt/resource_nsxt_policy_gateway_policy_test.go
+++ b/nsxt/resource_nsxt_policy_gateway_policy_test.go
@@ -386,7 +386,7 @@ func TestAccResourceNsxtGlobalPolicyGatewayPolicy_withSite(t *testing.T) {
 func TestAccResourceNsxtGlobalPolicyGatewayPolicy_withDomain(t *testing.T) {
 	name := "terraform-test"
 	siteName := getTestSiteName()
-	domainName := "new-domain"
+	domainName := getAccTestResourceName()
 	testResourceName := "nsxt_policy_gateway_policy.test"
 	comments := "Acceptance test create"
 

--- a/nsxt/resource_nsxt_policy_group_test.go
+++ b/nsxt/resource_nsxt_policy_group_test.go
@@ -269,7 +269,7 @@ func TestAccResourceNsxtGlobalPolicyGroup_externalIDCriteria(t *testing.T) {
 func TestAccResourceNsxtGlobalPolicyGroup_withDomain(t *testing.T) {
 	name := "test-nsx-global-policy-group-domain"
 	testResourceName := "nsxt_policy_group.test"
-	domainName := "new-domain"
+	domainName := getAccTestResourceName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {


### PR DESCRIPTION
Test fail occasionally due to delays in deletion of domains in global manager topologies.