### PR TITLE
Revise nsxt_management_cluster datasource

### DIFF
--- a/nsxt/data_source_nsxt_management_cluster_test.go
+++ b/nsxt/data_source_nsxt_management_cluster_test.go
@@ -13,7 +13,7 @@ func TestAccDataSourceNsxtManagementCluster_basic(t *testing.T) {
 	testResourceName := "data.nsxt_management_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccTestDeprecated(t); testAccPreCheck(t) },
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{


### PR DESCRIPTION
Management cluster datasource is required to retrieve the managemnet endpoint sha256 thumbprint.
This change un-deprecates this DS as it has no replacement and changes the API in use to the NSX golang SDK.