### PR TITLE
Handle edge_node import failures

### DIFF
--- a/nsxt/resource_nsxt_edge_transport_node.go
+++ b/nsxt/resource_nsxt_edge_transport_node.go
@@ -1232,14 +1232,18 @@ func resourceNsxtEdgeTransportNodeRead(d *schema.ResourceData, m interface{}) er
 	}
 	node := base.(model.EdgeNode)
 
-	err = setEdgeDeploymentConfigInSchema(d, node.DeploymentConfig)
-	if err != nil {
-		return handleReadError(d, "TransportNode", id, err)
+	if node.DeploymentConfig != nil {
+		err = setEdgeDeploymentConfigInSchema(d, node.DeploymentConfig)
+		if err != nil {
+			return handleReadError(d, "TransportNode", id, err)
+		}
 	}
 
-	err = setEdgeNodeSettingsInSchema(d, node.NodeSettings)
-	if err != nil {
-		return handleReadError(d, "TransportNode", id, err)
+	if node.NodeSettings != nil {
+		err = setEdgeNodeSettingsInSchema(d, node.NodeSettings)
+		if err != nil {
+			return handleReadError(d, "TransportNode", id, err)
+		}
 	}
 
 	// Set base object attributes


### PR DESCRIPTION
Some optional attributes aren't returned from NSX with v4.2.0 backend, the PR handles this matter.