### PR TITLE
Handle deletion of host_transport_node properly

### DIFF
--- a/nsxt/resource_nsxt_policy_host_transport_node_collection.go
+++ b/nsxt/resource_nsxt_policy_host_transport_node_collection.go
@@ -17,7 +17,7 @@ import (
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 )
 
-const removeOnDestroyDefault = false
+const removeOnDestroyDefault = true
 
 func resourceNsxtPolicyHostTransportNodeCollection() *schema.Resource {
 	return &schema.Resource{

--- a/website/docs/r/policy_host_transport_node.html.markdown
+++ b/website/docs/r/policy_host_transport_node.html.markdown
@@ -99,6 +99,7 @@ The following arguments are supported:
   * `vmk_install_migration` - (Optional) The vmknic and logical switch mappings.
       * `destination_network` - (Required) The network id to which the ESX vmk interface will be migrated.
       * `device_name` - (Required) ESX vmk interface name.
+* `remove_nsx_on_destroy` - (Optional) Upon deletion, uninstall NSX from Transport Node. Default is true.
 
 ## Attributes Reference
 

--- a/website/docs/r/policy_host_transport_node_collection.html.markdown
+++ b/website/docs/r/policy_host_transport_node_collection.html.markdown
@@ -44,7 +44,7 @@ The following arguments are supported:
     * `transport_node_profile_sub_config_name` - (Required) Name of the TransportNodeProfile sub configuration to be used.
   * `sub_cluster_id` - (Required) sub-cluster ID.
 * `transport_node_profile_path` - (Optional) Transport Node Profile Path.
-* `remove_nsx_on_destroy` - (Optional) Upon deletion, uninstall NSX from Transport Node Collection member hosts. Default is false. 
+* `remove_nsx_on_destroy` - (Optional) Upon deletion, uninstall NSX from Transport Node Collection member hosts. Default is true. 
 
 ## Attributes Reference
 


### PR DESCRIPTION
When a policy_host_transport_node is deleted, optionally remove the NSX components from the hypervisor.

Also, as NSX removal from hypervisor is the default for transport nodes, changed the behavior for transport_node_collections as well, and it make sense that destroy operation will revert the creation entirely.