### PR TITLE
Mark site_path as Computed in project resource

### DIFF
--- a/nsxt/resource_nsxt_policy_project.go
+++ b/nsxt/resource_nsxt_policy_project.go
@@ -44,7 +44,7 @@ func resourceNsxtPolicyProject() *schema.Resource {
 							Elem:     getElemPolicyPathSchemaWithFlags(false, false, false),
 							Optional: true,
 						},
-						"site_path": getElemPolicyPathSchemaWithFlags(true, false, false),
+						"site_path": getElemPolicyPathSchemaWithFlags(true, true, false),
 					},
 				},
 				Optional: true,


### PR DESCRIPTION
site is auto-assigned by NSX if edge cluster is specified