### PR TITLE
Return an error message for Ipv6 assignment in TNP

### DIFF
--- a/nsxt/resource_nsxt_edge_transport_node.go
+++ b/nsxt/resource_nsxt_edge_transport_node.go
@@ -1447,6 +1447,12 @@ func setHostSwitchSpecInSchema(d *schema.ResourceData, spec *data.StructValue, n
 		}
 		swEntry := entry.(model.StandardHostSwitchSpec)
 		for _, sw := range swEntry.HostSwitches {
+
+			// TODO - remove this when SDK is updated with NSX 4.1.2
+			if sw.IpAssignmentSpec == nil {
+				return fmt.Errorf("Ipv6 assignments are not supported yet")
+			}
+
 			elem := make(map[string]interface{})
 			elem["host_switch_id"] = sw.HostSwitchId
 			profiles := setHostSwitchProfileIDsInSchema(sw.HostSwitchProfileIds)


### PR DESCRIPTION
Transport node profile doesn not support ipv6 due to SDK being outdated. This change adds a comprehensive error message when transport node profile with IPv6 assignment is imported.

When SDK is updated, this change will be reverted together with new IPv6 structures support in the resource.
Signed-off-by: Anna Khmelnitsky <akhmelnitsky@vmware.com>