### PR TITLE
Set sub-config in transport_node_profile resource

### DIFF
--- a/nsxt/provider.go
+++ b/nsxt/provider.go
@@ -483,6 +483,7 @@ func Provider() *schema.Provider {
 			"nsxt_policy_site":                             resourceNsxtPolicySite(),
 			"nsxt_policy_global_manager":                   resourceNsxtPolicyGlobalManager(),
 			"nsxt_policy_metadata_proxy":                   resourceNsxtPolicyMetadataProxy(),
+			"nsxt_edge_transport_node_rtep":                resourceNsxtEdgeTransportNodeRTEP(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/nsxt/resource_nsxt_edge_transport_node_rtep.go
+++ b/nsxt/resource_nsxt_edge_transport_node_rtep.go
@@ -1,0 +1,178 @@
+/* Copyright © 2024 Broadcom, Inc. All Rights Reserved.
+   SPDX-License-Identifier: MPL-2.0 */
+
+package nsxt
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp/nsx"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp/nsx/model"
+)
+
+func resourceNsxtEdgeTransportNodeRTEP() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceNsxtEdgeTransportNodeRTEPCreate,
+		Read:   resourceNsxtEdgeTransportNodeRTEPRead,
+		Update: resourceNsxtEdgeTransportNodeRTEPUpdate,
+		Delete: resourceNsxtEdgeTransportNodeRTEPDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Schema: map[string]*schema.Schema{
+			"edge_id": {
+				Type:        schema.TypeString,
+				Description: "Edge ID to associate with remote tunnel endpoint.",
+				Required:    true,
+				ForceNew:    true,
+			},
+			"host_switch_name": {
+				Type:        schema.TypeString,
+				Description: "The host switch name to be used for the remote tunnel endpoint",
+				Required:    true,
+			},
+			"ip_assignment": getIPAssignmentSchema(),
+			"named_teaming_policy": {
+				Type:        schema.TypeString,
+				Description: "The named teaming policy to be used by the remote tunnel endpoint",
+				Optional:    true,
+			},
+			"rtep_vlan": {
+				Type:         schema.TypeInt,
+				Description:  "VLAN id for remote tunnel endpoint",
+				Required:     true,
+				ValidateFunc: validation.IntBetween(0, 4094),
+			},
+		},
+	}
+}
+
+func resourceNsxtEdgeTransportNodeRTEPCreate(d *schema.ResourceData, m interface{}) error {
+	connector := getPolicyConnector(m)
+	client := nsx.NewTransportNodesClient(connector)
+
+	id := d.Get("edge_id").(string)
+
+	obj, err := client.Get(id)
+	if err != nil {
+		return handleCreateError("TransportNodeRTEP", id, err)
+	}
+
+	if obj.RemoteTunnelEndpoint != nil {
+		return fmt.Errorf("remote tunnel endpoint for Edge appliance %s already exists", id)
+	}
+	hostSwitchName := d.Get("host_switch_name").(string)
+	namedTeamingPolicy := d.Get("named_teaming_policy").(string)
+	rtepVlan := int64(d.Get("rtep_vlan").(int))
+
+	ipAssignment, err := getIPAssignmentFromSchema(d.Get("ip_assignment").([]interface{}))
+	if err != nil {
+		return err
+	}
+
+	rtep := model.TransportNodeRemoteTunnelEndpointConfig{
+		HostSwitchName:     &hostSwitchName,
+		IpAssignmentSpec:   ipAssignment,
+		NamedTeamingPolicy: &namedTeamingPolicy,
+		RtepVlan:           &rtepVlan,
+	}
+	obj.RemoteTunnelEndpoint = &rtep
+	_, err = client.Update(id, obj, nil, nil, nil, nil, nil, nil, nil)
+	if err != nil {
+		return handleCreateError("TransportNodeRTEP", id, err)
+	}
+
+	d.SetId(id)
+
+	return resourceNsxtEdgeTransportNodeRTEPRead(d, m)
+}
+
+func resourceNsxtEdgeTransportNodeRTEPRead(d *schema.ResourceData, m interface{}) error {
+	connector := getPolicyConnector(m)
+	client := nsx.NewTransportNodesClient(connector)
+
+	id := d.Get("edge_id").(string)
+
+	obj, err := client.Get(id)
+	if err != nil {
+		return err
+	}
+
+	if obj.RemoteTunnelEndpoint == nil {
+		return errors.NotFound{}
+	}
+
+	d.Set("host_switch_name", obj.RemoteTunnelEndpoint.HostSwitchName)
+	ipAssignment, err := setIPAssignmentInSchema(obj.RemoteTunnelEndpoint.IpAssignmentSpec)
+	if err != nil {
+		return handleReadError(d, "TransportNodeRTEP", id, err)
+	}
+	d.Set("ip_assignment", ipAssignment)
+	d.Set("named_teaming_policy", obj.RemoteTunnelEndpoint.NamedTeamingPolicy)
+	d.Set("rtep_vlan", obj.RemoteTunnelEndpoint.RtepVlan)
+
+	return nil
+}
+
+func resourceNsxtEdgeTransportNodeRTEPUpdate(d *schema.ResourceData, m interface{}) error {
+	connector := getPolicyConnector(m)
+	client := nsx.NewTransportNodesClient(connector)
+
+	id := d.Get("edge_id").(string)
+
+	obj, err := client.Get(id)
+	if err != nil {
+		return err
+	}
+
+	if obj.RemoteTunnelEndpoint == nil {
+		return errors.NotFound{}
+	}
+
+	hostSwitchName := d.Get("host_switch_name").(string)
+	namedTeamingPolicy := d.Get("named_teaming_policy").(string)
+	rtepVlan := int64(d.Get("rtep_vlan").(int))
+
+	ipAssignment, err := getIPAssignmentFromSchema(d.Get("ip_assignment").([]interface{}))
+	if err != nil {
+		return err
+	}
+
+	rtep := model.TransportNodeRemoteTunnelEndpointConfig{
+		HostSwitchName:     &hostSwitchName,
+		IpAssignmentSpec:   ipAssignment,
+		NamedTeamingPolicy: &namedTeamingPolicy,
+		RtepVlan:           &rtepVlan,
+	}
+	obj.RemoteTunnelEndpoint = &rtep
+	_, err = client.Update(id, obj, nil, nil, nil, nil, nil, nil, nil)
+	if err != nil {
+		return handleUpdateError("TransportNodeRTEP", id, err)
+	}
+
+	return resourceNsxtEdgeTransportNodeRTEPRead(d, m)
+}
+
+func resourceNsxtEdgeTransportNodeRTEPDelete(d *schema.ResourceData, m interface{}) error {
+	connector := getPolicyConnector(m)
+	client := nsx.NewTransportNodesClient(connector)
+
+	id := d.Get("edge_id").(string)
+
+	obj, err := client.Get(id)
+	if err != nil {
+		return err
+	}
+
+	obj.RemoteTunnelEndpoint = nil
+
+	_, err = client.Update(id, obj, nil, nil, nil, nil, nil, nil, nil)
+	if err != nil {
+		return handleDeleteError("TransportNodeRTEP", id, err)
+	}
+
+	return nil
+}

