### PR TITLE
Add cpu_config attribute to host_transport_node

### DIFF
--- a/website/docs/r/policy_host_transport_node.html.markdown
+++ b/website/docs/r/policy_host_transport_node.html.markdown
@@ -59,46 +59,49 @@ The following arguments are supported:
 * `enforcement_point` - (Optional) The ID of enforcement point under given `site_path` to manage the Host Transport Node. Defaults to default enforcement point.
 * `discovered_node_id` - (Required)  Discovered node id to create Host Transport Node. Specify discovered node id to create Host Transport Node for Discovered Node. This field is required during Host Transport Node create from vCenter server managing the ESXi type HostNode.
 * `standard_host_switch` - (Required) Standard host switch specification.
+  * `cpu_config` - (Optional) Enhanced Networking Stack enabled HostSwitch CPU configuration.
+    * `num_lcores` - (Required) Number of Logical cpu cores (Lcores) to be placed on a specified NUMA node.
+    * `numa_node_index` - (Required) Unique index of the Non Uniform Memory Access (NUMA) node.
   * `host_switch_id` - (Optional) The host switch id. This ID will be used to reference a host switch.
   * `host_switch_mode` - (Optional) Operational mode of a HostSwitch. Accepted values - 'STANDARD', 'ENS', 'ENS_INTERRUPT' or 'LEGACY'. The default value is 'STANDARD'.
   * `host_switch_profile` - (Optional) Policy path of host switch profiles to be associated with this host switch.
   * `ip_assignment` - (Required) - Specification for IPs to be used with host switch virtual tunnel endpoints. Should contain exatly one of the below:
-      * `assigned_by_dhcp` - (Optional) Enables DHCP assignment.
-      * `static_ip` - (Optional) IP assignment specification for Static IP List.
-          * `ip_addresses` - (Required) List of IPs for transport node host switch virtual tunnel endpoints.
-          * `subnet_mask` - (Required) Subnet mask.
-          * `default_gateway` - (Required) Gateway IP.
-      * `static_ip_pool` - (Optional) Policy path of Static IP Pool used for IP assignment specification.
+    * `assigned_by_dhcp` - (Optional) Enables DHCP assignment.
+    * `static_ip` - (Optional) IP assignment specification for Static IP List.
+        * `ip_addresses` - (Required) List of IPs for transport node host switch virtual tunnel endpoints.
+        * `subnet_mask` - (Required) Subnet mask.
+        * `default_gateway` - (Required) Gateway IP.
+    * `static_ip_pool` - (Optional) Policy path of Static IP Pool used for IP assignment specification.
   * `is_migrate_pnics` - (Optional) Migrate any pnics which are in use.
   * `pnic` - (Optional) Physical NICs connected to the host switch.
-      * `device_name` - (Required) Device name or key.
-      * `uplink_name` - (Required) Uplink name for this Pnic.
+    * `device_name` - (Required) Device name or key.
+    * `uplink_name` - (Required) Uplink name for this Pnic.
   * `transport_node_profile_sub_config` - (Optional) Transport Node Profile sub-configuration Options.
