### PR TITLE
Read discovered id in host transport node resource

### DIFF
--- a/nsxt/resource_nsxt_policy_host_transport_node.go
+++ b/nsxt/resource_nsxt_policy_host_transport_node.go
@@ -89,6 +89,9 @@ func resourceNsxtPolicyHostTransportNodeRead(d *schema.ResourceData, m interface
 	d.Set("enforcement_point", epID)
 	d.Set("display_name", obj.DisplayName)
 	d.Set("description", obj.Description)
+	if obj.NodeDeploymentInfo != nil {
+		d.Set("discovered_node_id", obj.NodeDeploymentInfo.DiscoveredNodeId)
+	}
 	setPolicyTagsInSchema(d, obj.Tags)
 	d.Set("nsx_id", id)
 	d.Set("path", obj.Path)


### PR DESCRIPTION
Discovered node id was not set in Read function, which was causing it not to show in state post import.