### PR TITLE
Support testing of non-clustered ESXi nodes

### DIFF
--- a/nsxt/data_source_nsxt_compute_collection_test.go
+++ b/nsxt/data_source_nsxt_compute_collection_test.go
@@ -15,7 +15,11 @@ func TestAccDataSourceNsxtComputeCollection_basic(t *testing.T) {
 	testResourceName := "data.nsxt_compute_collection.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccOnlyLocalManager(t)
+			testAccPreCheck(t)
+			testAccEnvDefined(t, "NSXT_TEST_COMPUTE_COLLECTION")
+		},
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/nsxt/utils_test.go
+++ b/nsxt/utils_test.go
@@ -36,7 +36,6 @@ import (
 // Those defaults can be overridden using environment parameters
 const tier0RouterDefaultName string = "PLR-1 LogicalRouterTier0"
 const edgeClusterDefaultName string = "EDGECLUSTER1"
-const computeCollectionDefaultName string = "Cluster-1"
 const vlanTransportZoneName string = "transportzone2"
 const overlayTransportZoneNamePrefix string = "1-transportzone"
 const macPoolDefaultName string = "DefaultMacPool"
@@ -124,11 +123,7 @@ func getEdgeClusterName() string {
 }
 
 func getComputeCollectionName() string {
-	name := os.Getenv("NSXT_TEST_COMPUTE_COLLECTION")
-	if name == "" {
-		name = computeCollectionDefaultName
-	}
-	return name
+	return os.Getenv("NSXT_TEST_COMPUTE_COLLECTION")
 }
 
 func getComputeManagerName() string {


### PR DESCRIPTION
A topology where compute ESXi nodes are not a part of a compute cluster should be a usable use case with acceptance tests.