### PR TITLE
order realized VM results by external_id

### DIFF
--- a/nsxt/resource_nsxt_policy_vm_tags.go
+++ b/nsxt/resource_nsxt_policy_vm_tags.go
@@ -70,7 +70,8 @@ func listAllPolicyVirtualMachines(context utl.SessionContext, connector client.C
 		// NOTE: Contrary to the spec, this API does not populate cursor and result count
 		// parameters, respects cursor input. Therefore we determine end of VM list by
 		// looking for empty result.
-		vms, err := client.List(cursor, nil, &boolFalse, nil, nil, &boolFalse, nil)
+		sortBy := "external_id"
+		vms, err := client.List(cursor, nil, &boolFalse, nil, nil, &boolFalse, &sortBy)
 		if err != nil {
 			return results, err
 		}


### PR DESCRIPTION
This PR adds external_id as the sortByParam for calls to the realized VM endpoint. This is needed in larger environments (1k+ VMs) because as of NSX-T 3.2.3 the /policy/api/v1/infra/realized-state/virtual-machines endpoint is not respecting a consistent ordering by default. This means that the internal slice representing VMs returned from listAllPolicyVirtualMachines may include duplicates and may be missing VMs that actually exist. Explicitly setting an order forces consistent results across the paginated calls.

Resolves: #1193