### PR TITLE
Handle edge node with no host switch spec

### DIFF
--- a/nsxt/resource_nsxt_edge_transport_node.go
+++ b/nsxt/resource_nsxt_edge_transport_node.go
@@ -1222,9 +1222,11 @@ func resourceNsxtEdgeTransportNodeRead(d *schema.ResourceData, m interface{}) er
 	setMPTagsInSchema(d, obj.Tags)
 	d.Set("failure_domain", obj.FailureDomainId)
 
-	err = setHostSwitchSpecInSchema(d, obj.HostSwitchSpec, nodeTypeEdge)
-	if err != nil {
-		return handleReadError(d, "TransportNode", id, err)
+	if obj.HostSwitchSpec != nil {
+		err = setHostSwitchSpecInSchema(d, obj.HostSwitchSpec, nodeTypeEdge)
+		if err != nil {
+			return handleReadError(d, "TransportNode", id, err)
+		}
 	}
 
 	converter := bindings.NewTypeConverter()


### PR DESCRIPTION
When an edge node is created from OVA or is a bare metal node, it should be imported into state before it's being configured.

In this case it will not have a host switch configuration.