### PR TITLE
Add ForceNew to nested role bindings spec

### DIFF
--- a/nsxt/resource_nsxt_policy_role_binding.go
+++ b/nsxt/resource_nsxt_policy_role_binding.go
@@ -96,6 +96,7 @@ func getRolesForPathSchema(forceNew bool) *schema.Schema {
 					Type:        schema.TypeString,
 					Description: "Path of the entity in parent hierarchy.",
 					Required:    true,
+					ForceNew:    forceNew,
 				},
 				"roles": {
 					Type:        schema.TypeSet,
@@ -104,6 +105,7 @@ func getRolesForPathSchema(forceNew bool) *schema.Schema {
 					Elem: &schema.Schema{
 						Type: schema.TypeString,
 					},
+					ForceNew: forceNew,
 				},
 			},
 		},


### PR DESCRIPTION
Without ForceNew for the nested attributes, replace is not triggered for principal identity resource once roles are changed. Instead, the user gets an error "doesn't support update"