### PR TITLE
Increase sleep time before checking deletion

### DIFF
--- a/nsxt/resource_nsxt_edge_cluster_test.go
+++ b/nsxt/resource_nsxt_edge_cluster_test.go
@@ -102,7 +102,7 @@ func testAccNSXEdgeClusterCheckDestroy(state *terraform.State, displayName strin
 	connector := getPolicyConnector(testAccProvider.Meta().(nsxtClients))
 
 	// This addresses the fact that object is retrieved even though it had been deleted
-	time.Sleep(1 * time.Second)
+	time.Sleep(10 * time.Second)
 
 	for _, rs := range state.RootModule().Resources {
 		if rs.Type != "nsxt_edge_cluster" {


### PR DESCRIPTION
When an edge cluster is deleted in acceptance tests, occasionally the test is failing because the code checks for successful deletion - but deletion is sometimes too slow.

Change increases the wait time before checking.