### PR TITLE
Handle password change in update

### DIFF
--- a/nsxt/resource_nsxt_node_user.go
+++ b/nsxt/resource_nsxt_node_user.go
@@ -175,7 +175,10 @@ func resourceNsxtNodeUserUpdate(d *schema.ResourceData, m interface{}) error {
 	if id == "" {
 		return fmt.Errorf("error obtaining logical object id")
 	}
-	password := d.Get("password").(string)
+	oldPwd, pwd := d.GetChange("password")
+	password := pwd.(string)
+	oldPassword := oldPwd.(string)
+
 	active := d.Get("active").(bool)
 	status := d.Get("status").(string)
 
@@ -207,6 +210,13 @@ func resourceNsxtNodeUserUpdate(d *schema.ResourceData, m interface{}) error {
 		PasswordChangeWarning:   &passwordChangeWarning,
 		Username:                &username,
 	}
+
+	// If password is changed, handle password change.
+	if password != oldPassword {
+		userProp.Password = &password
+		userProp.OldPassword = &oldPassword
+	}
+
 	_, err := client.Update(id, userProp)
 	if err != nil {
 		return handleUpdateError("User", id, err)


### PR DESCRIPTION
NSX requires sending the old password while changing password. So the change uses the old password from the state, to verify that password change is legal.

There is an API to reset password - it requires an admin permission and won't check old password. IMO it's better so as otherwise it would indicate that state is not in sync with NSX.