### PR TITLE
Split edge RTEP config into separate resource

### DIFF
--- a/nsxt/resource_nsxt_edge_transport_node_rtep.go
+++ b/nsxt/resource_nsxt_edge_transport_node_rtep.go
@@ -74,10 +74,12 @@ func resourceNsxtEdgeTransportNodeRTEPCreate(d *schema.ResourceData, m interface
 	}
 
 	rtep := model.TransportNodeRemoteTunnelEndpointConfig{
-		HostSwitchName:     &hostSwitchName,
-		IpAssignmentSpec:   ipAssignment,
-		NamedTeamingPolicy: &namedTeamingPolicy,
-		RtepVlan:           &rtepVlan,
+		HostSwitchName:   &hostSwitchName,
+		IpAssignmentSpec: ipAssignment,
+		RtepVlan:         &rtepVlan,
+	}
+	if namedTeamingPolicy != "" {
+		rtep.NamedTeamingPolicy = &namedTeamingPolicy
 	}
 	obj.RemoteTunnelEndpoint = &rtep
 	_, err = client.Update(id, obj, nil, nil, nil, nil, nil, nil, nil)


### PR DESCRIPTION
RTEP configuration is used in federation topologies and should be defined after the LM managers are joined to a GM.

As edges could already exist in this point of time, it would make sense to configure the RTEP with a separate resource as also the NSX UI defines these elsewhere than the edge management (in the cluster panel).
