### PR TITLE
Add ignore_tags feature for segments

### DIFF
--- a/nsxt/policy_common.go
+++ b/nsxt/policy_common.go
@@ -395,6 +395,43 @@ func getPolicySecurityPolicySchema(isIds, withContext, withRule bool) map[string
 	return result
 }
 
+func getIgnoreTagsSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"scopes": {
+					Type:        schema.TypeList,
+					Description: "List of scopes to ignore",
+					Required:    true,
+					Elem: &schema.Schema{
+						Type: schema.TypeString,
+					},
+				},
+				"detected": {
+					Type:        schema.TypeSet,
+					Description: "Tags matching scopes to ignore",
+					Computed:    true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"scope": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"tag": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
 func setPolicyRulesInSchema(d *schema.ResourceData, rules []model.Rule) error {
 	var rulesList []map[string]interface{}
 	for _, rule := range rules {

--- a/nsxt/segment_common.go
+++ b/nsxt/segment_common.go
@@ -266,6 +266,7 @@ func getPolicyCommonSegmentSchema(vlanRequired bool, isFixed bool) map[string]*s
 		"description":  getDescriptionSchema(),
 		"revision":     getRevisionSchema(),
 		"tag":          getTagsSchema(),
+		"ignore_tags":  getIgnoreTagsSchema(),
 		"context":      getContextSchema(),
 		"advanced_config": {
 			Type:        schema.TypeList,

--- a/website/docs/r/policy_fixed_segment.html.markdown
+++ b/website/docs/r/policy_fixed_segment.html.markdown
@@ -88,6 +88,7 @@ The following arguments are supported:
 * `display_name` - (Required) Display name of the resource.
 * `description` - (Optional) Description of the resource.
 * `tag` - (Optional) A list of scope + tag pairs to associate with this policy.
+* `ignore_tags` - (Optional) A list of tag scopes that provider should ignore, more specifically, it should not detect drift when tags with such scope are present on NSX, and it should not overwrite them when applying its own tags. This feature is useful for external network with VCD scenario.
 * `nsx_id` - (Optional) The NSX ID of this resource. If set, this ID will be used to create the resource.
 * `connectivity_path` - (Required) Policy path to the connecting Tier-0 or Tier-1.
 * `context` - (Optional) The context which the object belongs to

--- a/website/docs/r/policy_segment.html.markdown
+++ b/website/docs/r/policy_segment.html.markdown
@@ -61,6 +61,24 @@ resource "nsxt_policy_segment" "segment1" {
 }
 ```
 
+## Example Usage with VCD network
+
+```hcl
+resource "nsxt_policy_segment" "segment1" {
+  display_name        = "external"
+  transport_zone_path = data.nsxt_policy_transport_zone.tz1.path
+
+  subnet {
+    cidr = "10.240.12.1/24"
+  }
+
+  ignore_tags {
+    scopes = ["SYSTEM"]
+  }
+
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -68,6 +86,8 @@ The following arguments are supported:
 * `display_name` - (Required) Display name of the resource.
 * `description` - (Optional) Description of the resource.
 * `tag` - (Optional) A list of scope + tag pairs to associate with this policy.
+* `ignore_tags` - (Optional) A list of tag scopes that provider should ignore, more specifically, it should not detect drift when tags with such scope are present on NSX, and it should not overwrite them when applying its own tags. This feature is useful for external network with VCD scenario.
+  * `scopes` - (Required) - List of scope values that should cause scope/tag pair to be ignored.
 * `nsx_id` - (Optional) The NSX ID of this resource. If set, this ID will be used to create the resource.
 * `connectivity_path` - (Optional) Policy path to the connecting Tier-0 or Tier-1.
 * `context` - (Optional) The context which the object belongs to

--- a/website/docs/r/policy_vlan_segment.html.markdown
+++ b/website/docs/r/policy_vlan_segment.html.markdown
@@ -105,6 +105,7 @@ The following arguments are supported:
 * `display_name` - (Required) Display name of the resource.
 * `description` - (Optional) Description of the resource.
 * `tag` - (Optional) A list of scope + tag pairs to associate with this policy.
+* `ignore_tags` - (Optional) A list of tag scopes that provider should ignore, more specifically, it should not detect drift when tags with such scope are present on NSX, and it should not overwrite them when applying its own tags. This feature is useful for external network with VCD scenario.
 * `nsx_id` - (Optional) The NSX ID of this resource. If set, this ID will be used to create the resource.
 * `domain_name`- (Optional) DNS domain names.
 * `transport_zone_path` - (Optional) Policy path to the VLAN backed transport zone. This property is required for NSX Local Manager, and should not be specified for NSX Global Manager, where NSX will automatically assign default transport zone on each site.


### PR DESCRIPTION
Other tools (like VCD) may add tags to certain NSX objects managed by terraform, and expect those tags to be persisted. However, terraform provider assumes itself to be the only source of truth, and in case described above it detects drift in tags, and deletes them with apply.
This PR allows user to specify a list of tag scopes that should be ignored by the provider, more specifically:
1. diff should not be detected when such tags are present on NSX but not in terraform config
2. when provider applies tags from its own config, tags from the `ignore` list should not be deleted.

Implementation suggested here changes the Read function to sort tags into two buckets: regular tags and ignored tags. Regular tags are managed as before, whilw ignored tags (computed attribute) are appended to regular tag list on each apply.

Future enhancements:
1. Add regexp to compare scopes
2. Add this feature to more resources if needed