### PR TITLE
Wait for subnet realization in ip_allocation test

### DIFF
--- a/nsxt/resource_nsxt_policy_ip_address_allocation_test.go
+++ b/nsxt/resource_nsxt_policy_ip_address_allocation_test.go
@@ -307,7 +307,7 @@ resource "nsxt_policy_ip_address_allocation" "test" {
   display_name = "%s"
   description  = "%s"
   pool_path    = nsxt_policy_ip_pool.test.path
-  depends_on   = [nsxt_policy_ip_pool_static_subnet.test]
+  depends_on   = [data.nsxt_policy_realization_info.subnet_realization]
 
   tag {
     scope = "scope1"
@@ -340,5 +340,8 @@ resource "nsxt_policy_ip_pool_static_subnet" "test" {
     start = "12.12.12.10"
     end   = "12.12.12.20"
   }
+}
+data "nsxt_policy_realization_info" "subnet_realization" {
+  path = nsxt_policy_ip_pool_static_subnet.test.path
 }`, context, accTestPolicyIPAddressAllocationPoolName, context, accTestPolicyIPAddressAllocationSubnetName)
 }


### PR DESCRIPTION
When an IP address is consument from an IP pool, wait for the subnet to be realized before consuming IPs from the pool.