### PR TITLE
Switch sub-config with no IP assignment bug

### DIFF
--- a/nsxt/resource_nsxt_edge_transport_node.go
+++ b/nsxt/resource_nsxt_edge_transport_node.go
@@ -1435,9 +1435,11 @@ func setHostSwitchSpecInSchema(d *schema.ResourceData, spec *data.StructValue, n
 					if len(profiles) > 0 {
 						hsCfgOpt["host_switch_profile"] = profiles
 					}
-					hsCfgOpt["ip_assignment"], err = setIPAssignmentInSchema(tnpsc.HostSwitchConfigOption.IpAssignmentSpec)
-					if err != nil {
-						return err
+					if tnpsc.HostSwitchConfigOption.IpAssignmentSpec != nil {
+						hsCfgOpt["ip_assignment"], err = setIPAssignmentInSchema(tnpsc.HostSwitchConfigOption.IpAssignmentSpec)
+						if err != nil {
+							return err
+						}
 					}
 					hsCfgOpt["uplink"] = setUplinksFromSchema(tnpsc.HostSwitchConfigOption.Uplinks)
 					e["host_switch_config_option"] = []interface{}{hsCfgOpt}


### PR DESCRIPTION
When a switch sub-config is created with no specification of IP assignment, the code mishandles it and tries set it anyway.