### PR TITLE
Set edge HostId to null when host_id isn't specified

### DIFF
--- a/nsxt/resource_nsxt_edge_transport_node.go
+++ b/nsxt/resource_nsxt_edge_transport_node.go
@@ -871,7 +871,6 @@ func getEdgeNodeDeploymentConfigFromSchema(cfg interface{}) (*model.EdgeNodeDepl
 			cfg := model.VsphereDeploymentConfig{
 				ComputeId:             &computeID,
 				DataNetworkIds:        dataNetworkIds,
-				HostId:                &hostID,
 				ManagementNetworkId:   &managementNetworkID,
 				ManagementPortSubnets: managemenPortSubnets,
 				ReservationInfo:       reservationInfo,
@@ -882,7 +881,9 @@ func getEdgeNodeDeploymentConfigFromSchema(cfg interface{}) (*model.EdgeNodeDepl
 			if len(defaultGatewayAddresses) > 0 {
 				cfg.DefaultGatewayAddresses = defaultGatewayAddresses
 			}
-
+			if hostID != "" {
+				cfg.HostId = &hostID
+			}
 			// Passing an empty folder here confuses vSphere while creating the Edge VM
 			if computeFolderID != "" {
 				cfg.ComputeFolderId = &computeFolderID

--- a/website/docs/r/edge_transport_node.html.markdown
+++ b/website/docs/r/edge_transport_node.html.markdown
@@ -93,7 +93,8 @@ The following arguments are supported:
     * `cli_username` - (Optional) CLI "admin" username. Defaults to "admin".
     * `root_password` - (Required) Node root user password.
   * `vm_deployment_config` - (Required) The vSphere deployment configuration determines where to deploy the edge node.
-    * `compute_folder_id` - (Optional) Cluster identifier or resourcepool identifier for specified vcenter server.
+    * `compute_folder_id` - (Optional) Compute folder identifier in the specified vcenter server.
+    * `compute_id` - (Required) Cluster identifier or resourcepool identifier for specified vcenter server.
     * `data_network_ids` - (Required) List of portgroups, logical switch identifiers or segment paths for datapath connectivity.
     * `default_gateway_address` - (Optional) Default gateway for the node.
     * `host_id` - (Optional) Host identifier in the specified vcenter server.


### PR DESCRIPTION
When an edge appliance is configured with no HostID attribute for the VM, the deployment fails. When host_id attribute isn't configured, HostID should be set to nil (or not set at all).

Fixes: #1053