### PR TITLE
Avoid returning nil object in StateRefreshFunc

### DIFF
--- a/nsxt/resource_nsxt_manager_cluster.go
+++ b/nsxt/resource_nsxt_manager_cluster.go
@@ -135,7 +135,7 @@ func getNodeConnectivityStateConf(connector client.Connector, delay int, interva
 			resp, err := siteClient.Get("default")
 			if err != nil {
 				log.Printf("[DEBUG]: NSX API endpoint not ready: %v", err)
-				return nil, "notyet", nil
+				return "notyet", "notyet", nil
 			}
 
 			log.Printf("[INFO]: NSX API endpoint ready")

--- a/nsxt/resource_nsxt_policy_host_transport_node.go
+++ b/nsxt/resource_nsxt_policy_host_transport_node.go
@@ -224,7 +224,7 @@ func getHostTransportNodeStateConf(connector client.Connector, id, siteID, epID 
 				return nil, "failed", err
 			}
 
-			return nil, "notyet", nil
+			return "notyet", "notyet", nil
 		},
 		Delay:        time.Duration(5) * time.Second,
 		Timeout:      time.Duration(1200) * time.Second,

--- a/nsxt/resource_nsxt_policy_host_transport_node_collection.go
+++ b/nsxt/resource_nsxt_policy_host_transport_node_collection.go
@@ -288,7 +288,7 @@ func getComputeCollectionMemberStateConf(connector client.Connector, id string) 
 
 			// When NSX bits are successfully, no member statuses will remain in the results list
 			if len(statuses.Results) > 0 {
-				return nil, "notyet", nil
+				return "notyet", "notyet", nil
 			}
 			return "success", "success", nil
 		},


### PR DESCRIPTION
When defining state refresh functions for terraform sdk wait mechanism, we normally return nil for object while waiting for state. This is actually 'not found' indication for sdk code, and sdk implements an additional stop mechanism for such cases, which causes the wait loop to exit prematurely before timeout is reached. For example, in host resouce, this would cause 'failed to remove nsx' error on delete.
In order to avoid for this mechanism to kick in, the code is changed to return 'notyet' string rather then nil object in the wait func.