### PR TITLE
Fix makefile error

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -3,7 +3,7 @@ GOFMT_FILES?=$$(find . -name '*.go' |grep -v vendor)
 WEBSITE_REPO=github.com/hashicorp/terraform-website
 PKG_NAME=nsxt
 GIT_COMMIT=$$(git rev-list -1 HEAD)
-GOPATH=$$(go env GOPATH)
+BUILD_PATH=$$(go env GOPATH)
 
 default: build
 
@@ -16,7 +16,7 @@ build: fmtcheck
 	go install -ldflags "-X github.com/vmware/terraform-provider-nsxt/nsxt.GitCommit=$(GIT_COMMIT)"
 
 build-coverage:
-	go build -cover -ldflags "-X github.com/vmware/terraform-provider-nsxt/nsxt.GitCommit=$(GIT_COMMIT)" -o $(GOPATH)/bin
+	go build -cover -ldflags "-X github.com/vmware/terraform-provider-nsxt/nsxt.GitCommit=$(GIT_COMMIT)" -o $(BUILD_PATH)/bin
 
 test: fmtcheck
 	go test -i $(TEST) || exit 1


### PR DESCRIPTION
Make failed when GOPATH was set as it was overwritten in the make script.
Used another name for output variable.