### PR TITLE
Documentation fixes

### DIFF
--- a/website/docs/d/compute_manager.html.markdown
+++ b/website/docs/d/compute_manager.html.markdown
@@ -14,6 +14,7 @@ When only single Compute Manager is present on NSX, no need to specify any filte
 
 ```hcl
 data "nsxt_compute_manager" "test_vcenter" {
+  display_name = "some-compute-mgr"
 }
 ```
 

--- a/website/docs/r/policy_host_transport_node_collection.html.markdown
+++ b/website/docs/r/policy_host_transport_node_collection.html.markdown
@@ -57,6 +57,7 @@ In addition to arguments listed above, the following attributes are exported:
 
 An existing policy Host Transport Node Collection can be [imported][docs-import] into this resource, via the following command:
 
+```
 terraform import nsxt_policy_host_transport_node_collection.test POLICY_PATH
-
+```
 The above command imports Policy Host Transport Node Collection named test with NSX policy path POLICY_PATH.

--- a/website/docs/r/policy_host_transport_node_profile.html.markdown
+++ b/website/docs/r/policy_host_transport_node_profile.html.markdown
@@ -87,7 +87,10 @@ In addition to arguments listed above, the following attributes are exported:
 * `id` - ID of the resource.
 * `revision` - Indicates current revision number of the object as seen by NSX-T API server. This attribute can be useful for debugging.
 
-[docs-import]: https://www.terraform.io/cli/import
+
+## Importing
+
+An existing policy Host Transport Node profile can be [imported][docs-import] into this resource, via the following command:
 
 ```
 terraform import nsxt_policy_host_transport_node_profile.test POLICY_PATH

--- a/website/docs/r/policy_ipsec_vpn_service.html.markdown
+++ b/website/docs/r/policy_ipsec_vpn_service.html.markdown
@@ -15,12 +15,12 @@ This resource is applicable to NSX Policy Manager.
 
 ```hcl
 resource "nsxt_policy_ipsec_vpn_service" "test" {
-  display_name        = "ipsec-vpn-service1"
-  description         = "Terraform provisioned IPSec VPN service"
-  locale_service_path = data.nsxt_policy_gateway_locale_service.test.path
-  enabled             = true
-  ha_sync             = true
-  ike_log_level       = "INFO"
+  display_name  = "ipsec-vpn-service1"
+  description   = "Terraform provisioned IPSec VPN service"
+  gateway_path  = data.nsxt_policy_tier0_gateway.gw1.path
+  enabled       = true
+  ha_sync       = true
+  ike_log_level = "INFO"
   bypass_rule {
     sources      = ["192.168.10.0/24"]
     destinations = ["192.169.10.0/24"]


### PR DESCRIPTION
For compute manager, lookup attribute was missing from example.
For host transport node resources, edit the import part to match the same convention used elsewhere.
For IPSec VPN service, replace deprecated attribute with supported one.