### PR TITLE
Clarify NAT rule docs with regards to ANY network

### DIFF
--- a/website/docs/r/policy_distributed_flood_protection_profile.html.markdown
+++ b/website/docs/r/policy_distributed_flood_protection_profile.html.markdown
@@ -66,6 +66,8 @@ The following arguments are supported:
 * `description` - (Optional) Description of the resource.
 * `tag` - (Optional) A list of scope + tag pairs to associate with this resource.
 * `nsx_id` - (Optional) The NSX ID of this resource. If set, this ID will be used to create the policy resource.
+* `context` - (Optional) The context which the object belongs to
+  * `project_id` - (Required) The ID of the project which the object belongs to
 * `icmp_active_flow_limit` - (Optional) Active ICMP connections limit. If this field is empty, firewall will not set a limit to active ICMP connections. Minimum: 1, Maximum: 1000000.
 * `other_active_conn_limit` - (Optional) Timeout after first TN. If this field is empty, firewall will not set a limit to other active connections. besides UDP, ICMP and half open TCP connections. Minimum: 1, Maximum: 1000000.
 * `tcp_half_open_conn_limit` - (Optional) Active half open TCP connections limit. If this field is empty, firewall will not set a limit to half open TCP connections. Minimum: 1, Maximum: 1000000.

--- a/website/docs/r/policy_gateway_flood_protection_profile.html.markdown
+++ b/website/docs/r/policy_gateway_flood_protection_profile.html.markdown
@@ -64,6 +64,8 @@ The following arguments are supported:
 * `description` - (Optional) Description of the resource.
 * `tag` - (Optional) A list of scope + tag pairs to associate with this resource.
 * `nsx_id` - (Optional) The NSX ID of this resource. If set, this ID will be used to create the policy resource.
+* `context` - (Optional) The context which the object belongs to
+  * `project_id` - (Required) The ID of the project which the object belongs to
 * `icmp_active_flow_limit` - (Optional) Active ICMP connections limit. If this field is empty, firewall will not set a limit to active ICMP connections. Minimum: 1, Maximum: 1000000.
 * `other_active_conn_limit` - (Optional) Timeout after first TN. If this field is empty, firewall will not set a limit to other active connections. besides UDP, ICMP and half open TCP connections. Minimum: 1, Maximum: 1000000.
 * `tcp_half_open_conn_limit` - (Optional) Active half open TCP connections limit. If this field is empty, firewall will not set a limit to half open TCP connections. Minimum: 1, Maximum: 1000000.

--- a/website/docs/r/policy_nat_rule.html.markdown
+++ b/website/docs/r/policy_nat_rule.html.markdown
@@ -72,13 +72,13 @@ The following arguments are supported:
     * `project_id` - (Required) The ID of the project which the object belongs to
 * `gateway_path` - (Required) The NSX Policy path to the Tier0 or Tier1 Gateway for this NAT Rule.
 * `action` - (Required) The action for the NAT Rule. One of `SNAT`, `DNAT`, `REFLEXIVE`, `NO_SNAT`, `NO_DNAT`, `NAT64`.
-* `destination_networks` - (Optional) A list of destination network IP addresses or CIDR.
+* `destination_networks` - (Optional) A list of destination network IP addresses or CIDR. If unspecified, the value will be `ANY`.
 * `enabled` - (Optional) Enable/disable the Rule. Defaults to `true`.
 * `firewall_match` - (Optional) Firewall match flag. One of `MATCH_EXTERNAL_ADDRESS`, `MATCH_INTERNAL_ADDRESS`, `BYPASS`.
 * `logging` - (Optional) Enable/disable rule logging. Defaults to `false`.
 * `rule_priority` - (Optional) The priority of the rule. Valid values between 0 to 2147483647. Defaults to `100`.
 * `service` - (Optional) Policy path of Service on which the NAT rule will be applied.
-* `source_networks` - (Optional) A list of source network IP addresses or CIDR.
+* `source_networks` - (Optional) A list of source network IP addresses or CIDR. If unspecified, the value will be `ANY`.
 * `translated_networks` - (Optional) A list of translated network IP addresses or CIDR.
 * `translated_ports` - (Optional) Port number or port range. For use with `DNAT` action only.
 * `scope` - (Optional) A list of paths to interfaces and/or labels where the NAT Rule is enforced.


### PR DESCRIPTION
In addition, add `context` attribute to flood protection profile docs.