### PR TITLE
Increase default retry timeouts and intervals

### DIFF
--- a/nsxt/provider.go
+++ b/nsxt/provider.go
@@ -125,19 +125,19 @@ func Provider() *schema.Provider {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				Description: "Maximum number of HTTP client retries",
-				DefaultFunc: schema.EnvDefaultFunc("NSXT_MAX_RETRIES", 4),
+				DefaultFunc: schema.EnvDefaultFunc("NSXT_MAX_RETRIES", 8),
 			},
 			"retry_min_delay": {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				Description: "Minimum delay in milliseconds between retries of a request",
-				DefaultFunc: schema.EnvDefaultFunc("NSXT_RETRY_MIN_DELAY", 0),
+				DefaultFunc: schema.EnvDefaultFunc("NSXT_RETRY_MIN_DELAY", 500),
 			},
 			"retry_max_delay": {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				Description: "Maximum delay in milliseconds between retries of a request",
-				DefaultFunc: schema.EnvDefaultFunc("NSXT_RETRY_MAX_DELAY", 500),
+				DefaultFunc: schema.EnvDefaultFunc("NSXT_RETRY_MAX_DELAY", 1000),
 			},
 			"retry_on_status_codes": {
 				Type:        schema.TypeList,


### PR DESCRIPTION
Fabric resources in general require bigger timeouts for the sake of async operation (f.e. several seconds might be required to clear edge node vm after edge delete operation). For now, we are increasing default timeout values for all resources in order to minimize errors. In future, we might want to introduce more granular approach to tumeouts.