-      * `host_switch_config_option` - (Required) Subset of the host switch configuration.
-          * `host_switch_id` - (Optional) The host switch id. This ID will be used to reference a host switch.
-          * `host_switch_profile` - (Optional) Identifiers of host switch profiles to be associated with this host switch.
-          * `ip_assignment` - (Required) - Specification for IPs to be used with host switch virtual tunnel endpoints. Should contain exatly one of the below:
-              * `assigned_by_dhcp` - (Optional) Enables DHCP assignment.
-              * `static_ip` - (Optional) IP assignment specification for Static IP List.
-                  * `ip_addresses` - (Required) List of IPs for transport node host switch virtual tunnel endpoints.
-                  * `subnet_mask` - (Required) Subnet mask.
-                  * `default_gateway` - (Required) Gateway IP.
-              * `static_ip_pool` - (Optional) IP assignment specification for Static IP Pool.
-          * `uplink` - (Optional) Uplink/LAG of VMware vSphere Distributed Switch connected to the HostSwitch.
-              * `uplink_name` - (Required) Uplink name from UplinkHostSwitch profile.
-              * `vds_lag_name` - (Optional) Link Aggregation Group (LAG) name of Virtual Distributed Switch.
-              * `vds_uplink_name` - (Optional) Uplink name of VMware vSphere Distributed Switch (VDS).
-      * `name` - (Required) Name of the transport node profile config option.
+    * `host_switch_config_option` - (Required) Subset of the host switch configuration.
+        * `host_switch_id` - (Optional) The host switch id. This ID will be used to reference a host switch.
+        * `host_switch_profile` - (Optional) Identifiers of host switch profiles to be associated with this host switch.
+        * `ip_assignment` - (Required) - Specification for IPs to be used with host switch virtual tunnel endpoints. Should contain exatly one of the below:
+            * `assigned_by_dhcp` - (Optional) Enables DHCP assignment.
+            * `static_ip` - (Optional) IP assignment specification for Static IP List.
+                * `ip_addresses` - (Required) List of IPs for transport node host switch virtual tunnel endpoints.
+                * `subnet_mask` - (Required) Subnet mask.
+                * `default_gateway` - (Required) Gateway IP.
+            * `static_ip_pool` - (Optional) IP assignment specification for Static IP Pool.
+        * `uplink` - (Optional) Uplink/LAG of VMware vSphere Distributed Switch connected to the HostSwitch.
+            * `uplink_name` - (Required) Uplink name from UplinkHostSwitch profile.
+            * `vds_lag_name` - (Optional) Link Aggregation Group (LAG) name of Virtual Distributed Switch.
+            * `vds_uplink_name` - (Optional) Uplink name of VMware vSphere Distributed Switch (VDS).
+    * `name` - (Required) Name of the transport node profile config option.
   * `transport_zone_endpoint` - (Optional) Transport zone endpoints
-      * `transport_zone` - (Required) Unique ID identifying the transport zone for this endpoint.
-      * `transport_zone_profiles` - (Optional) Identifiers of the transport zone profiles associated with this transport zone endpoint on this transport node.
+    * `transport_zone` - (Required) Unique ID identifying the transport zone for this endpoint.
+    * `transport_zone_profiles` - (Optional) Identifiers of the transport zone profiles associated with this transport zone endpoint on this transport node.
   * `uplink` - (Optional) Uplink/LAG of VMware vSphere Distributed Switch connected to the HostSwitch.
-      * `uplink_name` - (Required) Uplink name from UplinkHostSwitch profile.
-      * `vds_lag_name` - (Optional) Link Aggregation Group (LAG) name of Virtual Distributed Switch.
-      * `vds_uplink_name` - (Optional) Uplink name of VMware vSphere Distributed Switch (VDS).
+    * `uplink_name` - (Required) Uplink name from UplinkHostSwitch profile.
+    * `vds_lag_name` - (Optional) Link Aggregation Group (LAG) name of Virtual Distributed Switch.
+    * `vds_uplink_name` - (Optional) Uplink name of VMware vSphere Distributed Switch (VDS).
   * `vmk_install_migration` - (Optional) The vmknic and logical switch mappings.
-      * `destination_network` - (Required) The network id to which the ESX vmk interface will be migrated.
-      * `device_name` - (Required) ESX vmk interface name.
+    * `destination_network` - (Required) The network id to which the ESX vmk interface will be migrated.
+    * `device_name` - (Required) ESX vmk interface name.
 * `remove_nsx_on_destroy` - (Optional) Upon deletion, uninstall NSX from Transport Node. Default is true.
 
 ## Attributes Reference


### PR DESCRIPTION
cpu_config attribute has been ommited from
nsxt_policy_host_transport_node resource, this change readds it.