### PR TITLE
Fix a crash in security policy

### DIFF
--- a/nsxt/resource_nsxt_policy_parent_security_policy.go
+++ b/nsxt/resource_nsxt_policy_parent_security_policy.go
@@ -65,7 +65,7 @@ func parentSecurityPolicyModelToSchema(d *schema.ResourceData, m interface{}) (*
 	client := domains.NewSecurityPoliciesClient(getSessionContext(d, m), connector)
 	obj, err := client.Get(domainName, id)
 	if err != nil {
-		return nil, handleReadError(d, "SecurityPolicy", id, err)
+		return nil, err
 	}
 	d.Set("display_name", obj.DisplayName)
 	d.Set("description", obj.Description)

--- a/nsxt/resource_nsxt_policy_security_policy.go
+++ b/nsxt/resource_nsxt_policy_security_policy.go
@@ -137,7 +137,7 @@ func resourceNsxtPolicySecurityPolicyGeneralCreate(d *schema.ResourceData, m int
 func resourceNsxtPolicySecurityPolicyGeneralRead(d *schema.ResourceData, m interface{}, withRule bool) error {
 	obj, err := parentSecurityPolicyModelToSchema(d, m)
 	if err != nil {
-		return err
+		return handleReadError(d, "SecurityPolicy", d.Id(), err)
 	}
 	if withRule {
 		return setPolicyRulesInSchema(d, obj.Rules)


### PR DESCRIPTION
handleReadError swallows error in case of 404 response, so its not suitable as safeguard against returned object having nil value.