### PR TITLE
Refactor fabric realization data sources

### DIFF
--- a/nsxt/data_source_nsxt_compute_manager_realization.go
+++ b/nsxt/data_source_nsxt_compute_manager_realization.go
@@ -105,6 +105,9 @@ func dataSourceNsxtComputeManagerRealizationWait(d *schema.ResourceData, connect
 			}
 
 			log.Printf("[DEBUG] Current realization state for Compute Manager %s is %s", id, *state.State)
+			if *state.State == model.ConfigurationState_STATE_ERROR || *state.State == model.ConfigurationState_STATE_FAILED {
+				return state, *state.State, fmt.Errorf("compute manager %s failed to realize with state %v", id, *state.State)
+			}
 
 			d.Set("state", state.State)
 			return state, *state.State, nil
@@ -115,7 +118,7 @@ func dataSourceNsxtComputeManagerRealizationWait(d *schema.ResourceData, connect
 	}
 	_, err := stateConf.WaitForState()
 	if err != nil {
-		return fmt.Errorf("failed to get realization information for %s: %v", id, err)
+		return err
 	}
 	return nil
 }

--- a/nsxt/data_source_nsxt_policy_host_transport_node_collection_realization.go
+++ b/nsxt/data_source_nsxt_policy_host_transport_node_collection_realization.go
@@ -47,40 +47,6 @@ func dataSourceNsxtPolicyHostTransportNodeCollectionRealization() *schema.Resour
 				Description: "Application state of transport node profile on compute collection",
 				Computed:    true,
 			},
-			"aggregate_progress_percentage": {
-				Type:        schema.TypeInt,
-				Description: "Aggregate percentage of compute collection deployment",
-				Computed:    true,
-			},
-			"cluster_level_error": {
-				Type:        schema.TypeString,
-				Description: "Errors which needs cluster level to resolution",
-				Optional:    true,
-				Computed:    true,
-			},
-			"validation_errors": {
-				Type:        schema.TypeList,
-				Description: "Errors while applying transport node profile on discovered node",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"discovered_node_id": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"error_message": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-					},
-				},
-				Optional: true,
-				Computed: true,
-			},
-			"vlcm_transition_error": {
-				Type:        schema.TypeString,
-				Description: "Errors while enabling vLCM on the compute collection",
-				Computed:    true,
-			},
 		},
 	}
 }
@@ -118,11 +84,10 @@ func dataSourceNsxtPolicyHostTransportNodeCollectionRealizationRead(d *schema.Re
 			return handleListError("HostTransportNodeCollection", err)
 		}
 
-		if len(objList.Results) == 0 {
-			return fmt.Errorf("HostTransportNodeCollection was not found on %s/%s", objSitePath, objPolicyEnforcementPoint)
+		if len(objList.Results) != 1 {
+			return fmt.Errorf("Single HostTransportNodeCollection was not identified on %s/%s", objSitePath, objPolicyEnforcementPoint)
 		}
-		d.SetId(*objList.Results[0].Id)
-		d.Set("state", targetStates[3])
+		objID = *objList.Results[0].Id
 	}
 
 	stateConf := &resource.StateChangeConf{
@@ -131,25 +96,17 @@ func dataSourceNsxtPolicyHostTransportNodeCollectionRealizationRead(d *schema.Re
 		Refresh: func() (interface{}, string, error) {
 			state, err := client.Get(objSitePath, getPolicyEnforcementPoint(m), objID)
 			if err != nil {
-				return state, model.ConfigurationState_STATE_ERROR, logAPIError("Error while waiting for realization of Transport Node Collection", err)
+				return state, model.TransportNodeCollectionState_STATE_IN_PROGRESS, logAPIError("Error while waiting for realization of Transport Node Collection", err)
 			}
 
 			log.Printf("[DEBUG] Current realization state for Transport Node Collection %s is %s", objID, *state.State)
 
+			if *state.State != model.TransportNodeCollectionState_STATE_SUCCESS && *state.State != model.TransportNodeCollectionState_STATE_IN_PROGRESS {
+				return state, *state.State, getErrorFromState(&state)
+			}
+
 			d.SetId(objID)
 			d.Set("state", state.State)
-			d.Set("aggregate_progress_percentage", state.AggregateProgressPercentage)
-			d.Set("cluster_level_error", state.ClusterLevelError)
-			var validationErrorsList []map[string]interface{}
-			for _, item := range state.ValidationErrors {
-				data := make(map[string]interface{})
-				data["discovered_node_id"] = item.DiscoveredNodeId
-				data["error_message"] = item.ErrorMessage
-				validationErrorsList = append(validationErrorsList, data)
-			}
-			d.Set("validation_errors", validationErrorsList)
-			d.Set("vlcm_transition_error", state.VlcmTransitionError)
-
 			return state, *state.State, nil
 		},
 		Timeout:    time.Duration(timeout) * time.Second,
@@ -158,7 +115,22 @@ func dataSourceNsxtPolicyHostTransportNodeCollectionRealizationRead(d *schema.Re
 	}
 	_, err := stateConf.WaitForState()
 	if err != nil {
-		return fmt.Errorf("failed to get realization information for %s: %v", objID, err)
+		return err
 	}
 	return nil
+}
+
+func getErrorFromState(state *model.TransportNodeCollectionState) error {
+	var result string
+	if state.ClusterLevelError != nil {
+		result += fmt.Sprintf("cluster level error: %v\n", *state.ClusterLevelError)
+	}
+	for _, item := range state.ValidationErrors {
+		result += fmt.Sprintf("validation error for node %s: %v\n", item.DiscoveredNodeId, item.ErrorMessage)
+	}
+	if state.VlcmTransitionError != nil {
+		result += fmt.Sprintf("VCLM transition error: %v\n", *state.VlcmTransitionError)
+	}
+
+	return fmt.Errorf(result)
 }

--- a/nsxt/data_source_nsxt_transport_node_realization.go
+++ b/nsxt/data_source_nsxt_transport_node_realization.go
@@ -79,6 +79,9 @@ func dataSourceNsxtTransportNodeRealizationRead(d *schema.ResourceData, m interf
 			}
 
 			log.Printf("[DEBUG] Current realization state for Transport Node %s is %s", id, *state.State)
+			if *state.State == model.TransportNodeState_STATE_FAILED || *state.State == model.TransportNodeState_STATE_ERROR {
+				return state, *state.State, fmt.Errorf("transport node %s failed to realize with state %v: %v", id, state, state.FailureMessage)
+			}
 
 			d.Set("state", state.State)
 			return state, *state.State, nil
@@ -89,7 +92,7 @@ func dataSourceNsxtTransportNodeRealizationRead(d *schema.ResourceData, m interf
 	}
 	_, err := stateConf.WaitForState()
 	if err != nil {
-		return fmt.Errorf("failed to get realization information for %s: %v", id, err)
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
This changes the behavior of fabric data sources to fail in case of realization error.
Realization data sources for fabric are expected to fail apply, since further config likely depends on them. 