### PR TITLE
Add support of polymorphic struct in reflect lib

### DIFF
--- a/nsxt/metadata/metadata.go
+++ b/nsxt/metadata/metadata.go
@@ -64,8 +64,8 @@ type Testdata struct {
 }
 
 type TypeIdentifier struct {
-	SdkName  string
-	JsonName string
+	SdkName      string
+	APIFieldName string
 }
 
 // GetSdkName returns the SDK field type identifier
@@ -77,11 +77,11 @@ func (t TypeIdentifier) GetSdkName() string {
 	return "ResourceType"
 }
 
-// GetJsonName returns the API JSON type identifier
+// GetAPIFieldName returns the API JSON type identifier
 // Defaults to resource_type
-func (t TypeIdentifier) GetJsonName() string {
-	if t.JsonName != "" {
-		return t.JsonName
+func (t TypeIdentifier) GetAPIFieldName() string {
+	if t.APIFieldName != "" {
+		return t.APIFieldName
 	}
 	return "resource_type"
 }
@@ -413,14 +413,14 @@ func getItemListForSchemaToStruct(d *schema.ResourceData, schemaType, key, paren
 
 // getResourceTypeFromStructValue returns resource type from SDK object based on identifier
 func getResourceTypeFromStructValue(ctx string, value data.StructValue, identifier TypeIdentifier) (string, error) {
-	if !value.HasField(identifier.GetJsonName()) {
+	if !value.HasField(identifier.GetAPIFieldName()) {
 		err := fmt.Errorf(
 			"%s failed to get resource type", ctx)
 		logger.Printf("[ERROR] %v", err)
 		return "", err
 	}
 	var rTypeData data.DataValue
-	rTypeData, err := value.Field(identifier.GetJsonName())
+	rTypeData, err := value.Field(identifier.GetAPIFieldName())
 	if err != nil {
 		return "", err
 	}
@@ -432,7 +432,7 @@ func getResourceTypeFromStructValue(ctx string, value data.StructValue, identifi
 	}
 
 	err = fmt.Errorf("%s failed to convert resource type %s",
-		ctx, identifier.GetJsonName())
+		ctx, identifier.GetAPIFieldName())
 	logger.Printf("[ERROR] %v", err)
 	return "", err
 }

--- a/nsxt/metadata/metadata_poly_test.go
+++ b/nsxt/metadata/metadata_poly_test.go
@@ -11,9 +11,9 @@ import (
 )
 
 type testCatStruct struct {
-	Age   *int64
-	Name  *string
-	Type_ *string
+	Age  *int64
+	Name *string
+	Type *string
 }
 
 func testCatStructBindingType() vapiBindings_.BindingType {
@@ -24,7 +24,7 @@ func testCatStructBindingType() vapiBindings_.BindingType {
 	fields["name"] = vapiBindings_.NewOptionalType(vapiBindings_.NewStringType())
 	fieldNameMap["name"] = "Name"
 	fields["type"] = vapiBindings_.NewOptionalType(vapiBindings_.NewStringType())
-	fieldNameMap["type"] = "Type_"
+	fieldNameMap["type"] = "Type"
 	var validators = []vapiBindings_.Validator{}
 	return vapiBindings_.NewStructType("com.vmware.nsx.fake.cat", fields,
 		reflect.TypeOf(testCatStruct{}), fieldNameMap, validators)
@@ -35,9 +35,9 @@ func TestCatStructBinding(t *testing.T) {
 	name := "John"
 	rType := "FakeCat"
 	obj := testCatStruct{
-		Age:   &age,
-		Name:  &name,
-		Type_: &rType,
+		Age:  &age,
+		Name: &name,
+		Type: &rType,
 	}
 	converter := vapiBindings_.NewTypeConverter()
 	dv, err := converter.ConvertToVapi(obj, testCatStructBindingType())
@@ -50,7 +50,7 @@ func TestCatStructBinding(t *testing.T) {
 type testCoffeeStruct struct {
 	IsDecaf *bool
 	Name    *string
-	Type_   *string
+	Type    *string
 }
 
 func testCoffeeStructBindingType() vapiBindings_.BindingType {
@@ -61,7 +61,7 @@ func testCoffeeStructBindingType() vapiBindings_.BindingType {
 	fields["name"] = vapiBindings_.NewOptionalType(vapiBindings_.NewStringType())
 	fieldNameMap["name"] = "Name"
 	fields["type"] = vapiBindings_.NewOptionalType(vapiBindings_.NewStringType())
-	fieldNameMap["type"] = "Type_"
+	fieldNameMap["type"] = "Type"
 	var validators = []vapiBindings_.Validator{}
 	return vapiBindings_.NewStructType("com.vmware.nsx.fake.coffee", fields,
 		reflect.TypeOf(testCoffeeStruct{}), fieldNameMap, validators)
@@ -74,7 +74,7 @@ func TestCoffeeStructBinding(t *testing.T) {
 	obj := testCoffeeStruct{
 		IsDecaf: &decaf,
 		Name:    &name,
-		Type_:   &rType,
+		Type:    &rType,
 	}
 	converter := vapiBindings_.NewTypeConverter()
 	dv, err := converter.ConvertToVapi(obj, testCoffeeStructBindingType())
@@ -145,8 +145,8 @@ func testPolyStructWrappedSchema(t string) map[string]*schema.Schema {
 
 func testPolyStructWrappedExtSchema(t, sdkName string) map[string]*ExtendedSchema {
 	typeIdentier := TypeIdentifier{
-		SdkName:  "Type_",
-		JsonName: "type",
+		SdkName:      "Type",
+		APIFieldName: "type",
 	}
 
 	schemaType := schema.TypeList
@@ -224,9 +224,9 @@ func TestPolyStructToWrappedSchema(t *testing.T) {
 		rType := "FakeCat"
 		age := int64(1)
 		catObj := testCatStruct{
-			Age:   &age,
-			Name:  &name,
-			Type_: &rType,
+			Age:  &age,
+			Name: &name,
+			Type: &rType,
 		}
 		obj := testPolyStruct{}
 		converter := vapiBindings_.NewTypeConverter()
@@ -256,7 +256,7 @@ func TestPolyStructToWrappedSchema(t *testing.T) {
 		coffeeObj := testCoffeeStruct{
 			IsDecaf: &isDecaf,
 			Name:    &name,
-			Type_:   &rType,
+			Type:    &rType,
 		}
 		obj := testPolyStruct{}
 		converter := vapiBindings_.NewTypeConverter()
@@ -287,14 +287,14 @@ func TestPolyStructToWrappedSchema(t *testing.T) {
 		isDecaf := false
 		age := int64(2)
 		catObj := testCatStruct{
-			Age:   &age,
-			Name:  &catName,
-			Type_: &catResType,
+			Age:  &age,
+			Name: &catName,
+			Type: &catResType,
 		}
 		coffeeObj := testCoffeeStruct{
 			IsDecaf: &isDecaf,
 			Name:    &coffeeName,
-			Type_:   &coffeeResType,
+			Type:    &coffeeResType,
 		}
 		obj := testPolyListStruct{
 			PolyList: make([]*data.StructValue, 2),
@@ -339,14 +339,14 @@ func TestPolyStructToWrappedSchema(t *testing.T) {
 		isDecaf := false
 		age := int64(2)
 		catObj := testCatStruct{
-			Age:   &age,
-			Name:  &catName,
-			Type_: &catResType,
+			Age:  &age,
+			Name: &catName,
+			Type: &catResType,
 		}
 		coffeeObj := testCoffeeStruct{
 			IsDecaf: &isDecaf,
 			Name:    &coffeeName,
-			Type_:   &coffeeResType,
+			Type:    &coffeeResType,
 		}
 		obj := testPolyListStruct{
 			PolyList: make([]*data.StructValue, 2),
@@ -412,7 +412,7 @@ func TestWrappedSchemaToPolyStruct(t *testing.T) {
 		assert.Nil(t, errors, "unexpected error calling ConvertToGolang")
 		assert.Equal(t, "matcha", *obs.(testCatStruct).Name)
 		assert.Equal(t, int64(1), *obs.(testCatStruct).Age)
-		assert.Equal(t, "FakeCat", *obs.(testCatStruct).Type_)
+		assert.Equal(t, "FakeCat", *obs.(testCatStruct).Type)
 	})
 
 	t.Run("coffee struct", func(t *testing.T) {
@@ -440,7 +440,7 @@ func TestWrappedSchemaToPolyStruct(t *testing.T) {
 		assert.Nil(t, errors, "unexpected error calling ConvertToGolang")
 		assert.Equal(t, "latte", *obs.(testCoffeeStruct).Name)
 		assert.Equal(t, true, *obs.(testCoffeeStruct).IsDecaf)
-		assert.Equal(t, "FakeCoffee", *obs.(testCoffeeStruct).Type_)
+		assert.Equal(t, "FakeCoffee", *obs.(testCoffeeStruct).Type)
 	})
 
 	t.Run("mixed list", func(t *testing.T) {
@@ -477,12 +477,12 @@ func TestWrappedSchemaToPolyStruct(t *testing.T) {
 		assert.Nil(t, errors, "unexpected error calling ConvertToGolang")
 		assert.Equal(t, "latte", *coffee.(testCoffeeStruct).Name)
 		assert.Equal(t, true, *coffee.(testCoffeeStruct).IsDecaf)
-		assert.Equal(t, "FakeCoffee", *coffee.(testCoffeeStruct).Type_)
+		assert.Equal(t, "FakeCoffee", *coffee.(testCoffeeStruct).Type)
 		cat, errors := converter.ConvertToGolang(obj.PolyList[1], testCatStructBindingType())
 		assert.Nil(t, errors, "unexpected error calling ConvertToGolang")
 		assert.Equal(t, "matcha", *cat.(testCatStruct).Name)
 		assert.Equal(t, int64(1), *cat.(testCatStruct).Age)
-		assert.Equal(t, "FakeCat", *cat.(testCatStruct).Type_)
+		assert.Equal(t, "FakeCat", *cat.(testCatStruct).Type)
 	})
 
 	t.Run("mixed set", func(t *testing.T) {
@@ -521,13 +521,13 @@ func TestWrappedSchemaToPolyStruct(t *testing.T) {
 				assert.Nil(t, errors, "unexpected error calling ConvertToGolang")
 				assert.Equal(t, "oolong", *cat.(testCatStruct).Name)
 				assert.Equal(t, int64(2), *cat.(testCatStruct).Age)
-				assert.Equal(t, "FakeCat", *cat.(testCatStruct).Type_)
+				assert.Equal(t, "FakeCat", *cat.(testCatStruct).Type)
 			} else {
 				coffee, errors := converter.ConvertToGolang(item, testCoffeeStructBindingType())
 				assert.Nil(t, errors, "unexpected error calling ConvertToGolang")
 				assert.Equal(t, "mocha", *coffee.(testCoffeeStruct).Name)
 				assert.Equal(t, false, *coffee.(testCoffeeStruct).IsDecaf)
-				assert.Equal(t, "FakeCoffee", *coffee.(testCoffeeStruct).Type_)
+				assert.Equal(t, "FakeCoffee", *coffee.(testCoffeeStruct).Type)
 			}
 		}
 	})
@@ -566,8 +566,8 @@ func testPolyStructFlatSchema() map[string]*schema.Schema {
 
 func testPolyStructFlatExtSchema(sdkName string) map[string]*ExtendedSchema {
 	typeIdentifier := TypeIdentifier{
-		SdkName:  "Type_",
-		JsonName: "type",
+		SdkName:      "Type",
+		APIFieldName: "type",
 	}
 
 	return map[string]*ExtendedSchema{
@@ -623,14 +623,14 @@ func TestPolyStructToFlatSchema(t *testing.T) {
 		isDecaf := false
 		age := int64(2)
 		catObj := testCatStruct{
-			Age:   &age,
-			Name:  &catName,
-			Type_: &catResType,
+			Age:  &age,
+			Name: &catName,
+			Type: &catResType,
 		}
 		coffeeObj := testCoffeeStruct{
 			IsDecaf: &isDecaf,
 			Name:    &coffeeName,
-			Type_:   &coffeeResType,
+			Type:    &coffeeResType,
 		}
 		obj := testPolyListStruct{
 			PolyList: make([]*data.StructValue, 2),
@@ -694,13 +694,13 @@ func TestFlatSchemaToPolyStruct(t *testing.T) {
 				assert.Nil(t, errors, "unexpected error calling ConvertToGolang")
 				assert.Equal(t, "oolong", *cat.(testCatStruct).Name)
 				assert.Equal(t, int64(2), *cat.(testCatStruct).Age)
-				assert.Equal(t, "FakeCat", *cat.(testCatStruct).Type_)
+				assert.Equal(t, "FakeCat", *cat.(testCatStruct).Type)
 			} else {
 				coffee, errors := converter.ConvertToGolang(item, testCoffeeStructBindingType())
 				assert.Nil(t, errors, "unexpected error calling ConvertToGolang")
 				assert.Equal(t, "mocha", *coffee.(testCoffeeStruct).Name)
 				assert.Equal(t, true, *coffee.(testCoffeeStruct).IsDecaf)
-				assert.Equal(t, "FakeCoffee", *coffee.(testCoffeeStruct).Type_)
+				assert.Equal(t, "FakeCoffee", *coffee.(testCoffeeStruct).Type)
 			}
 		}
 	})

--- a/nsxt/metadata/metadata_poly_test.go
+++ b/nsxt/metadata/metadata_poly_test.go
@@ -1,0 +1,526 @@
+package metadata
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	vapiBindings_ "github.com/vmware/vsphere-automation-sdk-go/runtime/bindings"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/data"
+)
+
+type testCatStruct struct {
+	Age          *int64
+	Name         *string
+	ResourceType *string
+}
+
+func testCatStructBindingType() vapiBindings_.BindingType {
+	fields := make(map[string]vapiBindings_.BindingType)
+	fieldNameMap := make(map[string]string)
+	fields["age"] = vapiBindings_.NewOptionalType(vapiBindings_.NewIntegerType())
+	fieldNameMap["age"] = "Age"
+	fields["name"] = vapiBindings_.NewOptionalType(vapiBindings_.NewStringType())
+	fieldNameMap["name"] = "Name"
+	fields["resource_type"] = vapiBindings_.NewOptionalType(vapiBindings_.NewStringType())
+	fieldNameMap["resource_type"] = "ResourceType"
+	var validators = []vapiBindings_.Validator{}
+	return vapiBindings_.NewStructType("com.vmware.nsx.fake.cat", fields,
+		reflect.TypeOf(testCatStruct{}), fieldNameMap, validators)
+}
+
+func TestCatStructBinding(t *testing.T) {
+	age := int64(123)
+	name := "John"
+	rType := "FakeCat"
+	obj := testCatStruct{
+		Age:          &age,
+		Name:         &name,
+		ResourceType: &rType,
+	}
+	converter := vapiBindings_.NewTypeConverter()
+	dv, err := converter.ConvertToVapi(obj, testCatStructBindingType())
+	assert.Nil(t, err)
+	obs, err := converter.ConvertToGolang(dv, testCatStructBindingType())
+	assert.Nil(t, err)
+	assert.Equal(t, obj, obs.(testCatStruct))
+}
+
+type testCoffeeStruct struct {
+	IsDecaf      *bool
+	Name         *string
+	ResourceType *string
+}
+
+func testCoffeeStructBindingType() vapiBindings_.BindingType {
+	fields := make(map[string]vapiBindings_.BindingType)
+	fieldNameMap := make(map[string]string)
+	fields["is_decaf"] = vapiBindings_.NewOptionalType(vapiBindings_.NewBooleanType())
+	fieldNameMap["is_decaf"] = "IsDecaf"
+	fields["name"] = vapiBindings_.NewOptionalType(vapiBindings_.NewStringType())
+	fieldNameMap["name"] = "Name"
+	fields["resource_type"] = vapiBindings_.NewOptionalType(vapiBindings_.NewStringType())
+	fieldNameMap["resource_type"] = "ResourceType"
+	var validators = []vapiBindings_.Validator{}
+	return vapiBindings_.NewStructType("com.vmware.nsx.fake.coffee", fields,
+		reflect.TypeOf(testCoffeeStruct{}), fieldNameMap, validators)
+}
+
+func TestCoffeeStructBinding(t *testing.T) {
+	decaf := false
+	name := "Latte"
+	rType := "FakeCoffee"
+	obj := testCoffeeStruct{
+		IsDecaf:      &decaf,
+		Name:         &name,
+		ResourceType: &rType,
+	}
+	converter := vapiBindings_.NewTypeConverter()
+	dv, err := converter.ConvertToVapi(obj, testCoffeeStructBindingType())
+	assert.Nil(t, err)
+	obs, err := converter.ConvertToGolang(dv, testCoffeeStructBindingType())
+	assert.Nil(t, err)
+	assert.Equal(t, obj, obs.(testCoffeeStruct))
+}
+
+type testPolyStruct struct {
+	PolyStruct *data.StructValue
+}
+
+type testPolyListStruct struct {
+	PolyList []*data.StructValue
+}
+
+func testPolyStructSchema(t string) map[string]*schema.Schema {
+	schemaType := schema.TypeList
+	maxItems := 0
+	if t == "set" {
+		schemaType = schema.TypeSet
+	} else if t == "struct" {
+		maxItems = 1
+	}
+
+	return map[string]*schema.Schema{
+		"poly_struct": {
+			Type:     schemaType,
+			MaxItems: maxItems,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"cat": {
+						Type:          schema.TypeList,
+						MaxItems:      1,
+						ConflictsWith: []string{"coffee"},
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"name": {
+									Type: schema.TypeString,
+								},
+								"age": {
+									Type: schema.TypeInt,
+								},
+							},
+						},
+					},
+					"coffee": {
+						Type:          schema.TypeList,
+						MaxItems:      1,
+						ConflictsWith: []string{"cat"},
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"name": {
+									Type: schema.TypeString,
+								},
+								"is_decaf": {
+									Type: schema.TypeBool,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func testPolyStructExtSchema(t, sdkName string) map[string]*ExtendedSchema {
+	schemaType := schema.TypeList
+	maxItems := 0
+	if t == "set" {
+		schemaType = schema.TypeSet
+	} else if t == "struct" {
+		maxItems = 1
+	}
+	return map[string]*ExtendedSchema{
+		"poly_struct": {
+			Schema: schema.Schema{
+				Type:     schemaType,
+				MaxItems: maxItems,
+				Elem: &ExtendedResource{
+					Schema: map[string]*ExtendedSchema{
+						"cat": {
+							Schema: schema.Schema{
+								Type:          schema.TypeList,
+								MaxItems:      1,
+								ConflictsWith: []string{"coffee"},
+								Elem: &ExtendedResource{
+									Schema: map[string]*ExtendedSchema{
+										"name": basicStringSchema("Name", false),
+										"age":  basicIntSchema("Age", false),
+									},
+								},
+							},
+							Metadata: Metadata{
+								SchemaType:  "struct",
+								ReflectType: reflect.TypeOf(testCatStruct{}),
+								BindingType: testCatStructBindingType(),
+							},
+						},
+						"coffee": {
+							Schema: schema.Schema{
+								Type:          schema.TypeList,
+								MaxItems:      1,
+								ConflictsWith: []string{"cat"},
+								Elem: &ExtendedResource{
+									Schema: map[string]*ExtendedSchema{
+										"name":     basicStringSchema("Name", false),
+										"is_decaf": basicBoolSchema("IsDecaf", false),
+									},
+								},
+							},
+							Metadata: Metadata{
+								SchemaType:  "struct",
+								ReflectType: reflect.TypeOf(testCoffeeStruct{}),
+								BindingType: testCoffeeStructBindingType(),
+							},
+						},
+					},
+				},
+			},
+			Metadata: Metadata{
+				SchemaType:    t,
+				SdkFieldName:  sdkName,
+				IsPolymorphic: true,
+				ResourceTypeMap: map[string]string{
+					"cat":    "FakeCat",
+					"coffee": "FakeCoffee",
+				},
+			},
+		},
+	}
+}
+
+func TestPolyStructToSchema(t *testing.T) {
+	t.Run("cat struct", func(t *testing.T) {
+		name := "matcha"
+		rType := "FakeCat"
+		age := int64(1)
+		catObj := testCatStruct{
+			Age:          &age,
+			Name:         &name,
+			ResourceType: &rType,
+		}
+		obj := testPolyStruct{}
+		converter := vapiBindings_.NewTypeConverter()
+		dv, errors := converter.ConvertToVapi(catObj, testCatStructBindingType())
+		assert.Nil(t, errors, "unexpected error calling ConvertToGolang")
+		obj.PolyStruct = dv.(*data.StructValue)
+		d := schema.TestResourceDataRaw(
+			t, testPolyStructSchema("struct"), map[string]interface{}{})
+
+		elem := reflect.ValueOf(&obj).Elem()
+		err := StructToSchema(elem, d, testPolyStructExtSchema("struct", "PolyStruct"), "", nil)
+		assert.NoError(t, err, "unexpected error calling StructToSchema")
+		assert.Len(t, d.Get("poly_struct"), 1)
+		polyData := d.Get("poly_struct").([]interface{})[0].(map[string]interface{})
+		assert.Len(t, polyData["cat"], 1)
+		assert.Len(t, polyData["coffee"], 0)
+		assert.Equal(t, map[string]interface{}{
+			"name": name,
+			"age":  1,
+		}, polyData["cat"].([]interface{})[0].(map[string]interface{}))
+	})
+
+	t.Run("coffee struct", func(t *testing.T) {
+		name := "latte"
+		rType := "FakeCoffee"
+		isDecaf := true
+		coffeeObj := testCoffeeStruct{
+			IsDecaf:      &isDecaf,
+			Name:         &name,
+			ResourceType: &rType,
+		}
+		obj := testPolyStruct{}
+		converter := vapiBindings_.NewTypeConverter()
+		dv, errors := converter.ConvertToVapi(coffeeObj, testCoffeeStructBindingType())
+		assert.Nil(t, errors, "unexpected error calling ConvertToGolang")
+		obj.PolyStruct = dv.(*data.StructValue)
+		d := schema.TestResourceDataRaw(
+			t, testPolyStructSchema("struct"), map[string]interface{}{})
+
+		elem := reflect.ValueOf(&obj).Elem()
+		err := StructToSchema(elem, d, testPolyStructExtSchema("struct", "PolyStruct"), "", nil)
+		assert.NoError(t, err, "unexpected error calling StructToSchema")
+		assert.Len(t, d.Get("poly_struct"), 1)
+		polyData := d.Get("poly_struct").([]interface{})[0].(map[string]interface{})
+		assert.Len(t, polyData["cat"], 0)
+		assert.Len(t, polyData["coffee"], 1)
+		assert.Equal(t, map[string]interface{}{
+			"name":     name,
+			"is_decaf": true,
+		}, polyData["coffee"].([]interface{})[0].(map[string]interface{}))
+	})
+
+	t.Run("mixed list", func(t *testing.T) {
+		catName := "oolong"
+		coffeeName := "mocha"
+		catResType := "FakeCat"
+		coffeeResType := "FakeCoffee"
+		isDecaf := false
+		age := int64(2)
+		catObj := testCatStruct{
+			Age:          &age,
+			Name:         &catName,
+			ResourceType: &catResType,
+		}
+		coffeeObj := testCoffeeStruct{
+			IsDecaf:      &isDecaf,
+			Name:         &coffeeName,
+			ResourceType: &coffeeResType,
+		}
+		obj := testPolyListStruct{
+			PolyList: make([]*data.StructValue, 2),
+		}
+		converter := vapiBindings_.NewTypeConverter()
+		dv, errors := converter.ConvertToVapi(coffeeObj, testCoffeeStructBindingType())
+		assert.Nil(t, errors, "unexpected error calling ConvertToGolang")
+		obj.PolyList[0] = dv.(*data.StructValue)
+		dv, errors = converter.ConvertToVapi(catObj, testCatStructBindingType())
+		assert.Nil(t, errors, "unexpected error calling ConvertToGolang")
+		obj.PolyList[1] = dv.(*data.StructValue)
+		d := schema.TestResourceDataRaw(
+			t, testPolyStructSchema("struct"), map[string]interface{}{})
+
+		elem := reflect.ValueOf(&obj).Elem()
+		err := StructToSchema(elem, d, testPolyStructExtSchema("list", "PolyList"), "", nil)
+		assert.NoError(t, err, "unexpected error calling StructToSchema")
+		assert.Len(t, d.Get("poly_struct"), 2)
+		// idx 0: coffee
+		coffeeData := d.Get("poly_struct").([]interface{})[0].(map[string]interface{})
+		assert.Len(t, coffeeData["cat"], 0)
+		assert.Len(t, coffeeData["coffee"], 1)
+		assert.Equal(t, map[string]interface{}{
+			"name":     coffeeName,
+			"is_decaf": false,
+		}, coffeeData["coffee"].([]interface{})[0].(map[string]interface{}))
+		// idx 1: cat
+		catData := d.Get("poly_struct").([]interface{})[1].(map[string]interface{})
+		assert.Len(t, catData["cat"], 1)
+		assert.Len(t, catData["coffee"], 0)
+		assert.Equal(t, map[string]interface{}{
+			"name": catName,
+			"age":  2,
+		}, catData["cat"].([]interface{})[0].(map[string]interface{}))
+	})
+
+	t.Run("mixed set", func(t *testing.T) {
+		catName := "oolong"
+		coffeeName := "mocha"
+		catResType := "FakeCat"
+		coffeeResType := "FakeCoffee"
+		isDecaf := false
+		age := int64(2)
+		catObj := testCatStruct{
+			Age:          &age,
+			Name:         &catName,
+			ResourceType: &catResType,
+		}
+		coffeeObj := testCoffeeStruct{
+			IsDecaf:      &isDecaf,
+			Name:         &coffeeName,
+			ResourceType: &coffeeResType,
+		}
+		obj := testPolyListStruct{
+			PolyList: make([]*data.StructValue, 2),
+		}
+		converter := vapiBindings_.NewTypeConverter()
+		dv, errors := converter.ConvertToVapi(coffeeObj, testCoffeeStructBindingType())
+		assert.Nil(t, errors, "unexpected error calling ConvertToGolang")
+		obj.PolyList[1] = dv.(*data.StructValue)
+		dv, errors = converter.ConvertToVapi(catObj, testCatStructBindingType())
+		assert.Nil(t, errors, "unexpected error calling ConvertToGolang")
+		obj.PolyList[0] = dv.(*data.StructValue)
+		d := schema.TestResourceDataRaw(
+			t, testPolyStructSchema("struct"), map[string]interface{}{})
+
+		elem := reflect.ValueOf(&obj).Elem()
+		err := StructToSchema(elem, d, testPolyStructExtSchema("set", "PolyList"), "", nil)
+		assert.NoError(t, err, "unexpected error calling StructToSchema")
+		assert.Len(t, d.Get("poly_struct"), 2)
+		for _, v := range d.Get("poly_struct").([]interface{}) {
+			dataVal := v.(map[string]interface{})
+			if len(dataVal["cat"].([]interface{})) > 0 {
+				assert.Len(t, dataVal["cat"], 1)
+				assert.Len(t, dataVal["coffee"], 0)
+				assert.Equal(t, map[string]interface{}{
+					"name": catName,
+					"age":  2,
+				}, dataVal["cat"].([]interface{})[0].(map[string]interface{}))
+			} else {
+				assert.Len(t, dataVal["cat"], 0)
+				assert.Len(t, dataVal["coffee"], 1)
+				assert.Equal(t, map[string]interface{}{
+					"name":     coffeeName,
+					"is_decaf": false,
+				}, dataVal["coffee"].([]interface{})[0].(map[string]interface{}))
+			}
+		}
+	})
+}
+
+func TestSchemaToPolyStruct(t *testing.T) {
+	t.Run("cat struct", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(
+			t, testPolyStructSchema("struct"), map[string]interface{}{
+				"poly_struct": []interface{}{
+					map[string]interface{}{
+						"cat": []interface{}{
+							map[string]interface{}{
+								"name": "matcha",
+								"age":  1,
+							},
+						},
+					},
+				},
+			})
+
+		obj := testPolyStruct{}
+		elem := reflect.ValueOf(&obj).Elem()
+		err := SchemaToStruct(elem, d, testPolyStructExtSchema("struct", "PolyStruct"), "", nil)
+		assert.NoError(t, err, "unexpected error calling SchemaToStruct")
+
+		converter := vapiBindings_.NewTypeConverter()
+		obs, errors := converter.ConvertToGolang(obj.PolyStruct, testCatStructBindingType())
+		assert.Nil(t, errors, "unexpected error calling ConvertToGolang")
+		assert.Equal(t, "matcha", *obs.(testCatStruct).Name)
+		assert.Equal(t, int64(1), *obs.(testCatStruct).Age)
+		assert.Equal(t, "FakeCat", *obs.(testCatStruct).ResourceType)
+	})
+
+	t.Run("coffee struct", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(
+			t, testPolyStructSchema("struct"), map[string]interface{}{
+				"poly_struct": []interface{}{
+					map[string]interface{}{
+						"coffee": []interface{}{
+							map[string]interface{}{
+								"name":     "latte",
+								"is_decaf": true,
+							},
+						},
+					},
+				},
+			})
+
+		obj := testPolyStruct{}
+		elem := reflect.ValueOf(&obj).Elem()
+		err := SchemaToStruct(elem, d, testPolyStructExtSchema("struct", "PolyStruct"), "", nil)
+		assert.NoError(t, err, "unexpected error calling SchemaToStruct")
+
+		converter := vapiBindings_.NewTypeConverter()
+		obs, errors := converter.ConvertToGolang(obj.PolyStruct, testCoffeeStructBindingType())
+		assert.Nil(t, errors, "unexpected error calling ConvertToGolang")
+		assert.Equal(t, "latte", *obs.(testCoffeeStruct).Name)
+		assert.Equal(t, true, *obs.(testCoffeeStruct).IsDecaf)
+		assert.Equal(t, "FakeCoffee", *obs.(testCoffeeStruct).ResourceType)
+	})
+
+	t.Run("mixed list", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(
+			t, testPolyStructSchema("list"), map[string]interface{}{
+				"poly_struct": []interface{}{
+					map[string]interface{}{
+						"coffee": []interface{}{
+							map[string]interface{}{
+								"name":     "latte",
+								"is_decaf": true,
+							},
+						},
+					},
+					map[string]interface{}{
+						"cat": []interface{}{
+							map[string]interface{}{
+								"name": "matcha",
+								"age":  1,
+							},
+						},
+					},
+				},
+			})
+
+		obj := testPolyListStruct{}
+		elem := reflect.ValueOf(&obj).Elem()
+		err := SchemaToStruct(elem, d, testPolyStructExtSchema("list", "PolyList"), "", nil)
+		assert.NoError(t, err, "unexpected error calling SchemaToStruct")
+
+		converter := vapiBindings_.NewTypeConverter()
+		assert.Len(t, obj.PolyList, 2)
+		coffee, errors := converter.ConvertToGolang(obj.PolyList[0], testCoffeeStructBindingType())
+		assert.Nil(t, errors, "unexpected error calling ConvertToGolang")
+		assert.Equal(t, "latte", *coffee.(testCoffeeStruct).Name)
+		assert.Equal(t, true, *coffee.(testCoffeeStruct).IsDecaf)
+		assert.Equal(t, "FakeCoffee", *coffee.(testCoffeeStruct).ResourceType)
+		cat, errors := converter.ConvertToGolang(obj.PolyList[1], testCatStructBindingType())
+		assert.Nil(t, errors, "unexpected error calling ConvertToGolang")
+		assert.Equal(t, "matcha", *cat.(testCatStruct).Name)
+		assert.Equal(t, int64(1), *cat.(testCatStruct).Age)
+		assert.Equal(t, "FakeCat", *cat.(testCatStruct).ResourceType)
+	})
+
+	t.Run("mixed set", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(
+			t, testPolyStructSchema("set"), map[string]interface{}{
+				"poly_struct": []interface{}{
+					map[string]interface{}{
+						"cat": []interface{}{
+							map[string]interface{}{
+								"name": "oolong",
+								"age":  2,
+							},
+						},
+					},
+					map[string]interface{}{
+						"coffee": []interface{}{
+							map[string]interface{}{
+								"name":     "mocha",
+								"is_decaf": false,
+							},
+						},
+					},
+				},
+			})
+
+		obj := testPolyListStruct{}
+		elem := reflect.ValueOf(&obj).Elem()
+		err := SchemaToStruct(elem, d, testPolyStructExtSchema("set", "PolyList"), "", nil)
+		assert.NoError(t, err, "unexpected error calling SchemaToStruct")
+
+		converter := vapiBindings_.NewTypeConverter()
+		assert.Len(t, obj.PolyList, 2)
+		for _, item := range obj.PolyList {
+			if item.HasField("age") {
+				cat, errors := converter.ConvertToGolang(item, testCatStructBindingType())
+				assert.Nil(t, errors, "unexpected error calling ConvertToGolang")
+				assert.Equal(t, "oolong", *cat.(testCatStruct).Name)
+				assert.Equal(t, int64(2), *cat.(testCatStruct).Age)
+				assert.Equal(t, "FakeCat", *cat.(testCatStruct).ResourceType)
+			} else {
+				coffee, errors := converter.ConvertToGolang(obj.PolyList[0], testCoffeeStructBindingType())
+				assert.Nil(t, errors, "unexpected error calling ConvertToGolang")
+				assert.Equal(t, "mocha", *coffee.(testCoffeeStruct).Name)
+				assert.Equal(t, false, *coffee.(testCoffeeStruct).IsDecaf)
+				assert.Equal(t, "FakeCoffee", *coffee.(testCoffeeStruct).ResourceType)
+			}
+		}
+	})
+}

--- a/nsxt/metadata/metadata_poly_test.go
+++ b/nsxt/metadata/metadata_poly_test.go
@@ -92,7 +92,7 @@ type testPolyListStruct struct {
 	PolyList []*data.StructValue
 }
 
-func testPolyStructSchema(t string) map[string]*schema.Schema {
+func testPolyStructWrappedSchema(t string) map[string]*schema.Schema {
 	schemaType := schema.TypeList
 	maxItems := 0
 	if t == "set" {
@@ -143,7 +143,7 @@ func testPolyStructSchema(t string) map[string]*schema.Schema {
 	}
 }
 
-func testPolyStructExtSchema(t, sdkName string) map[string]*ExtendedSchema {
+func testPolyStructWrappedExtSchema(t, sdkName string) map[string]*ExtendedSchema {
 	typeIdentier := TypeIdentifier{
 		SdkName:  "Type_",
 		JsonName: "type",
@@ -218,7 +218,7 @@ func testPolyStructExtSchema(t, sdkName string) map[string]*ExtendedSchema {
 	}
 }
 
-func TestPolyStructToSchema(t *testing.T) {
+func TestPolyStructToWrappedSchema(t *testing.T) {
 	t.Run("cat struct", func(t *testing.T) {
 		name := "matcha"
 		rType := "FakeCat"
@@ -234,10 +234,10 @@ func TestPolyStructToSchema(t *testing.T) {
 		assert.Nil(t, errors, "unexpected error calling ConvertToGolang")
 		obj.PolyStruct = dv.(*data.StructValue)
 		d := schema.TestResourceDataRaw(
-			t, testPolyStructSchema("struct"), map[string]interface{}{})
+			t, testPolyStructWrappedSchema("struct"), map[string]interface{}{})
 
 		elem := reflect.ValueOf(&obj).Elem()
-		err := StructToSchema(elem, d, testPolyStructExtSchema("struct", "PolyStruct"), "", nil)
+		err := StructToSchema(elem, d, testPolyStructWrappedExtSchema("struct", "PolyStruct"), "", nil)
 		assert.NoError(t, err, "unexpected error calling StructToSchema")
 		assert.Len(t, d.Get("poly_struct"), 1)
 		polyData := d.Get("poly_struct").([]interface{})[0].(map[string]interface{})
@@ -264,10 +264,10 @@ func TestPolyStructToSchema(t *testing.T) {
 		assert.Nil(t, errors, "unexpected error calling ConvertToGolang")
 		obj.PolyStruct = dv.(*data.StructValue)
 		d := schema.TestResourceDataRaw(
-			t, testPolyStructSchema("struct"), map[string]interface{}{})
+			t, testPolyStructWrappedSchema("struct"), map[string]interface{}{})
 
 		elem := reflect.ValueOf(&obj).Elem()
-		err := StructToSchema(elem, d, testPolyStructExtSchema("struct", "PolyStruct"), "", nil)
+		err := StructToSchema(elem, d, testPolyStructWrappedExtSchema("struct", "PolyStruct"), "", nil)
 		assert.NoError(t, err, "unexpected error calling StructToSchema")
 		assert.Len(t, d.Get("poly_struct"), 1)
 		polyData := d.Get("poly_struct").([]interface{})[0].(map[string]interface{})
@@ -307,10 +307,10 @@ func TestPolyStructToSchema(t *testing.T) {
 		assert.Nil(t, errors, "unexpected error calling ConvertToGolang")
 		obj.PolyList[1] = dv.(*data.StructValue)
 		d := schema.TestResourceDataRaw(
-			t, testPolyStructSchema("struct"), map[string]interface{}{})
+			t, testPolyStructWrappedSchema("struct"), map[string]interface{}{})
 
 		elem := reflect.ValueOf(&obj).Elem()
-		err := StructToSchema(elem, d, testPolyStructExtSchema("list", "PolyList"), "", nil)
+		err := StructToSchema(elem, d, testPolyStructWrappedExtSchema("list", "PolyList"), "", nil)
 		assert.NoError(t, err, "unexpected error calling StructToSchema")
 		assert.Len(t, d.Get("poly_struct"), 2)
 		// idx 0: coffee
@@ -359,10 +359,10 @@ func TestPolyStructToSchema(t *testing.T) {
 		assert.Nil(t, errors, "unexpected error calling ConvertToGolang")
 		obj.PolyList[0] = dv.(*data.StructValue)
 		d := schema.TestResourceDataRaw(
-			t, testPolyStructSchema("struct"), map[string]interface{}{})
+			t, testPolyStructWrappedSchema("struct"), map[string]interface{}{})
 
 		elem := reflect.ValueOf(&obj).Elem()
-		err := StructToSchema(elem, d, testPolyStructExtSchema("set", "PolyList"), "", nil)
+		err := StructToSchema(elem, d, testPolyStructWrappedExtSchema("set", "PolyList"), "", nil)
 		assert.NoError(t, err, "unexpected error calling StructToSchema")
 		assert.Len(t, d.Get("poly_struct"), 2)
 		for _, v := range d.Get("poly_struct").([]interface{}) {
@@ -386,10 +386,10 @@ func TestPolyStructToSchema(t *testing.T) {
 	})
 }
 
-func TestSchemaToPolyStruct(t *testing.T) {
+func TestWrappedSchemaToPolyStruct(t *testing.T) {
 	t.Run("cat struct", func(t *testing.T) {
 		d := schema.TestResourceDataRaw(
-			t, testPolyStructSchema("struct"), map[string]interface{}{
+			t, testPolyStructWrappedSchema("struct"), map[string]interface{}{
 				"poly_struct": []interface{}{
 					map[string]interface{}{
 						"cat": []interface{}{
@@ -404,7 +404,7 @@ func TestSchemaToPolyStruct(t *testing.T) {
 
 		obj := testPolyStruct{}
 		elem := reflect.ValueOf(&obj).Elem()
-		err := SchemaToStruct(elem, d, testPolyStructExtSchema("struct", "PolyStruct"), "", nil)
+		err := SchemaToStruct(elem, d, testPolyStructWrappedExtSchema("struct", "PolyStruct"), "", nil)
 		assert.NoError(t, err, "unexpected error calling SchemaToStruct")
 
 		converter := vapiBindings_.NewTypeConverter()
@@ -417,7 +417,7 @@ func TestSchemaToPolyStruct(t *testing.T) {
 
 	t.Run("coffee struct", func(t *testing.T) {
 		d := schema.TestResourceDataRaw(
-			t, testPolyStructSchema("struct"), map[string]interface{}{
+			t, testPolyStructWrappedSchema("struct"), map[string]interface{}{
 				"poly_struct": []interface{}{
 					map[string]interface{}{
 						"coffee": []interface{}{
@@ -432,7 +432,7 @@ func TestSchemaToPolyStruct(t *testing.T) {
 
 		obj := testPolyStruct{}
 		elem := reflect.ValueOf(&obj).Elem()
-		err := SchemaToStruct(elem, d, testPolyStructExtSchema("struct", "PolyStruct"), "", nil)
+		err := SchemaToStruct(elem, d, testPolyStructWrappedExtSchema("struct", "PolyStruct"), "", nil)
 		assert.NoError(t, err, "unexpected error calling SchemaToStruct")
 
 		converter := vapiBindings_.NewTypeConverter()
@@ -445,7 +445,7 @@ func TestSchemaToPolyStruct(t *testing.T) {
 
 	t.Run("mixed list", func(t *testing.T) {
 		d := schema.TestResourceDataRaw(
-			t, testPolyStructSchema("list"), map[string]interface{}{
+			t, testPolyStructWrappedSchema("list"), map[string]interface{}{
 				"poly_struct": []interface{}{
 					map[string]interface{}{
 						"coffee": []interface{}{
@@ -468,7 +468,7 @@ func TestSchemaToPolyStruct(t *testing.T) {
 
 		obj := testPolyListStruct{}
 		elem := reflect.ValueOf(&obj).Elem()
-		err := SchemaToStruct(elem, d, testPolyStructExtSchema("list", "PolyList"), "", nil)
+		err := SchemaToStruct(elem, d, testPolyStructWrappedExtSchema("list", "PolyList"), "", nil)
 		assert.NoError(t, err, "unexpected error calling SchemaToStruct")
 
 		converter := vapiBindings_.NewTypeConverter()
@@ -487,7 +487,7 @@ func TestSchemaToPolyStruct(t *testing.T) {
 
 	t.Run("mixed set", func(t *testing.T) {
 		d := schema.TestResourceDataRaw(
-			t, testPolyStructSchema("set"), map[string]interface{}{
+			t, testPolyStructWrappedSchema("set"), map[string]interface{}{
 				"poly_struct": []interface{}{
 					map[string]interface{}{
 						"cat": []interface{}{
@@ -510,7 +510,7 @@ func TestSchemaToPolyStruct(t *testing.T) {
 
 		obj := testPolyListStruct{}
 		elem := reflect.ValueOf(&obj).Elem()
-		err := SchemaToStruct(elem, d, testPolyStructExtSchema("set", "PolyList"), "", nil)
+		err := SchemaToStruct(elem, d, testPolyStructWrappedExtSchema("set", "PolyList"), "", nil)
 		assert.NoError(t, err, "unexpected error calling SchemaToStruct")
 
 		converter := vapiBindings_.NewTypeConverter()
@@ -523,10 +523,183 @@ func TestSchemaToPolyStruct(t *testing.T) {
 				assert.Equal(t, int64(2), *cat.(testCatStruct).Age)
 				assert.Equal(t, "FakeCat", *cat.(testCatStruct).Type_)
 			} else {
-				coffee, errors := converter.ConvertToGolang(obj.PolyList[0], testCoffeeStructBindingType())
+				coffee, errors := converter.ConvertToGolang(item, testCoffeeStructBindingType())
 				assert.Nil(t, errors, "unexpected error calling ConvertToGolang")
 				assert.Equal(t, "mocha", *coffee.(testCoffeeStruct).Name)
 				assert.Equal(t, false, *coffee.(testCoffeeStruct).IsDecaf)
+				assert.Equal(t, "FakeCoffee", *coffee.(testCoffeeStruct).Type_)
+			}
+		}
+	})
+}
+
+func testPolyStructFlatSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"cat": {
+			Type: schema.TypeList,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"name": {
+						Type: schema.TypeString,
+					},
+					"age": {
+						Type: schema.TypeInt,
+					},
+				},
+			},
+		},
+		"coffee": {
+			Type: schema.TypeList,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"name": {
+						Type: schema.TypeString,
+					},
+					"is_decaf": {
+						Type: schema.TypeBool,
+					},
+				},
+			},
+		},
+	}
+}
+
+func testPolyStructFlatExtSchema(sdkName string) map[string]*ExtendedSchema {
+	typeIdentifier := TypeIdentifier{
+		SdkName:  "Type_",
+		JsonName: "type",
+	}
+
+	return map[string]*ExtendedSchema{
+		"cat": {
+			Schema: schema.Schema{
+				Type: schema.TypeList,
+				Elem: &ExtendedResource{
+					Schema: map[string]*ExtendedSchema{
+						"name": basicStringSchema("Name", false),
+						"age":  basicIntSchema("Age", false),
+					},
+				},
+			},
+			Metadata: Metadata{
+				SchemaType:      "list",
+				ReflectType:     reflect.TypeOf(testCatStruct{}),
+				BindingType:     testCatStructBindingType(),
+				TypeIdentifier:  typeIdentifier,
+				PolymorphicType: PolymorphicTypeFlat,
+				ResourceType:    "FakeCat",
+				SdkFieldName:    sdkName,
+			},
+		},
+		"coffee": {
+			Schema: schema.Schema{
+				Type: schema.TypeList,
+				Elem: &ExtendedResource{
+					Schema: map[string]*ExtendedSchema{
+						"name":     basicStringSchema("Name", false),
+						"is_decaf": basicBoolSchema("IsDecaf", false),
+					},
+				},
+			},
+			Metadata: Metadata{
+				SchemaType:      "list",
+				ReflectType:     reflect.TypeOf(testCoffeeStruct{}),
+				BindingType:     testCoffeeStructBindingType(),
+				TypeIdentifier:  typeIdentifier,
+				PolymorphicType: PolymorphicTypeFlat,
+				ResourceType:    "FakeCoffee",
+				SdkFieldName:    sdkName,
+			},
+		},
+	}
+}
+
+func TestPolyStructToFlatSchema(t *testing.T) {
+	t.Run("mixed list", func(t *testing.T) {
+		catName := "oolong"
+		coffeeName := "mocha"
+		catResType := "FakeCat"
+		coffeeResType := "FakeCoffee"
+		isDecaf := false
+		age := int64(2)
+		catObj := testCatStruct{
+			Age:   &age,
+			Name:  &catName,
+			Type_: &catResType,
+		}
+		coffeeObj := testCoffeeStruct{
+			IsDecaf: &isDecaf,
+			Name:    &coffeeName,
+			Type_:   &coffeeResType,
+		}
+		obj := testPolyListStruct{
+			PolyList: make([]*data.StructValue, 2),
+		}
+		converter := vapiBindings_.NewTypeConverter()
+		dv, errors := converter.ConvertToVapi(coffeeObj, testCoffeeStructBindingType())
+		assert.Nil(t, errors, "unexpected error calling ConvertToGolang")
+		obj.PolyList[0] = dv.(*data.StructValue)
+		dv, errors = converter.ConvertToVapi(catObj, testCatStructBindingType())
+		assert.Nil(t, errors, "unexpected error calling ConvertToGolang")
+		obj.PolyList[1] = dv.(*data.StructValue)
+		d := schema.TestResourceDataRaw(
+			t, testPolyStructFlatSchema(), map[string]interface{}{})
+
+		elem := reflect.ValueOf(&obj).Elem()
+		err := StructToSchema(elem, d, testPolyStructFlatExtSchema("PolyList"), "", nil)
+		assert.NoError(t, err, "unexpected error calling StructToSchema")
+
+		assert.Len(t, d.Get("coffee"), 1)
+		assert.Equal(t, map[string]interface{}{
+			"name":     coffeeName,
+			"is_decaf": false,
+		}, d.Get("coffee").([]interface{})[0].(map[string]interface{}))
+
+		assert.Len(t, d.Get("cat"), 1)
+		assert.Equal(t, map[string]interface{}{
+			"name": catName,
+			"age":  2,
+		}, d.Get("cat").([]interface{})[0].(map[string]interface{}))
+	})
+}
+
+func TestFlatSchemaToPolyStruct(t *testing.T) {
+	t.Run("mixed list", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(
+			t, testPolyStructFlatSchema(), map[string]interface{}{
+				"coffee": []interface{}{
+					map[string]interface{}{
+						"name":     "mocha",
+						"is_decaf": true,
+					},
+				},
+				"cat": []interface{}{
+					map[string]interface{}{
+						"name": "oolong",
+						"age":  2,
+					},
+				},
+			})
+
+		obj := testPolyListStruct{}
+		elem := reflect.ValueOf(&obj).Elem()
+		err := SchemaToStruct(elem, d, testPolyStructFlatExtSchema("PolyList"), "", nil)
+		assert.NoError(t, err, "unexpected error calling SchemaToStruct")
+
+		converter := vapiBindings_.NewTypeConverter()
+		assert.Len(t, obj.PolyList, 2)
+		for _, item := range obj.PolyList {
+			if item.HasField("age") {
+				cat, errors := converter.ConvertToGolang(item, testCatStructBindingType())
+				assert.Nil(t, errors, "unexpected error calling ConvertToGolang")
+				assert.Equal(t, "oolong", *cat.(testCatStruct).Name)
+				assert.Equal(t, int64(2), *cat.(testCatStruct).Age)
+				assert.Equal(t, "FakeCat", *cat.(testCatStruct).Type_)
+			} else {
+				coffee, errors := converter.ConvertToGolang(item, testCoffeeStructBindingType())
+				assert.Nil(t, errors, "unexpected error calling ConvertToGolang")
+				assert.Equal(t, "mocha", *coffee.(testCoffeeStruct).Name)
+				assert.Equal(t, true, *coffee.(testCoffeeStruct).IsDecaf)
 				assert.Equal(t, "FakeCoffee", *coffee.(testCoffeeStruct).Type_)
 			}
 		}

--- a/nsxt/metadata/metadata_poly_test.go
+++ b/nsxt/metadata/metadata_poly_test.go
@@ -11,9 +11,9 @@ import (
 )
 
 type testCatStruct struct {
-	Age          *int64
-	Name         *string
-	ResourceType *string
+	Age   *int64
+	Name  *string
+	Type_ *string
 }
 
 func testCatStructBindingType() vapiBindings_.BindingType {
@@ -23,8 +23,8 @@ func testCatStructBindingType() vapiBindings_.BindingType {
 	fieldNameMap["age"] = "Age"
 	fields["name"] = vapiBindings_.NewOptionalType(vapiBindings_.NewStringType())
 	fieldNameMap["name"] = "Name"
-	fields["resource_type"] = vapiBindings_.NewOptionalType(vapiBindings_.NewStringType())
-	fieldNameMap["resource_type"] = "ResourceType"
+	fields["type"] = vapiBindings_.NewOptionalType(vapiBindings_.NewStringType())
+	fieldNameMap["type"] = "Type_"
 	var validators = []vapiBindings_.Validator{}
 	return vapiBindings_.NewStructType("com.vmware.nsx.fake.cat", fields,
 		reflect.TypeOf(testCatStruct{}), fieldNameMap, validators)
@@ -35,9 +35,9 @@ func TestCatStructBinding(t *testing.T) {
 	name := "John"
 	rType := "FakeCat"
 	obj := testCatStruct{
-		Age:          &age,
-		Name:         &name,
-		ResourceType: &rType,
+		Age:   &age,
+		Name:  &name,
+		Type_: &rType,
 	}
 	converter := vapiBindings_.NewTypeConverter()
 	dv, err := converter.ConvertToVapi(obj, testCatStructBindingType())
@@ -48,9 +48,9 @@ func TestCatStructBinding(t *testing.T) {
 }
 
 type testCoffeeStruct struct {
-	IsDecaf      *bool
-	Name         *string
-	ResourceType *string
+	IsDecaf *bool
+	Name    *string
+	Type_   *string
 }
 
 func testCoffeeStructBindingType() vapiBindings_.BindingType {
@@ -60,8 +60,8 @@ func testCoffeeStructBindingType() vapiBindings_.BindingType {
 	fieldNameMap["is_decaf"] = "IsDecaf"
 	fields["name"] = vapiBindings_.NewOptionalType(vapiBindings_.NewStringType())
 	fieldNameMap["name"] = "Name"
-	fields["resource_type"] = vapiBindings_.NewOptionalType(vapiBindings_.NewStringType())
-	fieldNameMap["resource_type"] = "ResourceType"
+	fields["type"] = vapiBindings_.NewOptionalType(vapiBindings_.NewStringType())
+	fieldNameMap["type"] = "Type_"
 	var validators = []vapiBindings_.Validator{}
 	return vapiBindings_.NewStructType("com.vmware.nsx.fake.coffee", fields,
 		reflect.TypeOf(testCoffeeStruct{}), fieldNameMap, validators)
@@ -72,9 +72,9 @@ func TestCoffeeStructBinding(t *testing.T) {
 	name := "Latte"
 	rType := "FakeCoffee"
 	obj := testCoffeeStruct{
-		IsDecaf:      &decaf,
-		Name:         &name,
-		ResourceType: &rType,
+		IsDecaf: &decaf,
+		Name:    &name,
+		Type_:   &rType,
 	}
 	converter := vapiBindings_.NewTypeConverter()
 	dv, err := converter.ConvertToVapi(obj, testCoffeeStructBindingType())
@@ -144,6 +144,11 @@ func testPolyStructSchema(t string) map[string]*schema.Schema {
 }
 
 func testPolyStructExtSchema(t, sdkName string) map[string]*ExtendedSchema {
+	typeIdentier := TypeIdentifier{
+		SdkName:  "Type_",
+		JsonName: "type",
+	}
+
 	schemaType := schema.TypeList
 	maxItems := 0
 	if t == "set" {
@@ -171,9 +176,10 @@ func testPolyStructExtSchema(t, sdkName string) map[string]*ExtendedSchema {
 								},
 							},
 							Metadata: Metadata{
-								SchemaType:  "struct",
-								ReflectType: reflect.TypeOf(testCatStruct{}),
-								BindingType: testCatStructBindingType(),
+								SchemaType:     "struct",
+								ReflectType:    reflect.TypeOf(testCatStruct{}),
+								BindingType:    testCatStructBindingType(),
+								TypeIdentifier: typeIdentier,
 							},
 						},
 						"coffee": {
@@ -189,9 +195,10 @@ func testPolyStructExtSchema(t, sdkName string) map[string]*ExtendedSchema {
 								},
 							},
 							Metadata: Metadata{
-								SchemaType:  "struct",
-								ReflectType: reflect.TypeOf(testCoffeeStruct{}),
-								BindingType: testCoffeeStructBindingType(),
+								SchemaType:     "struct",
+								ReflectType:    reflect.TypeOf(testCoffeeStruct{}),
+								BindingType:    testCoffeeStructBindingType(),
+								TypeIdentifier: typeIdentier,
 							},
 						},
 					},
@@ -205,6 +212,7 @@ func testPolyStructExtSchema(t, sdkName string) map[string]*ExtendedSchema {
 					"cat":    "FakeCat",
 					"coffee": "FakeCoffee",
 				},
+				TypeIdentifier: typeIdentier,
 			},
 		},
 	}
@@ -216,9 +224,9 @@ func TestPolyStructToSchema(t *testing.T) {
 		rType := "FakeCat"
 		age := int64(1)
 		catObj := testCatStruct{
-			Age:          &age,
-			Name:         &name,
-			ResourceType: &rType,
+			Age:   &age,
+			Name:  &name,
+			Type_: &rType,
 		}
 		obj := testPolyStruct{}
 		converter := vapiBindings_.NewTypeConverter()
@@ -246,9 +254,9 @@ func TestPolyStructToSchema(t *testing.T) {
 		rType := "FakeCoffee"
 		isDecaf := true
 		coffeeObj := testCoffeeStruct{
-			IsDecaf:      &isDecaf,
-			Name:         &name,
-			ResourceType: &rType,
+			IsDecaf: &isDecaf,
+			Name:    &name,
+			Type_:   &rType,
 		}
 		obj := testPolyStruct{}
 		converter := vapiBindings_.NewTypeConverter()
@@ -279,14 +287,14 @@ func TestPolyStructToSchema(t *testing.T) {
 		isDecaf := false
 		age := int64(2)
 		catObj := testCatStruct{
-			Age:          &age,
-			Name:         &catName,
-			ResourceType: &catResType,
+			Age:   &age,
+			Name:  &catName,
+			Type_: &catResType,
 		}
 		coffeeObj := testCoffeeStruct{
-			IsDecaf:      &isDecaf,
-			Name:         &coffeeName,
-			ResourceType: &coffeeResType,
+			IsDecaf: &isDecaf,
+			Name:    &coffeeName,
+			Type_:   &coffeeResType,
 		}
 		obj := testPolyListStruct{
 			PolyList: make([]*data.StructValue, 2),
@@ -331,14 +339,14 @@ func TestPolyStructToSchema(t *testing.T) {
 		isDecaf := false
 		age := int64(2)
 		catObj := testCatStruct{
-			Age:          &age,
-			Name:         &catName,
-			ResourceType: &catResType,
+			Age:   &age,
+			Name:  &catName,
+			Type_: &catResType,
 		}
 		coffeeObj := testCoffeeStruct{
-			IsDecaf:      &isDecaf,
-			Name:         &coffeeName,
-			ResourceType: &coffeeResType,
+			IsDecaf: &isDecaf,
+			Name:    &coffeeName,
+			Type_:   &coffeeResType,
 		}
 		obj := testPolyListStruct{
 			PolyList: make([]*data.StructValue, 2),
@@ -404,7 +412,7 @@ func TestSchemaToPolyStruct(t *testing.T) {
 		assert.Nil(t, errors, "unexpected error calling ConvertToGolang")
 		assert.Equal(t, "matcha", *obs.(testCatStruct).Name)
 		assert.Equal(t, int64(1), *obs.(testCatStruct).Age)
-		assert.Equal(t, "FakeCat", *obs.(testCatStruct).ResourceType)
+		assert.Equal(t, "FakeCat", *obs.(testCatStruct).Type_)
 	})
 
 	t.Run("coffee struct", func(t *testing.T) {
@@ -432,7 +440,7 @@ func TestSchemaToPolyStruct(t *testing.T) {
 		assert.Nil(t, errors, "unexpected error calling ConvertToGolang")
 		assert.Equal(t, "latte", *obs.(testCoffeeStruct).Name)
 		assert.Equal(t, true, *obs.(testCoffeeStruct).IsDecaf)
-		assert.Equal(t, "FakeCoffee", *obs.(testCoffeeStruct).ResourceType)
+		assert.Equal(t, "FakeCoffee", *obs.(testCoffeeStruct).Type_)
 	})
 
 	t.Run("mixed list", func(t *testing.T) {
@@ -469,12 +477,12 @@ func TestSchemaToPolyStruct(t *testing.T) {
 		assert.Nil(t, errors, "unexpected error calling ConvertToGolang")
 		assert.Equal(t, "latte", *coffee.(testCoffeeStruct).Name)
 		assert.Equal(t, true, *coffee.(testCoffeeStruct).IsDecaf)
-		assert.Equal(t, "FakeCoffee", *coffee.(testCoffeeStruct).ResourceType)
+		assert.Equal(t, "FakeCoffee", *coffee.(testCoffeeStruct).Type_)
 		cat, errors := converter.ConvertToGolang(obj.PolyList[1], testCatStructBindingType())
 		assert.Nil(t, errors, "unexpected error calling ConvertToGolang")
 		assert.Equal(t, "matcha", *cat.(testCatStruct).Name)
 		assert.Equal(t, int64(1), *cat.(testCatStruct).Age)
-		assert.Equal(t, "FakeCat", *cat.(testCatStruct).ResourceType)
+		assert.Equal(t, "FakeCat", *cat.(testCatStruct).Type_)
 	})
 
 	t.Run("mixed set", func(t *testing.T) {
@@ -513,13 +521,13 @@ func TestSchemaToPolyStruct(t *testing.T) {
 				assert.Nil(t, errors, "unexpected error calling ConvertToGolang")
 				assert.Equal(t, "oolong", *cat.(testCatStruct).Name)
 				assert.Equal(t, int64(2), *cat.(testCatStruct).Age)
-				assert.Equal(t, "FakeCat", *cat.(testCatStruct).ResourceType)
+				assert.Equal(t, "FakeCat", *cat.(testCatStruct).Type_)
 			} else {
 				coffee, errors := converter.ConvertToGolang(obj.PolyList[0], testCoffeeStructBindingType())
 				assert.Nil(t, errors, "unexpected error calling ConvertToGolang")
 				assert.Equal(t, "mocha", *coffee.(testCoffeeStruct).Name)
 				assert.Equal(t, false, *coffee.(testCoffeeStruct).IsDecaf)
-				assert.Equal(t, "FakeCoffee", *coffee.(testCoffeeStruct).ResourceType)
+				assert.Equal(t, "FakeCoffee", *coffee.(testCoffeeStruct).Type_)
 			}
 		}
 	})

--- a/nsxt/metadata/metadata_poly_test.go
+++ b/nsxt/metadata/metadata_poly_test.go
@@ -92,7 +92,7 @@ type testPolyListStruct struct {
 	PolyList []*data.StructValue
 }
 
-func testPolyStructWrappedSchema(t string) map[string]*schema.Schema {
+func testPolyStructNestedSchema(t string) map[string]*schema.Schema {
 	schemaType := schema.TypeList
 	maxItems := 0
 	if t == "set" {
@@ -143,7 +143,7 @@ func testPolyStructWrappedSchema(t string) map[string]*schema.Schema {
 	}
 }
 
-func testPolyStructWrappedExtSchema(t, sdkName string) map[string]*ExtendedSchema {
+func testPolyStructNestedExtSchema(t, sdkName string) map[string]*ExtendedSchema {
 	typeIdentier := TypeIdentifier{
 		SdkName:      "Type",
 		APIFieldName: "type",
@@ -207,7 +207,7 @@ func testPolyStructWrappedExtSchema(t, sdkName string) map[string]*ExtendedSchem
 			Metadata: Metadata{
 				SchemaType:      t,
 				SdkFieldName:    sdkName,
-				PolymorphicType: PolymorphicTypeWrapped,
+				PolymorphicType: PolymorphicTypeNested,
 				ResourceTypeMap: map[string]string{
 					"cat":    "FakeCat",
 					"coffee": "FakeCoffee",
@@ -218,7 +218,7 @@ func testPolyStructWrappedExtSchema(t, sdkName string) map[string]*ExtendedSchem
 	}
 }
 
-func TestPolyStructToWrappedSchema(t *testing.T) {
+func TestPolyStructToNestedSchema(t *testing.T) {
 	t.Run("cat struct", func(t *testing.T) {
 		name := "matcha"
 		rType := "FakeCat"
@@ -234,10 +234,10 @@ func TestPolyStructToWrappedSchema(t *testing.T) {
 		assert.Nil(t, errors, "unexpected error calling ConvertToGolang")
 		obj.PolyStruct = dv.(*data.StructValue)
 		d := schema.TestResourceDataRaw(
-			t, testPolyStructWrappedSchema("struct"), map[string]interface{}{})
+			t, testPolyStructNestedSchema("struct"), map[string]interface{}{})
 
 		elem := reflect.ValueOf(&obj).Elem()
-		err := StructToSchema(elem, d, testPolyStructWrappedExtSchema("struct", "PolyStruct"), "", nil)
+		err := StructToSchema(elem, d, testPolyStructNestedExtSchema("struct", "PolyStruct"), "", nil)
 		assert.NoError(t, err, "unexpected error calling StructToSchema")
 		assert.Len(t, d.Get("poly_struct"), 1)
 		polyData := d.Get("poly_struct").([]interface{})[0].(map[string]interface{})
@@ -264,10 +264,10 @@ func TestPolyStructToWrappedSchema(t *testing.T) {
 		assert.Nil(t, errors, "unexpected error calling ConvertToGolang")
 		obj.PolyStruct = dv.(*data.StructValue)
 		d := schema.TestResourceDataRaw(
-			t, testPolyStructWrappedSchema("struct"), map[string]interface{}{})
+			t, testPolyStructNestedSchema("struct"), map[string]interface{}{})
 
 		elem := reflect.ValueOf(&obj).Elem()
-		err := StructToSchema(elem, d, testPolyStructWrappedExtSchema("struct", "PolyStruct"), "", nil)
+		err := StructToSchema(elem, d, testPolyStructNestedExtSchema("struct", "PolyStruct"), "", nil)
 		assert.NoError(t, err, "unexpected error calling StructToSchema")
 		assert.Len(t, d.Get("poly_struct"), 1)
 		polyData := d.Get("poly_struct").([]interface{})[0].(map[string]interface{})
@@ -307,10 +307,10 @@ func TestPolyStructToWrappedSchema(t *testing.T) {
 		assert.Nil(t, errors, "unexpected error calling ConvertToGolang")
 		obj.PolyList[1] = dv.(*data.StructValue)
 		d := schema.TestResourceDataRaw(
-			t, testPolyStructWrappedSchema("struct"), map[string]interface{}{})
+			t, testPolyStructNestedSchema("struct"), map[string]interface{}{})
 
 		elem := reflect.ValueOf(&obj).Elem()
-		err := StructToSchema(elem, d, testPolyStructWrappedExtSchema("list", "PolyList"), "", nil)
+		err := StructToSchema(elem, d, testPolyStructNestedExtSchema("list", "PolyList"), "", nil)
 		assert.NoError(t, err, "unexpected error calling StructToSchema")
 		assert.Len(t, d.Get("poly_struct"), 2)
 		// idx 0: coffee
@@ -359,10 +359,10 @@ func TestPolyStructToWrappedSchema(t *testing.T) {
 		assert.Nil(t, errors, "unexpected error calling ConvertToGolang")
 		obj.PolyList[0] = dv.(*data.StructValue)
 		d := schema.TestResourceDataRaw(
-			t, testPolyStructWrappedSchema("struct"), map[string]interface{}{})
+			t, testPolyStructNestedSchema("struct"), map[string]interface{}{})
 
 		elem := reflect.ValueOf(&obj).Elem()
-		err := StructToSchema(elem, d, testPolyStructWrappedExtSchema("set", "PolyList"), "", nil)
+		err := StructToSchema(elem, d, testPolyStructNestedExtSchema("set", "PolyList"), "", nil)
 		assert.NoError(t, err, "unexpected error calling StructToSchema")
 		assert.Len(t, d.Get("poly_struct"), 2)
 		for _, v := range d.Get("poly_struct").([]interface{}) {
@@ -386,10 +386,10 @@ func TestPolyStructToWrappedSchema(t *testing.T) {
 	})
 }
 
-func TestWrappedSchemaToPolyStruct(t *testing.T) {
+func TestNestedSchemaToPolyStruct(t *testing.T) {
 	t.Run("cat struct", func(t *testing.T) {
 		d := schema.TestResourceDataRaw(
-			t, testPolyStructWrappedSchema("struct"), map[string]interface{}{
+			t, testPolyStructNestedSchema("struct"), map[string]interface{}{
 				"poly_struct": []interface{}{
 					map[string]interface{}{
 						"cat": []interface{}{
@@ -404,7 +404,7 @@ func TestWrappedSchemaToPolyStruct(t *testing.T) {
 
 		obj := testPolyStruct{}
 		elem := reflect.ValueOf(&obj).Elem()
-		err := SchemaToStruct(elem, d, testPolyStructWrappedExtSchema("struct", "PolyStruct"), "", nil)
+		err := SchemaToStruct(elem, d, testPolyStructNestedExtSchema("struct", "PolyStruct"), "", nil)
 		assert.NoError(t, err, "unexpected error calling SchemaToStruct")
 
 		converter := vapiBindings_.NewTypeConverter()
@@ -417,7 +417,7 @@ func TestWrappedSchemaToPolyStruct(t *testing.T) {
 
 	t.Run("coffee struct", func(t *testing.T) {
 		d := schema.TestResourceDataRaw(
-			t, testPolyStructWrappedSchema("struct"), map[string]interface{}{
+			t, testPolyStructNestedSchema("struct"), map[string]interface{}{
 				"poly_struct": []interface{}{
 					map[string]interface{}{
 						"coffee": []interface{}{
@@ -432,7 +432,7 @@ func TestWrappedSchemaToPolyStruct(t *testing.T) {
 
 		obj := testPolyStruct{}
 		elem := reflect.ValueOf(&obj).Elem()
-		err := SchemaToStruct(elem, d, testPolyStructWrappedExtSchema("struct", "PolyStruct"), "", nil)
+		err := SchemaToStruct(elem, d, testPolyStructNestedExtSchema("struct", "PolyStruct"), "", nil)
 		assert.NoError(t, err, "unexpected error calling SchemaToStruct")
 
 		converter := vapiBindings_.NewTypeConverter()
@@ -445,7 +445,7 @@ func TestWrappedSchemaToPolyStruct(t *testing.T) {
 
 	t.Run("mixed list", func(t *testing.T) {
 		d := schema.TestResourceDataRaw(
-			t, testPolyStructWrappedSchema("list"), map[string]interface{}{
+			t, testPolyStructNestedSchema("list"), map[string]interface{}{
 				"poly_struct": []interface{}{
 					map[string]interface{}{
 						"coffee": []interface{}{
@@ -468,7 +468,7 @@ func TestWrappedSchemaToPolyStruct(t *testing.T) {
 
 		obj := testPolyListStruct{}
 		elem := reflect.ValueOf(&obj).Elem()
-		err := SchemaToStruct(elem, d, testPolyStructWrappedExtSchema("list", "PolyList"), "", nil)
+		err := SchemaToStruct(elem, d, testPolyStructNestedExtSchema("list", "PolyList"), "", nil)
 		assert.NoError(t, err, "unexpected error calling SchemaToStruct")
 
 		converter := vapiBindings_.NewTypeConverter()
@@ -487,7 +487,7 @@ func TestWrappedSchemaToPolyStruct(t *testing.T) {
 
 	t.Run("mixed set", func(t *testing.T) {
 		d := schema.TestResourceDataRaw(
-			t, testPolyStructWrappedSchema("set"), map[string]interface{}{
+			t, testPolyStructNestedSchema("set"), map[string]interface{}{
 				"poly_struct": []interface{}{
 					map[string]interface{}{
 						"cat": []interface{}{
@@ -510,7 +510,7 @@ func TestWrappedSchemaToPolyStruct(t *testing.T) {
 
 		obj := testPolyListStruct{}
 		elem := reflect.ValueOf(&obj).Elem()
-		err := SchemaToStruct(elem, d, testPolyStructWrappedExtSchema("set", "PolyList"), "", nil)
+		err := SchemaToStruct(elem, d, testPolyStructNestedExtSchema("set", "PolyList"), "", nil)
 		assert.NoError(t, err, "unexpected error calling SchemaToStruct")
 
 		converter := vapiBindings_.NewTypeConverter()
@@ -533,7 +533,7 @@ func TestWrappedSchemaToPolyStruct(t *testing.T) {
 	})
 }
 
-func testPolyStructFlatSchema() map[string]*schema.Schema {
+func testPolyStructFlattenSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"cat": {
 			Type: schema.TypeList,
@@ -564,7 +564,7 @@ func testPolyStructFlatSchema() map[string]*schema.Schema {
 	}
 }
 
-func testPolyStructFlatExtSchema(sdkName string) map[string]*ExtendedSchema {
+func testPolyStructFlattenExtSchema(sdkName string) map[string]*ExtendedSchema {
 	typeIdentifier := TypeIdentifier{
 		SdkName:      "Type",
 		APIFieldName: "type",
@@ -586,7 +586,7 @@ func testPolyStructFlatExtSchema(sdkName string) map[string]*ExtendedSchema {
 				ReflectType:     reflect.TypeOf(testCatStruct{}),
 				BindingType:     testCatStructBindingType(),
 				TypeIdentifier:  typeIdentifier,
-				PolymorphicType: PolymorphicTypeFlat,
+				PolymorphicType: PolymorphicTypeFlatten,
 				ResourceType:    "FakeCat",
 				SdkFieldName:    sdkName,
 			},
@@ -606,7 +606,7 @@ func testPolyStructFlatExtSchema(sdkName string) map[string]*ExtendedSchema {
 				ReflectType:     reflect.TypeOf(testCoffeeStruct{}),
 				BindingType:     testCoffeeStructBindingType(),
 				TypeIdentifier:  typeIdentifier,
-				PolymorphicType: PolymorphicTypeFlat,
+				PolymorphicType: PolymorphicTypeFlatten,
 				ResourceType:    "FakeCoffee",
 				SdkFieldName:    sdkName,
 			},
@@ -614,7 +614,7 @@ func testPolyStructFlatExtSchema(sdkName string) map[string]*ExtendedSchema {
 	}
 }
 
-func TestPolyStructToFlatSchema(t *testing.T) {
+func TestPolyStructToFlattenSchema(t *testing.T) {
 	t.Run("mixed list", func(t *testing.T) {
 		catName := "oolong"
 		coffeeName := "mocha"
@@ -643,10 +643,10 @@ func TestPolyStructToFlatSchema(t *testing.T) {
 		assert.Nil(t, errors, "unexpected error calling ConvertToGolang")
 		obj.PolyList[1] = dv.(*data.StructValue)
 		d := schema.TestResourceDataRaw(
-			t, testPolyStructFlatSchema(), map[string]interface{}{})
+			t, testPolyStructFlattenSchema(), map[string]interface{}{})
 
 		elem := reflect.ValueOf(&obj).Elem()
-		err := StructToSchema(elem, d, testPolyStructFlatExtSchema("PolyList"), "", nil)
+		err := StructToSchema(elem, d, testPolyStructFlattenExtSchema("PolyList"), "", nil)
 		assert.NoError(t, err, "unexpected error calling StructToSchema")
 
 		assert.Len(t, d.Get("coffee"), 1)
@@ -663,10 +663,10 @@ func TestPolyStructToFlatSchema(t *testing.T) {
 	})
 }
 
-func TestFlatSchemaToPolyStruct(t *testing.T) {
+func TestFlattenSchemaToPolyStruct(t *testing.T) {
 	t.Run("mixed list", func(t *testing.T) {
 		d := schema.TestResourceDataRaw(
-			t, testPolyStructFlatSchema(), map[string]interface{}{
+			t, testPolyStructFlattenSchema(), map[string]interface{}{
 				"coffee": []interface{}{
 					map[string]interface{}{
 						"name":     "mocha",
@@ -683,7 +683,7 @@ func TestFlatSchemaToPolyStruct(t *testing.T) {
 
 		obj := testPolyListStruct{}
 		elem := reflect.ValueOf(&obj).Elem()
-		err := SchemaToStruct(elem, d, testPolyStructFlatExtSchema("PolyList"), "", nil)
+		err := SchemaToStruct(elem, d, testPolyStructFlattenExtSchema("PolyList"), "", nil)
 		assert.NoError(t, err, "unexpected error calling SchemaToStruct")
 
 		converter := vapiBindings_.NewTypeConverter()

--- a/nsxt/metadata/metadata_poly_test.go
+++ b/nsxt/metadata/metadata_poly_test.go
@@ -205,9 +205,9 @@ func testPolyStructExtSchema(t, sdkName string) map[string]*ExtendedSchema {
 				},
 			},
 			Metadata: Metadata{
-				SchemaType:    t,
-				SdkFieldName:  sdkName,
-				IsPolymorphic: true,
+				SchemaType:      t,
+				SdkFieldName:    sdkName,
+				PolymorphicType: PolymorphicTypeWrapped,
 				ResourceTypeMap: map[string]string{
 					"cat":    "FakeCat",
 					"coffee": "FakeCoffee",


### PR DESCRIPTION
This PR adds support of polymorphic struct for the reflect lib. Two approaches used in existing TF resource schema are supported in this PR.

## Dedicated attribute wrapping polymorphic classes 

Suppose an attr `poly_struct` can accept two types: `cat` and `coffee`, the "wrapped" format expects the followings:

Suppose `poly_struct` is a list, and resource is defined as below:
```
resource "fake_poly_res" "test" {
  poly_struct {
    cat {
      name = "matcha"
      age  = 1
    }
  }

  poly_struct {
    coffee {
      name      = "latte"
      is_decaf  = false
    }
  }
}
```

`metadata` definition expects the followings:
#### At `poly_struct` level
- Declare `PolymorphicType` as `wrapped`
- Provide `ResourceTypeMap`, where the key is all potential tf sub-object (in this case, `cat` and `coffee`), and value is the `ResourceType` value reported from NSX
- Optional `TypeIdentifier` providing the SDK field name and API JSON name for the attr to identify the resource type. Defaults to use `ResourceType` and `resource_type` respectively
- The schema of `poly_struct` should include all sub-objects, while indicating them as mutal exclusive using `ConflictsWith`


#### At sub-object level
- `ReflectType` should be the golang type directly matching with this sub class
- `BindingType` is required from SDK so it can be statically converted as `*data.StructValue`(or slice equivalant)
- `TypeIdentifier` to match with the wrapping level
- `SdkFieldName` will be ignored

## No wrapping level ("flat")
Similiarly, if the SDK field is a polymorphic list, it's also possible to express elements of the same child class as a separate terraform schema attr. In this case, the resource is defined as below:
```
resource "fake_poly_res" "test" {
  cat {
    name = "oolong"
    age  = 2
  }

  coffee {
    name      = "mocha"
    is_decaf  = false
  }
}
```

In this case, multiple attrs will be combined into one SDK list. For each object, the followings are expected:
- Declare `PolymorphicType` as `flat`
- `ReflectType` matching with the corresponding sub class
- `BindingType` matching with `ReflectType`
- Optional `TypeIdentifier`
- `ResourceType`


Refer to `nsxt/metadata/metadata_poly_test.go` for the full example for both use cases.
 