### PR TITLE
Fix port validation in compute manager

### DIFF
--- a/nsxt/resource_nsxt_compute_manager.go
+++ b/nsxt/resource_nsxt_compute_manager.go
@@ -197,7 +197,7 @@ func resourceNsxtComputeManager() *schema.Resource {
 				Type:         schema.TypeInt,
 				Description:  "Proxy https port of compute manager",
 				Optional:     true,
-				ValidateFunc: validateSinglePort(),
+				ValidateFunc: validation.IntBetween(0, 65535),
 				Default:      443,
 			},
 			"server": {


### PR DESCRIPTION
Since port is int rather than string, int validation is required