### PR TITLE
Fix empty QoS profile issue in segment

### DIFF
--- a/nsxt/segment_common.go
+++ b/nsxt/segment_common.go
@@ -1214,12 +1214,14 @@ func nsxtPolicySegmentQosProfileRead(d *schema.ResourceData, m interface{}) erro
 	var configList []map[string]interface{}
 
 	for _, obj := range results.Results {
-		config["qos_profile_path"] = obj.QosProfilePath
-		config["binding_map_path"] = obj.Path
-		config["revision"] = obj.Revision
-		configList = append(configList, config)
-		d.Set("qos_profile", configList)
-		return nil
+		if obj.QosProfilePath != nil && (len(*obj.QosProfilePath) > 0) {
+			config["qos_profile_path"] = obj.QosProfilePath
+			config["binding_map_path"] = obj.Path
+			config["revision"] = obj.Revision
+			configList = append(configList, config)
+			d.Set("qos_profile", configList)
+			return nil
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Sometimes NSX sends a segment binding map with empty segment for QoS profile. This change works around this NSX issue by ignoring binding map with empty profile path.
Signed-off-by: Anna Khmelnitsky <akhmelnitsky@vmware.com>