### PR TITLE
Add host_switch_name attribute to transport node

### DIFF
--- a/nsxt/resource_nsxt_edge_transport_node.go
+++ b/nsxt/resource_nsxt_edge_transport_node.go
@@ -456,6 +456,12 @@ func getStandardHostSwitchSchema(nodeType string) *schema.Schema {
 					Optional:    true,
 					Computed:    true,
 				},
+				"host_switch_name": {
+					Type:        schema.TypeString,
+					Description: "Host switch name. This name will be used to reference a host switch",
+					Optional:    true,
+					Computed:    true,
+				},
 				"host_switch_profile": getHostSwitchProfileIDsSchema(),
 				"ip_assignment":       getIPAssignmentSchema(),
 				"pnic": {
@@ -1100,6 +1106,7 @@ func getHostSwitchSpecFromSchema(d *schema.ResourceData, nodeType string) (*data
 		swData := swEntry.(map[string]interface{})
 
 		hostSwitchID := swData["host_switch_id"].(string)
+		hostSwitchName := swData["host_switch_name"].(string)
 		var hostSwitchMode, hostSwitchType string
 		var isMigratePNics bool
 		var uplinks []model.VdsUplink
@@ -1144,6 +1151,9 @@ func getHostSwitchSpecFromSchema(d *schema.ResourceData, nodeType string) (*data
 			IpAssignmentSpec:       iPAssignmentSpec,
 			Pnics:                  pNics,
 			TransportZoneEndpoints: transportZoneEndpoints,
+		}
+		if hostSwitchName != "" {
+			hsw.HostSwitchName = &hostSwitchName
 		}
 		if nodeType == nodeTypeHost {
 			hsw.CpuConfig = cpuConfig
@@ -1449,6 +1459,7 @@ func setHostSwitchSpecInSchema(d *schema.ResourceData, spec *data.StructValue, n
 		for _, sw := range swEntry.HostSwitches {
 			elem := make(map[string]interface{})
 			elem["host_switch_id"] = sw.HostSwitchId
+			elem["host_switch_name"] = sw.HostSwitchName
 			profiles := setHostSwitchProfileIDsInSchema(sw.HostSwitchProfileIds)
 			if len(profiles) > 0 {
 				elem["host_switch_profile"] = profiles

--- a/website/docs/r/edge_transport_node.html.markdown
+++ b/website/docs/r/edge_transport_node.html.markdown
@@ -66,6 +66,7 @@ The following arguments are supported:
 * `failure_domain` - (Optional)  Id of the failure domain.
 * `standard_host_switch` - (Required) Standard host switch specification.
   * `host_switch_id` - (Optional) The host switch id. This ID will be used to reference a host switch.
+  * `host_switch_name` - (Optional) Host switch name. This name will be used to reference a host switch.
   * `host_switch_profile` - (Optional) Identifiers of host switch profiles to be associated with this host switch.
   * `ip_assignment` - (Required) - Specification for IPs to be used with host switch virtual tunnel endpoints. Should contain exatly one of the below:
     * `assigned_by_dhcp` - (Optional) Enables DHCP assignment.

--- a/website/docs/r/policy_host_transport_node.html.markdown
+++ b/website/docs/r/policy_host_transport_node.html.markdown
@@ -63,6 +63,7 @@ The following arguments are supported:
     * `num_lcores` - (Required) Number of Logical cpu cores (Lcores) to be placed on a specified NUMA node.
     * `numa_node_index` - (Required) Unique index of the Non Uniform Memory Access (NUMA) node.
   * `host_switch_id` - (Optional) The host switch id. This ID will be used to reference a host switch.
+  * `host_switch_name` - (Optional) Host switch name. This name will be used to reference a host switch.
   * `host_switch_mode` - (Optional) Operational mode of a HostSwitch. Accepted values - 'STANDARD', 'ENS', 'ENS_INTERRUPT' or 'LEGACY'. The default value is 'STANDARD'.
   * `host_switch_profile` - (Optional) Policy path of host switch profiles to be associated with this host switch.
   * `ip_assignment` - (Required) - Specification for IPs to be used with host switch virtual tunnel endpoints. Should contain exatly one of the below:

--- a/website/docs/r/policy_host_transport_node_profile.html.markdown
+++ b/website/docs/r/policy_host_transport_node_profile.html.markdown
@@ -42,6 +42,7 @@ The following arguments are supported:
 * `ignore_overridden_hosts` - (Optional) Determines if cluster-level configuration should be applied on overridden hosts
 * `standard_host_switch` - (Required) Standard host switch specification.
     * `host_switch_id` - (Optional) The host switch id. This ID will be used to reference a host switch.
+    * `host_switch_name` - (Optional) Host switch name. This name will be used to reference a host switch.
     * `host_switch_mode` - (Optional) Operational mode of a HostSwitch. Accepted values - 'STANDARD', 'ENS', 'ENS_INTERRUPT' or 'LEGACY'. The default value is 'STANDARD'.
     * `host_switch_profile` - (Optional) Policy paths of host switch profiles to be associated with this host switch.
     * `ip_assignment` - (Required) - Specification for IPs to be used with host switch virtual tunnel endpoints. Should contain exactly one of the below:


### PR DESCRIPTION
NSX requires host_switch_name specification even though this attribute is marked as deprecated.
Without it, NSX issues an error when using multiple host switches. As this is an issue even if NSX addresses this later, it's better to add this attribute to the provider resources.

Fixes: #1146