### PR TITLE
Add reflect lib for auto generation

### DIFF
--- a/.github/workflows/golangci-ut.yml
+++ b/.github/workflows/golangci-ut.yml
@@ -1,0 +1,25 @@
+name: golangci-ut
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+  workflow_dispatch:
+
+jobs:
+  golangci:
+    name: Unit test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v5
+        with:
+          go-version: 1.19
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          go get .
+          go mod tidy
+      - name: Build
+        run: go build -v ./...
+      - name: Test with the Go CLI
+        run: go test -v ./nsxt/metadata/...

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.29.0
+	github.com/stretchr/testify v1.7.2
 	github.com/vmware/go-vmware-nsxt v0.0.0-20220328155605-f49a14c1ef5f
 	github.com/vmware/vsphere-automation-sdk-go/lib v0.7.0
 	github.com/vmware/vsphere-automation-sdk-go/runtime v0.7.0
@@ -22,6 +23,7 @@ require (
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/beevik/etree v1.1.0 // indirect
 	github.com/cloudflare/circl v1.3.7 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/gibson042/canonicaljson-go v1.0.3 // indirect
 	github.com/golang-jwt/jwt/v4 v4.3.0 // indirect
@@ -53,6 +55,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/oklog/run v1.0.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
 	github.com/vmihailenco/msgpack/v5 v5.3.5 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
@@ -67,4 +70,5 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230525234030-28d5490b6b19 // indirect
 	google.golang.org/grpc v1.57.1 // indirect
 	google.golang.org/protobuf v1.33.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/nsxt/data_source_nsxt_policy_edge_node.go
+++ b/nsxt/data_source_nsxt_policy_edge_node.go
@@ -8,6 +8,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/vmware/terraform-provider-nsxt/nsxt/util"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/bindings"
@@ -42,7 +44,7 @@ func dataSourceNsxtPolicyEdgeNodeRead(d *schema.ResourceData, m interface{}) err
 	// for bool types, but in this case it works and GetOk doesn't
 	memberIndex, memberIndexSet := d.GetOkExists("member_index")
 
-	if isPolicyGlobalManager(m) || nsxVersionHigherOrEqual("3.2.0") {
+	if isPolicyGlobalManager(m) || util.NsxVersionHigherOrEqual("3.2.0") {
 		query := make(map[string]string)
 		query["parent_path"] = edgeClusterPath
 		if memberIndexSet {

--- a/nsxt/gateway_common.go
+++ b/nsxt/gateway_common.go
@@ -5,6 +5,10 @@ import (
 	"log"
 	"strings"
 
+	nsx_policy "github.com/vmware/terraform-provider-nsxt/api"
+	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
+	"github.com/vmware/terraform-provider-nsxt/nsxt/util"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/bindings"
@@ -15,9 +19,6 @@ import (
 	gm_model "github.com/vmware/vsphere-automation-sdk-go/services/nsxt-gm/model"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_0s"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
-
-	nsx_policy "github.com/vmware/terraform-provider-nsxt/api"
-	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
 )
 
 var nsxtPolicyTier0GatewayRedistributionRuleTypes = []string{
@@ -534,7 +535,7 @@ func setLocaleServiceRedistributionRulesConfig(rulesConfig []interface{}, config
 			rule.RouteMapPath = &routeMapPath
 		}
 
-		if nsxVersionHigherOrEqual("3.1.0") {
+		if util.NsxVersionHigherOrEqual("3.1.0") {
 			if bgp {
 				rule.Destinations = append(rule.Destinations, model.Tier0RouteRedistributionRule_DESTINATIONS_BGP)
 			}
@@ -565,7 +566,7 @@ func setLocaleServiceRedistributionConfig(redistributionConfigs []interface{}, s
 		BgpEnabled: &bgpEnabled,
 	}
 
-	if nsxVersionHigherOrEqual("3.1.0") {
+	if util.NsxVersionHigherOrEqual("3.1.0") {
 		redistributionStruct.OspfEnabled = &ospfEnabled
 	}
 
@@ -580,7 +581,7 @@ func getLocaleServiceRedistributionRuleConfig(config *model.Tier0RouteRedistribu
 		rule["name"] = ruleConfig.Name
 		rule["route_map_path"] = ruleConfig.RouteMapPath
 		rule["types"] = ruleConfig.RouteRedistributionTypes
-		if nsxVersionHigherOrEqual("3.1.0") {
+		if util.NsxVersionHigherOrEqual("3.1.0") {
 			bgp := false
 			ospf := false
 			for _, destination := range ruleConfig.Destinations {

--- a/nsxt/metadata/metadata.go
+++ b/nsxt/metadata/metadata.go
@@ -130,6 +130,13 @@ func SchemaToStruct(elem reflect.Value, d *schema.ResourceData, metadata map[str
 		if item.Metadata.IntroducedInVersion != "" && util.NsxVersionLower(item.Metadata.IntroducedInVersion) {
 			continue
 		}
+		if len(parent) == 0 {
+			_, ok := d.GetOk(key)
+			if !ok {
+				log.Printf("[INFO] Skipping key %s with unset value", key)
+				continue
+			}
+		}
 
 		log.Printf("[INFO] inspecting key %s with type %s", key, item.Metadata.SchemaType)
 		if len(parent) > 0 {
@@ -178,7 +185,6 @@ func SchemaToStruct(elem reflect.Value, d *schema.ResourceData, metadata map[str
 			nestedSchema := nestedSchemaList[0].(map[string]interface{})
 
 			childElem := item.Schema.Elem.(*ExtendedResource)
-			log.Printf("[INFO] calling recur %s", key)
 			SchemaToStruct(nestedObj.Elem(), d, childElem.Schema, key, nestedSchema)
 			log.Printf("[INFO] assigning struct %v to %s", nestedObj, key)
 			elem.FieldByName(item.Metadata.SdkFieldName).Set(nestedObj)

--- a/nsxt/metadata/metadata.go
+++ b/nsxt/metadata/metadata.go
@@ -153,13 +153,6 @@ func SchemaToStruct(elem reflect.Value, d *schema.ResourceData, metadata map[str
 		if item.Metadata.IntroducedInVersion != "" && util.NsxVersionLower(item.Metadata.IntroducedInVersion) {
 			continue
 		}
-		if len(parent) == 0 {
-			_, ok := d.GetOk(key)
-			if !ok {
-				log.Printf("[INFO] Skipping key %s with unset value", key)
-				continue
-			}
-		}
 
 		log.Printf("[INFO] inspecting key %s with type %s", key, item.Metadata.SchemaType)
 		if len(parent) > 0 {

--- a/nsxt/metadata/metadata.go
+++ b/nsxt/metadata/metadata.go
@@ -1,0 +1,183 @@
+package metadata
+
+import (
+	"log"
+	"reflect"
+
+	"github.com/vmware/terraform-provider-nsxt/nsxt/util"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type Metadata struct {
+	// we need a separate schema type, in addition to terraform SDK type,
+	// in order to distinguish between single subclause and a list of entries
+	SchemaType   string
+	ReadOnly     bool
+	SdkFieldName string
+	// This attribute is parent path for the object
+	IsParentPath        bool
+	IntroducedInVersion string
+	// skip handling of this attribute - it will be done manually
+	Skip        bool
+	ReflectType reflect.Type
+	TestData    Testdata
+}
+
+type ExtendedSchema struct {
+	Schema   schema.Schema
+	Metadata Metadata
+}
+
+type ExtendedResource struct {
+	Schema map[string]*ExtendedSchema
+}
+
+type Testdata struct {
+	CreateValue interface{}
+	UpdateValue interface{}
+}
+
+// GetExtendedSchema is a helper to convert terraform sdk schema to extended schema
+func GetExtendedSchema(sch *schema.Schema) *ExtendedSchema {
+	shallowCopy := *sch
+	return &ExtendedSchema{
+		Schema: shallowCopy,
+		Metadata: Metadata{
+			Skip: true,
+		},
+	}
+}
+
+// GetSchemaFromExtendedSchema gets terraform sdk schema from extended schema definition
+func GetSchemaFromExtendedSchema(ext map[string]*ExtendedSchema) map[string]*schema.Schema {
+	result := make(map[string]*schema.Schema)
+
+	for key, value := range ext {
+		log.Printf("[INFO] inspecting schema key %s, value %v", key, value)
+		shallowCopy := value.Schema
+		if (value.Schema.Type == schema.TypeList) || (value.Schema.Type == schema.TypeSet) {
+			elem, ok := shallowCopy.Elem.(*ExtendedSchema)
+			if ok {
+				shallowCopy.Elem = elem.Schema
+			} else {
+				elem, ok := shallowCopy.Elem.(*ExtendedResource)
+				if ok {
+					shallowCopy.Elem = &schema.Resource{
+						Schema: GetSchemaFromExtendedSchema(elem.Schema),
+					}
+				}
+			}
+		}
+		// TODO: deepcopy needed?
+		result[key] = &shallowCopy
+	}
+
+	return result
+}
+
+// StructToSchema converts NSX model struct to terraform schema
+// currently supports nested subtype and trivial types
+// TODO - support a list of structs
+func StructToSchema(elem reflect.Value, d *schema.ResourceData, metadata map[string]*ExtendedSchema, parent string, parentMap map[string]interface{}) {
+	for key, item := range metadata {
+		if item.Metadata.Skip {
+			continue
+		}
+
+		log.Printf("[INFO] inspecting key %s", key)
+		if len(parent) > 0 {
+			log.Printf("[INFO] parent %s key %s", parent, key)
+		}
+		if item.Metadata.SchemaType == "struct" {
+			nestedObj := elem.FieldByName(item.Metadata.SdkFieldName)
+			nestedSchema := make(map[string]interface{})
+			childElem := item.Schema.Elem.(*ExtendedResource)
+			StructToSchema(nestedObj.Elem(), d, childElem.Schema, key, nestedSchema)
+			log.Printf("[INFO] assigning struct %v to %s", nestedObj, key)
+			// TODO - get the schema from nested type if parent in present
+			var nestedSlice []map[string]interface{}
+			nestedSlice = append(nestedSlice, nestedSchema)
+			if len(parent) > 0 {
+				parentMap[key] = nestedSlice
+			} else {
+				d.Set(key, nestedSlice)
+			}
+		} else {
+			if len(parent) > 0 {
+				log.Printf("[INFO] assigning nested value %v to %s", elem.FieldByName(item.Metadata.SdkFieldName).Interface(), key)
+				parentMap[key] = elem.FieldByName(item.Metadata.SdkFieldName).Interface()
+			} else {
+				log.Printf("[INFO] assigning value %v to %s", elem.FieldByName(item.Metadata.SdkFieldName).Interface(), key)
+				d.Set(key, elem.FieldByName(item.Metadata.SdkFieldName).Interface())
+			}
+		}
+	}
+}
+
+// SchemaToStruct converts terraform schema to NSX model struct
+// currently supports nested subtype and trivial types
+// TODO - support a list of structs
+func SchemaToStruct(elem reflect.Value, d *schema.ResourceData, metadata map[string]*ExtendedSchema, parent string, parentMap map[string]interface{}) {
+	for key, item := range metadata {
+		if item.Metadata.ReadOnly || item.Metadata.Skip {
+			continue
+		}
+		if item.Metadata.IntroducedInVersion != "" && util.NsxVersionLower(item.Metadata.IntroducedInVersion) {
+			continue
+		}
+
+		log.Printf("[INFO] inspecting key %s", key)
+		if len(parent) > 0 {
+			log.Printf("[INFO] parent %s key %s", parent, key)
+		}
+		if item.Metadata.SchemaType == "string" {
+			var value string
+			if len(parent) > 0 {
+				value = parentMap[key].(string)
+			} else {
+				value = d.Get(key).(string)
+			}
+			log.Printf("[INFO] assigning string %v to %s", value, key)
+			elem.FieldByName(item.Metadata.SdkFieldName).Set(reflect.ValueOf(&value))
+		}
+		if item.Metadata.SchemaType == "bool" {
+			var value bool
+			if len(parent) > 0 {
+				value = parentMap[key].(bool)
+			} else {
+				value = d.Get(key).(bool)
+			}
+			log.Printf("[INFO] assigning bool %v to %s", value, key)
+			elem.FieldByName(item.Metadata.SdkFieldName).Set(reflect.ValueOf(&value))
+		}
+		if item.Metadata.SchemaType == "int" {
+			var value int64
+			if len(parent) > 0 {
+				value = int64(parentMap[key].(int))
+			} else {
+				value = int64(d.Get(key).(int))
+			}
+			log.Printf("[INFO] assigning int %v to %s", value, key)
+			elem.FieldByName(item.Metadata.SdkFieldName).Set(reflect.ValueOf(&value))
+		}
+		if item.Metadata.SchemaType == "struct" {
+			nestedObj := reflect.New(item.Metadata.ReflectType)
+			/*
+				// Helper for list of structs
+				slice := reflect.MakeSlice(reflect.TypeOf(nestedObj), 1, 1)
+			*/
+			nestedSchemaList := d.Get(key).([]interface{})
+			if len(nestedSchemaList) == 0 {
+				continue
+			}
+			nestedSchema := nestedSchemaList[0].(map[string]interface{})
+
+			childElem := item.Schema.Elem.(*ExtendedResource)
+			SchemaToStruct(nestedObj.Elem(), d, childElem.Schema, key, nestedSchema)
+			log.Printf("[INFO] assigning struct %v to %s", nestedObj, key)
+			elem.FieldByName(item.Metadata.SdkFieldName).Set(nestedObj)
+			// TODO - get the schema from nested type if parent in present
+		}
+	}
+}

--- a/nsxt/metadata/metadata.go
+++ b/nsxt/metadata/metadata.go
@@ -237,10 +237,6 @@ func SchemaToStruct(elem reflect.Value, d *schema.ResourceData, metadata map[str
 				}
 			}
 
-			if len(itemList) == 0 {
-				continue
-			}
-
 			// List of string, bool, int
 			if childElem, ok := item.Schema.Elem.(*ExtendedSchema); ok {
 				sliceElem := elem.FieldByName(item.Metadata.SdkFieldName)

--- a/nsxt/metadata/metadata_test.go
+++ b/nsxt/metadata/metadata_test.go
@@ -1,6 +1,7 @@
 package metadata
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -9,19 +10,28 @@ import (
 )
 
 type testStruct struct {
-	StringField    *string
-	BoolField      *bool
-	IntField       *int64
-	StringFieldNil *string
-	BoolFieldNil   *bool
-	IntFieldNil    *int64
-	StructField    *testNestedStruct
+	StringField      *string
+	BoolField        *bool
+	IntField         *int64
+	StringFieldNil   *string
+	BoolFieldNil     *bool
+	IntFieldNil      *int64
+	StructField      *testNestedStruct
+	StringListField  []string
+	StructList       []testNestedStruct
+	DeepNestedStruct *testDeepNestedStruct
 }
 
 type testNestedStruct struct {
 	StringField *string
 	BoolField   *bool
 	IntField    *int64
+}
+
+type testDeepNestedStruct struct {
+	StringField *string
+	BoolList    []bool
+	StructList  []testNestedStruct
 }
 
 var testSchema = map[string]*schema.Schema{
@@ -63,12 +73,68 @@ var testSchema = map[string]*schema.Schema{
 			},
 		},
 	},
+	"string_list": {
+		Type: schema.TypeList,
+		Elem: &schema.Schema{
+			Type: schema.TypeString,
+		},
+	},
+	"struct_list": {
+		Type: schema.TypeList,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"string_field": {
+					Type: schema.TypeString,
+				},
+				"bool_field": {
+					Type: schema.TypeBool,
+				},
+				"int_field": {
+					Type: schema.TypeInt,
+				},
+			},
+		},
+	},
+	"deep_nested_struct": {
+		Type:     schema.TypeList,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"string_field": {
+					Type: schema.TypeString,
+				},
+				"bool_list": {
+					Type: schema.TypeList,
+					Elem: &schema.Schema{
+						Type: schema.TypeBool,
+					},
+				},
+				"struct_list": {
+					Type: schema.TypeList,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"string_field": {
+								Type: schema.TypeString,
+							},
+							"bool_field": {
+								Type: schema.TypeBool,
+							},
+							"int_field": {
+								Type: schema.TypeInt,
+							},
+						},
+					},
+				},
+			},
+		},
+	},
 }
 
-func basicStringSchema(sdkName string) *ExtendedSchema {
+func basicStringSchema(sdkName string, optional bool) *ExtendedSchema {
 	return &ExtendedSchema{
 		Schema: schema.Schema{
-			Type: schema.TypeString,
+			Type:     schema.TypeString,
+			Optional: optional,
 		},
 		Metadata: Metadata{
 			SchemaType:   "string",
@@ -77,10 +143,11 @@ func basicStringSchema(sdkName string) *ExtendedSchema {
 	}
 }
 
-func basicBoolSchema(sdkName string) *ExtendedSchema {
+func basicBoolSchema(sdkName string, optional bool) *ExtendedSchema {
 	return &ExtendedSchema{
 		Schema: schema.Schema{
-			Type: schema.TypeBool,
+			Type:     schema.TypeBool,
+			Optional: optional,
 		},
 		Metadata: Metadata{
 			SchemaType:   "bool",
@@ -89,10 +156,11 @@ func basicBoolSchema(sdkName string) *ExtendedSchema {
 	}
 }
 
-func basicIntSchema(sdkName string) *ExtendedSchema {
+func basicIntSchema(sdkName string, optional bool) *ExtendedSchema {
 	return &ExtendedSchema{
 		Schema: schema.Schema{
-			Type: schema.TypeInt,
+			Type:     schema.TypeInt,
+			Optional: optional,
 		},
 		Metadata: Metadata{
 			SchemaType:   "int",
@@ -101,37 +169,127 @@ func basicIntSchema(sdkName string) *ExtendedSchema {
 	}
 }
 
-var testExtendedSchema = map[string]*ExtendedSchema{
-	"string_field":     basicStringSchema("StringField"),
-	"bool_field":       basicBoolSchema("BoolField"),
-	"int_field":        basicIntSchema("IntField"),
-	"string_field_nil": basicStringSchema("StringFieldNil"),
-	"bool_field_nil":   basicBoolSchema("BoolFieldNil"),
-	"int_field_nil":    basicIntSchema("IntFieldNil"),
-	"struct_field": {
-		Schema: schema.Schema{
-			Type:     schema.TypeList,
-			MaxItems: 1,
-			Elem: &ExtendedResource{
-				Schema: map[string]*ExtendedSchema{
-					"string_field": basicStringSchema("StringField"),
-					"bool_field":   basicBoolSchema("BoolField"),
-					"int_field":    basicIntSchema("IntField"),
+func basicStructSchema() schema.Schema {
+	return schema.Schema{
+		Type:     schema.TypeList,
+		MaxItems: 1,
+		Elem: &ExtendedResource{
+			Schema: map[string]*ExtendedSchema{
+				"string_field": basicStringSchema("StringField", false),
+				"bool_field":   basicBoolSchema("BoolField", false),
+				"int_field":    basicIntSchema("IntField", false),
+			},
+		},
+	}
+}
+
+func mixedStructSchema() schema.Schema {
+	return schema.Schema{
+		Type:     schema.TypeList,
+		MaxItems: 1,
+		Elem: &ExtendedResource{
+			Schema: map[string]*ExtendedSchema{
+				"string_field": basicStringSchema("StringField", false),
+				"bool_list": {
+					Schema: schema.Schema{
+						Type: schema.TypeList,
+						Elem: basicBoolSchema("BoolList", false),
+					},
+					Metadata: Metadata{
+						SchemaType:   "list",
+						SdkFieldName: "BoolList",
+					},
+				},
+				"struct_list": {
+					Schema: basicStructSchema(),
+					Metadata: Metadata{
+						SchemaType:   "list",
+						SdkFieldName: "StructList",
+						ReflectType:  reflect.TypeOf(testNestedStruct{}),
+					},
 				},
 			},
 		},
+	}
+}
+
+var testExtendedSchema = map[string]*ExtendedSchema{
+	"string_field":     basicStringSchema("StringField", false),
+	"bool_field":       basicBoolSchema("BoolField", false),
+	"int_field":        basicIntSchema("IntField", false),
+	"string_field_nil": basicStringSchema("StringFieldNil", true),
+	"bool_field_nil":   basicBoolSchema("BoolFieldNil", true),
+	"int_field_nil":    basicIntSchema("IntFieldNil", true),
+	"struct_field": {
+		Schema: basicStructSchema(),
 		Metadata: Metadata{
 			SchemaType:   "struct",
 			SdkFieldName: "StructField",
 			ReflectType:  reflect.TypeOf(testNestedStruct{}),
 		},
 	},
+	"string_list": {
+		Schema: schema.Schema{
+			Type: schema.TypeList,
+			Elem: basicStringSchema("StringListField", false),
+		},
+		Metadata: Metadata{
+			SchemaType:   "list",
+			SdkFieldName: "StringListField",
+		},
+	},
+	"struct_list": {
+		Schema: basicStructSchema(),
+		Metadata: Metadata{
+			SchemaType:   "list",
+			SdkFieldName: "StructList",
+			ReflectType:  reflect.TypeOf(testNestedStruct{}),
+		},
+	},
+	"deep_nested_struct": {
+		Schema: mixedStructSchema(),
+		Metadata: Metadata{
+			SchemaType:   "struct",
+			SdkFieldName: "DeepNestedStruct",
+			ReflectType:  reflect.TypeOf(testDeepNestedStruct{}),
+		},
+	},
+}
+
+func TestGetSchemaFromExtendedSchema(t *testing.T) {
+	obs := GetSchemaFromExtendedSchema(testExtendedSchema)
+	assertSchemaEqual(t, testSchema, obs)
+}
+
+func assertSchemaEqual(t *testing.T, expected, actual map[string]*schema.Schema) {
+	for k, v := range actual {
+		assert.Contains(t, expected, k, "unexpected schema key %s", k)
+		expectedSchema := expected[k]
+		assert.Equal(t, expectedSchema.Type, v.Type,
+			"expected type %s, actual schema %s", expectedSchema.Type, v.Type)
+		if v.Type == schema.TypeList || v.Type == schema.TypeSet {
+			if _, ok := v.Elem.(*schema.Resource); ok {
+				assertSchemaEqual(t,
+					expectedSchema.Elem.(*schema.Resource).Schema,
+					v.Elem.(*schema.Resource).Schema)
+			} else if _, ok := v.Elem.(*schema.Schema); ok {
+				assert.Equal(t, expectedSchema, v)
+			} else {
+				assert.Fail(t, fmt.Sprintf("unexpected schema element type %s", reflect.TypeOf(v.Elem)))
+			}
+		} else {
+			assert.Equal(t, expectedSchema, v, "schema for key %s not equal", k)
+		}
+	}
 }
 
 func TestStructToSchema(t *testing.T) {
 	testStr := "test_string"
+	nestStr1, nestStr2 := "nest_str1", "nest_str2"
 	testBool := true
+	nestBool1, nestBool2 := true, false
 	testInt := int64(123)
+	nestInt1, nestInt2 := int64(123), int64(456)
 	obj := testStruct{
 		StringField: &testStr,
 		BoolField:   &testBool,
@@ -141,6 +299,30 @@ func TestStructToSchema(t *testing.T) {
 			BoolField:   &testBool,
 			IntField:    &testInt,
 		},
+		StringListField: []string{"string_1", "string_2"},
+		StructList: []testNestedStruct{
+			{
+				StringField: &nestStr1,
+				BoolField:   &nestBool1,
+				IntField:    &nestInt1,
+			},
+			{
+				StringField: &nestStr2,
+				BoolField:   &nestBool2,
+				IntField:    &nestInt2,
+			},
+		},
+		DeepNestedStruct: &testDeepNestedStruct{
+			StringField: &nestStr2,
+			BoolList:    []bool{false, true},
+			StructList: []testNestedStruct{
+				{
+					StringField: &nestStr1,
+					BoolField:   &nestBool2,
+					IntField:    &nestInt2,
+				},
+			},
+		},
 	}
 	d := schema.TestResourceDataRaw(
 		t, testSchema, map[string]interface{}{})
@@ -148,24 +330,60 @@ func TestStructToSchema(t *testing.T) {
 	elem := reflect.ValueOf(&obj).Elem()
 	StructToSchema(elem, d, testExtendedSchema, "", nil)
 
-	// Base types
-	assert.Equal(t, "test_string", d.Get("string_field").(string))
-	assert.Equal(t, true, d.Get("bool_field").(bool))
-	assert.Equal(t, 123, d.Get("int_field").(int))
+	t.Run("Base types", func(t *testing.T) {
+		assert.Equal(t, "test_string", d.Get("string_field").(string))
+		assert.Equal(t, true, d.Get("bool_field").(bool))
+		assert.Equal(t, 123, d.Get("int_field").(int))
+	})
 
-	// Zero values
-	_, ok := d.GetOk("string_field_nil")
-	assert.False(t, ok)
-	_, ok = d.GetOk("bool_field_nil")
-	assert.False(t, ok)
-	_, ok = d.GetOk("int_field_nil")
-	assert.False(t, ok)
+	t.Run("Zero values", func(t *testing.T) {
+		_, ok := d.GetOk("string_field_nil")
+		assert.False(t, ok)
+		_, ok = d.GetOk("bool_field_nil")
+		assert.False(t, ok)
+		_, ok = d.GetOk("int_field_nil")
+		assert.False(t, ok)
+	})
 
-	// Nested struct
-	nestedObj := d.Get("struct_field").([]interface{})[0].(map[string]interface{})
-	assert.Equal(t, "test_string", nestedObj["string_field"].(string))
-	assert.Equal(t, true, nestedObj["bool_field"].(bool))
-	assert.Equal(t, 123, nestedObj["int_field"].(int))
+	t.Run("Nested struct", func(t *testing.T) {
+		nestedObj := d.Get("struct_field").([]interface{})[0].(map[string]interface{})
+		assert.Equal(t, "test_string", nestedObj["string_field"].(string))
+		assert.Equal(t, true, nestedObj["bool_field"].(bool))
+		assert.Equal(t, 123, nestedObj["int_field"].(int))
+	})
+
+	t.Run("Base list", func(t *testing.T) {
+		stringSlice := d.Get("string_list").([]interface{})
+		assert.Equal(t, []interface{}{"string_1", "string_2"}, stringSlice)
+	})
+
+	t.Run("Struct list", func(t *testing.T) {
+		structSlice := d.Get("struct_list").([]interface{})
+		assert.Equal(t, 2, len(structSlice))
+		assert.Equal(t, map[string]interface{}{
+			"string_field": nestStr1,
+			"bool_field":   nestBool1,
+			"int_field":    123,
+		}, structSlice[0].(map[string]interface{}))
+		assert.Equal(t, map[string]interface{}{
+			"string_field": nestStr2,
+			"bool_field":   nestBool2,
+			"int_field":    456,
+		}, structSlice[1].(map[string]interface{}))
+	})
+
+	t.Run("Deep nested struct", func(t *testing.T) {
+		deepNestedObj := d.Get("deep_nested_struct").([]interface{})[0].(map[string]interface{})
+		assert.Equal(t, nestStr2, deepNestedObj["string_field"].(string))
+		assert.Equal(t, []interface{}{false, true}, deepNestedObj["bool_list"].([]interface{}))
+		nestedStructList := deepNestedObj["struct_list"].([]interface{})
+		assert.Equal(t, 1, len(nestedStructList))
+		assert.Equal(t, map[string]interface{}{
+			"string_field": nestStr1,
+			"bool_field":   nestBool2,
+			"int_field":    456,
+		}, nestedStructList[0].(map[string]interface{}))
+	})
 }
 
 func TestSchemaToStruct(t *testing.T) {
@@ -181,24 +399,87 @@ func TestSchemaToStruct(t *testing.T) {
 					"int_field":    1,
 				},
 			},
+			"string_list": []interface{}{"string_1", "string_2"},
+			"struct_list": []interface{}{
+				map[string]interface{}{
+					"string_field": "nested_string_1",
+					"bool_field":   true,
+					"int_field":    1,
+				},
+				map[string]interface{}{
+					"string_field": "nested_string_2",
+					"bool_field":   true,
+					"int_field":    2,
+				},
+			},
+			"deep_nested_struct": []interface{}{
+				map[string]interface{}{
+					"string_field": "nested_string_1",
+					"bool_list":    []interface{}{true, false},
+					"struct_list": []interface{}{
+						map[string]interface{}{
+							"string_field": "nested_string_2",
+							"bool_field":   true,
+							"int_field":    1,
+						},
+					},
+				},
+			},
 		})
 
 	obj := testStruct{}
 	elem := reflect.ValueOf(&obj).Elem()
 	SchemaToStruct(elem, d, testExtendedSchema, "", nil)
 
-	// Base types
-	assert.Equal(t, "test_string", *obj.StringField)
-	assert.Equal(t, true, *obj.BoolField)
-	assert.Equal(t, int64(100), *obj.IntField)
+	nestStr1, nestStr2 := "nested_string_1", "nested_string_2"
+	trueVal := true
+	intVal1, intVal2 := int64(1), int64(2)
 
-	// Zero values
-	assert.Nil(t, obj.StringFieldNil)
-	assert.Nil(t, obj.BoolFieldNil)
-	assert.Nil(t, obj.IntFieldNil)
+	t.Run("Base types", func(t *testing.T) {
+		assert.Equal(t, "test_string", *obj.StringField)
+		assert.Equal(t, true, *obj.BoolField)
+		assert.Equal(t, int64(100), *obj.IntField)
+	})
 
-	// Nested struct
-	assert.Equal(t, "nested_string", *obj.StructField.StringField)
-	assert.Equal(t, true, *obj.StructField.BoolField)
-	assert.Equal(t, int64(1), *obj.StructField.IntField)
+	t.Run("Zero values", func(t *testing.T) {
+		assert.Nil(t, obj.StringFieldNil)
+		assert.Nil(t, obj.BoolFieldNil)
+		assert.Nil(t, obj.IntFieldNil)
+	})
+
+	t.Run("Nested struct", func(t *testing.T) {
+		assert.Equal(t, "nested_string", *obj.StructField.StringField)
+		assert.Equal(t, true, *obj.StructField.BoolField)
+		assert.Equal(t, int64(1), *obj.StructField.IntField)
+	})
+
+	t.Run("Base list", func(t *testing.T) {
+		assert.Equal(t, []string{"string_1", "string_2"}, obj.StringListField)
+	})
+
+	t.Run("Struct list", func(t *testing.T) {
+		assert.Equal(t, 2, len(obj.StructList))
+		assert.EqualValues(t, testNestedStruct{
+			StringField: &nestStr1,
+			BoolField:   &trueVal,
+			IntField:    &intVal1,
+		}, obj.StructList[0])
+		assert.EqualValues(t, testNestedStruct{
+			StringField: &nestStr2,
+			BoolField:   &trueVal,
+			IntField:    &intVal2,
+		}, obj.StructList[1])
+	})
+
+	t.Run("Deep nested struct", func(t *testing.T) {
+		assert.EqualValues(t, &testDeepNestedStruct{
+			StringField: &nestStr1,
+			BoolList:    []bool{true, false},
+			StructList: []testNestedStruct{{
+				StringField: &nestStr2,
+				BoolField:   &trueVal,
+				IntField:    &intVal1,
+			}},
+		}, obj.DeepNestedStruct)
+	})
 }

--- a/nsxt/metadata/metadata_test.go
+++ b/nsxt/metadata/metadata_test.go
@@ -1,0 +1,165 @@
+package metadata
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+)
+
+type testStruct struct {
+	StringField *string
+	BoolField   *bool
+	IntField    *int64
+	StructField *testNestedStruct
+}
+
+type testNestedStruct struct {
+	StringField *string
+	BoolField   *bool
+	IntField    *int64
+}
+
+var testSchema = map[string]*schema.Schema{
+	"string_field": {
+		Type: schema.TypeString,
+	},
+	"bool_field": {
+		Type: schema.TypeBool,
+	},
+	"int_field": {
+		Type: schema.TypeInt,
+	},
+	"struct_field": {
+		Type:     schema.TypeList,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"string_field": {
+					Type: schema.TypeString,
+				},
+				"bool_field": {
+					Type: schema.TypeBool,
+				},
+				"int_field": {
+					Type: schema.TypeInt,
+				},
+			},
+		},
+	},
+}
+
+func basicStringSchema() *ExtendedSchema {
+	return &ExtendedSchema{
+		Schema: schema.Schema{
+			Type: schema.TypeString,
+		},
+		Metadata: Metadata{
+			SchemaType:   "string",
+			SdkFieldName: "StringField",
+		},
+	}
+}
+
+func basicBoolSchema() *ExtendedSchema {
+	return &ExtendedSchema{
+		Schema: schema.Schema{
+			Type: schema.TypeBool,
+		},
+		Metadata: Metadata{
+			SchemaType:   "bool",
+			SdkFieldName: "BoolField",
+		},
+	}
+}
+
+func basicIntSchema() *ExtendedSchema {
+	return &ExtendedSchema{
+		Schema: schema.Schema{
+			Type: schema.TypeInt,
+		},
+		Metadata: Metadata{
+			SchemaType:   "int",
+			SdkFieldName: "IntField",
+		},
+	}
+}
+
+var testExtendedSchema = map[string]*ExtendedSchema{
+	"string_field": basicStringSchema(),
+	"bool_field":   basicBoolSchema(),
+	"int_field":    basicIntSchema(),
+	"struct_field": {
+		Schema: schema.Schema{
+			Type:     schema.TypeList,
+			MaxItems: 1,
+			Elem: &ExtendedResource{
+				Schema: map[string]*ExtendedSchema{
+					"string_field": basicStringSchema(),
+					"bool_field":   basicBoolSchema(),
+					"int_field":    basicIntSchema(),
+				},
+			},
+		},
+		Metadata: Metadata{
+			SchemaType:   "struct",
+			SdkFieldName: "StructField",
+			ReflectType:  reflect.TypeOf(testNestedStruct{}),
+		},
+	},
+}
+
+func TestStructToSchema(t *testing.T) {
+	testStr := "test_string"
+	testBool := true
+	testInt := int64(123)
+	obj := testStruct{
+		StringField: &testStr,
+		BoolField:   &testBool,
+		IntField:    &testInt,
+		StructField: &testNestedStruct{
+			StringField: &testStr,
+			BoolField:   &testBool,
+			IntField:    &testInt,
+		},
+	}
+	d := schema.TestResourceDataRaw(
+		t, testSchema, map[string]interface{}{})
+
+	elem := reflect.ValueOf(&obj).Elem()
+	StructToSchema(elem, d, testExtendedSchema, "", nil)
+	assert.Equal(t, "test_string", d.Get("string_field").(string))
+	assert.Equal(t, true, d.Get("bool_field").(bool))
+	assert.Equal(t, 123, d.Get("int_field").(int))
+	nestedObj := d.Get("struct_field").([]interface{})[0].(map[string]interface{})
+	assert.Equal(t, "test_string", nestedObj["string_field"].(string))
+	assert.Equal(t, true, nestedObj["bool_field"].(bool))
+	assert.Equal(t, 123, nestedObj["int_field"].(int))
+}
+
+func TestSchemaToStruct(t *testing.T) {
+	d := schema.TestResourceDataRaw(
+		t, testSchema, map[string]interface{}{
+			"string_field": "test_string",
+			"bool_field":   true,
+			"int_field":    100,
+			"struct_field": []interface{}{
+				map[string]interface{}{
+					"string_field": "nested_string",
+					"bool_field":   true,
+					"int_field":    1,
+				},
+			},
+		})
+
+	obj := testStruct{}
+	elem := reflect.ValueOf(&obj).Elem()
+	SchemaToStruct(elem, d, testExtendedSchema, "", nil)
+	assert.Equal(t, "test_string", *obj.StringField)
+	assert.Equal(t, true, *obj.BoolField)
+	assert.Equal(t, int64(100), *obj.IntField)
+	assert.Equal(t, "nested_string", *obj.StructField.StringField)
+	assert.Equal(t, true, *obj.StructField.BoolField)
+	assert.Equal(t, int64(1), *obj.StructField.IntField)
+}

--- a/nsxt/metadata/metadata_test.go
+++ b/nsxt/metadata/metadata_test.go
@@ -685,3 +685,32 @@ func TestSchemaToStruct(t *testing.T) {
 		}, obj.DeepNestedStruct)
 	})
 }
+
+func TestSchemaToStructEmptySlice(t *testing.T) {
+	d := schema.TestResourceDataRaw(
+		t, testSchema, map[string]interface{}{
+			"bool_list":   []interface{}{},
+			"int_set":     []interface{}{},
+			"struct_list": []interface{}{},
+		})
+
+	obj := testDeepNestedStruct{}
+	elem := reflect.ValueOf(&obj).Elem()
+	testSch := mixedStructSchema().Elem.(*ExtendedResource).Schema
+	SchemaToStruct(elem, d, testSch, "", nil)
+
+	t.Run("Empty bool list", func(t *testing.T) {
+		assert.NotNil(t, obj.BoolList)
+		assert.Equal(t, 0, len(obj.BoolList))
+	})
+
+	t.Run("Empty int set", func(t *testing.T) {
+		assert.NotNil(t, obj.IntSet)
+		assert.Equal(t, 0, len(obj.IntSet))
+	})
+
+	t.Run("Struct list", func(t *testing.T) {
+		assert.NotNil(t, obj.StructList)
+		assert.Equal(t, 0, len(obj.StructList))
+	})
+}

--- a/nsxt/metadata/metadata_test.go
+++ b/nsxt/metadata/metadata_test.go
@@ -442,9 +442,9 @@ func TestSchemaToStruct(t *testing.T) {
 	})
 
 	t.Run("Zero values", func(t *testing.T) {
-		assert.Nil(t, obj.StringFieldNil)
-		assert.Nil(t, obj.BoolFieldNil)
-		assert.Nil(t, obj.IntFieldNil)
+		assert.Equal(t, "", *obj.StringFieldNil)
+		assert.Equal(t, false, *obj.BoolFieldNil)
+		assert.Equal(t, int64(0), *obj.IntFieldNil)
 	})
 
 	t.Run("Nested struct", func(t *testing.T) {

--- a/nsxt/metadata/metadata_test.go
+++ b/nsxt/metadata/metadata_test.go
@@ -475,7 +475,8 @@ func TestStructToSchema(t *testing.T) {
 		t, testSchema, map[string]interface{}{})
 
 	elem := reflect.ValueOf(&obj).Elem()
-	StructToSchema(elem, d, testExtendedSchema, "", nil)
+	err := StructToSchema(elem, d, testExtendedSchema, "", nil)
+	assert.NoError(t, err, "unexpected error calling StructToSchema")
 
 	t.Run("Base types", func(t *testing.T) {
 		assert.Equal(t, "test_string", d.Get("string_field").(string))
@@ -613,7 +614,8 @@ func TestSchemaToStruct(t *testing.T) {
 
 	obj := testStruct{}
 	elem := reflect.ValueOf(&obj).Elem()
-	SchemaToStruct(elem, d, testExtendedSchema, "", nil)
+	err := SchemaToStruct(elem, d, testExtendedSchema, "", nil)
+	assert.NoError(t, err, "unexpected error calling SchemaToStruct")
 
 	nestStr1, nestStr2, nestStr3 := "nested_string_1", "nested_string_2", "nested_string_3"
 	trueVal, falseVal := true, false
@@ -697,7 +699,8 @@ func TestSchemaToStructEmptySlice(t *testing.T) {
 	obj := testDeepNestedStruct{}
 	elem := reflect.ValueOf(&obj).Elem()
 	testSch := mixedStructSchema().Elem.(*ExtendedResource).Schema
-	SchemaToStruct(elem, d, testSch, "", nil)
+	err := SchemaToStruct(elem, d, testSch, "", nil)
+	assert.NoError(t, err, "unexpected error calling SchemaToStruct")
 
 	t.Run("Empty bool list", func(t *testing.T) {
 		assert.NotNil(t, obj.BoolList)

--- a/nsxt/provider.go
+++ b/nsxt/provider.go
@@ -19,6 +19,9 @@ import (
 	"strings"
 	"time"
 
+	tf_api "github.com/vmware/terraform-provider-nsxt/api/utl"
+	"github.com/vmware/terraform-provider-nsxt/nsxt/util"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	api "github.com/vmware/go-vmware-nsxt"
@@ -29,8 +32,6 @@ import (
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp/nsx"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp/nsx/model"
 	"golang.org/x/exp/slices"
-
-	tf_api "github.com/vmware/terraform-provider-nsxt/api/utl"
 )
 
 var defaultRetryOnStatusCodes = []int{400, 409, 429, 500, 503, 504}
@@ -1182,7 +1183,7 @@ func getPolicyConnectorWithHeaders(clients interface{}, customHeaders *map[strin
 	// Init NSX version on demand if not done yet
 	// This is also our indication to apply licenses, in case of delayed connection
 	// This step is skipped if the connector is for special purpose, or for different endpoint
-	if nsxVersion == "" && !standaloneFlow {
+	if util.NsxVersion == "" && !standaloneFlow {
 		initNSXVersion(connector)
 		err := configureLicenses(connector, c.CommonConfig.LicenseKeys)
 		if err != nil {

--- a/nsxt/provider_test.go
+++ b/nsxt/provider_test.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/vmware/terraform-provider-nsxt/nsxt/util"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	api "github.com/vmware/go-vmware-nsxt"
@@ -89,7 +91,7 @@ func testAccGetClient() (*api.APIClient, error) {
 }
 
 func testAccNSXVersion(t *testing.T, requiredVersion string) {
-	if nsxVersion == "" {
+	if util.NsxVersion == "" {
 		connector, err := testAccGetPolicyConnector()
 		if err != nil {
 			t.Errorf("Failed to get policy connector")
@@ -103,13 +105,13 @@ func testAccNSXVersion(t *testing.T, requiredVersion string) {
 		}
 	}
 
-	if nsxVersionLower(requiredVersion) {
-		t.Skipf("This test can only run in NSX %s or above (Current version %s)", requiredVersion, nsxVersion)
+	if util.NsxVersionLower(requiredVersion) {
+		t.Skipf("This test can only run in NSX %s or above (Current version %s)", requiredVersion, util.NsxVersion)
 	}
 }
 
 func testAccNSXVersionLessThan(t *testing.T, requiredVersion string) {
-	if nsxVersion == "" {
+	if util.NsxVersion == "" {
 		connector, err := testAccGetPolicyConnector()
 		if err != nil {
 			t.Errorf("Failed to get policy connector")
@@ -123,8 +125,8 @@ func testAccNSXVersionLessThan(t *testing.T, requiredVersion string) {
 		}
 	}
 
-	if nsxVersionHigherOrEqual(requiredVersion) {
-		t.Skipf("This test can only run in NSX below %s (Current version %s)", requiredVersion, nsxVersion)
+	if util.NsxVersionHigherOrEqual(requiredVersion) {
+		t.Skipf("This test can only run in NSX below %s (Current version %s)", requiredVersion, util.NsxVersion)
 	}
 }
 

--- a/nsxt/resource_nsxt_cluster_virtual_ip.go
+++ b/nsxt/resource_nsxt_cluster_virtual_ip.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/vmware/terraform-provider-nsxt/nsxt/util"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp/nsx/cluster"
@@ -104,7 +106,7 @@ func setClusterVirtualIP(d *schema.ResourceData, m interface{}) error {
 		forceStr = nsxModel.ClusterVirtualIpProperties_FORCE_FALSE
 	}
 	var err error
-	if nsxVersionHigherOrEqual("4.0.0") {
+	if util.NsxVersionHigherOrEqual("4.0.0") {
 		_, err = client.Setvirtualip(&forceStr, &ipv6Address, &ipAddress)
 	} else {
 		// IPv6 not supported
@@ -138,7 +140,7 @@ func resourceNsxtClusterVirualIPDelete(d *schema.ResourceData, m interface{}) er
 		log.Printf("[WARNING] Failed to clear virtual ip: %v", err)
 		return handleDeleteError("ClusterVirtualIP", id, err)
 	}
-	if nsxVersionHigherOrEqual("4.0.0") {
+	if util.NsxVersionHigherOrEqual("4.0.0") {
 		_, err = client.Clearvirtualip6()
 		if err != nil {
 			log.Printf("[WARNING] Failed to clear virtual ipv6 ip: %v", err)

--- a/nsxt/resource_nsxt_edge_transport_node.go
+++ b/nsxt/resource_nsxt_edge_transport_node.go
@@ -9,6 +9,8 @@ import (
 	"reflect"
 	"time"
 
+	"github.com/vmware/terraform-provider-nsxt/nsxt/util"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -896,7 +898,7 @@ func getEdgeNodeSettingsFromSchema(s interface{}) (*model.EdgeNodeSettings, erro
 			SearchDomains:         searchDomains,
 			SyslogServers:         syslogServers,
 		}
-		if nsxVersionHigherOrEqual("4.0.0") {
+		if util.NsxVersionHigherOrEqual("4.0.0") {
 			obj.EnableUptMode = &enableUptMode
 		}
 		return obj, nil

--- a/nsxt/resource_nsxt_firewall_section.go
+++ b/nsxt/resource_nsxt_firewall_section.go
@@ -8,6 +8,8 @@ import (
 	"log"
 	"net/http"
 
+	"github.com/vmware/terraform-provider-nsxt/nsxt/util"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/vmware/go-vmware-nsxt/manager"
@@ -379,7 +381,7 @@ func resourceNsxtFirewallSectionUpdate(d *schema.ResourceData, m interface{}) er
 
 	var resp *http.Response
 	var err error
-	if len(rules) == 0 || nsxVersionLower("2.2.0") {
+	if len(rules) == 0 || util.NsxVersionLower("2.2.0") {
 		// Due to an NSX bug, the empty update should also be called to update ToS & tags fields
 		section := *firewallSection.GetFirewallSection()
 		// Update the section ignoring the rules

--- a/nsxt/resource_nsxt_logical_router_downlink_port_test.go
+++ b/nsxt/resource_nsxt_logical_router_downlink_port_test.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/vmware/terraform-provider-nsxt/nsxt/util"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
@@ -69,7 +71,7 @@ func TestAccResourceNsxtLogicalRouterDownlinkPort_withRelay(t *testing.T) {
 	resourceType := "DhcpRelayService"
 	// this is needed to init the version
 	testAccNSXVersion(t, "2.2.0")
-	if nsxVersionLower("2.5.0") {
+	if util.NsxVersionLower("2.5.0") {
 		resourceType = "LogicalService"
 	}
 

--- a/nsxt/resource_nsxt_nat_rule.go
+++ b/nsxt/resource_nsxt_nat_rule.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/vmware/terraform-provider-nsxt/nsxt/util"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp/nsx/logical_routers/nat"
@@ -121,7 +123,7 @@ func resourceNsxtNatRuleCreate(d *schema.ResourceData, m interface{}) error {
 	displayName := d.Get("display_name").(string)
 	tags := getMPTagsFromSchema(d)
 	action := d.Get("action").(string)
-	if action == "NO_NAT" && nsxVersionHigherOrEqual("3.0.0") {
+	if action == "NO_NAT" && util.NsxVersionHigherOrEqual("3.0.0") {
 		return fmt.Errorf("NO_NAT action is not supported in NSX versions 3.0.0 and greater. Use NO_SNAT and NO_DNAT instead")
 	}
 	enabled := d.Get("enabled").(bool)
@@ -230,7 +232,7 @@ func resourceNsxtNatRuleUpdate(d *schema.ResourceData, m interface{}) error {
 	displayName := d.Get("display_name").(string)
 	tags := getMPTagsFromSchema(d)
 	action := d.Get("action").(string)
-	if action == "NO_NAT" && nsxVersionHigherOrEqual("3.0.0") {
+	if action == "NO_NAT" && util.NsxVersionHigherOrEqual("3.0.0") {
 		return fmt.Errorf("NO_NAT action is not supported in NSX versions 3.0.0 and greater. Use NO_SNAT and NO_DNAT instead")
 	}
 	enabled := d.Get("enabled").(bool)

--- a/nsxt/resource_nsxt_policy_bgp_neighbor.go
+++ b/nsxt/resource_nsxt_policy_bgp_neighbor.go
@@ -8,6 +8,8 @@ import (
 	"log"
 	"strings"
 
+	"github.com/vmware/terraform-provider-nsxt/nsxt/util"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
@@ -243,13 +245,13 @@ func resourceNsxtPolicyBgpNeighborResourceDataToStruct(d *schema.ResourceData, i
 
 	var rFilters []model.BgpRouteFiltering
 	routeFiltering := d.Get("route_filtering").([]interface{})
-	if len(routeFiltering) > 1 && nsxVersionLower("3.0.0") {
+	if len(routeFiltering) > 1 && util.NsxVersionLower("3.0.0") {
 		return neighborStruct, fmt.Errorf("Only 1 element for 'route_filtering' is supported with NSX-T versions up to 3.0.0")
 	}
 	for _, filter := range routeFiltering {
 		data := filter.(map[string]interface{})
 		addrFamily := data["address_family"].(string)
-		if addrFamily == model.BgpRouteFiltering_ADDRESS_FAMILY_L2VPN_EVPN && nsxVersionLower("3.0.0") {
+		if addrFamily == model.BgpRouteFiltering_ADDRESS_FAMILY_L2VPN_EVPN && util.NsxVersionLower("3.0.0") {
 			return neighborStruct, fmt.Errorf("'%s' is not supported for 'address_family' with NSX-T versions less than 3.0.0", model.BgpRouteFiltering_ADDRESS_FAMILY_L2VPN_EVPN)
 		}
 		enabled := data["enabled"].(bool)
@@ -271,7 +273,7 @@ func resourceNsxtPolicyBgpNeighborResourceDataToStruct(d *schema.ResourceData, i
 			filterStruct.OutRouteFilters = outFilters
 		}
 
-		if nsxVersionHigherOrEqual("3.0.0") && data["maximum_routes"] != 0 {
+		if util.NsxVersionHigherOrEqual("3.0.0") && data["maximum_routes"] != 0 {
 			maxRoutes := int64(data["maximum_routes"].(int))
 			filterStruct.MaximumRoutes = &maxRoutes
 		}
@@ -448,7 +450,7 @@ func resourceNsxtPolicyBgpNeighborRead(d *schema.ResourceData, m interface{}) er
 		}
 		rf["in_route_filter"] = inFilter
 		rf["out_route_filter"] = outFilter
-		if nsxVersionHigherOrEqual("3.0.0") && filter.MaximumRoutes != nil {
+		if util.NsxVersionHigherOrEqual("3.0.0") && filter.MaximumRoutes != nil {
 			rf["maximum_routes"] = int(*filter.MaximumRoutes)
 		}
 		rFilters = append(rFilters, rf)

--- a/nsxt/resource_nsxt_policy_context_profile.go
+++ b/nsxt/resource_nsxt_policy_context_profile.go
@@ -7,14 +7,15 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
-	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
-
 	"github.com/vmware/terraform-provider-nsxt/api/infra"
 	cont_prof "github.com/vmware/terraform-provider-nsxt/api/infra/context_profiles"
 	custom_attr "github.com/vmware/terraform-provider-nsxt/api/infra/context_profiles/custom_attributes"
 	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
+	"github.com/vmware/terraform-provider-nsxt/nsxt/util"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 )
 
 var attributeKeyMap = map[string]string{
@@ -470,7 +471,7 @@ func fillAttributesInSchema(d *schema.ResourceData, policyAttributes []model.Pol
 				elem["sub_attribute"] = fillSubAttributesInSchema(policyAttribute.SubAttributes)
 			}
 			elem["is_alg_type"] = policyAttribute.IsALGType
-		} else if *policyAttribute.Key == model.PolicyAttributes_KEY_CUSTOM_URL && nsxVersionHigherOrEqual("4.0.0") {
+		} else if *policyAttribute.Key == model.PolicyAttributes_KEY_CUSTOM_URL && util.NsxVersionHigherOrEqual("4.0.0") {
 			elem["custom_url_partial_match"] = policyAttribute.CustomUrlPartialMatch
 		}
 		attributes[key] = append(attributes[key], elem)

--- a/nsxt/resource_nsxt_policy_gateway_dns_forwarder.go
+++ b/nsxt/resource_nsxt_policy_gateway_dns_forwarder.go
@@ -7,14 +7,15 @@ import (
 	"fmt"
 	"log"
 
+	tier0s "github.com/vmware/terraform-provider-nsxt/api/infra/tier_0s"
+	tier1s "github.com/vmware/terraform-provider-nsxt/api/infra/tier_1s"
+	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
+	"github.com/vmware/terraform-provider-nsxt/nsxt/util"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
-
-	tier0s "github.com/vmware/terraform-provider-nsxt/api/infra/tier_0s"
-	tier1s "github.com/vmware/terraform-provider-nsxt/api/infra/tier_1s"
-	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
 )
 
 var gatewayDNSForwarderLogLevelTypeValues = []string{
@@ -149,7 +150,7 @@ func patchNsxtPolicyGatewayDNSForwarder(sessionContext utl.SessionContext, conne
 		obj.ConditionalForwarderZonePaths = conditionalZonePaths
 	}
 
-	if nsxVersionHigherOrEqual("3.2.0") {
+	if util.NsxVersionHigherOrEqual("3.2.0") {
 		obj.CacheSize = &cacheSize
 	}
 

--- a/nsxt/resource_nsxt_policy_gateway_redistribution_config.go
+++ b/nsxt/resource_nsxt_policy_gateway_redistribution_config.go
@@ -7,10 +7,11 @@ import (
 	"fmt"
 	"strings"
 
+	tier0s "github.com/vmware/terraform-provider-nsxt/api/infra/tier_0s"
+	"github.com/vmware/terraform-provider-nsxt/nsxt/util"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
-
-	tier0s "github.com/vmware/terraform-provider-nsxt/api/infra/tier_0s"
 )
 
 func resourceNsxtPolicyGatewayRedistributionConfig() *schema.Resource {
@@ -71,7 +72,7 @@ func policyGatewayRedistributionConfigPatch(d *schema.ResourceData, m interface{
 		BgpEnabled: &bgpEnabled,
 	}
 
-	if nsxVersionHigherOrEqual("3.1.0") {
+	if util.NsxVersionHigherOrEqual("3.1.0") {
 		redistributionStruct.OspfEnabled = &ospfEnabled
 	}
 

--- a/nsxt/resource_nsxt_policy_group.go
+++ b/nsxt/resource_nsxt_policy_group.go
@@ -8,15 +8,16 @@ import (
 	"log"
 	"strings"
 
+	"github.com/vmware/terraform-provider-nsxt/api/infra/domains"
+	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
+	"github.com/vmware/terraform-provider-nsxt/nsxt/util"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/bindings"
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/data"
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
-
-	"github.com/vmware/terraform-provider-nsxt/api/infra/domains"
-	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
 )
 
 var conditionKeyValues = []string{
@@ -874,7 +875,7 @@ func resourceNsxtPolicyGroupCreate(d *schema.ResourceData, m interface{}) error 
 		ExtendedExpression: extendedExpressionList,
 	}
 
-	if groupType != "" && nsxVersionHigherOrEqual("3.2.0") {
+	if groupType != "" && util.NsxVersionHigherOrEqual("3.2.0") {
 		obj.GroupType = groupTypes
 	}
 
@@ -913,7 +914,7 @@ func resourceNsxtPolicyGroupRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("domain", getDomainFromResourcePath(*obj.Path))
 	d.Set("revision", obj.Revision)
 	groupType := ""
-	if len(obj.GroupType) > 0 && nsxVersionHigherOrEqual("3.2.0") {
+	if len(obj.GroupType) > 0 && util.NsxVersionHigherOrEqual("3.2.0") {
 		groupType = obj.GroupType[0]
 		d.Set("group_type", groupType)
 	}
@@ -987,7 +988,7 @@ func resourceNsxtPolicyGroupUpdate(d *schema.ResourceData, m interface{}) error 
 		ExtendedExpression: extendedExpressionList,
 	}
 
-	if groupType != "" && nsxVersionHigherOrEqual("3.2.0") {
+	if groupType != "" && util.NsxVersionHigherOrEqual("3.2.0") {
 		obj.GroupType = groupTypes
 	}
 

--- a/nsxt/resource_nsxt_policy_ip_block.go
+++ b/nsxt/resource_nsxt_policy_ip_block.go
@@ -7,13 +7,14 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/vmware/terraform-provider-nsxt/api/infra"
+	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
+	"github.com/vmware/terraform-provider-nsxt/nsxt/util"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
-
-	"github.com/vmware/terraform-provider-nsxt/api/infra"
-	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
 )
 
 var visibilityTypes = []string{
@@ -117,7 +118,7 @@ func resourceNsxtPolicyIPBlockCreate(d *schema.ResourceData, m interface{}) erro
 		Cidr:        &cidr,
 		Tags:        tags,
 	}
-	if nsxVersionHigherOrEqual("4.2.0") && len(visibility) > 0 {
+	if util.NsxVersionHigherOrEqual("4.2.0") && len(visibility) > 0 {
 		obj.Visibility = &visibility
 	}
 	// Create the resource using PATCH
@@ -157,7 +158,7 @@ func resourceNsxtPolicyIPBlockUpdate(d *schema.ResourceData, m interface{}) erro
 		Tags:        tags,
 		Revision:    &revision,
 	}
-	if nsxVersionHigherOrEqual("4.2.0") && len(visibility) > 0 {
+	if util.NsxVersionHigherOrEqual("4.2.0") && len(visibility) > 0 {
 		obj.Visibility = &visibility
 	}
 

--- a/nsxt/resource_nsxt_policy_ipsec_vpn_session.go
+++ b/nsxt/resource_nsxt_policy_ipsec_vpn_session.go
@@ -8,12 +8,13 @@ import (
 	"log"
 	"strings"
 
+	"github.com/vmware/terraform-provider-nsxt/nsxt/util"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/bindings"
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/data"
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
-
 	t0_ipsec_services "github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_0s/ipsec_vpn_services"
 	t0_ipsec_nested_services "github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_0s/locale_services/ipsec_vpn_services"
 	t1_ipsec_services "github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_1s/ipsec_vpn_services"
@@ -223,7 +224,7 @@ func getIPSecVPNSessionFromSchema(d *schema.ResourceData) (*data.StructValue, er
 			Psk:                      &psk,
 			Tags:                     tags,
 		}
-		if nsxVersionHigherOrEqual("3.2.0") {
+		if util.NsxVersionHigherOrEqual("3.2.0") {
 			if direction != "" {
 				tcpMSSClamping := model.TcpMaximumSegmentSizeClamping{
 					Direction: &direction,
@@ -271,7 +272,7 @@ func getIPSecVPNSessionFromSchema(d *schema.ResourceData) (*data.StructValue, er
 			Psk:                      &psk,
 			Tags:                     tags,
 		}
-		if nsxVersionHigherOrEqual("3.2.0") {
+		if util.NsxVersionHigherOrEqual("3.2.0") {
 			if direction != "" {
 				tcpMSSClamping := model.TcpMaximumSegmentSizeClamping{
 					Direction: &direction,
@@ -627,7 +628,7 @@ func resourceNsxtPolicyIPSecVpnSessionRead(d *schema.ResourceData, m interface{}
 		d.Set("tunnel_profile_path", blockVPN.TunnelProfilePath)
 		d.Set("peer_address", blockVPN.PeerAddress)
 		d.Set("peer_id", blockVPN.PeerId)
-		if nsxVersionHigherOrEqual("3.2.0") {
+		if util.NsxVersionHigherOrEqual("3.2.0") {
 			if blockVPN.TcpMssClamping != nil {
 				direction := blockVPN.TcpMssClamping.Direction
 				mss := blockVPN.TcpMssClamping.MaxSegmentSize
@@ -684,7 +685,7 @@ func resourceNsxtPolicyIPSecVpnSessionRead(d *schema.ResourceData, m interface{}
 		if blockVPN.Rules != nil {
 			setRuleInSchema(d, blockVPN.Rules)
 		}
-		if nsxVersionHigherOrEqual("3.2.0") {
+		if util.NsxVersionHigherOrEqual("3.2.0") {
 			if blockVPN.TcpMssClamping != nil {
 				direction := blockVPN.TcpMssClamping.Direction
 				mss := blockVPN.TcpMssClamping.MaxSegmentSize

--- a/nsxt/resource_nsxt_policy_l2_vpn_session.go
+++ b/nsxt/resource_nsxt_policy_l2_vpn_session.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/vmware/terraform-provider-nsxt/nsxt/util"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
@@ -125,7 +127,7 @@ func resourceNsxtPolicyL2VPNSessionCreate(d *schema.ResourceData, m interface{})
 		TransportTunnels: transportTunnel,
 	}
 
-	if nsxVersionHigherOrEqual("3.2.0") {
+	if util.NsxVersionHigherOrEqual("3.2.0") {
 		direction := d.Get("direction").(string)
 		maxSegmentSize := int64(d.Get("max_segment_size").(int))
 		if direction != "" {
@@ -244,7 +246,7 @@ func resourceNsxtPolicyL2VPNSessionRead(d *schema.ResourceData, m interface{}) e
 	if len(obj.TransportTunnels) > 0 {
 		d.Set("transport_tunnels", obj.TransportTunnels)
 	}
-	if nsxVersionHigherOrEqual("3.2.0") {
+	if util.NsxVersionHigherOrEqual("3.2.0") {
 		if obj.TcpMssClamping != nil {
 			direction := obj.TcpMssClamping.Direction
 			mss := obj.TcpMssClamping.MaxSegmentSize
@@ -324,7 +326,7 @@ func resourceNsxtPolicyL2VPNSessionUpdate(d *schema.ResourceData, m interface{})
 		Revision:         &revision,
 		Enabled:          &enabled,
 	}
-	if nsxVersionHigherOrEqual("3.2.0") {
+	if util.NsxVersionHigherOrEqual("3.2.0") {
 		direction := d.Get("direction").(string)
 		maxSegmentSize := int64(d.Get("max_segment_size").(int))
 		if direction != "" {

--- a/nsxt/resource_nsxt_policy_lb_service.go
+++ b/nsxt/resource_nsxt_policy_lb_service.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/vmware/terraform-provider-nsxt/nsxt/util"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
@@ -110,7 +112,7 @@ func resourceNsxtPolicyLBServiceCreate(d *schema.ResourceData, m interface{}) er
 	enabled := d.Get("enabled").(bool)
 	errorLogLevel := d.Get("error_log_level").(string)
 	size := d.Get("size").(string)
-	if size == "XLARGE" && nsxVersionLower("3.0.0") {
+	if size == "XLARGE" && util.NsxVersionLower("3.0.0") {
 		return fmt.Errorf("XLARGE size is not supported before NSX version 3.0.0")
 	}
 
@@ -191,7 +193,7 @@ func resourceNsxtPolicyLBServiceUpdate(d *schema.ResourceData, m interface{}) er
 	enabled := d.Get("enabled").(bool)
 	errorLogLevel := d.Get("error_log_level").(string)
 	size := d.Get("size").(string)
-	if size == "XLARGE" && nsxVersionLower("3.0.0") {
+	if size == "XLARGE" && util.NsxVersionLower("3.0.0") {
 		return fmt.Errorf("XLARGE size is not supported before NSX version 3.0.0")
 	}
 

--- a/nsxt/resource_nsxt_policy_lb_virtual_server.go
+++ b/nsxt/resource_nsxt_policy_lb_virtual_server.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/vmware/terraform-provider-nsxt/nsxt/util"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/bindings"
@@ -1561,7 +1563,7 @@ func getPolicyLbRulesFromSchema(d *schema.ResourceData) []model.LBRule {
 }
 
 func policyLBVirtualServerVersionDependantSet(d *schema.ResourceData, obj *model.LBVirtualServer) {
-	if nsxVersionHigherOrEqual("3.0.0") {
+	if util.NsxVersionHigherOrEqual("3.0.0") {
 		logSignificantOnly := d.Get("log_significant_event_only").(bool)
 		obj.LogSignificantEventOnly = &logSignificantOnly
 		obj.AccessListControl = getPolicyAccessListControlFromSchema(d)

--- a/nsxt/resource_nsxt_policy_mac_discovery_profile.go
+++ b/nsxt/resource_nsxt_policy_mac_discovery_profile.go
@@ -81,14 +81,14 @@ var macDiscoveryProfileSchema = map[string]*metadata.ExtendedSchema{
 			Type:         schema.TypeString,
 			ValidateFunc: validation.StringInSlice(macDiscoveryProfileMacLimitPolicyValues, false),
 			Optional:     true,
-			Default:      "ALLOW",
+			Default:      model.MacDiscoveryProfile_MAC_LIMIT_POLICY_ALLOW,
 		},
 		Metadata: metadata.Metadata{
 			SchemaType:   "string",
 			SdkFieldName: "MacLimitPolicy",
 			TestData: metadata.Testdata{
-				CreateValue: "ALLOW",
-				UpdateValue: "DROP",
+				CreateValue: model.MacDiscoveryProfile_MAC_LIMIT_POLICY_ALLOW,
+				UpdateValue: model.MacDiscoveryProfile_MAC_LIMIT_POLICY_DROP,
 			},
 		},
 	},
@@ -114,9 +114,8 @@ var macDiscoveryProfileSchema = map[string]*metadata.ExtendedSchema{
 			Optional: true,
 		},
 		Metadata: metadata.Metadata{
-			SchemaType:          "bool",
-			SdkFieldName:        "UnknownUnicastFloodingEnabled",
-			IntroducedInVersion: "4.0.0",
+			SchemaType:   "bool",
+			SdkFieldName: "UnknownUnicastFloodingEnabled",
 			TestData: metadata.Testdata{
 				CreateValue: "true",
 				UpdateValue: "false",

--- a/nsxt/resource_nsxt_policy_mac_discovery_profile.go
+++ b/nsxt/resource_nsxt_policy_mac_discovery_profile.go
@@ -174,7 +174,9 @@ func resourceNsxtPolicyMacDiscoveryProfileCreate(d *schema.ResourceData, m inter
 	}
 
 	elem := reflect.ValueOf(&obj).Elem()
-	metadata.SchemaToStruct(elem, d, macDiscoveryProfileSchema, "", nil)
+	if err := metadata.SchemaToStruct(elem, d, macDiscoveryProfileSchema, "", nil); err != nil {
+		return err
+	}
 
 	// Create the resource using PATCH
 	log.Printf("[INFO] Creating MacDiscoveryProfile with ID %s", id)
@@ -213,9 +215,7 @@ func resourceNsxtPolicyMacDiscoveryProfileRead(d *schema.ResourceData, m interfa
 	d.Set("path", obj.Path)
 
 	elem := reflect.ValueOf(&obj).Elem()
-	metadata.StructToSchema(elem, d, macDiscoveryProfileSchema, "", nil)
-
-	return nil
+	return metadata.StructToSchema(elem, d, macDiscoveryProfileSchema, "", nil)
 }
 
 func resourceNsxtPolicyMacDiscoveryProfileUpdate(d *schema.ResourceData, m interface{}) error {
@@ -241,7 +241,9 @@ func resourceNsxtPolicyMacDiscoveryProfileUpdate(d *schema.ResourceData, m inter
 	}
 
 	elem := reflect.ValueOf(&obj).Elem()
-	metadata.SchemaToStruct(elem, d, macDiscoveryProfileSchema, "", nil)
+	if err := metadata.SchemaToStruct(elem, d, macDiscoveryProfileSchema, "", nil); err != nil {
+		return err
+	}
 
 	// Update the resource using PATCH
 	boolFalse := false

--- a/nsxt/resource_nsxt_policy_mac_discovery_profile_test.go
+++ b/nsxt/resource_nsxt_policy_mac_discovery_profile_test.go
@@ -8,6 +8,8 @@ import (
 	"log"
 	"testing"
 
+	"github.com/vmware/terraform-provider-nsxt/nsxt/util"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -44,16 +46,16 @@ func getMacDiscoveryProfileTestCheckFunc(testResourceName string, create bool) [
 		resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
 	}
 	for key, item := range macDiscoveryProfileSchema {
-		if item.m.skip {
+		if item.Metadata.Skip {
 			continue
 		}
-		if item.m.introducedInVersion != "" && nsxVersionLower(item.m.introducedInVersion) {
+		if item.Metadata.IntroducedInVersion != "" && util.NsxVersionLower(item.Metadata.IntroducedInVersion) {
 			continue
 		}
 
-		value := item.m.testData.createValue
+		value := item.Metadata.TestData.CreateValue
 		if !create {
-			value = item.m.testData.updateValue
+			value = item.Metadata.TestData.UpdateValue
 		}
 		result = append(result, resource.TestCheckResourceAttr(testResourceName, key, value.(string)))
 	}
@@ -65,17 +67,17 @@ func getMacDiscoveryProfileTestConfigAttributes(create bool) string {
 	result := ""
 	schemaDef := resourceNsxtPolicyMacDiscoveryProfile().Schema
 	for key, item := range macDiscoveryProfileSchema {
-		if item.m.skip {
+		if item.Metadata.Skip {
 			continue
 		}
 		log.Printf("[INFO] inspecting schema test key %s", key)
-		if item.m.introducedInVersion != "" && nsxVersionLower(item.m.introducedInVersion) {
+		if item.Metadata.IntroducedInVersion != "" && util.NsxVersionLower(item.Metadata.IntroducedInVersion) {
 			continue
 		}
 
-		value := item.m.testData.createValue
+		value := item.Metadata.TestData.CreateValue
 		if !create {
-			value = item.m.testData.updateValue
+			value = item.Metadata.TestData.UpdateValue
 		}
 
 		if schemaDef[key].Type == schema.TypeString {

--- a/nsxt/resource_nsxt_policy_mac_discovery_profile_test.go
+++ b/nsxt/resource_nsxt_policy_mac_discovery_profile_test.go
@@ -5,6 +5,7 @@ package nsxt
 
 import (
 	"fmt"
+	"log"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -42,14 +43,17 @@ func getMacDiscoveryProfileTestCheckFunc(testResourceName string, create bool) [
 		resource.TestCheckResourceAttrSet(testResourceName, "revision"),
 		resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
 	}
-	for key, item := range macDiscoveryProfileMetadata {
-		if item.introducedInVersion != "" && nsxVersionLower(item.introducedInVersion) {
+	for key, item := range macDiscoveryProfileSchema {
+		if item.m.skip {
+			continue
+		}
+		if item.m.introducedInVersion != "" && nsxVersionLower(item.m.introducedInVersion) {
 			continue
 		}
 
-		value := item.testData.createValue
+		value := item.m.testData.createValue
 		if !create {
-			value = item.testData.updateValue
+			value = item.m.testData.updateValue
 		}
 		result = append(result, resource.TestCheckResourceAttr(testResourceName, key, value.(string)))
 	}
@@ -60,14 +64,18 @@ func getMacDiscoveryProfileTestCheckFunc(testResourceName string, create bool) [
 func getMacDiscoveryProfileTestConfigAttributes(create bool) string {
 	result := ""
 	schemaDef := resourceNsxtPolicyMacDiscoveryProfile().Schema
-	for key, item := range macDiscoveryProfileMetadata {
-		if item.introducedInVersion != "" && nsxVersionLower(item.introducedInVersion) {
+	for key, item := range macDiscoveryProfileSchema {
+		if item.m.skip {
+			continue
+		}
+		log.Printf("[INFO] inspecting schema test key %s", key)
+		if item.m.introducedInVersion != "" && nsxVersionLower(item.m.introducedInVersion) {
 			continue
 		}
 
-		value := item.testData.createValue
+		value := item.m.testData.createValue
 		if !create {
-			value = item.testData.updateValue
+			value = item.m.testData.updateValue
 		}
 
 		if schemaDef[key].Type == schema.TypeString {

--- a/nsxt/resource_nsxt_policy_mac_discovery_profile_test.go
+++ b/nsxt/resource_nsxt_policy_mac_discovery_profile_test.go
@@ -26,6 +26,7 @@ func TestAccResourceNsxtPolicyMacDiscoveryProfile_basic(t *testing.T) {
 func TestAccResourceNsxtPolicyMacDiscoveryProfile_multitenancy(t *testing.T) {
 	testAccResourceNsxtPolicyMacDiscoveryProfileBasic(t, true, func() {
 		testAccPreCheck(t)
+		testAccNSXVersion(t, "3.0.0")
 		testAccOnlyMultitenancy(t)
 	})
 }

--- a/nsxt/resource_nsxt_policy_nat_rule.go
+++ b/nsxt/resource_nsxt_policy_nat_rule.go
@@ -9,15 +9,16 @@ import (
 	"log"
 	"strings"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
-	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
-
 	"github.com/vmware/terraform-provider-nsxt/api/infra"
 	t0nat "github.com/vmware/terraform-provider-nsxt/api/infra/tier_0s/nat"
 	t1nat "github.com/vmware/terraform-provider-nsxt/api/infra/tier_1s/nat"
 	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
+	"github.com/vmware/terraform-provider-nsxt/nsxt/util"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 )
 
 var policyNATRuleActionTypeValues = []string{
@@ -197,7 +198,7 @@ func patchNsxtPolicyNATRule(sessionContext utl.SessionContext, connector client.
 	if err != nil {
 		return err
 	}
-	if nsxVersionHigherOrEqual("4.0.0") {
+	if util.NsxVersionHigherOrEqual("4.0.0") {
 		_, err = getPolicyBasedVpnMode(rule)
 		if err != nil {
 			return err
@@ -295,7 +296,7 @@ func resourceNsxtPolicyNATRuleRead(d *schema.ResourceData, m interface{}) error 
 	}
 	d.Set("translated_ports", obj.TranslatedPorts)
 	d.Set("scope", obj.Scope)
-	if nsxVersionHigherOrEqual("4.0.0") {
+	if util.NsxVersionHigherOrEqual("4.0.0") {
 		d.Set("policy_based_vpn_mode", obj.PolicyBasedVpnMode)
 	}
 	d.SetId(id)
@@ -369,7 +370,7 @@ func resourceNsxtPolicyNATRuleCreate(d *schema.ResourceData, m interface{}) erro
 	if ports != "" {
 		ruleStruct.TranslatedPorts = &ports
 	}
-	if pbvmMatch != "" && nsxVersionHigherOrEqual("4.0.0") {
+	if pbvmMatch != "" && util.NsxVersionHigherOrEqual("4.0.0") {
 		ruleStruct.PolicyBasedVpnMode = &pbvmMatch
 	}
 
@@ -443,7 +444,7 @@ func resourceNsxtPolicyNATRuleUpdate(d *schema.ResourceData, m interface{}) erro
 		ruleStruct.TranslatedPorts = &tPorts
 	}
 	pbvmMatch := d.Get("policy_based_vpn_mode").(string)
-	if pbvmMatch != "" && nsxVersionHigherOrEqual("4.0.0") {
+	if pbvmMatch != "" && util.NsxVersionHigherOrEqual("4.0.0") {
 		ruleStruct.PolicyBasedVpnMode = &pbvmMatch
 	}
 

--- a/nsxt/resource_nsxt_policy_project_test.go
+++ b/nsxt/resource_nsxt_policy_project_test.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/vmware/terraform-provider-nsxt/nsxt/util"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
@@ -26,7 +28,7 @@ var accTestPolicyProjectUpdateAttributes = map[string]string{
 }
 
 func getExpectedSiteInfoCount(t *testing.T) string {
-	if nsxVersion == "" {
+	if util.NsxVersion == "" {
 		connector, err := testAccGetPolicyConnector()
 		if err != nil {
 			t.Errorf("Failed to get policy connector")
@@ -39,7 +41,7 @@ func getExpectedSiteInfoCount(t *testing.T) string {
 			return "0"
 		}
 	}
-	if nsxVersionHigherOrEqual("4.1.1") {
+	if util.NsxVersionHigherOrEqual("4.1.1") {
 		return "1"
 	}
 	return "0"

--- a/nsxt/resource_nsxt_policy_segment_security_profile.go
+++ b/nsxt/resource_nsxt_policy_segment_security_profile.go
@@ -17,109 +17,221 @@ import (
 	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
 )
 
-var segmentSecurityProfileMetadata = map[string]*metadata{
+var segmentSecurityProfileSchema = map[string]*extendedSchema{
+	"nsx_id":       getExtendedSchema(getNsxIDSchema()),
+	"path":         getExtendedSchema(getPathSchema()),
+	"display_name": getExtendedSchema(getDisplayNameSchema()),
+	"description":  getExtendedSchema(getDescriptionSchema()),
+	"revision":     getExtendedSchema(getRevisionSchema()),
+	"tag":          getExtendedSchema(getTagsSchema()),
+	"context":      getExtendedSchema(getContextSchema(false, false)),
 	"bpdu_filter_allow": {
-		skip: true,
+		s: schema.Schema{
+			Type: schema.TypeSet,
+			Elem: &schema.Schema{
+				Type:         schema.TypeString,
+				ValidateFunc: validation.IsMACAddress,
+			},
+			Optional: true,
+		},
+		m: metadata{
+			skip: true,
+		},
 	},
 	"bpdu_filter_enable": {
-		schemaType:   "bool",
-		sdkFieldName: "BpduFilterEnable",
-		testData: testdata{
-			createValue: "true",
-			updateValue: "false",
+		s: schema.Schema{
+			Type:     schema.TypeBool,
+			Optional: true,
+			Default:  true,
+		},
+		m: metadata{
+			schemaType:   "bool",
+			sdkFieldName: "BpduFilterEnable",
+			testData: testdata{
+				createValue: "true",
+				updateValue: "false",
+			},
 		},
 	},
 	"dhcp_client_block_enabled": {
-		schemaType:   "bool",
-		sdkFieldName: "DhcpClientBlockEnabled",
-		testData: testdata{
-			createValue: "true",
-			updateValue: "false",
+		s: schema.Schema{
+			Type:     schema.TypeBool,
+			Optional: true,
+			Default:  false,
+		},
+		m: metadata{
+			schemaType:   "bool",
+			sdkFieldName: "DhcpClientBlockEnabled",
+			testData: testdata{
+				createValue: "true",
+				updateValue: "false",
+			},
 		},
 	},
 	"dhcp_server_block_enabled": {
-		schemaType:   "bool",
-		sdkFieldName: "DhcpServerBlockEnabled",
-		testData: testdata{
-			createValue: "true",
-			updateValue: "false",
+		s: schema.Schema{
+			Type:     schema.TypeBool,
+			Optional: true,
+			Default:  true,
+		},
+		m: metadata{
+			schemaType:   "bool",
+			sdkFieldName: "DhcpServerBlockEnabled",
+			testData: testdata{
+				createValue: "true",
+				updateValue: "false",
+			},
 		},
 	},
 	"dhcp_client_block_v6_enabled": {
-		schemaType:   "bool",
-		sdkFieldName: "DhcpClientBlockV6Enabled",
-		testData: testdata{
-			createValue: "true",
-			updateValue: "false",
+		s: schema.Schema{
+			Type:     schema.TypeBool,
+			Optional: true,
+			Default:  false,
+		},
+		m: metadata{
+			schemaType:   "bool",
+			sdkFieldName: "DhcpClientBlockV6Enabled",
+			testData: testdata{
+				createValue: "true",
+				updateValue: "false",
+			},
 		},
 	},
 	"dhcp_server_block_v6_enabled": {
-		schemaType:   "bool",
-		sdkFieldName: "DhcpServerBlockV6Enabled",
-		testData: testdata{
-			createValue: "true",
-			updateValue: "false",
+		s: schema.Schema{
+			Type:     schema.TypeBool,
+			Optional: true,
+			Default:  true,
+		},
+		m: metadata{
+			schemaType:   "bool",
+			sdkFieldName: "DhcpServerBlockV6Enabled",
+			testData: testdata{
+				createValue: "true",
+				updateValue: "false",
+			},
 		},
 	},
 	"non_ip_traffic_block_enabled": {
-		schemaType:   "bool",
-		sdkFieldName: "NonIpTrafficBlockEnabled",
-		testData: testdata{
-			createValue: "true",
-			updateValue: "false",
+		s: schema.Schema{
+			Type:     schema.TypeBool,
+			Optional: true,
+			Default:  false,
+		},
+		m: metadata{
+			schemaType:   "bool",
+			sdkFieldName: "NonIpTrafficBlockEnabled",
+			testData: testdata{
+				createValue: "true",
+				updateValue: "false",
+			},
 		},
 	},
 	"ra_guard_enabled": {
-		schemaType:   "bool",
-		sdkFieldName: "RaGuardEnabled",
-		testData: testdata{
-			createValue: "true",
-			updateValue: "false",
+		s: schema.Schema{
+			Type:     schema.TypeBool,
+			Optional: true,
+			Default:  false,
+		},
+		m: metadata{
+			schemaType:   "bool",
+			sdkFieldName: "RaGuardEnabled",
+			testData: testdata{
+				createValue: "true",
+				updateValue: "false",
+			},
 		},
 	},
 	"rate_limits_enabled": {
-		schemaType:   "bool",
-		sdkFieldName: "RateLimitsEnabled",
-		testData: testdata{
-			createValue: "true",
-			updateValue: "false",
+		s: schema.Schema{
+			Type:     schema.TypeBool,
+			Optional: true,
+			Default:  false,
+		},
+		m: metadata{
+			schemaType:   "bool",
+			sdkFieldName: "RateLimitsEnabled",
+			testData: testdata{
+				createValue: "true",
+				updateValue: "false",
+			},
 		},
 	},
 	"rate_limit": {
-		schemaType:   "struct",
-		sdkFieldName: "RateLimits",
-		reflectType:  reflect.TypeOf(model.TrafficRateLimits{}),
-	},
-	"rate_limit.rx_broadcast": {
-		schemaType:   "int",
-		sdkFieldName: "RxBroadcast",
-		testData: testdata{
-			createValue: "100",
-			updateValue: "1000",
+		s: schema.Schema{
+			Type: schema.TypeList,
+			Elem: &extendedResource{
+				Schema: map[string]*extendedSchema{
+					"rx_broadcast": {
+						s: schema.Schema{
+							Type:     schema.TypeInt,
+							Optional: true,
+							Default:  0,
+						},
+						m: metadata{
+							schemaType:   "int",
+							sdkFieldName: "RxBroadcast",
+							testData: testdata{
+								createValue: "100",
+								updateValue: "1000",
+							},
+						},
+					},
+					"rx_multicast": {
+						s: schema.Schema{
+							Type:     schema.TypeInt,
+							Optional: true,
+							Default:  0,
+						},
+						m: metadata{
+							schemaType:   "int",
+							sdkFieldName: "RxMulticast",
+							testData: testdata{
+								createValue: "100",
+								updateValue: "1000",
+							},
+						},
+					},
+					"tx_broadcast": {
+						s: schema.Schema{
+							Type:     schema.TypeInt,
+							Optional: true,
+							Default:  0,
+						},
+						m: metadata{
+							schemaType:   "int",
+							sdkFieldName: "TxBroadcast",
+							testData: testdata{
+								createValue: "100",
+								updateValue: "1000",
+							},
+						},
+					},
+					"tx_multicast": {
+						s: schema.Schema{
+							Type:     schema.TypeInt,
+							Optional: true,
+							Default:  0,
+						},
+						m: metadata{
+							schemaType:   "int",
+							sdkFieldName: "TxMulticast",
+							testData: testdata{
+								createValue: "100",
+								updateValue: "1000",
+							},
+						},
+					},
+				},
+			},
+			Optional: true,
+			Computed: true,
 		},
-	},
-	"rate_limit.tx_broadcast": {
-		schemaType:   "int",
-		sdkFieldName: "TxBroadcast",
-		testData: testdata{
-			createValue: "100",
-			updateValue: "1000",
-		},
-	},
-	"rate_limit.rx_multicast": {
-		schemaType:   "int",
-		sdkFieldName: "RxMulticast",
-		testData: testdata{
-			createValue: "100",
-			updateValue: "1000",
-		},
-	},
-	"rate_limit.tx_multicast": {
-		schemaType:   "int",
-		sdkFieldName: "TxMulticast",
-		testData: testdata{
-			createValue: "100",
-			updateValue: "1000",
+		m: metadata{
+			schemaType:   "struct",
+			sdkFieldName: "RateLimits",
+			reflectType:  reflect.TypeOf(model.TrafficRateLimits{}),
 		},
 	},
 }
@@ -133,93 +245,7 @@ func resourceNsxtPolicySegmentSecurityProfile() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: nsxtPolicyPathResourceImporter,
 		},
-
-		Schema: map[string]*schema.Schema{
-			"nsx_id":       getNsxIDSchema(),
-			"path":         getPathSchema(),
-			"display_name": getDisplayNameSchema(),
-			"description":  getDescriptionSchema(),
-			"revision":     getRevisionSchema(),
-			"tag":          getTagsSchema(),
-			"context":      getContextSchema(false, false),
-			"bpdu_filter_allow": {
-				Type: schema.TypeSet,
-				Elem: &schema.Schema{
-					Type:         schema.TypeString,
-					ValidateFunc: validation.IsMACAddress,
-				},
-				Optional: true,
-			},
-			"bpdu_filter_enable": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  true,
-			},
-			"dhcp_client_block_enabled": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
-			"dhcp_client_block_v6_enabled": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
-			"dhcp_server_block_enabled": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  true,
-			},
-			"dhcp_server_block_v6_enabled": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  true,
-			},
-			"non_ip_traffic_block_enabled": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
-			"ra_guard_enabled": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
-			"rate_limit": {
-				Type: schema.TypeList,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"rx_broadcast": {
-							Type:     schema.TypeInt,
-							Optional: true,
-							Default:  0,
-						},
-						"rx_multicast": {
-							Type:     schema.TypeInt,
-							Optional: true,
-							Default:  0,
-						},
-						"tx_broadcast": {
-							Type:     schema.TypeInt,
-							Optional: true,
-							Default:  0,
-						},
-						"tx_multicast": {
-							Type:     schema.TypeInt,
-							Optional: true,
-							Default:  0,
-						},
-					},
-				},
-				Optional: true,
-				Computed: true,
-			},
-			"rate_limits_enabled": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
-		},
+		Schema: getSchemaFromExtendedSchema(segmentSecurityProfileSchema),
 	}
 }
 
@@ -243,54 +269,18 @@ func resourceNsxtPolicySegmentSecurityProfilePatch(d *schema.ResourceData, m int
 	displayName := d.Get("display_name").(string)
 	description := d.Get("description").(string)
 	tags := getPolicyTagsFromSchema(d)
+	// example of attribute that we prefer to handle manually in the code
+	// it is marked with `skip` in metadata
 	bpduFilterAllow := getStringListFromSchemaSet(d, "bpdu_filter_allow")
-	/*
-		bpduFilterEnable := d.Get("bpdu_filter_enable").(bool)
-		dhcpClientBlockEnabled := d.Get("dhcp_client_block_enabled").(bool)
-		dhcpClientBlockV6Enabled := d.Get("dhcp_client_block_v6_enabled").(bool)
-		dhcpServerBlockEnabled := d.Get("dhcp_server_block_enabled").(bool)
-		dhcpServerBlockV6Enabled := d.Get("dhcp_server_block_v6_enabled").(bool)
-		nonIPTrafficBlockEnabled := d.Get("non_ip_traffic_block_enabled").(bool)
-		raGuardEnabled := d.Get("ra_guard_enabled").(bool)
-		rateLimitsList := d.Get("rate_limit").([]interface{})
-		var rateLimits *model.TrafficRateLimits
-		for _, item := range rateLimitsList {
-			data := item.(map[string]interface{})
-			rxBroadcast := int64(data["rx_broadcast"].(int))
-			rxMulticast := int64(data["rx_multicast"].(int))
-			txBroadcast := int64(data["tx_broadcast"].(int))
-			txMulticast := int64(data["tx_multicast"].(int))
-			obj := model.TrafficRateLimits{
-				RxBroadcast: &rxBroadcast,
-				RxMulticast: &rxMulticast,
-				TxBroadcast: &txBroadcast,
-				TxMulticast: &txMulticast,
-			}
-			rateLimits = &obj
-			break
-		}
-		rateLimitsEnabled := d.Get("rate_limits_enabled").(bool)
-	*/
 
 	obj := model.SegmentSecurityProfile{
 		DisplayName:     &displayName,
 		Description:     &description,
 		Tags:            tags,
 		BpduFilterAllow: bpduFilterAllow,
-		/*
-			BpduFilterEnable:         &bpduFilterEnable,
-			DhcpClientBlockEnabled:   &dhcpClientBlockEnabled,
-			DhcpClientBlockV6Enabled: &dhcpClientBlockV6Enabled,
-			DhcpServerBlockEnabled:   &dhcpServerBlockEnabled,
-			DhcpServerBlockV6Enabled: &dhcpServerBlockV6Enabled,
-			NonIpTrafficBlockEnabled: &nonIPTrafficBlockEnabled,
-			RaGuardEnabled:           &raGuardEnabled,
-			RateLimits:               rateLimits,
-			RateLimitsEnabled:        &rateLimitsEnabled,
-		*/
 	}
 	elem := reflect.ValueOf(&obj).Elem()
-	schemaToStruct(elem, d, segmentSecurityProfileMetadata, "", nil)
+	schemaToStruct(elem, d, segmentSecurityProfileSchema, "", nil)
 
 	log.Printf("[INFO] Sending SegmentSecurityProfile with ID %s", id)
 	client := infra.NewSegmentSecurityProfilesClient(getSessionContext(d, m), connector)
@@ -331,7 +321,7 @@ func resourceNsxtPolicySegmentSecurityProfileRead(d *schema.ResourceData, m inte
 	}
 
 	elem := reflect.ValueOf(&obj).Elem()
-	structToSchema(elem, d, segmentSecurityProfileMetadata, "", nil)
+	structToSchema(elem, d, segmentSecurityProfileSchema, "", nil)
 
 	d.Set("display_name", obj.DisplayName)
 	d.Set("description", obj.Description)
@@ -339,30 +329,6 @@ func resourceNsxtPolicySegmentSecurityProfileRead(d *schema.ResourceData, m inte
 	d.Set("nsx_id", id)
 	d.Set("path", obj.Path)
 	d.Set("revision", obj.Revision)
-
-	/*
-		d.Set("bpdu_filter_allow", obj.BpduFilterAllow)
-		d.Set("bpdu_filter_enable", obj.BpduFilterEnable)
-		d.Set("dhcp_client_block_enabled", obj.DhcpClientBlockEnabled)
-		d.Set("dhcp_client_block_v6_enabled", obj.DhcpClientBlockV6Enabled)
-		d.Set("dhcp_server_block_enabled", obj.DhcpServerBlockEnabled)
-		d.Set("dhcp_server_block_v6_enabled", obj.DhcpServerBlockV6Enabled)
-		d.Set("non_ip_traffic_block_enabled", obj.NonIpTrafficBlockEnabled)
-		d.Set("ra_guard_enabled", obj.RaGuardEnabled)
-		d.Set("rate_limits_enabled", obj.RateLimitsEnabled)
-
-		var rateLimitsList []map[string]interface{}
-		if obj.RateLimits != nil {
-			item := obj.RateLimits
-			data := make(map[string]interface{})
-			data["rx_broadcast"] = item.RxBroadcast
-			data["rx_multicast"] = item.RxMulticast
-			data["tx_broadcast"] = item.TxBroadcast
-			data["tx_multicast"] = item.TxMulticast
-			rateLimitsList = append(rateLimitsList, data)
-		}
-		d.Set("rate_limit", rateLimitsList)
-	*/
 
 	return nil
 }

--- a/nsxt/resource_nsxt_policy_segment_security_profile.go
+++ b/nsxt/resource_nsxt_policy_segment_security_profile.go
@@ -8,25 +8,26 @@ import (
 	"log"
 	"reflect"
 
+	"github.com/vmware/terraform-provider-nsxt/api/infra"
+	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
+	"github.com/vmware/terraform-provider-nsxt/nsxt/metadata"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
-
-	"github.com/vmware/terraform-provider-nsxt/api/infra"
-	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
 )
 
-var segmentSecurityProfileSchema = map[string]*extendedSchema{
-	"nsx_id":       getExtendedSchema(getNsxIDSchema()),
-	"path":         getExtendedSchema(getPathSchema()),
-	"display_name": getExtendedSchema(getDisplayNameSchema()),
-	"description":  getExtendedSchema(getDescriptionSchema()),
-	"revision":     getExtendedSchema(getRevisionSchema()),
-	"tag":          getExtendedSchema(getTagsSchema()),
-	"context":      getExtendedSchema(getContextSchema(false, false)),
+var segmentSecurityProfileSchema = map[string]*metadata.ExtendedSchema{
+	"nsx_id":       metadata.GetExtendedSchema(getNsxIDSchema()),
+	"path":         metadata.GetExtendedSchema(getPathSchema()),
+	"display_name": metadata.GetExtendedSchema(getDisplayNameSchema()),
+	"description":  metadata.GetExtendedSchema(getDescriptionSchema()),
+	"revision":     metadata.GetExtendedSchema(getRevisionSchema()),
+	"tag":          metadata.GetExtendedSchema(getTagsSchema()),
+	"context":      metadata.GetExtendedSchema(getContextSchema(false, false)),
 	"bpdu_filter_allow": {
-		s: schema.Schema{
+		Schema: schema.Schema{
 			Type: schema.TypeSet,
 			Elem: &schema.Schema{
 				Type:         schema.TypeString,
@@ -34,192 +35,192 @@ var segmentSecurityProfileSchema = map[string]*extendedSchema{
 			},
 			Optional: true,
 		},
-		m: metadata{
-			skip: true,
+		Metadata: metadata.Metadata{
+			Skip: true,
 		},
 	},
 	"bpdu_filter_enable": {
-		s: schema.Schema{
+		Schema: schema.Schema{
 			Type:     schema.TypeBool,
 			Optional: true,
 			Default:  true,
 		},
-		m: metadata{
-			schemaType:   "bool",
-			sdkFieldName: "BpduFilterEnable",
-			testData: testdata{
-				createValue: "true",
-				updateValue: "false",
+		Metadata: metadata.Metadata{
+			SchemaType:   "bool",
+			SdkFieldName: "BpduFilterEnable",
+			TestData: metadata.Testdata{
+				CreateValue: "true",
+				UpdateValue: "false",
 			},
 		},
 	},
 	"dhcp_client_block_enabled": {
-		s: schema.Schema{
+		Schema: schema.Schema{
 			Type:     schema.TypeBool,
 			Optional: true,
 			Default:  false,
 		},
-		m: metadata{
-			schemaType:   "bool",
-			sdkFieldName: "DhcpClientBlockEnabled",
-			testData: testdata{
-				createValue: "true",
-				updateValue: "false",
+		Metadata: metadata.Metadata{
+			SchemaType:   "bool",
+			SdkFieldName: "DhcpClientBlockEnabled",
+			TestData: metadata.Testdata{
+				CreateValue: "true",
+				UpdateValue: "false",
 			},
 		},
 	},
 	"dhcp_server_block_enabled": {
-		s: schema.Schema{
+		Schema: schema.Schema{
 			Type:     schema.TypeBool,
 			Optional: true,
 			Default:  true,
 		},
-		m: metadata{
-			schemaType:   "bool",
-			sdkFieldName: "DhcpServerBlockEnabled",
-			testData: testdata{
-				createValue: "true",
-				updateValue: "false",
+		Metadata: metadata.Metadata{
+			SchemaType:   "bool",
+			SdkFieldName: "DhcpServerBlockEnabled",
+			TestData: metadata.Testdata{
+				CreateValue: "true",
+				UpdateValue: "false",
 			},
 		},
 	},
 	"dhcp_client_block_v6_enabled": {
-		s: schema.Schema{
+		Schema: schema.Schema{
 			Type:     schema.TypeBool,
 			Optional: true,
 			Default:  false,
 		},
-		m: metadata{
-			schemaType:   "bool",
-			sdkFieldName: "DhcpClientBlockV6Enabled",
-			testData: testdata{
-				createValue: "true",
-				updateValue: "false",
+		Metadata: metadata.Metadata{
+			SchemaType:   "bool",
+			SdkFieldName: "DhcpClientBlockV6Enabled",
+			TestData: metadata.Testdata{
+				CreateValue: "true",
+				UpdateValue: "false",
 			},
 		},
 	},
 	"dhcp_server_block_v6_enabled": {
-		s: schema.Schema{
+		Schema: schema.Schema{
 			Type:     schema.TypeBool,
 			Optional: true,
 			Default:  true,
 		},
-		m: metadata{
-			schemaType:   "bool",
-			sdkFieldName: "DhcpServerBlockV6Enabled",
-			testData: testdata{
-				createValue: "true",
-				updateValue: "false",
+		Metadata: metadata.Metadata{
+			SchemaType:   "bool",
+			SdkFieldName: "DhcpServerBlockV6Enabled",
+			TestData: metadata.Testdata{
+				CreateValue: "true",
+				UpdateValue: "false",
 			},
 		},
 	},
 	"non_ip_traffic_block_enabled": {
-		s: schema.Schema{
+		Schema: schema.Schema{
 			Type:     schema.TypeBool,
 			Optional: true,
 			Default:  false,
 		},
-		m: metadata{
-			schemaType:   "bool",
-			sdkFieldName: "NonIpTrafficBlockEnabled",
-			testData: testdata{
-				createValue: "true",
-				updateValue: "false",
+		Metadata: metadata.Metadata{
+			SchemaType:   "bool",
+			SdkFieldName: "NonIpTrafficBlockEnabled",
+			TestData: metadata.Testdata{
+				CreateValue: "true",
+				UpdateValue: "false",
 			},
 		},
 	},
 	"ra_guard_enabled": {
-		s: schema.Schema{
+		Schema: schema.Schema{
 			Type:     schema.TypeBool,
 			Optional: true,
 			Default:  false,
 		},
-		m: metadata{
-			schemaType:   "bool",
-			sdkFieldName: "RaGuardEnabled",
-			testData: testdata{
-				createValue: "true",
-				updateValue: "false",
+		Metadata: metadata.Metadata{
+			SchemaType:   "bool",
+			SdkFieldName: "RaGuardEnabled",
+			TestData: metadata.Testdata{
+				CreateValue: "true",
+				UpdateValue: "false",
 			},
 		},
 	},
 	"rate_limits_enabled": {
-		s: schema.Schema{
+		Schema: schema.Schema{
 			Type:     schema.TypeBool,
 			Optional: true,
 			Default:  false,
 		},
-		m: metadata{
-			schemaType:   "bool",
-			sdkFieldName: "RateLimitsEnabled",
-			testData: testdata{
-				createValue: "true",
-				updateValue: "false",
+		Metadata: metadata.Metadata{
+			SchemaType:   "bool",
+			SdkFieldName: "RateLimitsEnabled",
+			TestData: metadata.Testdata{
+				CreateValue: "true",
+				UpdateValue: "false",
 			},
 		},
 	},
 	"rate_limit": {
-		s: schema.Schema{
+		Schema: schema.Schema{
 			Type: schema.TypeList,
-			Elem: &extendedResource{
-				Schema: map[string]*extendedSchema{
+			Elem: &metadata.ExtendedResource{
+				Schema: map[string]*metadata.ExtendedSchema{
 					"rx_broadcast": {
-						s: schema.Schema{
+						Schema: schema.Schema{
 							Type:     schema.TypeInt,
 							Optional: true,
 							Default:  0,
 						},
-						m: metadata{
-							schemaType:   "int",
-							sdkFieldName: "RxBroadcast",
-							testData: testdata{
-								createValue: "100",
-								updateValue: "1000",
+						Metadata: metadata.Metadata{
+							SchemaType:   "int",
+							SdkFieldName: "RxBroadcast",
+							TestData: metadata.Testdata{
+								CreateValue: "100",
+								UpdateValue: "1000",
 							},
 						},
 					},
 					"rx_multicast": {
-						s: schema.Schema{
+						Schema: schema.Schema{
 							Type:     schema.TypeInt,
 							Optional: true,
 							Default:  0,
 						},
-						m: metadata{
-							schemaType:   "int",
-							sdkFieldName: "RxMulticast",
-							testData: testdata{
-								createValue: "100",
-								updateValue: "1000",
+						Metadata: metadata.Metadata{
+							SchemaType:   "int",
+							SdkFieldName: "RxMulticast",
+							TestData: metadata.Testdata{
+								CreateValue: "100",
+								UpdateValue: "1000",
 							},
 						},
 					},
 					"tx_broadcast": {
-						s: schema.Schema{
+						Schema: schema.Schema{
 							Type:     schema.TypeInt,
 							Optional: true,
 							Default:  0,
 						},
-						m: metadata{
-							schemaType:   "int",
-							sdkFieldName: "TxBroadcast",
-							testData: testdata{
-								createValue: "100",
-								updateValue: "1000",
+						Metadata: metadata.Metadata{
+							SchemaType:   "int",
+							SdkFieldName: "TxBroadcast",
+							TestData: metadata.Testdata{
+								CreateValue: "100",
+								UpdateValue: "1000",
 							},
 						},
 					},
 					"tx_multicast": {
-						s: schema.Schema{
+						Schema: schema.Schema{
 							Type:     schema.TypeInt,
 							Optional: true,
 							Default:  0,
 						},
-						m: metadata{
-							schemaType:   "int",
-							sdkFieldName: "TxMulticast",
-							testData: testdata{
-								createValue: "100",
-								updateValue: "1000",
+						Metadata: metadata.Metadata{
+							SchemaType:   "int",
+							SdkFieldName: "TxMulticast",
+							TestData: metadata.Testdata{
+								CreateValue: "100",
+								UpdateValue: "1000",
 							},
 						},
 					},
@@ -228,10 +229,10 @@ var segmentSecurityProfileSchema = map[string]*extendedSchema{
 			Optional: true,
 			Computed: true,
 		},
-		m: metadata{
-			schemaType:   "struct",
-			sdkFieldName: "RateLimits",
-			reflectType:  reflect.TypeOf(model.TrafficRateLimits{}),
+		Metadata: metadata.Metadata{
+			SchemaType:   "struct",
+			SdkFieldName: "RateLimits",
+			ReflectType:  reflect.TypeOf(model.TrafficRateLimits{}),
 		},
 	},
 }
@@ -245,7 +246,8 @@ func resourceNsxtPolicySegmentSecurityProfile() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: nsxtPolicyPathResourceImporter,
 		},
-		Schema: getSchemaFromExtendedSchema(segmentSecurityProfileSchema),
+
+		Schema: metadata.GetSchemaFromExtendedSchema(segmentSecurityProfileSchema),
 	}
 }
 
@@ -280,7 +282,7 @@ func resourceNsxtPolicySegmentSecurityProfilePatch(d *schema.ResourceData, m int
 		BpduFilterAllow: bpduFilterAllow,
 	}
 	elem := reflect.ValueOf(&obj).Elem()
-	schemaToStruct(elem, d, segmentSecurityProfileSchema, "", nil)
+	metadata.SchemaToStruct(elem, d, segmentSecurityProfileSchema, "", nil)
 
 	log.Printf("[INFO] Sending SegmentSecurityProfile with ID %s", id)
 	client := infra.NewSegmentSecurityProfilesClient(getSessionContext(d, m), connector)
@@ -321,7 +323,7 @@ func resourceNsxtPolicySegmentSecurityProfileRead(d *schema.ResourceData, m inte
 	}
 
 	elem := reflect.ValueOf(&obj).Elem()
-	structToSchema(elem, d, segmentSecurityProfileSchema, "", nil)
+	metadata.StructToSchema(elem, d, segmentSecurityProfileSchema, "", nil)
 
 	d.Set("display_name", obj.DisplayName)
 	d.Set("description", obj.Description)

--- a/nsxt/resource_nsxt_policy_segment_security_profile.go
+++ b/nsxt/resource_nsxt_policy_segment_security_profile.go
@@ -6,6 +6,7 @@ package nsxt
 import (
 	"fmt"
 	"log"
+	"reflect"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -15,6 +16,113 @@ import (
 	"github.com/vmware/terraform-provider-nsxt/api/infra"
 	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
 )
+
+var segmentSecurityProfileMetadata = map[string]*metadata{
+	"bpdu_filter_allow": {
+		skip: true,
+	},
+	"bpdu_filter_enable": {
+		schemaType:   "bool",
+		sdkFieldName: "BpduFilterEnable",
+		testData: testdata{
+			createValue: "true",
+			updateValue: "false",
+		},
+	},
+	"dhcp_client_block_enabled": {
+		schemaType:   "bool",
+		sdkFieldName: "DhcpClientBlockEnabled",
+		testData: testdata{
+			createValue: "true",
+			updateValue: "false",
+		},
+	},
+	"dhcp_server_block_enabled": {
+		schemaType:   "bool",
+		sdkFieldName: "DhcpServerBlockEnabled",
+		testData: testdata{
+			createValue: "true",
+			updateValue: "false",
+		},
+	},
+	"dhcp_client_block_v6_enabled": {
+		schemaType:   "bool",
+		sdkFieldName: "DhcpClientBlockV6Enabled",
+		testData: testdata{
+			createValue: "true",
+			updateValue: "false",
+		},
+	},
+	"dhcp_server_block_v6_enabled": {
+		schemaType:   "bool",
+		sdkFieldName: "DhcpServerBlockV6Enabled",
+		testData: testdata{
+			createValue: "true",
+			updateValue: "false",
+		},
+	},
+	"non_ip_traffic_block_enabled": {
+		schemaType:   "bool",
+		sdkFieldName: "NonIpTrafficBlockEnabled",
+		testData: testdata{
+			createValue: "true",
+			updateValue: "false",
+		},
+	},
+	"ra_guard_enabled": {
+		schemaType:   "bool",
+		sdkFieldName: "RaGuardEnabled",
+		testData: testdata{
+			createValue: "true",
+			updateValue: "false",
+		},
+	},
+	"rate_limits_enabled": {
+		schemaType:   "bool",
+		sdkFieldName: "RateLimitsEnabled",
+		testData: testdata{
+			createValue: "true",
+			updateValue: "false",
+		},
+	},
+	"rate_limit": {
+		schemaType:   "struct",
+		sdkFieldName: "RateLimits",
+		reflectType:  reflect.TypeOf(model.TrafficRateLimits{}),
+	},
+	"rate_limit.rx_broadcast": {
+		schemaType:   "int",
+		sdkFieldName: "RxBroadcast",
+		testData: testdata{
+			createValue: "100",
+			updateValue: "1000",
+		},
+	},
+	"rate_limit.tx_broadcast": {
+		schemaType:   "int",
+		sdkFieldName: "TxBroadcast",
+		testData: testdata{
+			createValue: "100",
+			updateValue: "1000",
+		},
+	},
+	"rate_limit.rx_multicast": {
+		schemaType:   "int",
+		sdkFieldName: "RxMulticast",
+		testData: testdata{
+			createValue: "100",
+			updateValue: "1000",
+		},
+	},
+	"rate_limit.tx_multicast": {
+		schemaType:   "int",
+		sdkFieldName: "TxMulticast",
+		testData: testdata{
+			createValue: "100",
+			updateValue: "1000",
+		},
+	},
+}
 
 func resourceNsxtPolicySegmentSecurityProfile() *schema.Resource {
 	return &schema.Resource{
@@ -136,47 +244,53 @@ func resourceNsxtPolicySegmentSecurityProfilePatch(d *schema.ResourceData, m int
 	description := d.Get("description").(string)
 	tags := getPolicyTagsFromSchema(d)
 	bpduFilterAllow := getStringListFromSchemaSet(d, "bpdu_filter_allow")
-	bpduFilterEnable := d.Get("bpdu_filter_enable").(bool)
-	dhcpClientBlockEnabled := d.Get("dhcp_client_block_enabled").(bool)
-	dhcpClientBlockV6Enabled := d.Get("dhcp_client_block_v6_enabled").(bool)
-	dhcpServerBlockEnabled := d.Get("dhcp_server_block_enabled").(bool)
-	dhcpServerBlockV6Enabled := d.Get("dhcp_server_block_v6_enabled").(bool)
-	nonIPTrafficBlockEnabled := d.Get("non_ip_traffic_block_enabled").(bool)
-	raGuardEnabled := d.Get("ra_guard_enabled").(bool)
-	rateLimitsList := d.Get("rate_limit").([]interface{})
-	var rateLimits *model.TrafficRateLimits
-	for _, item := range rateLimitsList {
-		data := item.(map[string]interface{})
-		rxBroadcast := int64(data["rx_broadcast"].(int))
-		rxMulticast := int64(data["rx_multicast"].(int))
-		txBroadcast := int64(data["tx_broadcast"].(int))
-		txMulticast := int64(data["tx_multicast"].(int))
-		obj := model.TrafficRateLimits{
-			RxBroadcast: &rxBroadcast,
-			RxMulticast: &rxMulticast,
-			TxBroadcast: &txBroadcast,
-			TxMulticast: &txMulticast,
+	/*
+		bpduFilterEnable := d.Get("bpdu_filter_enable").(bool)
+		dhcpClientBlockEnabled := d.Get("dhcp_client_block_enabled").(bool)
+		dhcpClientBlockV6Enabled := d.Get("dhcp_client_block_v6_enabled").(bool)
+		dhcpServerBlockEnabled := d.Get("dhcp_server_block_enabled").(bool)
+		dhcpServerBlockV6Enabled := d.Get("dhcp_server_block_v6_enabled").(bool)
+		nonIPTrafficBlockEnabled := d.Get("non_ip_traffic_block_enabled").(bool)
+		raGuardEnabled := d.Get("ra_guard_enabled").(bool)
+		rateLimitsList := d.Get("rate_limit").([]interface{})
+		var rateLimits *model.TrafficRateLimits
+		for _, item := range rateLimitsList {
+			data := item.(map[string]interface{})
+			rxBroadcast := int64(data["rx_broadcast"].(int))
+			rxMulticast := int64(data["rx_multicast"].(int))
+			txBroadcast := int64(data["tx_broadcast"].(int))
+			txMulticast := int64(data["tx_multicast"].(int))
+			obj := model.TrafficRateLimits{
+				RxBroadcast: &rxBroadcast,
+				RxMulticast: &rxMulticast,
+				TxBroadcast: &txBroadcast,
+				TxMulticast: &txMulticast,
+			}
+			rateLimits = &obj
+			break
 		}
-		rateLimits = &obj
-		break
-	}
-	rateLimitsEnabled := d.Get("rate_limits_enabled").(bool)
+		rateLimitsEnabled := d.Get("rate_limits_enabled").(bool)
+	*/
 
 	obj := model.SegmentSecurityProfile{
-		DisplayName:              &displayName,
-		Description:              &description,
-		Tags:                     tags,
-		BpduFilterAllow:          bpduFilterAllow,
-		BpduFilterEnable:         &bpduFilterEnable,
-		DhcpClientBlockEnabled:   &dhcpClientBlockEnabled,
-		DhcpClientBlockV6Enabled: &dhcpClientBlockV6Enabled,
-		DhcpServerBlockEnabled:   &dhcpServerBlockEnabled,
-		DhcpServerBlockV6Enabled: &dhcpServerBlockV6Enabled,
-		NonIpTrafficBlockEnabled: &nonIPTrafficBlockEnabled,
-		RaGuardEnabled:           &raGuardEnabled,
-		RateLimits:               rateLimits,
-		RateLimitsEnabled:        &rateLimitsEnabled,
+		DisplayName:     &displayName,
+		Description:     &description,
+		Tags:            tags,
+		BpduFilterAllow: bpduFilterAllow,
+		/*
+			BpduFilterEnable:         &bpduFilterEnable,
+			DhcpClientBlockEnabled:   &dhcpClientBlockEnabled,
+			DhcpClientBlockV6Enabled: &dhcpClientBlockV6Enabled,
+			DhcpServerBlockEnabled:   &dhcpServerBlockEnabled,
+			DhcpServerBlockV6Enabled: &dhcpServerBlockV6Enabled,
+			NonIpTrafficBlockEnabled: &nonIPTrafficBlockEnabled,
+			RaGuardEnabled:           &raGuardEnabled,
+			RateLimits:               rateLimits,
+			RateLimitsEnabled:        &rateLimitsEnabled,
+		*/
 	}
+	elem := reflect.ValueOf(&obj).Elem()
+	schemaToStruct(elem, d, segmentSecurityProfileMetadata, "", nil)
 
 	log.Printf("[INFO] Sending SegmentSecurityProfile with ID %s", id)
 	client := infra.NewSegmentSecurityProfilesClient(getSessionContext(d, m), connector)
@@ -216,6 +330,9 @@ func resourceNsxtPolicySegmentSecurityProfileRead(d *schema.ResourceData, m inte
 		return handleReadError(d, "SegmentSecurityProfile", id, err)
 	}
 
+	elem := reflect.ValueOf(&obj).Elem()
+	structToSchema(elem, d, segmentSecurityProfileMetadata, "", nil)
+
 	d.Set("display_name", obj.DisplayName)
 	d.Set("description", obj.Description)
 	setPolicyTagsInSchema(d, obj.Tags)
@@ -223,27 +340,29 @@ func resourceNsxtPolicySegmentSecurityProfileRead(d *schema.ResourceData, m inte
 	d.Set("path", obj.Path)
 	d.Set("revision", obj.Revision)
 
-	d.Set("bpdu_filter_allow", obj.BpduFilterAllow)
-	d.Set("bpdu_filter_enable", obj.BpduFilterEnable)
-	d.Set("dhcp_client_block_enabled", obj.DhcpClientBlockEnabled)
-	d.Set("dhcp_client_block_v6_enabled", obj.DhcpClientBlockV6Enabled)
-	d.Set("dhcp_server_block_enabled", obj.DhcpServerBlockEnabled)
-	d.Set("dhcp_server_block_v6_enabled", obj.DhcpServerBlockV6Enabled)
-	d.Set("non_ip_traffic_block_enabled", obj.NonIpTrafficBlockEnabled)
-	d.Set("ra_guard_enabled", obj.RaGuardEnabled)
-	d.Set("rate_limits_enabled", obj.RateLimitsEnabled)
+	/*
+		d.Set("bpdu_filter_allow", obj.BpduFilterAllow)
+		d.Set("bpdu_filter_enable", obj.BpduFilterEnable)
+		d.Set("dhcp_client_block_enabled", obj.DhcpClientBlockEnabled)
+		d.Set("dhcp_client_block_v6_enabled", obj.DhcpClientBlockV6Enabled)
+		d.Set("dhcp_server_block_enabled", obj.DhcpServerBlockEnabled)
+		d.Set("dhcp_server_block_v6_enabled", obj.DhcpServerBlockV6Enabled)
+		d.Set("non_ip_traffic_block_enabled", obj.NonIpTrafficBlockEnabled)
+		d.Set("ra_guard_enabled", obj.RaGuardEnabled)
+		d.Set("rate_limits_enabled", obj.RateLimitsEnabled)
 
-	var rateLimitsList []map[string]interface{}
-	if obj.RateLimits != nil {
-		item := obj.RateLimits
-		data := make(map[string]interface{})
-		data["rx_broadcast"] = item.RxBroadcast
-		data["rx_multicast"] = item.RxMulticast
-		data["tx_broadcast"] = item.TxBroadcast
-		data["tx_multicast"] = item.TxMulticast
-		rateLimitsList = append(rateLimitsList, data)
-	}
-	d.Set("rate_limit", rateLimitsList)
+		var rateLimitsList []map[string]interface{}
+		if obj.RateLimits != nil {
+			item := obj.RateLimits
+			data := make(map[string]interface{})
+			data["rx_broadcast"] = item.RxBroadcast
+			data["rx_multicast"] = item.RxMulticast
+			data["tx_broadcast"] = item.TxBroadcast
+			data["tx_multicast"] = item.TxMulticast
+			rateLimitsList = append(rateLimitsList, data)
+		}
+		d.Set("rate_limit", rateLimitsList)
+	*/
 
 	return nil
 }

--- a/nsxt/resource_nsxt_policy_segment_security_profile.go
+++ b/nsxt/resource_nsxt_policy_segment_security_profile.go
@@ -282,7 +282,9 @@ func resourceNsxtPolicySegmentSecurityProfilePatch(d *schema.ResourceData, m int
 		BpduFilterAllow: bpduFilterAllow,
 	}
 	elem := reflect.ValueOf(&obj).Elem()
-	metadata.SchemaToStruct(elem, d, segmentSecurityProfileSchema, "", nil)
+	if err := metadata.SchemaToStruct(elem, d, segmentSecurityProfileSchema, "", nil); err != nil {
+		return err
+	}
 
 	log.Printf("[INFO] Sending SegmentSecurityProfile with ID %s", id)
 	client := infra.NewSegmentSecurityProfilesClient(getSessionContext(d, m), connector)
@@ -323,7 +325,9 @@ func resourceNsxtPolicySegmentSecurityProfileRead(d *schema.ResourceData, m inte
 	}
 
 	elem := reflect.ValueOf(&obj).Elem()
-	metadata.StructToSchema(elem, d, segmentSecurityProfileSchema, "", nil)
+	if err := metadata.StructToSchema(elem, d, segmentSecurityProfileSchema, "", nil); err != nil {
+		return err
+	}
 
 	d.Set("display_name", obj.DisplayName)
 	d.Set("description", obj.Description)

--- a/nsxt/resource_nsxt_policy_segment_security_profile.go
+++ b/nsxt/resource_nsxt_policy_segment_security_profile.go
@@ -336,7 +336,7 @@ func resourceNsxtPolicySegmentSecurityProfileRead(d *schema.ResourceData, m inte
 }
 
 func resourceNsxtPolicySegmentSecurityProfileUpdate(d *schema.ResourceData, m interface{}) error {
-
+	log.Printf("[INFO] updating SegmentSecurityProfile")
 	id := d.Id()
 	if id == "" {
 		return fmt.Errorf("Error obtaining SegmentSecurityProfile ID")

--- a/nsxt/resource_nsxt_policy_tier0_gateway.go
+++ b/nsxt/resource_nsxt_policy_tier0_gateway.go
@@ -7,6 +7,9 @@ import (
 	"fmt"
 	"log"
 
+	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
+	"github.com/vmware/terraform-provider-nsxt/nsxt/util"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/bindings"
@@ -15,8 +18,6 @@ import (
 	gm_infra "github.com/vmware/vsphere-automation-sdk-go/services/nsxt-gm/global_infra"
 	gm_tier_0s "github.com/vmware/vsphere-automation-sdk-go/services/nsxt-gm/global_infra/tier_0s"
 	gm_model "github.com/vmware/vsphere-automation-sdk-go/services/nsxt-gm/model"
-
-	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_0s"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_0s/locale_services"
@@ -438,7 +439,7 @@ func resourceNsxtPolicyTier0GatewayReadBGPConfig(d *schema.ResourceData, connect
 
 func getPolicyVRFConfigFromSchema(d *schema.ResourceData) *model.Tier0VrfConfig {
 
-	if nsxVersionLower("3.0.0") {
+	if util.NsxVersionLower("3.0.0") {
 		// VRF Lite is supported from 3.0.0 onwards
 		return nil
 	}
@@ -758,11 +759,11 @@ func policyTier0GatewayResourceToInfraStruct(context utl.SessionContext, d *sche
 		VrfConfig:              vrfConfig,
 	}
 
-	if nsxVersionHigherOrEqual("3.0.0") {
+	if util.NsxVersionHigherOrEqual("3.0.0") {
 		t0Struct.RdAdminField = rdAdminField
 	}
 
-	if nsxVersionHigherOrEqual("4.1.0") {
+	if util.NsxVersionHigherOrEqual("4.1.0") {
 		t0Struct.VrfTransitSubnets = vrfTransitSubnets
 	}
 
@@ -928,7 +929,7 @@ func resourceNsxtPolicyTier0GatewayRead(d *schema.ResourceData, m interface{}) e
 	d.Set("transit_subnets", obj.TransitSubnets)
 	d.Set("vrf_transit_subnets", obj.VrfTransitSubnets)
 	d.Set("revision", obj.Revision)
-	if nsxVersionHigherOrEqual("3.0.0") {
+	if util.NsxVersionHigherOrEqual("3.0.0") {
 		d.Set("rd_admin_address", obj.RdAdminField)
 	}
 	vrfErr := setPolicyVRFConfigInSchema(d, obj.VrfConfig)

--- a/nsxt/resource_nsxt_policy_tier0_gateway_interface.go
+++ b/nsxt/resource_nsxt_policy_tier0_gateway_interface.go
@@ -8,6 +8,8 @@ import (
 	"log"
 	"strings"
 
+	"github.com/vmware/terraform-provider-nsxt/nsxt/util"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	gm_infra "github.com/vmware/vsphere-automation-sdk-go/services/nsxt-gm/global_infra"
@@ -144,7 +146,7 @@ func getGatewayInterfaceOspfSchema() *schema.Schema {
 }
 
 func gatewayInterfaceVersionDepenantSet(d *schema.ResourceData, m interface{}, obj *model.Tier0Interface) error {
-	if nsxVersionLower("3.0.0") {
+	if util.NsxVersionLower("3.0.0") {
 		return nil
 	}
 	interfaceType := d.Get("type").(string)

--- a/nsxt/resource_nsxt_policy_tier1_gateway.go
+++ b/nsxt/resource_nsxt_policy_tier1_gateway.go
@@ -7,16 +7,17 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/vmware/terraform-provider-nsxt/api/infra"
+	tier1s "github.com/vmware/terraform-provider-nsxt/api/infra/tier_1s"
+	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
+	"github.com/vmware/terraform-provider-nsxt/nsxt/util"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/bindings"
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/data"
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
-
-	"github.com/vmware/terraform-provider-nsxt/api/infra"
-	tier1s "github.com/vmware/terraform-provider-nsxt/api/infra/tier_1s"
-	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
 )
 
 var advertismentTypeValues = []string{
@@ -318,7 +319,7 @@ func resourceNsxtPolicyTier1GatewaySetQos(d *schema.ResourceData, obj *model.Tie
 }
 
 func resourceNsxtPolicyTier1GatewaySetVersionDependentAttrs(d *schema.ResourceData, obj *model.Tier1) {
-	if nsxVersionLower("3.0.0") {
+	if util.NsxVersionLower("3.0.0") {
 		return
 	}
 
@@ -382,7 +383,7 @@ func policyTier1GatewayResourceToInfraStruct(context utl.SessionContext, d *sche
 	connectivityType := d.Get("type").(string)
 	revision := int64(d.Get("revision").(int))
 
-	if haMode == model.Tier1_HA_MODE_ACTIVE && nsxVersionLower("4.0.0") {
+	if haMode == model.Tier1_HA_MODE_ACTIVE && util.NsxVersionLower("4.0.0") {
 		return infraStruct, fmt.Errorf("ACTIVE_ACTIVE HA mode is not supported in NSX versions lower than 4.0.0. Use ACTIVE_BACKUP instead")
 	}
 
@@ -404,7 +405,7 @@ func policyTier1GatewayResourceToInfraStruct(context utl.SessionContext, d *sche
 		ResourceType:            &t1Type,
 	}
 
-	if nsxVersionHigherOrEqual("3.2.0") {
+	if util.NsxVersionHigherOrEqual("3.2.0") {
 		if haMode != "NONE" && haMode != "" {
 			obj.HaMode = &haMode
 		}
@@ -546,7 +547,7 @@ func resourceNsxtPolicyTier1GatewayRead(d *schema.ResourceData, m interface{}) e
 	d.Set("enable_firewall", !(*obj.DisableFirewall))
 	d.Set("enable_standby_relocation", obj.EnableStandbyRelocation)
 	d.Set("force_whitelisting", obj.ForceWhitelisting)
-	if nsxVersionHigherOrEqual("3.2.0") {
+	if util.NsxVersionHigherOrEqual("3.2.0") {
 		if obj.HaMode == nil {
 			d.Set("ha_mode", "NONE")
 		} else {

--- a/nsxt/resource_nsxt_policy_tier1_gateway_interface.go
+++ b/nsxt/resource_nsxt_policy_tier1_gateway_interface.go
@@ -10,14 +10,15 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/vmware/terraform-provider-nsxt/api/infra"
+	localeservices "github.com/vmware/terraform-provider-nsxt/api/infra/tier_1s/locale_services"
+	"github.com/vmware/terraform-provider-nsxt/nsxt/util"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	gm_tier1s "github.com/vmware/vsphere-automation-sdk-go/services/nsxt-gm/global_infra/tier_1s"
 	gm_locale_services "github.com/vmware/vsphere-automation-sdk-go/services/nsxt-gm/global_infra/tier_1s/locale_services"
 	gm_model "github.com/vmware/vsphere-automation-sdk-go/services/nsxt-gm/model"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
-
-	"github.com/vmware/terraform-provider-nsxt/api/infra"
-	localeservices "github.com/vmware/terraform-provider-nsxt/api/infra/tier_1s/locale_services"
 )
 
 func resourceNsxtPolicyTier1GatewayInterface() *schema.Resource {
@@ -153,7 +154,7 @@ func resourceNsxtPolicyTier1GatewayInterfaceCreate(d *schema.ResourceData, m int
 		obj.Mtu = &mtu
 	}
 
-	if nsxVersionHigherOrEqual("3.0.0") {
+	if util.NsxVersionHigherOrEqual("3.0.0") {
 		urpfMode := d.Get("urpf_mode").(string)
 		obj.UrpfMode = &urpfMode
 	}
@@ -279,7 +280,7 @@ func resourceNsxtPolicyTier1GatewayInterfaceUpdate(d *schema.ResourceData, m int
 		obj.Mtu = &mtu
 	}
 
-	if nsxVersionHigherOrEqual("3.0.0") {
+	if util.NsxVersionHigherOrEqual("3.0.0") {
 		urpfMode := d.Get("urpf_mode").(string)
 		obj.UrpfMode = &urpfMode
 	}

--- a/nsxt/resource_nsxt_policy_vm_tags.go
+++ b/nsxt/resource_nsxt_policy_vm_tags.go
@@ -9,11 +9,13 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	realizedstate "github.com/vmware/terraform-provider-nsxt/api/infra/realized_state"
 	"github.com/vmware/terraform-provider-nsxt/api/infra/segments"
 	t1_segments "github.com/vmware/terraform-provider-nsxt/api/infra/tier_1s/segments"
 	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
+	"github.com/vmware/terraform-provider-nsxt/nsxt/util"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/bindings"
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/data"
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
@@ -167,7 +169,7 @@ func findNsxtPolicyVMByNamePrefix(context utl.SessionContext, connector client.C
 	var perfectMatch, prefixMatch, allVMs []model.VirtualMachine
 	var err error
 
-	if nsxVersionHigherOrEqual("4.1.2") {
+	if util.NsxVersionHigherOrEqual("4.1.2") {
 		// Search API works for inventory objects for 4.1.2 and above
 		resourceType := "VirtualMachine"
 		resultValues, err1 := listInventoryResourcesByNameAndType(connector, context, namePrefix, resourceType, nil)
@@ -215,7 +217,7 @@ func findNsxtPolicyVMByID(context utl.SessionContext, connector client.Connector
 	var vms []model.VirtualMachine
 	var err error
 
-	if nsxVersionHigherOrEqual("4.1.2") {
+	if util.NsxVersionHigherOrEqual("4.1.2") {
 		// Search API works for inventory objects for 4.1.2 and above
 		resourceType := "VirtualMachine"
 		resultValues, err1 := listInventoryResourcesByAnyFieldAndType(connector, context, vmID, resourceType, nil)
@@ -252,7 +254,7 @@ func updateNsxtPolicyVMTags(connector client.Connector, externalID string, tags 
 		Tags:             tags,
 		VirtualMachineId: &externalID,
 	}
-	if nsxVersionHigherOrEqual("4.1.1") {
+	if util.NsxVersionHigherOrEqual("4.1.1") {
 		client := virtual_machines.NewTagsClient(connector)
 		return client.Create(externalID, tagUpdate, nil, nil, nil, nil, nil, nil, nil)
 	}

--- a/nsxt/resource_nsxt_upgrade_prepare.go
+++ b/nsxt/resource_nsxt_upgrade_prepare.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/vmware/terraform-provider-nsxt/nsxt/util"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
@@ -248,10 +250,10 @@ func uploadPrecheckAndUpgradeBundle(d *schema.ResourceData, m interface{}) error
 }
 
 func precheckBundleCompatibilityCheck(precheckBundleURL string) bool {
-	if nsxVersionLower("4.1.1") && len(precheckBundleURL) > 0 {
+	if util.NsxVersionLower("4.1.1") && len(precheckBundleURL) > 0 {
 		return false
 	}
-	if nsxVersionHigherOrEqual("4.1.1") && len(precheckBundleURL) == 0 {
+	if util.NsxVersionHigherOrEqual("4.1.1") && len(precheckBundleURL) == 0 {
 		return false
 	}
 	return true
@@ -299,7 +301,7 @@ func uploadUpgradeBundle(d *schema.ResourceData, m interface{}, bundleType strin
 	bundleFetchRequest := nsxModel.UpgradeBundleFetchRequest{
 		Url: &url,
 	}
-	if nsxVersionHigherOrEqual("4.1.1") {
+	if util.NsxVersionHigherOrEqual("4.1.1") {
 		bundleFetchRequest.BundleType = &bundleType
 		bundleFetchRequest.Password = &password
 		bundleFetchRequest.Username = &userName

--- a/nsxt/segment_common.go
+++ b/nsxt/segment_common.go
@@ -6,7 +6,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/vmware/terraform-provider-nsxt/api/infra"
+	"github.com/vmware/terraform-provider-nsxt/api/infra/segments"
 	tier1s "github.com/vmware/terraform-provider-nsxt/api/infra/tier_1s"
+	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
+	"github.com/vmware/terraform-provider-nsxt/nsxt/util"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -17,10 +21,6 @@ import (
 	gm_segments "github.com/vmware/vsphere-automation-sdk-go/services/nsxt-gm/global_infra/segments"
 	gm_model "github.com/vmware/vsphere-automation-sdk-go/services/nsxt-gm/model"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
-
-	"github.com/vmware/terraform-provider-nsxt/api/infra"
-	"github.com/vmware/terraform-provider-nsxt/api/infra/segments"
-	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
 )
 
 var connectivityValues = []string{
@@ -491,7 +491,7 @@ func getDhcpOptsFromMap(dhcpConfig map[string]interface{}) *model.DhcpV4Options 
 }
 
 func getSegmentSubnetDhcpConfigFromSchema(schemaConfig map[string]interface{}) (*data.StructValue, error) {
-	if nsxVersionLower("3.0.0") {
+	if util.NsxVersionLower("3.0.0") {
 		return nil, nil
 	}
 
@@ -727,7 +727,7 @@ func policySegmentResourceToInfraStruct(context utl.SessionContext, id string, d
 	if tzPath != "" {
 		obj.TransportZonePath = &tzPath
 	}
-	if nsxVersionHigherOrEqual("3.0.0") {
+	if util.NsxVersionHigherOrEqual("3.0.0") {
 		obj.ReplicationMode = &replicationMode
 		if dhcpConfigPath != "" {
 			obj.DhcpConfigPath = &dhcpConfigPath
@@ -807,7 +807,7 @@ func policySegmentResourceToInfraStruct(context utl.SessionContext, id string, d
 			advConfigStruct.Connectivity = &connectivity
 		}
 
-		if nsxVersionHigherOrEqual("3.0.0") {
+		if util.NsxVersionHigherOrEqual("3.0.0") {
 			teamingPolicy := advConfigMap["uplink_teaming_policy"].(string)
 			if teamingPolicy != "" {
 				advConfigStruct.UplinkTeamingPolicyName = &teamingPolicy
@@ -818,7 +818,7 @@ func policySegmentResourceToInfraStruct(context utl.SessionContext, id string, d
 				advConfigStruct.AddressPoolPaths = append(advConfigStruct.AddressPoolPaths, poolPath)
 			}
 
-			if nsxVersionHigherOrEqual("3.1.0") {
+			if util.NsxVersionHigherOrEqual("3.1.0") {
 				urpfMode := advConfigMap["urpf_mode"].(string)
 				advConfigStruct.UrpfMode = &urpfMode
 			}
@@ -1370,7 +1370,7 @@ func nsxtPolicySegmentRead(d *schema.ResourceData, m interface{}, isVlan bool, i
 		}
 	}
 
-	if nsxVersionHigherOrEqual("3.0.0") {
+	if util.NsxVersionHigherOrEqual("3.0.0") {
 		d.Set("replication_mode", obj.ReplicationMode)
 	}
 
@@ -1389,7 +1389,7 @@ func nsxtPolicySegmentRead(d *schema.ResourceData, m interface{}, isVlan bool, i
 		if obj.AdvancedConfig.UrpfMode != nil {
 			advConfig["urpf_mode"] = *obj.AdvancedConfig.UrpfMode
 		} else {
-			if nsxVersionLower("3.1.0") {
+			if util.NsxVersionLower("3.1.0") {
 				// set to default in early versions
 				advConfig["urpf_mode"] = model.SegmentAdvancedConfig_URPF_MODE_STRICT
 			}

--- a/nsxt/util/utils.go
+++ b/nsxt/util/utils.go
@@ -1,0 +1,31 @@
+package util
+
+import (
+	"log"
+
+	"github.com/hashicorp/go-version"
+)
+
+var NsxVersion = ""
+
+func NsxVersionLower(ver string) bool {
+
+	requestedVersion, err1 := version.NewVersion(ver)
+	currentVersion, err2 := version.NewVersion(NsxVersion)
+	if err1 != nil || err2 != nil {
+		log.Printf("[ERROR] Failed perform version check for version %s", ver)
+		return true
+	}
+	return currentVersion.LessThan(requestedVersion)
+}
+
+func NsxVersionHigherOrEqual(ver string) bool {
+
+	requestedVersion, err1 := version.NewVersion(ver)
+	currentVersion, err2 := version.NewVersion(NsxVersion)
+	if err1 != nil || err2 != nil {
+		log.Printf("[ERROR] Failed perform version check for version %s", ver)
+		return false
+	}
+	return currentVersion.Compare(requestedVersion) >= 0
+}

--- a/nsxt/utils.go
+++ b/nsxt/utils.go
@@ -9,7 +9,8 @@ import (
 	"hash/crc32"
 	"log"
 
-	"github.com/hashicorp/go-version"
+	"github.com/vmware/terraform-provider-nsxt/nsxt/util"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	api "github.com/vmware/go-vmware-nsxt"
@@ -23,7 +24,6 @@ import (
 )
 
 var adminStateValues = []string{"UP", "DOWN"}
-var nsxVersion = ""
 
 func interface2StringList(configured []interface{}) []string {
 	vs := make([]string, 0, len(configured))
@@ -583,7 +583,7 @@ func getNSXVersion(connector client.Connector) (string, error) {
 
 func initNSXVersion(connector client.Connector) error {
 	var err error
-	nsxVersion, err = getNSXVersion(connector)
+	util.NsxVersion, err = getNSXVersion(connector)
 	return err
 }
 
@@ -591,7 +591,7 @@ func initNSXVersionVMC(clients interface{}) {
 	// TODO: find a ireliable way to retrieve NSX version on VMC
 	// For now, we need to determine whether the deployment is 3.0.0 and up, or below
 	// For this purpose, we fire indicator search API (introduced in 3.0.0)
-	nsxVersion = "3.0.0"
+	util.NsxVersion = "3.0.0"
 
 	connector := getPolicyConnector(clients)
 	client := search.NewQueryClient(connector)
@@ -607,34 +607,12 @@ func initNSXVersionVMC(clients interface{}) {
 	if isNotFoundError(err) {
 		// search API not supported
 		log.Printf("[INFO] Assuming NSX version < 3.0.0 in VMC environment")
-		nsxVersion = "2.5.0"
+		util.NsxVersion = "2.5.0"
 		return
 	}
 
 	// Connectivity error - alert the user
 	log.Printf("[ERROR] Failed to determine NSX version in VMC environment: %s", err)
-}
-
-func nsxVersionLower(ver string) bool {
-
-	requestedVersion, err1 := version.NewVersion(ver)
-	currentVersion, err2 := version.NewVersion(nsxVersion)
-	if err1 != nil || err2 != nil {
-		log.Printf("[ERROR] Failed perform version check for version %s", ver)
-		return true
-	}
-	return currentVersion.LessThan(requestedVersion)
-}
-
-func nsxVersionHigherOrEqual(ver string) bool {
-
-	requestedVersion, err1 := version.NewVersion(ver)
-	currentVersion, err2 := version.NewVersion(nsxVersion)
-	if err1 != nil || err2 != nil {
-		log.Printf("[ERROR] Failed perform version check for version %s", ver)
-		return false
-	}
-	return currentVersion.Compare(requestedVersion) >= 0
 }
 
 func resourceNotSupportedError() error {


### PR DESCRIPTION
This PR is a continuation of previous work by @annakhm on test-reflect branch on the following aspects.

### Functional
- Support conversion of primitive schema types: int, bool, string
- Support conversion of nested schema types: list, set
- Nested struct in sdk model should be represented as list with at most 1 element, with metadata `SchemaType` set to `struct`
- List or set of primitive data types (int, bool, string) should use `*ExtendedSchema` as `Schema.Elem`
- List or set of struct data types should use `*ExtendedResource` as `Schema.Elem`, and set `Metadata.ReflectType` to the type of element type in the slice, rather than a slice type.
- UT under `metadata/metaddata_test.go` can be referenced as example use cases.

### Non-Functional
- Refactored reflect code into own package for adding isolated UT
- Moved version check logic to `utils` package, so both `nsxt` and `metadata` package can share the code
- Added Github action for UT

### TBD in a future PR
- Support of polymorphous struct or list of structs
- Support of Schema.TypeMap