### PR TITLE
Add debug capabilities to main.go

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,15 +4,33 @@
 package main
 
 import (
+	"context"
+	"flag"
+	"log"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 	"github.com/vmware/terraform-provider-nsxt/nsxt"
 )
 
 func main() {
-	plugin.Serve(&plugin.ServeOpts{
+	var debugMode bool
+	flag.BoolVar(&debugMode, "debug", false, "set to true to run the provider with support for debuggers like delve")
+	flag.Parse()
+
+	opts := &plugin.ServeOpts{
 		ProviderFunc: func() *schema.Provider {
 			return nsxt.Provider()
 		},
-	})
+	}
+
+	if debugMode {
+		err := plugin.Debug(context.Background(), "registry.terraform.io/vmware/nsxt", opts)
+		if err != nil {
+			log.Fatal(err.Error())
+		}
+		return
+	}
+
+	plugin.Serve(opts)
 }


### PR DESCRIPTION
Add some necessary code for execution of the provider with a debugger, e.g delve.
More information about using debuggers is available [here](https://developer.hashicorp.com/terraform/plugin/debugging) and [here](https://opencredo.com/blogs/running-a-terraform-provider-with-a-debugger/).