### PR TITLE
Escape password when requesting for session token

### DIFF
--- a/nsxt/provider.go
+++ b/nsxt/provider.go
@@ -13,6 +13,7 @@ import (
 	"math/rand"
 	"net/http"
 	"net/http/httputil"
+	"net/url"
 	"os"
 	"regexp"
 	"strings"
@@ -554,6 +555,12 @@ func configureNsxtClient(d *schema.ResourceData, clients *nsxtClients) error {
 	insecure := d.Get("allow_unverified_ssl").(bool)
 	username := d.Get("username").(string)
 	password := d.Get("password").(string)
+
+	// The correct place to escape special chars would be inside the SDK
+	// However since the SDK is deprecated, we implement escaping here
+	// TODO implement this functionality with new mp-sdk
+	username = url.QueryEscape(username)
+	password = url.QueryEscape(password)
 
 	if needCreds {
 		if username == "" {


### PR DESCRIPTION
When NSX password contains certain special characters(such as &), those need to be encoded when sent to session/create API