### PR TITLE
Remove hard-coded maxint default in flood profile

### DIFF
--- a/nsxt/resource_nsxt_policy_gateway_flood_protection_profile.go
+++ b/nsxt/resource_nsxt_policy_gateway_flood_protection_profile.go
@@ -8,7 +8,6 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/bindings"
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/data"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
@@ -32,11 +31,10 @@ func resourceNsxtPolicyGatewayFloodProtectionProfile() *schema.Resource {
 func getGatewayFloodProtectionProfile() map[string]*schema.Schema {
 	baseProfile := getFloodProtectionProfile()
 	baseProfile["nat_active_conn_limit"] = &schema.Schema{
-		Type:         schema.TypeInt,
-		Description:  "Maximum limit of active NAT connections",
-		Optional:     true,
-		ValidateFunc: validation.IntBetween(1, 4294967295),
-		Default:      4294967295,
+		Type:        schema.TypeInt,
+		Description: "Maximum limit of active NAT connections",
+		Optional:    true,
+		Computed:    true,
 	}
 	return baseProfile
 }


### PR DESCRIPTION
It causes compilation error on some platforms. Set default value to Computed instead.