### PR TITLE
Fix edge transport node state func

### DIFF
--- a/nsxt/resource_nsxt_edge_transport_node.go
+++ b/nsxt/resource_nsxt_edge_transport_node.go
@@ -1632,7 +1632,7 @@ func getTransportNodeStateConf(connector client.Connector, id string) *resource.
 				return nil, "failed", err
 			}
 
-			return nil, "notyet", nil
+			return "notyet", "notyet", nil
 		},
 		Delay:        time.Duration(5) * time.Second,
 		Timeout:      time.Duration(1200) * time.Second,


### PR DESCRIPTION
When defining state refresh functions for terraform sdk wait mechanism, we normally return nil for object while waiting for state. This is actually 'not found' indication for sdk code, and sdk implements an additional stop mechanism for such cases, which causes the wait loop to exit  prematurely before timeout is reached. This fix was made for all resources in previous commit. This change completes the fix for edge transport node, which had its delete wait mechanism introduced recently and thus does not contain the fix.