### PR TITLE
Validate project_id can not be whitespace string

### DIFF
--- a/nsxt/resource_nsxt_policy_context_profile.go
+++ b/nsxt/resource_nsxt_policy_context_profile.go
@@ -334,7 +334,7 @@ func checkAttributesValid(context utl.SessionContext, attributes []interface{}, 
 	}
 	attributeValues, err := listAttributesWithKey(context, attributeKeyMap[key], m)
 	if err != nil {
-		return err
+		return logAPIError("Error listing attributes", err)
 	}
 	for _, attribute := range attributes {
 		attributeMap := attribute.(map[string]interface{})

--- a/nsxt/utils.go
+++ b/nsxt/utils.go
@@ -715,7 +715,7 @@ func getContextSchema() *schema.Schema {
 					Description:  "Id of the project which the resource belongs to.",
 					Required:     true,
 					ForceNew:     true,
-					ValidateFunc: validation.StringIsNotEmpty,
+					ValidateFunc: validation.StringIsNotWhiteSpace,
 				},
 			},
 		},


### PR DESCRIPTION
In addition, make sure context profile resource renders errors correctly when NSX validation fails for attributes