--- a/nsxt/resource_nsxt_edge_transport_node_rtep.go
+++ b/nsxt/resource_nsxt_edge_transport_node_rtep.go
@@ -34,7 +34,7 @@ func resourceNsxtEdgeTransportNodeRTEP() *schema.Resource {
 				Description: "The host switch name to be used for the remote tunnel endpoint",
 				Required:    true,
 			},
-			"ip_assignment": getIPAssignmentSchema(),
+			"ip_assignment": getIPAssignmentSchema(true),
 			"named_teaming_policy": {
 				Type:        schema.TypeString,
 				Description: "The named teaming policy to be used by the remote tunnel endpoint",

--- a/website/docs/r/edge_transport_node.html.markdown
+++ b/website/docs/r/edge_transport_node.html.markdown
@@ -126,17 +126,6 @@ The following arguments are supported:
     * `port` - (Optional) Syslog server port. Defaults to 514.
     * `protocol` - (Optional) Syslog protocol. Accepted values - 'TCP', 'UDP', 'TLS', 'LI', 'LI_TLS'. The default value is 'UDP'.
     * `server` - (Required) Server IP or fqdn.
-* `remote_tunnel_endpoint` - (Optional) Configuration for a remote tunnel endpoint.
-  * `host_switch_name` - (Required) The host switch name to be used for the remote tunnel endpoint.
-  * `ip_assignment` - (Required) - Specification for IPs to be used with host switch virtual tunnel endpoints. Should contain exatly one of the below:
-    * `assigned_by_dhcp` - (Optional) Enables DHCP assignment.
-    * `static_ip` - (Optional) IP assignment specification for Static IP List.
-      * `ip_addresses` - (Required) List of IPs for transport node host switch virtual tunnel endpoints.
-      * `subnet_mask` - (Required) Subnet mask.
-      * `default_gateway` - (Required) Gateway IP.
-    * `static_ip_pool` - (Optional) IP assignment specification for Static IP Pool.
-  * `named_teaming_policy` - (Optional) The named teaming policy to be used by the remote tunnel endpoint.
-  * `rtep_vlan` - (Required) VLAN id for remote tunnel endpoint.
 
 ## Attributes Reference
 

--- a/website/docs/r/edge_transport_node_rtep.html.markdown
+++ b/website/docs/r/edge_transport_node_rtep.html.markdown
@@ -1,0 +1,62 @@
+---
+subcategory: "Beta"
+layout: "nsxt"
+page_title: "NSXT: nsxt_edge_transport_node_rtep"
+description: A resource to configure an Edge Transport Node RTEP (remote tunnel endpoint).
+---
+
+# nsxt_edge_transport_node
+
+This resource provides a method for the management of an Edge Transport Node RTEP (remote tunnel endpoint).
+This resource is supported with NSX 4.1.0 onwards.
+
+## Example Usage
+
+```hcl
+data "nsxt_edge_transport_node" "test_node" {
+  display_name = "edgenode1"
+}
+
+resource "nsxt_edge_transport_node_rtep" "test_rtep" {
+  edge_id = data.nsxt_edge_transport_node.test_node.id
+
+  host_switch_name = "someSwitch"
+  ip_assignment {
+    assigned_by_dhcp = true
+  }
+  named_teaming_policy = "tp123"
+  rtep_vlan            = 500
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `host_switch_name` - (Required) The host switch name to be used for the remote tunnel endpoint.
+* `ip_assignment` - (Required) - Specification for IPs to be used with host switch virtual tunnel endpoints. Should contain exatly one of the below:
+    * `assigned_by_dhcp` - (Optional) Enables DHCP assignment.
+    * `static_ip` - (Optional) IP assignment specification for Static IP List.
+        * `ip_addresses` - (Required) List of IPs for transport node host switch virtual tunnel endpoints.
+        * `subnet_mask` - (Required) Subnet mask.
+        * `default_gateway` - (Required) Gateway IP.
+    * `static_ip_pool` - (Optional) IP assignment specification for Static IP Pool.
+* `named_teaming_policy` - (Optional) The named teaming policy to be used by the remote tunnel endpoint.
+* `rtep_vlan` - (Required) VLAN id for remote tunnel endpoint.
+
+## Attributes Reference
+
+In addition to arguments listed above, the following attributes are exported:
+
+* `edge_id` - Edge ID to associate with remote tunnel endpoint.
+
+## Importing
+
+An existing Edge Transport Node RTEP can be [imported][docs-import] into this resource, via the following command:
+
+[docs-import]: https://www.terraform.io/cli/import
+
+```
+terraform import nsxt_edge_transport_node_rtep.test UUID
+```
+The above command imports Edge Transport Node RTEP named `test` with the NSX Transport Node ID `UUID`.


### PR DESCRIPTION
Sub-config objects were not set into schema in read operation.