### PR TITLE
Use search API for pulling VM on latest nsx

### DIFF
--- a/nsxt/data_source_nsxt_policy_vm.go
+++ b/nsxt/data_source_nsxt_policy_vm.go
@@ -45,7 +45,6 @@ func dataSourceNsxtPolicyVMIDRead(d *schema.ResourceData, m interface{}) error {
 	var vmModel model.VirtualMachine
 	connector := getPolicyConnector(m)
 
-	// TODO: test with KVM based VM
 	objID := getNsxtPolicyVMIDFromSchema(d)
 	context := getSessionContext(d, m)
 	if objID != "" {


### PR DESCRIPTION
Since 4.1.2, search API works for inventory objects, this change uses it instead of listing all VMs, dependant of NSX version. For older versions, previous codepath is used.
Signed-off-by: Anna Khmelnitsky <akhmelnitsky@vmware.com>