### PR TITLE
Handle invalid context errors

### DIFF
--- a/nsxt/data_source_nsxt_policy_gateway_interface_realization.go
+++ b/nsxt/data_source_nsxt_policy_gateway_interface_realization.go
@@ -73,6 +73,9 @@ func dataSourceNsxtPolicyGatewayInterfaceRealization() *schema.Resource {
 func dataSourceNsxtPolicyGatewayInterfaceRealizationRead(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
 	client := realizedstate.NewRealizedEntitiesClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 
 	id := d.Get("id").(string)
 	gatewayPath := d.Get("gateway_path").(string)

--- a/nsxt/data_source_nsxt_policy_gateway_policy.go
+++ b/nsxt/data_source_nsxt_policy_gateway_policy.go
@@ -45,6 +45,9 @@ func dataSourceNsxtPolicyGatewayPolicy() *schema.Resource {
 // Local Manager Only
 func listGatewayPolicies(context utl.SessionContext, domain string, connector client.Connector) ([]model.GatewayPolicy, error) {
 	client := domains.NewGatewayPoliciesClient(context, connector)
+	if client == nil {
+		return nil, policyResourceNotSupportedError()
+	}
 
 	var results []model.GatewayPolicy
 	boolFalse := false
@@ -104,6 +107,9 @@ func dataSourceNsxtPolicyGatewayPolicyRead(d *schema.ResourceData, m interface{}
 	if objID != "" {
 		// Get by id
 		client := domains.NewGatewayPoliciesClient(context, connector)
+		if client == nil {
+			return policyResourceNotSupportedError()
+		}
 		objGet, err := client.Get(domain, objID)
 		if isNotFoundError(err) {
 			return fmt.Errorf("Gateway Policy with ID %s was not found", objID)

--- a/nsxt/data_source_nsxt_policy_gateway_qos_profile_test.go
+++ b/nsxt/data_source_nsxt_policy_gateway_qos_profile_test.go
@@ -83,6 +83,9 @@ func testAccDataSourceNsxtPolicyGatewayQosProfileCreate(name string) error {
 		err = client.Patch(id, gmObj.(gm_model.GatewayQosProfile), nil)
 	} else {
 		client := infra.NewGatewayQosProfilesClient(testAccGetSessionContext(), connector)
+		if client == nil {
+			return policyResourceNotSupportedError()
+		}
 		err = client.Patch(id, obj, nil)
 	}
 
@@ -111,6 +114,9 @@ func testAccDataSourceNsxtPolicyGatewayQosProfileDeleteByName(name string) error
 		}
 	} else {
 		client := infra.NewGatewayQosProfilesClient(testAccGetSessionContext(), connector)
+		if client == nil {
+			return policyResourceNotSupportedError()
+		}
 		// Find the object by name
 		objList, err := client.List(nil, nil, nil, nil, nil, nil)
 		if err != nil {

--- a/nsxt/data_source_nsxt_policy_group_test.go
+++ b/nsxt/data_source_nsxt_policy_group_test.go
@@ -108,6 +108,9 @@ func testAccDataSourceNsxtPolicyGroupCreate(domain string, name string) error {
 	id := newUUID()
 
 	client := domains.NewGroupsClient(testAccGetSessionContext(), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	err = client.Patch(domain, id, obj)
 
 	if err != nil {
@@ -124,6 +127,9 @@ func testAccDataSourceNsxtPolicyGroupDeleteByName(domain string, name string) er
 
 	// Find the object by name and delete it
 	client := domains.NewGroupsClient(testAccGetSessionContext(), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	objList, err := client.List(domain, nil, nil, nil, nil, nil, nil, nil)
 	if err != nil {
 		return handleListError("Group", err)

--- a/nsxt/data_source_nsxt_policy_ip_block.go
+++ b/nsxt/data_source_nsxt_policy_ip_block.go
@@ -30,6 +30,9 @@ func dataSourceNsxtPolicyIPBlock() *schema.Resource {
 func dataSourceNsxtPolicyIPBlockRead(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
 	client := infra.NewIpBlocksClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 
 	objID := d.Get("id").(string)
 	objName := d.Get("display_name").(string)

--- a/nsxt/data_source_nsxt_policy_ip_block_test.go
+++ b/nsxt/data_source_nsxt_policy_ip_block_test.go
@@ -63,6 +63,9 @@ func testAccDataSourceNsxtPolicyIPBlockCreate(name, id, cidr string, isPrivate b
 		return fmt.Errorf("Error during test client initialization: %v", err)
 	}
 	client := infra.NewIpBlocksClient(testAccGetSessionContext(), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 
 	displayName := name
 	description := name
@@ -89,6 +92,9 @@ func testAccDataSourceNsxtPolicyIPBlockDeleteByName(name string) error {
 		return fmt.Errorf("Error during test client initialization: %v", err)
 	}
 	client := infra.NewIpBlocksClient(testAccGetSessionContext(), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 
 	// Find the object by name
 	objList, err := client.List(nil, nil, nil, nil, nil, nil)

--- a/nsxt/data_source_nsxt_policy_ip_pool_test.go
+++ b/nsxt/data_source_nsxt_policy_ip_pool_test.go
@@ -63,6 +63,9 @@ func testAccDataSourceNsxtPolicyIPPoolCreate(name string) error {
 		return fmt.Errorf("Error during test client initialization: %v", err)
 	}
 	client := infra.NewIpPoolsClient(testAccGetSessionContext(), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 
 	displayName := name
 	description := name
@@ -87,6 +90,9 @@ func testAccDataSourceNsxtPolicyIPPoolDeleteByName(name string) error {
 		return fmt.Errorf("Error during test client initialization: %v", err)
 	}
 	client := infra.NewIpPoolsClient(testAccGetSessionContext(), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 
 	// Find the object by name
 	objList, err := client.List(nil, nil, nil, nil, nil, nil)

--- a/nsxt/data_source_nsxt_policy_ipv6_dad_profile_test.go
+++ b/nsxt/data_source_nsxt_policy_ipv6_dad_profile_test.go
@@ -71,6 +71,9 @@ func testAccDataSourceNsxtPolicyIpv6DadProfileCreate(name string) error {
 	// Generate a random ID for the resource
 	id := newUUID()
 	client := infra.NewIpv6DadProfilesClient(testAccGetSessionContext(), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	err = client.Patch(id, obj, nil)
 
 	if err != nil {
@@ -86,6 +89,9 @@ func testAccDataSourceNsxtPolicyIpv6DadProfileDeleteByName(name string) error {
 	}
 	// Find the object by name and delete it
 	client := infra.NewIpv6DadProfilesClient(testAccGetSessionContext(), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 
 	// Find the object by name
 	objList, err := client.List(nil, nil, nil, nil, nil, nil)

--- a/nsxt/data_source_nsxt_policy_ipv6_ndra_profile_test.go
+++ b/nsxt/data_source_nsxt_policy_ipv6_ndra_profile_test.go
@@ -76,6 +76,9 @@ func testAccDataSourceNsxtPolicyIpv6NdraProfileCreate(name string) error {
 	id := newUUID()
 
 	client := infra.NewIpv6NdraProfilesClient(testAccGetSessionContext(), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	err = client.Patch(id, obj, nil)
 	if err != nil {
 		return handleCreateError("Ipv6NdraProfile", id, err)
@@ -90,6 +93,9 @@ func testAccDataSourceNsxtPolicyIpv6NdraProfileDeleteByName(name string) error {
 	}
 	// Find the object by name and delete it
 	client := infra.NewIpv6NdraProfilesClient(testAccGetSessionContext(), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 
 	// Find the object by name
 	objList, err := client.List(nil, nil, nil, nil, nil, nil)

--- a/nsxt/data_source_nsxt_policy_qos_profile_test.go
+++ b/nsxt/data_source_nsxt_policy_qos_profile_test.go
@@ -72,6 +72,9 @@ func testAccDataSourceNsxtPolicyQosProfileCreate(name string) error {
 	id := newUUID()
 
 	client := infra.NewQosProfilesClient(testAccGetSessionContext(), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	err = client.Patch(id, obj, nil)
 
 	if err != nil {
@@ -88,6 +91,9 @@ func testAccDataSourceNsxtPolicyQosProfileDeleteByName(name string) error {
 
 	// Find the object by name and delete it
 	client := infra.NewQosProfilesClient(testAccGetSessionContext(), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	objList, err := client.List(nil, nil, nil, nil, nil)
 	if err != nil {
 		return handleListError("QosProfile", err)

--- a/nsxt/data_source_nsxt_policy_realization_info.go
+++ b/nsxt/data_source_nsxt_policy_realization_info.go
@@ -105,6 +105,9 @@ func dataSourceNsxtPolicyRealizationInfoRead(d *schema.ResourceData, m interface
 			var realizationError error
 			var realizationResult model.GenericPolicyRealizedResourceListResult
 			client := realizedstate.NewRealizedEntitiesClient(getSessionContext(d, m), connector)
+			if client == nil {
+				return nil, "ERROR", policyResourceNotSupportedError()
+			}
 			realizationResult, realizationError = client.List(path, nil)
 			state := "UNKNOWN"
 			if realizationError == nil {

--- a/nsxt/data_source_nsxt_policy_security_policy.go
+++ b/nsxt/data_source_nsxt_policy_security_policy.go
@@ -47,6 +47,9 @@ func dataSourceNsxtPolicySecurityPolicy() *schema.Resource {
 // Local Manager Only
 func listSecurityPolicies(context utl.SessionContext, domain string, connector client.Connector) ([]model.SecurityPolicy, error) {
 	client := domains.NewSecurityPoliciesClient(context, connector)
+	if client == nil {
+		return nil, policyResourceNotSupportedError()
+	}
 
 	var results []model.SecurityPolicy
 	boolFalse := false
@@ -86,6 +89,9 @@ func dataSourceNsxtPolicySecurityPolicyRead(d *schema.ResourceData, m interface{
 	if objID != "" {
 		// Get by id
 		client := domains.NewSecurityPoliciesClient(context, connector)
+		if client == nil {
+			return policyResourceNotSupportedError()
+		}
 		objGet, err := client.Get(domain, objID)
 		if isNotFoundError(err) {
 			return fmt.Errorf("Security Policy with ID %s was not found", objID)

--- a/nsxt/data_source_nsxt_policy_segment_realization.go
+++ b/nsxt/data_source_nsxt_policy_segment_realization.go
@@ -62,6 +62,9 @@ func dataSourceNsxtPolicySegmentRealizationRead(d *schema.ResourceData, m interf
 	segmentID := getPolicyIDFromPath(path)
 	enforcementPointPath := getPolicyEnforcementPointPath(m)
 	client := segments.NewStateClient(context, connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	pendingStates := []string{model.SegmentConfigurationState_STATE_PENDING,
 		model.SegmentConfigurationState_STATE_IN_PROGRESS,
 		model.SegmentConfigurationState_STATE_IN_SYNC,
@@ -104,6 +107,9 @@ func dataSourceNsxtPolicySegmentRealizationRead(d *schema.ResourceData, m interf
 	// return it in details yet. For now, we'll use segment display name, since its always
 	// translates to network name
 	segClient := infra.NewSegmentsClient(context, connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	obj, err := segClient.Get(segmentID)
 	if err != nil {
 		return handleReadError(d, "Segment", segmentID, err)

--- a/nsxt/data_source_nsxt_policy_segment_test.go
+++ b/nsxt/data_source_nsxt_policy_segment_test.go
@@ -74,6 +74,9 @@ func testAccDataSourceNsxtPolicySegmentCreate(name string) error {
 	id := uuid.String()
 
 	client := infra.NewSegmentsClient(testAccGetSessionContext(), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	err = client.Patch(id, obj)
 	if err != nil {
 		return fmt.Errorf("Error during Segment creation: %v", err)
@@ -93,6 +96,9 @@ func testAccDataSourceNsxtPolicySegmentDeleteByName(name string) error {
 		return nil
 	}
 	client := infra.NewSegmentsClient(testAccGetSessionContext(), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	err = client.Delete(objID)
 
 	if err != nil {

--- a/nsxt/data_source_nsxt_policy_tier1_gateway_test.go
+++ b/nsxt/data_source_nsxt_policy_tier1_gateway_test.go
@@ -71,6 +71,9 @@ func testAccDataSourceNsxtPolicyTier1GatewayCreate(routerName string) error {
 	// Generate a random ID for the resource
 	id := newUUID()
 	client := infra.NewTier1sClient(testAccGetSessionContext(), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	err = client.Patch(id, obj)
 
 	if err != nil {
@@ -87,6 +90,9 @@ func testAccDataSourceNsxtPolicyTier1GatewayDeleteByName(routerName string) erro
 
 	// Find the object by name
 	client := infra.NewTier1sClient(testAccGetSessionContext(), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 
 	// Find the object by name
 	objList, err := client.List(nil, nil, nil, nil, nil, nil)

--- a/nsxt/gateway_common.go
+++ b/nsxt/gateway_common.go
@@ -439,6 +439,9 @@ func policyInfraPatch(context utl.SessionContext, obj model.Infra, connector cli
 	}
 
 	infraClient := nsx_policy.NewInfraClient(context, connector)
+	if infraClient == nil {
+		return policyResourceNotSupportedError()
+	}
 	return infraClient.Patch(obj, &enforceRevision)
 }
 

--- a/nsxt/resource_nsxt_policy_context_profile.go
+++ b/nsxt/resource_nsxt_policy_context_profile.go
@@ -172,6 +172,9 @@ func getPolicyAttributeSubAttributeValueSchema(subAttributeKey string) *schema.S
 
 func resourceNsxtPolicyContextProfileExists(sessionContext utl.SessionContext, id string, connector client.Connector) (bool, error) {
 	client := infra.NewContextProfilesClient(sessionContext, connector)
+	if client == nil {
+		return false, policyResourceNotSupportedError()
+	}
 	_, err := client.Get(id)
 
 	if err == nil {
@@ -227,6 +230,9 @@ func resourceNsxtPolicyContextProfileCreate(d *schema.ResourceData, m interface{
 	// Create the resource using PATCH
 	log.Printf("[INFO] Creating ContextProfile with ID %s", id)
 	client := infra.NewContextProfilesClient(context, connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	err = client.Patch(id, obj, nil)
 	if err != nil {
 		return handleCreateError("ContextProfile", id, err)
@@ -246,6 +252,9 @@ func resourceNsxtPolicyContextProfileRead(d *schema.ResourceData, m interface{})
 	}
 
 	client := infra.NewContextProfilesClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	obj, err := client.Get(id)
 	if err != nil {
 		return handleReadError(d, "ContextProfile", id, err)
@@ -298,6 +307,9 @@ func resourceNsxtPolicyContextProfileUpdate(d *schema.ResourceData, m interface{
 
 	// Update the resource using PATCH
 	client := infra.NewContextProfilesClient(context, connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	err = client.Patch(id, obj, nil)
 
 	if err != nil {
@@ -317,6 +329,9 @@ func resourceNsxtPolicyContextProfileDelete(d *schema.ResourceData, m interface{
 	var err error
 	force := true
 	client := infra.NewContextProfilesClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	err = client.Delete(id, &force, nil)
 	if err != nil {
 		return handleDeleteError("ContextProfile", id, err)
@@ -388,7 +403,11 @@ func listAttributesWithKey(context utl.SessionContext, attributeKey string, m in
 func listSystemAttributesWithKey(context utl.SessionContext, attributeKey *string, m interface{}) (model.PolicyContextProfileListResult, error) {
 	includeMarkForDeleteObjectsParam := false
 	connector := getPolicyConnector(m)
+	var policyContextProfileListResult model.PolicyContextProfileListResult
 	client := cont_prof.NewAttributesClient(context, connector)
+	if client == nil {
+		return policyContextProfileListResult, policyResourceNotSupportedError()
+	}
 	policyContextProfileListResult, err := client.List(attributeKey, nil, nil, &includeMarkForDeleteObjectsParam, nil, nil, nil, nil)
 	return policyContextProfileListResult, err
 }
@@ -396,7 +415,11 @@ func listSystemAttributesWithKey(context utl.SessionContext, attributeKey *strin
 func listCustomAttributesWithKey(context utl.SessionContext, attributeKey *string, m interface{}) (model.PolicyContextProfileListResult, error) {
 	includeMarkForDeleteObjectsParam := false
 	connector := getPolicyConnector(m)
+	var policyContextProfileListResult model.PolicyContextProfileListResult
 	client := custom_attr.NewDefaultClient(context, connector)
+	if client == nil {
+		return policyContextProfileListResult, policyResourceNotSupportedError()
+	}
 	policyContextProfileListResult, err := client.List(attributeKey, nil, nil, &includeMarkForDeleteObjectsParam, nil, nil, nil, nil)
 	return policyContextProfileListResult, err
 }

--- a/nsxt/resource_nsxt_policy_context_profile_custom_attribute.go
+++ b/nsxt/resource_nsxt_policy_context_profile_custom_attribute.go
@@ -67,6 +67,9 @@ func resourceNsxtPolicyContextProfileCustomAttributeExists(sessionContext utl.Se
 	key, attribute := splitCustomAttributeID(id)
 	source := model.PolicyCustomAttributes_ATTRIBUTE_SOURCE_CUSTOM
 	client := infra.NewDefaultClient(sessionContext, connector)
+	if client == nil {
+		return false, policyResourceNotSupportedError()
+	}
 	attrList, err = client.List(&key, &source, nil, nil, nil, nil, nil, nil)
 	if err != nil {
 		return false, err
@@ -133,6 +136,9 @@ func resourceNsxtPolicyContextProfileCustomAttributeCreate(d *schema.ResourceDat
 
 	// PATCH the resource
 	client := infra.NewDefaultClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	err = client.Create(obj, "add")
 	if err != nil {
 		return handleCreateError("ContextProfileCustomAttribute", attribute, err)
@@ -166,6 +172,9 @@ func resourceNsxtPolicyContextProfileCustomAttributeDelete(d *schema.ResourceDat
 
 	// PATCH the resource
 	client := infra.NewDefaultClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	err = client.Create(obj, "remove")
 
 	if err != nil {

--- a/nsxt/resource_nsxt_policy_context_profile_test.go
+++ b/nsxt/resource_nsxt_policy_context_profile_test.go
@@ -388,6 +388,9 @@ func nsxtPolicyContextProfileExists(resourceID string) error {
 	connector := getPolicyConnector(testAccProvider.Meta().(nsxtClients))
 	var err error
 	nsxClient := infra.NewContextProfilesClient(testAccGetSessionContext(), connector)
+	if nsxClient == nil {
+		return policyResourceNotSupportedError()
+	}
 	_, err = nsxClient.Get(resourceID)
 
 	return err

--- a/nsxt/resource_nsxt_policy_dhcp_relay.go
+++ b/nsxt/resource_nsxt_policy_dhcp_relay.go
@@ -47,6 +47,9 @@ func resourceNsxtPolicyDhcpRelayConfig() *schema.Resource {
 
 func resourceNsxtPolicyDhcpRelayConfigExists(sessionContext utl.SessionContext, id string, connector client.Connector) (bool, error) {
 	client := infra.NewDhcpRelayConfigsClient(sessionContext, connector)
+	if client == nil {
+		return false, policyResourceNotSupportedError()
+	}
 
 	_, err := client.Get(id)
 	if err == nil {
@@ -63,7 +66,6 @@ func resourceNsxtPolicyDhcpRelayConfigExists(sessionContext utl.SessionContext, 
 func resourceNsxtPolicyDhcpRelayConfigCreate(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
 	client := infra.NewDhcpRelayConfigsClient(getSessionContext(d, m), connector)
-
 	if client == nil {
 		return policyResourceNotSupportedError()
 	}
@@ -102,7 +104,6 @@ func resourceNsxtPolicyDhcpRelayConfigCreate(d *schema.ResourceData, m interface
 func resourceNsxtPolicyDhcpRelayConfigRead(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
 	client := infra.NewDhcpRelayConfigsClient(getSessionContext(d, m), connector)
-
 	if client == nil {
 		return policyResourceNotSupportedError()
 	}

--- a/nsxt/resource_nsxt_policy_dhcp_server.go
+++ b/nsxt/resource_nsxt_policy_dhcp_server.go
@@ -70,6 +70,9 @@ func resourceNsxtPolicyDhcpServer() *schema.Resource {
 func resourceNsxtPolicyDhcpServerExists(sessionContext utl.SessionContext, id string, connector client.Connector) (bool, error) {
 
 	client := infra.NewDhcpServerConfigsClient(sessionContext, connector)
+	if client == nil {
+		return false, policyResourceNotSupportedError()
+	}
 	_, err := client.Get(id)
 	if err == nil {
 		return true, nil
@@ -125,6 +128,9 @@ func resourceNsxtPolicyDhcpServerCreate(d *schema.ResourceData, m interface{}) e
 	// Create the resource using PATCH
 	log.Printf("[INFO] Creating DhcpServer with ID %s", id)
 	client := infra.NewDhcpServerConfigsClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	err = client.Patch(id, resourceNsxtPolicyDhcpServerSchemaToModel(d))
 	if err != nil {
 		return handleCreateError("DhcpServer", id, err)
@@ -145,6 +151,9 @@ func resourceNsxtPolicyDhcpServerRead(d *schema.ResourceData, m interface{}) err
 	}
 
 	client := infra.NewDhcpServerConfigsClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	obj, err := client.Get(id)
 	if err != nil {
 		return handleReadError(d, "DhcpServer", id, err)
@@ -195,6 +204,9 @@ func resourceNsxtPolicyDhcpServerDelete(d *schema.ResourceData, m interface{}) e
 	var err error
 	connector := getPolicyConnector(m)
 	client := infra.NewDhcpServerConfigsClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	err = client.Delete(id)
 
 	if err != nil {

--- a/nsxt/resource_nsxt_policy_dhcp_v4_static_binding.go
+++ b/nsxt/resource_nsxt_policy_dhcp_v4_static_binding.go
@@ -77,10 +77,16 @@ func getPolicyDchpStaticBindingOnSegment(context utl.SessionContext, id string, 
 	}
 	if context.ClientType == utl.Global || gwID == "" {
 		client := segments.NewDhcpStaticBindingConfigsClient(context, connector)
+		if client == nil {
+			return nil, policyResourceNotSupportedError()
+		}
 		return client.Get(segmentID, id)
 	}
 
 	client := t1_segments.NewDhcpStaticBindingConfigsClient(context, connector)
+	if client == nil {
+		return nil, policyResourceNotSupportedError()
+	}
 	return client.Get(gwID, segmentID, id)
 }
 
@@ -153,11 +159,17 @@ func policyDhcpV4StaticBindingConvertAndPatch(d *schema.ResourceData, segmentPat
 	if gwID == "" {
 		// infra segment
 		client := segments.NewDhcpStaticBindingConfigsClient(context, connector)
+		if client == nil {
+			return policyResourceNotSupportedError()
+		}
 		return client.Patch(segmentID, id, convObj.(*data.StructValue))
 	}
 
 	// fixed segment
 	client := t1_segments.NewDhcpStaticBindingConfigsClient(context, connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	return client.Patch(gwID, segmentID, id, convObj.(*data.StructValue))
 }
 
@@ -233,10 +245,16 @@ func resourceNsxtPolicyDhcpV4StaticBindingRead(d *schema.ResourceData, m interfa
 	if gwID == "" {
 		// infra segment
 		client := segments.NewDhcpStaticBindingConfigsClient(context, connector)
+		if client == nil {
+			return policyResourceNotSupportedError()
+		}
 		dhcpObj, err = client.Get(segmentID, id)
 	} else {
 		// fixed segment
 		client := t1_segments.NewDhcpStaticBindingConfigsClient(context, connector)
+		if client == nil {
+			return policyResourceNotSupportedError()
+		}
 		dhcpObj, err = client.Get(gwID, segmentID, id)
 	}
 
@@ -310,10 +328,16 @@ func resourceNsxtPolicyDhcpStaticBindingDelete(d *schema.ResourceData, m interfa
 	if gwID == "" {
 		// infra segment
 		client := segments.NewDhcpStaticBindingConfigsClient(context, connector)
+		if client == nil {
+			return policyResourceNotSupportedError()
+		}
 		err = client.Delete(segmentID, id)
 	} else {
 		// fixed segment
 		client := t1_segments.NewDhcpStaticBindingConfigsClient(context, connector)
+		if client == nil {
+			return policyResourceNotSupportedError()
+		}
 		err = client.Delete(gwID, segmentID, id)
 	}
 

--- a/nsxt/resource_nsxt_policy_dhcp_v6_static_binding.go
+++ b/nsxt/resource_nsxt_policy_dhcp_v6_static_binding.go
@@ -137,11 +137,17 @@ func policyDhcpV6StaticBindingConvertAndPatch(d *schema.ResourceData, segmentPat
 	if gwID == "" {
 		// infra segment
 		client := segments.NewDhcpStaticBindingConfigsClient(context, connector)
+		if client == nil {
+			return policyResourceNotSupportedError()
+		}
 		return client.Patch(segmentID, id, convObj.(*data.StructValue))
 	}
 
 	// fixed segment
 	client := t1_segments.NewDhcpStaticBindingConfigsClient(context, connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	return client.Patch(gwID, segmentID, id, convObj.(*data.StructValue))
 }
 
@@ -190,10 +196,16 @@ func resourceNsxtPolicyDhcpV6StaticBindingRead(d *schema.ResourceData, m interfa
 	if gwID == "" {
 		// infra segment
 		client := segments.NewDhcpStaticBindingConfigsClient(context, connector)
+		if client == nil {
+			return policyResourceNotSupportedError()
+		}
 		dhcpObj, err = client.Get(segmentID, id)
 	} else {
 		// fixed segment
 		client := t1_segments.NewDhcpStaticBindingConfigsClient(context, connector)
+		if client == nil {
+			return policyResourceNotSupportedError()
+		}
 		dhcpObj, err = client.Get(gwID, segmentID, id)
 	}
 	if err != nil {

--- a/nsxt/resource_nsxt_policy_distributed_flood_protection_profile.go
+++ b/nsxt/resource_nsxt_policy_distributed_flood_protection_profile.go
@@ -87,6 +87,9 @@ func getDistributedFloodProtectionProfile() map[string]*schema.Schema {
 func resourceNsxtPolicyFloodProtectionProfileExists(sessionContext utl.SessionContext, id string, connector client.Connector) (bool, error) {
 
 	client := infra.NewFloodProtectionProfilesClient(sessionContext, connector)
+	if client == nil {
+		return false, policyResourceNotSupportedError()
+	}
 	_, err := client.Get(id)
 	if err == nil {
 		return true, nil
@@ -142,6 +145,9 @@ func resourceNsxtPolicyDistributedFloodProtectionProfilePatch(d *schema.Resource
 
 	log.Printf("[INFO] Patching DistributedFloodProtectionProfile with ID %s", id)
 	client := infra.NewFloodProtectionProfilesClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	return client.Patch(id, profileStruct, nil)
 }
 
@@ -174,6 +180,9 @@ func resourceNsxtPolicyDistributedFloodProtectionProfileRead(d *schema.ResourceD
 	}
 
 	client := infra.NewFloodProtectionProfilesClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	dpffData, err := client.Get(id)
 	if err != nil {
 		return handleReadError(d, "FloodProtectionProfile", id, err)
@@ -225,6 +234,9 @@ func resourceNsxtPolicyFloodProtectionProfileDelete(d *schema.ResourceData, m in
 
 	connector := getPolicyConnector(m)
 	client := infra.NewFloodProtectionProfilesClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	err := client.Delete(id, nil)
 	if err != nil {
 		return handleDeleteError("FloodProtectionProfile", id, err)

--- a/nsxt/resource_nsxt_policy_distributed_flood_protection_profile_binding.go
+++ b/nsxt/resource_nsxt_policy_distributed_flood_protection_profile_binding.go
@@ -56,6 +56,9 @@ func resourceNsxtPolicyDistributedFloodProtectionProfileBinding() *schema.Resour
 func resourceNsxtPolicyDistributedFloodProtectionProfileBindingPatch(d *schema.ResourceData, m interface{}, id string, isCreate bool) error {
 	connector := getPolicyConnector(m)
 	bindingClient := groups.NewFirewallFloodProtectionProfileBindingMapsClient(getSessionContext(d, m), connector)
+	if bindingClient == nil {
+		return policyResourceNotSupportedError()
+	}
 
 	displayName := d.Get("display_name").(string)
 	description := d.Get("description").(string)
@@ -83,6 +86,9 @@ func resourceNsxtPolicyDistributedFloodProtectionProfileBindingPatch(d *schema.R
 
 func resourceNsxtPolicyDistributedFloodProtectionProfileBindingExists(sessionContext utl.SessionContext, connector client.Connector, groupPath, id string) (bool, error) {
 	bindingClient := groups.NewFirewallFloodProtectionProfileBindingMapsClient(sessionContext, connector)
+	if bindingClient == nil {
+		return false, policyResourceNotSupportedError()
+	}
 	domain := getDomainFromResourcePath(groupPath)
 	groupID := getPolicyIDFromPath(groupPath)
 	_, err := bindingClient.Get(domain, groupID, id)
@@ -132,6 +138,9 @@ func resourceNsxtPolicyDistributedFloodProtectionProfileBindingRead(d *schema.Re
 
 	connector := getPolicyConnector(m)
 	bindingClient := groups.NewFirewallFloodProtectionProfileBindingMapsClient(getSessionContext(d, m), connector)
+	if bindingClient == nil {
+		return policyResourceNotSupportedError()
+	}
 
 	groupPath := d.Get("group_path").(string)
 	domain := getDomainFromResourcePath(groupPath)
@@ -169,6 +178,9 @@ func resourceNsxtPolicyDistributedFloodProtectionProfileBindingDelete(d *schema.
 
 	connector := getPolicyConnector(m)
 	bindingClient := groups.NewFirewallFloodProtectionProfileBindingMapsClient(getSessionContext(d, m), connector)
+	if bindingClient == nil {
+		return policyResourceNotSupportedError()
+	}
 
 	groupPath := d.Get("group_path").(string)
 	domain := getDomainFromResourcePath(groupPath)

--- a/nsxt/resource_nsxt_policy_dns_forwarder_zone.go
+++ b/nsxt/resource_nsxt_policy_dns_forwarder_zone.go
@@ -57,6 +57,9 @@ func resourceNsxtPolicyDNSForwarderZone() *schema.Resource {
 
 func resourceNsxtPolicyDNSForwarderZoneExists(sessionContext utl.SessionContext, id string, connector client.Connector) (bool, error) {
 	client := infra.NewDnsForwarderZonesClient(sessionContext, connector)
+	if client == nil {
+		return false, policyResourceNotSupportedError()
+	}
 	_, err := client.Get(id)
 	if err == nil {
 		return true, nil
@@ -94,6 +97,9 @@ func policyDNSForwarderZonePatch(id string, d *schema.ResourceData, m interface{
 
 	// Create the resource using PATCH
 	client := infra.NewDnsForwarderZonesClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	return client.Patch(id, obj)
 }
 
@@ -128,6 +134,9 @@ func resourceNsxtPolicyDNSForwarderZoneRead(d *schema.ResourceData, m interface{
 	}
 
 	client := infra.NewDnsForwarderZonesClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	obj, err := client.Get(id)
 	if err != nil {
 		return handleReadError(d, "Dns Forwarder Zone", id, err)
@@ -172,6 +181,9 @@ func resourceNsxtPolicyDNSForwarderZoneDelete(d *schema.ResourceData, m interfac
 
 	connector := getPolicyConnector(m)
 	client := infra.NewDnsForwarderZonesClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	err := client.Delete(id)
 
 	if err != nil {

--- a/nsxt/resource_nsxt_policy_firewall_exclude_list_member.go
+++ b/nsxt/resource_nsxt_policy_firewall_exclude_list_member.go
@@ -45,6 +45,9 @@ func memberInList(member string, members []string) int {
 func resourceNsxtPolicyFirewallExcludeListMemberExists(sessionContext utl.SessionContext, id string, connector client.Connector) (bool, error) {
 
 	client := security.NewExcludeListClient(sessionContext, connector)
+	if client == nil {
+		return false, policyResourceNotSupportedError()
+	}
 	obj, err := client.Get()
 	if isNotFoundError(err) {
 		return false, nil
@@ -66,6 +69,9 @@ func resourceNsxtPolicyFirewallExcludeListMemberCreate(d *schema.ResourceData, m
 		var obj model.PolicyExcludeList
 
 		client := security.NewExcludeListClient(getSessionContext(d, m), connector)
+		if client == nil {
+			return policyResourceNotSupportedError()
+		}
 		obj, err := client.Get()
 		if isNotFoundError(err) {
 			obj = model.PolicyExcludeList{
@@ -101,6 +107,9 @@ func resourceNsxtPolicyFirewallExcludeListMemberRead(d *schema.ResourceData, m i
 	member := d.Id()
 
 	client := security.NewExcludeListClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	obj, err := client.Get()
 	if err != nil {
 		return handleReadError(d, "PolicyFirewallExcludeListMember", member, err)
@@ -120,6 +129,9 @@ func resourceNsxtPolicyFirewallExcludeListMemberDelete(d *schema.ResourceData, m
 		var obj model.PolicyExcludeList
 
 		client := security.NewExcludeListClient(getSessionContext(d, m), connector)
+		if client == nil {
+			return policyResourceNotSupportedError()
+		}
 		obj, err := client.Get()
 		if isNotFoundError(err) {
 			return nil

--- a/nsxt/resource_nsxt_policy_gateway_dns_forwarder.go
+++ b/nsxt/resource_nsxt_policy_gateway_dns_forwarder.go
@@ -81,11 +81,19 @@ func resourceNsxtPolicyGatewayDNSForwarder() *schema.Resource {
 }
 
 func policyGatewayDNSForwarderGet(sessionContext utl.SessionContext, connector client.Connector, gwID string, isT0 bool) (model.PolicyDnsForwarder, error) {
+	var emptyFwdr model.PolicyDnsForwarder
 	if isT0 {
 		client := tier0s.NewDnsForwarderClient(sessionContext, connector)
+		if client == nil {
+			return emptyFwdr, policyResourceNotSupportedError()
+		}
+
 		return client.Get(gwID)
 	}
 	client := tier1s.NewDnsForwarderClient(sessionContext, connector)
+	if client == nil {
+		return emptyFwdr, policyResourceNotSupportedError()
+	}
 	return client.Get(gwID)
 }
 
@@ -156,9 +164,15 @@ func patchNsxtPolicyGatewayDNSForwarder(sessionContext utl.SessionContext, conne
 
 	if isT0 {
 		client := tier0s.NewDnsForwarderClient(sessionContext, connector)
+		if client == nil {
+			return policyResourceNotSupportedError()
+		}
 		return client.Patch(gwID, obj)
 	}
 	client := tier1s.NewDnsForwarderClient(sessionContext, connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	return client.Patch(gwID, obj)
 }
 
@@ -181,9 +195,15 @@ func resourceNsxtPolicyGatewayDNSForwarderCreate(d *schema.ResourceData, m inter
 
 	if isT0 {
 		client := tier0s.NewDnsForwarderClient(context, connector)
+		if client == nil {
+			return policyResourceNotSupportedError()
+		}
 		_, err = client.Get(gwID)
 	} else {
 		client := tier1s.NewDnsForwarderClient(context, connector)
+		if client == nil {
+			return policyResourceNotSupportedError()
+		}
 		_, err = client.Get(gwID)
 	}
 	if err == nil {
@@ -242,9 +262,15 @@ func resourceNsxtPolicyGatewayDNSForwarderDelete(d *schema.ResourceData, m inter
 
 	if isT0 {
 		client := tier0s.NewDnsForwarderClient(context, connector)
+		if client == nil {
+			return policyResourceNotSupportedError()
+		}
 		err = client.Delete(gwID)
 	} else {
 		client := tier1s.NewDnsForwarderClient(context, connector)
+		if client == nil {
+			return policyResourceNotSupportedError()
+		}
 		err = client.Delete(gwID)
 	}
 	if err != nil {

--- a/nsxt/resource_nsxt_policy_gateway_flood_protection_profile.go
+++ b/nsxt/resource_nsxt_policy_gateway_flood_protection_profile.go
@@ -84,6 +84,9 @@ func resourceNsxtPolicyGatewayFloodProtectionProfilePatch(d *schema.ResourceData
 
 	log.Printf("[INFO] Patching GatewayFloodProtectionProfile with ID %s", id)
 	client := infra.NewFloodProtectionProfilesClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	return client.Patch(id, profileStruct, nil)
 }
 
@@ -116,6 +119,9 @@ func resourceNsxtPolicyGatewayFloodProtectionProfileRead(d *schema.ResourceData,
 	}
 
 	client := infra.NewFloodProtectionProfilesClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	gpffData, err := client.Get(id)
 	if err != nil {
 		return handleReadError(d, "GatewayFloodProtectionProfile", id, err)

--- a/nsxt/resource_nsxt_policy_gateway_flood_protection_profile_binding.go
+++ b/nsxt/resource_nsxt_policy_gateway_flood_protection_profile_binding.go
@@ -98,9 +98,15 @@ func resourceNsxtPolicyGatewayFloodProtectionProfileBindingPatch(d *schema.Resou
 	if tier0ID != "" {
 		if localeServiceID == "" {
 			bindingClient := tier0s.NewFloodProtectionProfileBindingsClient(getSessionContext(d, m), connector)
+			if bindingClient == nil {
+				return policyResourceNotSupportedError()
+			}
 			err = bindingClient.Patch(tier0ID, id, obj)
 		} else {
 			bindingClient := t0localeservices.NewFloodProtectionProfileBindingsClient(getSessionContext(d, m), connector)
+			if bindingClient == nil {
+				return policyResourceNotSupportedError()
+			}
 			err = bindingClient.Patch(tier0ID, localeServiceID, id, obj)
 		}
 		if err != nil {
@@ -109,9 +115,15 @@ func resourceNsxtPolicyGatewayFloodProtectionProfileBindingPatch(d *schema.Resou
 	} else if tier1ID != "" {
 		if localeServiceID == "" {
 			bindingClient := tier1s.NewFloodProtectionProfileBindingsClient(getSessionContext(d, m), connector)
+			if bindingClient == nil {
+				return policyResourceNotSupportedError()
+			}
 			err = bindingClient.Patch(tier1ID, id, obj)
 		} else {
 			bindingClient := t1localeservices.NewFloodProtectionProfileBindingsClient(getSessionContext(d, m), connector)
+			if bindingClient == nil {
+				return policyResourceNotSupportedError()
+			}
 			err = bindingClient.Patch(tier1ID, localeServiceID, id, obj)
 		}
 	}
@@ -128,17 +140,29 @@ func resourceNsxtPolicyGatewayFloodProtectionProfileBindingGet(sessionContext ut
 	if tier0ID != "" {
 		if localeServiceID == "" {
 			bindingClient := tier0s.NewFloodProtectionProfileBindingsClient(sessionContext, connector)
+			if bindingClient == nil {
+				return binding, policyResourceNotSupportedError()
+			}
 			binding, err = bindingClient.Get(tier0ID, id)
 		} else {
 			bindingClient := t0localeservices.NewFloodProtectionProfileBindingsClient(sessionContext, connector)
+			if bindingClient == nil {
+				return binding, policyResourceNotSupportedError()
+			}
 			binding, err = bindingClient.Get(tier0ID, localeServiceID, id)
 		}
 	} else if tier1ID != "" {
 		if localeServiceID == "" {
 			bindingClient := tier1s.NewFloodProtectionProfileBindingsClient(sessionContext, connector)
+			if bindingClient == nil {
+				return binding, policyResourceNotSupportedError()
+			}
 			binding, err = bindingClient.Get(tier1ID, id)
 		} else {
 			bindingClient := t1localeservices.NewFloodProtectionProfileBindingsClient(sessionContext, connector)
+			if bindingClient == nil {
+				return binding, policyResourceNotSupportedError()
+			}
 			binding, err = bindingClient.Get(tier1ID, localeServiceID, id)
 		}
 	}
@@ -250,9 +274,15 @@ func resourceNsxtPolicyGatewayFloodProtectionProfileBindingDelete(d *schema.Reso
 	if tier0ID != "" {
 		if localeServiceID == "" {
 			bindingClient := tier0s.NewFloodProtectionProfileBindingsClient(getSessionContext(d, m), connector)
+			if bindingClient == nil {
+				return policyResourceNotSupportedError()
+			}
 			err = bindingClient.Delete(tier0ID, id)
 		} else {
 			bindingClient := t0localeservices.NewFloodProtectionProfileBindingsClient(getSessionContext(d, m), connector)
+			if bindingClient == nil {
+				return policyResourceNotSupportedError()
+			}
 			err = bindingClient.Delete(tier0ID, localeServiceID, id)
 		}
 		if err != nil {
@@ -261,9 +291,15 @@ func resourceNsxtPolicyGatewayFloodProtectionProfileBindingDelete(d *schema.Reso
 	} else if tier1ID != "" {
 		if localeServiceID == "" {
 			bindingClient := tier1s.NewFloodProtectionProfileBindingsClient(getSessionContext(d, m), connector)
+			if bindingClient == nil {
+				return policyResourceNotSupportedError()
+			}
 			err = bindingClient.Delete(tier1ID, id)
 		} else {
 			bindingClient := t1localeservices.NewFloodProtectionProfileBindingsClient(getSessionContext(d, m), connector)
+			if bindingClient == nil {
+				return policyResourceNotSupportedError()
+			}
 			err = bindingClient.Delete(tier1ID, localeServiceID, id)
 		}
 	}

--- a/nsxt/resource_nsxt_policy_gateway_policy.go
+++ b/nsxt/resource_nsxt_policy_gateway_policy.go
@@ -32,6 +32,9 @@ func resourceNsxtPolicyGatewayPolicy() *schema.Resource {
 
 func getGatewayPolicyInDomain(sessionContext utl.SessionContext, id string, domainName string, connector client.Connector) (model.GatewayPolicy, error) {
 	client := domains.NewGatewayPoliciesClient(sessionContext, connector)
+	if client == nil {
+		return model.GatewayPolicy{}, policyResourceNotSupportedError()
+	}
 	return client.Get(domainName, id)
 
 }
@@ -245,6 +248,9 @@ func resourceNsxtPolicyGatewayPolicyDelete(d *schema.ResourceData, m interface{}
 
 	connector := getPolicyConnector(m)
 	client := domains.NewGatewayPoliciesClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	err := client.Delete(d.Get("domain").(string), id)
 	if err != nil {
 		return handleDeleteError("Gateway Policy", id, err)

--- a/nsxt/resource_nsxt_policy_gateway_redistribution_config.go
+++ b/nsxt/resource_nsxt_policy_gateway_redistribution_config.go
@@ -87,6 +87,9 @@ func policyGatewayRedistributionConfigPatch(d *schema.ResourceData, m interface{
 
 	doPatch := func() error {
 		client := tier0s.NewLocaleServicesClient(getSessionContext(d, m), connector)
+		if client == nil {
+			return policyResourceNotSupportedError()
+		}
 		return client.Patch(gwID, localeServiceID, serviceStruct)
 	}
 	// since redistribution config is not a separate API endpoint, but sub-clause of Tier0,
@@ -156,6 +159,9 @@ func resourceNsxtPolicyGatewayRedistributionConfigRead(d *schema.ResourceData, m
 	}
 
 	client := tier0s.NewLocaleServicesClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	obj, err := client.Get(gwID, localeServiceID)
 	if err != nil {
 		return handleReadError(d, "Tier0 Redistribution Config", id, err)
@@ -207,6 +213,9 @@ func resourceNsxtPolicyGatewayRedistributionConfigDelete(d *schema.ResourceData,
 	// Update the locale service with empty Redistribution config using get/post
 	doUpdate := func() error {
 		client := tier0s.NewLocaleServicesClient(getSessionContext(d, m), connector)
+		if client == nil {
+			return policyResourceNotSupportedError()
+		}
 		obj, err := client.Get(gwID, localeServiceID)
 		if err != nil {
 			return err
@@ -237,6 +246,9 @@ func resourceNsxtPolicyGatewayRedistributionConfigImport(d *schema.ResourceData,
 	localeServiceID := s[1]
 	connector := getPolicyConnector(m)
 	client := tier0s.NewLocaleServicesClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return nil, policyResourceNotSupportedError()
+	}
 	obj, err := client.Get(gwID, localeServiceID)
 	if err != nil || obj.RouteRedistributionConfig == nil {
 		return nil, fmt.Errorf("Failed to retrieve redistribution config for locale service %s on gateway %s", localeServiceID, gwID)

--- a/nsxt/resource_nsxt_policy_group.go
+++ b/nsxt/resource_nsxt_policy_group.go
@@ -320,6 +320,9 @@ func getExtendedCriteriaSetSchema() *schema.Resource {
 
 func resourceNsxtPolicyGroupExistsInDomain(sessionContext utl.SessionContext, id string, domain string, connector client.Connector) (bool, error) {
 	client := domains.NewGroupsClient(sessionContext, connector)
+	if client == nil {
+		return false, policyResourceNotSupportedError()
+	}
 	_, err := client.Get(domain, id)
 	if err == nil {
 		return true, nil
@@ -880,6 +883,9 @@ func resourceNsxtPolicyGroupCreate(d *schema.ResourceData, m interface{}) error 
 	}
 
 	client := domains.NewGroupsClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	err = client.Patch(d.Get("domain").(string), id, obj)
 
 	// Create the resource using PATCH
@@ -902,6 +908,9 @@ func resourceNsxtPolicyGroupRead(d *schema.ResourceData, m interface{}) error {
 		return fmt.Errorf("Error obtaining Group ID")
 	}
 	client := domains.NewGroupsClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	obj, err := client.Get(domainName, id)
 	if err != nil {
 		return handleReadError(d, "Group", id, err)
@@ -993,6 +1002,9 @@ func resourceNsxtPolicyGroupUpdate(d *schema.ResourceData, m interface{}) error 
 	}
 
 	client := domains.NewGroupsClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 
 	// Update the resource using PATCH
 	err = client.Patch(d.Get("domain").(string), id, obj)
@@ -1015,6 +1027,9 @@ func resourceNsxtPolicyGroupDelete(d *schema.ResourceData, m interface{}) error 
 
 	doDelete := func() error {
 		client := domains.NewGroupsClient(getSessionContext(d, m), connector)
+		if client == nil {
+			return policyResourceNotSupportedError()
+		}
 		return client.Delete(d.Get("domain").(string), id, &failIfSubtreeExists, &forceDelete)
 	}
 

--- a/nsxt/resource_nsxt_policy_group_test.go
+++ b/nsxt/resource_nsxt_policy_group_test.go
@@ -675,6 +675,9 @@ func testAccNsxtPolicyGroupExists(resourceName string, domainName string) resour
 		}
 
 		nsxClient := domains.NewGroupsClient(testAccGetSessionContext(), connector)
+		if nsxClient == nil {
+			return policyResourceNotSupportedError()
+		}
 		_, err := nsxClient.Get(domainName, resourceID)
 		if err != nil {
 			return fmt.Errorf("Error while retrieving policy Group ID %s domain %s. Error: %v", resourceID, domainName, err)

--- a/nsxt/resource_nsxt_policy_intrusion_service_policy.go
+++ b/nsxt/resource_nsxt_policy_intrusion_service_policy.go
@@ -47,6 +47,9 @@ func getIdsProfilesSchema() *schema.Schema {
 
 func resourceNsxtPolicyIntrusionServicePolicyExistsInDomain(sessionContext utl.SessionContext, id string, domainName string, connector client.Connector) (bool, error) {
 	client := domains.NewIntrusionServicePoliciesClient(sessionContext, connector)
+	if client == nil {
+		return false, policyResourceNotSupportedError()
+	}
 	_, err := client.Get(domainName, id)
 
 	if err == nil {
@@ -335,6 +338,9 @@ func resourceNsxtPolicyIntrusionServicePolicyRead(d *schema.ResourceData, m inte
 		return fmt.Errorf("Error obtaining Intrusion Service Policy id")
 	}
 	client := domains.NewIntrusionServicePoliciesClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	obj, err := client.Get(domainName, id)
 	if err != nil {
 		return handleReadError(d, "Intrusion Service Policy", id, err)
@@ -379,6 +385,9 @@ func resourceNsxtPolicyIntrusionServicePolicyDelete(d *schema.ResourceData, m in
 	connector := getPolicyConnector(m)
 
 	client := domains.NewIntrusionServicePoliciesClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	err := client.Delete(d.Get("domain").(string), id)
 
 	if err != nil {

--- a/nsxt/resource_nsxt_policy_intrusion_service_profile.go
+++ b/nsxt/resource_nsxt_policy_intrusion_service_profile.go
@@ -331,6 +331,9 @@ func setIdsProfileSignaturesInSchema(profileList []model.IdsProfileLocalSignatur
 func resourceNsxtPolicyIntrusionServiceProfileExists(sessionContext utl.SessionContext, id string, connector client.Connector) (bool, error) {
 	var err error
 	client := services.NewProfilesClient(sessionContext, connector)
+	if client == nil {
+		return false, policyResourceNotSupportedError()
+	}
 	_, err = client.Get(id)
 	if err == nil {
 		return true, nil
@@ -374,6 +377,9 @@ func resourceNsxtPolicyIntrusionServiceProfileCreate(d *schema.ResourceData, m i
 	// Create the resource using PATCH
 	log.Printf("[INFO] Creating Intrusion Service Profile with ID %s", id)
 	client := services.NewProfilesClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	err = client.Patch(id, obj)
 	if err != nil {
 		return handleCreateError("Ids Profile", id, err)
@@ -394,6 +400,9 @@ func resourceNsxtPolicyIntrusionServiceProfileRead(d *schema.ResourceData, m int
 	}
 
 	client := services.NewProfilesClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	obj, err := client.Get(id)
 	if err != nil {
 		return handleReadError(d, "Ids Profile", id, err)
@@ -450,6 +459,9 @@ func resourceNsxtPolicyIntrusionServiceProfileUpdate(d *schema.ResourceData, m i
 	// Create the resource using PATCH
 	log.Printf("[INFO] Update Intrusion Service Profile with ID %s", id)
 	client := services.NewProfilesClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	err = client.Patch(id, obj)
 	if err != nil {
 		return handleUpdateError("Ids Profile", id, err)
@@ -470,6 +482,9 @@ func resourceNsxtPolicyIntrusionServiceProfileDelete(d *schema.ResourceData, m i
 	connector := getPolicyConnector(m)
 	var err error
 	client := services.NewProfilesClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	err = client.Delete(id)
 
 	if err != nil {

--- a/nsxt/resource_nsxt_policy_ip_address_allocation.go
+++ b/nsxt/resource_nsxt_policy_ip_address_allocation.go
@@ -62,6 +62,9 @@ func resourceNsxtPolicyIPAddressAllocation() *schema.Resource {
 
 func resourceNsxtPolicyIPAddressAllocationExists(sessionContext utl.SessionContext, poolID string, allocationID string, connector client.Connector) (bool, error) {
 	client := ippools.NewIpAllocationsClient(sessionContext, connector)
+	if client == nil {
+		return false, policyResourceNotSupportedError()
+	}
 
 	_, err := client.Get(poolID, allocationID)
 	if err == nil {
@@ -79,6 +82,9 @@ func resourceNsxtPolicyIPAddressAllocationCreate(d *schema.ResourceData, m inter
 	connector := getPolicyConnector(m)
 	sessionContext := getSessionContext(d, m)
 	client := ippools.NewIpAllocationsClient(sessionContext, connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 
 	if client == nil {
 		return policyResourceNotSupportedError()
@@ -131,6 +137,9 @@ func resourceNsxtPolicyIPAddressAllocationCreate(d *schema.ResourceData, m inter
 func resourceNsxtPolicyIPAddressAllocationRead(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
 	client := ippools.NewIpAllocationsClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 
 	if client == nil {
 		return policyResourceNotSupportedError()
@@ -183,6 +192,9 @@ func resourceNsxtPolicyIPAddressAllocationRead(d *schema.ResourceData, m interfa
 func resourceNsxtPolicyIPAddressAllocationUpdate(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
 	client := ippools.NewIpAllocationsClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 
 	if client == nil {
 		return policyResourceNotSupportedError()
@@ -261,6 +273,9 @@ func resourceNsxtPolicyIPAddressAllocationImport(d *schema.ResourceData, m inter
 	poolID := s[0]
 	connector := getPolicyConnector(m)
 	client := infra.NewIpPoolsClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return nil, policyResourceNotSupportedError()
+	}
 
 	pool, err := client.Get(poolID)
 	if err != nil {

--- a/nsxt/resource_nsxt_policy_ip_address_allocation_test.go
+++ b/nsxt/resource_nsxt_policy_ip_address_allocation_test.go
@@ -213,6 +213,9 @@ func testAccNsxtPolicyIPAddressAllocationExists(resourceName string) resource.Te
 
 		connector := getPolicyConnector(testAccProvider.Meta().(nsxtClients))
 		nsxClient := ippools.NewIpAllocationsClient(testAccGetSessionContext(), connector)
+		if nsxClient == nil {
+			return policyResourceNotSupportedError()
+		}
 
 		rs, ok := state.RootModule().Resources[resourceName]
 		if !ok {
@@ -242,6 +245,9 @@ func testAccNsxtPolicyIPAddressAllocationExists(resourceName string) resource.Te
 func testAccNsxtPolicyIPAddressAllocationCheckDestroy(state *terraform.State, displayName string) error {
 	connector := getPolicyConnector(testAccProvider.Meta().(nsxtClients))
 	nsxClient := ippools.NewIpAllocationsClient(testAccGetSessionContext(), connector)
+	if nsxClient == nil {
+		return policyResourceNotSupportedError()
+	}
 	for _, rs := range state.RootModule().Resources {
 
 		if rs.Type != "nsxt_policy_ip_address_allocation" {

--- a/nsxt/resource_nsxt_policy_ip_block.go
+++ b/nsxt/resource_nsxt_policy_ip_block.go
@@ -58,6 +58,9 @@ func resourceNsxtPolicyIPBlock() *schema.Resource {
 
 func resourceNsxtPolicyIPBlockExists(sessionContext utl.SessionContext, id string, connector client.Connector) (bool, error) {
 	client := infra.NewIpBlocksClient(sessionContext, connector)
+	if client == nil {
+		return false, policyResourceNotSupportedError()
+	}
 
 	_, err := client.Get(id, nil)
 	if err == nil {
@@ -74,6 +77,9 @@ func resourceNsxtPolicyIPBlockExists(sessionContext utl.SessionContext, id strin
 func resourceNsxtPolicyIPBlockRead(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
 	client := infra.NewIpBlocksClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 
 	id := d.Id()
 	if id == "" {
@@ -102,6 +108,9 @@ func resourceNsxtPolicyIPBlockRead(d *schema.ResourceData, m interface{}) error 
 func resourceNsxtPolicyIPBlockCreate(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
 	client := infra.NewIpBlocksClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 
 	id, err := getOrGenerateID2(d, m, resourceNsxtPolicyIPBlockExists)
 	if err != nil {
@@ -138,6 +147,9 @@ func resourceNsxtPolicyIPBlockCreate(d *schema.ResourceData, m interface{}) erro
 func resourceNsxtPolicyIPBlockUpdate(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
 	client := infra.NewIpBlocksClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 
 	id := d.Id()
 	if id == "" {
@@ -180,6 +192,9 @@ func resourceNsxtPolicyIPBlockDelete(d *schema.ResourceData, m interface{}) erro
 
 	connector := getPolicyConnector(m)
 	client := infra.NewIpBlocksClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	err := client.Delete(id)
 	if err != nil {
 		return handleDeleteError("IP Block", id, err)

--- a/nsxt/resource_nsxt_policy_ip_block_test.go
+++ b/nsxt/resource_nsxt_policy_ip_block_test.go
@@ -180,6 +180,9 @@ func testAccNSXPolicyIPBlockCheckExists(resourceName string) resource.TestCheckF
 	return func(state *terraform.State) error {
 		connector := getPolicyConnector(testAccProvider.Meta().(nsxtClients))
 		client := infra.NewIpBlocksClient(testAccGetSessionContext(), connector)
+		if client == nil {
+			return policyResourceNotSupportedError()
+		}
 
 		rs, ok := state.RootModule().Resources[resourceName]
 		if !ok {
@@ -212,6 +215,9 @@ func testAccNSXPolicyIPBlockVisibility(resourceName string, withVisibility bool,
 func testAccNSXPolicyIPBlockCheckDestroy(state *terraform.State) error {
 	connector := getPolicyConnector(testAccProvider.Meta().(nsxtClients))
 	client := infra.NewIpBlocksClient(testAccGetSessionContext(), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 
 	for _, rs := range state.RootModule().Resources {
 		if rs.Type != "nsxt_policy_ip_block" {

--- a/nsxt/resource_nsxt_policy_ip_discovery_profile.go
+++ b/nsxt/resource_nsxt_policy_ip_discovery_profile.go
@@ -156,6 +156,9 @@ func ipDiscoveryProfileObjFromSchema(d *schema.ResourceData) model.IPDiscoveryPr
 
 func resourceNsxtPolicyIPDiscoveryProfileExists(sessionContext utl.SessionContext, id string, connector client.Connector) (bool, error) {
 	client := infra.NewIpDiscoveryProfilesClient(sessionContext, connector)
+	if client == nil {
+		return false, policyResourceNotSupportedError()
+	}
 	_, err := client.Get(id)
 	if err == nil {
 		return true, nil
@@ -183,6 +186,9 @@ func resourceNsxtPolicyIPDiscoveryProfileCreate(d *schema.ResourceData, m interf
 	log.Printf("[INFO] Creating IPDiscoveryProfile with ID %s", id)
 	boolFalse := false
 	client := infra.NewIpDiscoveryProfilesClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	err = client.Patch(id, obj, &boolFalse)
 	if err != nil {
 		return handleCreateError("IPDiscoveryProfile", id, err)
@@ -203,6 +209,9 @@ func resourceNsxtPolicyIPDiscoveryProfileRead(d *schema.ResourceData, m interfac
 	}
 
 	client := infra.NewIpDiscoveryProfilesClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	obj, err := client.Get(id)
 	if err != nil {
 		return handleReadError(d, "IPDiscoveryProfile", id, err)
@@ -233,6 +242,9 @@ func resourceNsxtPolicyIPDiscoveryProfileRead(d *schema.ResourceData, m interfac
 func resourceNsxtPolicyIPDiscoveryProfileUpdate(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
 	client := infra.NewIpDiscoveryProfilesClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	if client == nil {
 		return policyResourceNotSupportedError()
 	}
@@ -267,6 +279,9 @@ func resourceNsxtPolicyIPDiscoveryProfileDelete(d *schema.ResourceData, m interf
 	boolFalse := false
 
 	client := infra.NewIpDiscoveryProfilesClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	err = client.Delete(id, &boolFalse)
 
 	if err != nil {

--- a/nsxt/resource_nsxt_policy_ip_pool.go
+++ b/nsxt/resource_nsxt_policy_ip_pool.go
@@ -44,6 +44,9 @@ func resourceNsxtPolicyIPPool() *schema.Resource {
 
 func resourceNsxtPolicyIPPoolExists(sessionContext utl.SessionContext, id string, connector client.Connector) (bool, error) {
 	client := infra.NewIpPoolsClient(sessionContext, connector)
+	if client == nil {
+		return false, policyResourceNotSupportedError()
+	}
 
 	_, err := client.Get(id)
 	if err == nil {
@@ -60,6 +63,9 @@ func resourceNsxtPolicyIPPoolExists(sessionContext utl.SessionContext, id string
 func resourceNsxtPolicyIPPoolRead(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
 	client := infra.NewIpPoolsClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 
 	id := d.Id()
 	if id == "" {
@@ -90,6 +96,9 @@ func resourceNsxtPolicyIPPoolRead(d *schema.ResourceData, m interface{}) error {
 func resourceNsxtPolicyIPPoolCreate(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
 	client := infra.NewIpPoolsClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 
 	id, err := getOrGenerateID2(d, m, resourceNsxtPolicyIPPoolExists)
 	if err != nil {
@@ -121,6 +130,9 @@ func resourceNsxtPolicyIPPoolCreate(d *schema.ResourceData, m interface{}) error
 func resourceNsxtPolicyIPPoolUpdate(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
 	client := infra.NewIpPoolsClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 
 	id := d.Id()
 	if id == "" {
@@ -152,6 +164,9 @@ func resourceNsxtPolicyIPPoolUpdate(d *schema.ResourceData, m interface{}) error
 func resourceNsxtPolicyIPPoolDelete(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
 	client := infra.NewIpPoolsClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 
 	id := d.Id()
 	if id == "" {

--- a/nsxt/resource_nsxt_policy_ip_pool_block_subnet.go
+++ b/nsxt/resource_nsxt_policy_ip_pool_block_subnet.go
@@ -93,6 +93,9 @@ func resourceNsxtPolicyIPPoolBlockSubnetSchemaToStructValue(d *schema.ResourceDa
 func resourceNsxtPolicyIPPoolBlockSubnetRead(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
 	client := ippools.NewIpSubnetsClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	converter := bindings.NewTypeConverter()
 
 	poolPath := d.Get("pool_path").(string)
@@ -136,6 +139,9 @@ func resourceNsxtPolicyIPPoolBlockSubnetRead(d *schema.ResourceData, m interface
 func resourceNsxtPolicyIPPoolBlockSubnetCreate(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
 	client := ippools.NewIpSubnetsClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 
 	poolPath := d.Get("pool_path").(string)
 	poolID := getPolicyIDFromPath(poolPath)
@@ -171,6 +177,9 @@ func resourceNsxtPolicyIPPoolBlockSubnetCreate(d *schema.ResourceData, m interfa
 func resourceNsxtPolicyIPPoolBlockSubnetUpdate(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
 	client := ippools.NewIpSubnetsClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 
 	poolPath := d.Get("pool_path").(string)
 	poolID := getPolicyIDFromPath(poolPath)
@@ -199,6 +208,9 @@ func resourceNsxtPolicyIPPoolBlockSubnetUpdate(d *schema.ResourceData, m interfa
 func resourceNsxtPolicyIPPoolBlockSubnetDelete(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
 	client := ippools.NewIpSubnetsClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 
 	poolPath := d.Get("pool_path").(string)
 	poolID := getPolicyIDFromPath(poolPath)
@@ -221,6 +233,9 @@ func resourceNsxtPolicyIPPoolBlockSubnetDelete(d *schema.ResourceData, m interfa
 func resourceNsxtPolicyIPPoolBlockSubnetVerifyDelete(sessionContext utl.SessionContext, d *schema.ResourceData, connector client.Connector) error {
 
 	client := realizedstate.NewRealizedEntitiesClient(sessionContext, connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 
 	path := d.Get("path").(string)
 	// Wait for realization state to disappear (not_found) - this means
@@ -276,6 +291,9 @@ func resourceNsxtPolicyIPPoolSubnetImport(d *schema.ResourceData, m interface{})
 	poolID := s[0]
 	connector := getPolicyConnector(m)
 	client := infra.NewIpPoolsClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return nil, policyResourceNotSupportedError()
+	}
 
 	pool, err := client.Get(poolID)
 	if err != nil {

--- a/nsxt/resource_nsxt_policy_ip_pool_block_subnet_test.go
+++ b/nsxt/resource_nsxt_policy_ip_pool_block_subnet_test.go
@@ -192,6 +192,9 @@ func testAccNSXPolicyIPPoolBlockSubnetCheckExists(resourceName string) resource.
 	return func(state *terraform.State) error {
 		connector := getPolicyConnector(testAccProvider.Meta().(nsxtClients))
 		client := ippools.NewIpSubnetsClient(testAccGetSessionContext(), connector)
+		if client == nil {
+			return policyResourceNotSupportedError()
+		}
 
 		rs, ok := state.RootModule().Resources[resourceName]
 		if !ok {
@@ -216,6 +219,9 @@ func testAccNSXPolicyIPPoolBlockSubnetCheckExists(resourceName string) resource.
 func testAccNSXPolicyIPPoolBlockSubnetCheckDestroy(state *terraform.State) error {
 	connector := getPolicyConnector(testAccProvider.Meta().(nsxtClients))
 	client := ippools.NewIpSubnetsClient(testAccGetSessionContext(), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 
 	for _, rs := range state.RootModule().Resources {
 		if rs.Type != "nsxt_policy_ip_pool_block_subnet" {

--- a/nsxt/resource_nsxt_policy_ip_pool_static_subnet.go
+++ b/nsxt/resource_nsxt_policy_ip_pool_static_subnet.go
@@ -121,6 +121,9 @@ func resourceNsxtPolicyIPPoolStaticSubnetSchemaToStructValue(d *schema.ResourceD
 func resourceNsxtPolicyIPPoolStaticSubnetRead(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
 	client := ippools.NewIpSubnetsClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	converter := bindings.NewTypeConverter()
 
 	poolPath := d.Get("pool_path").(string)
@@ -174,6 +177,9 @@ func resourceNsxtPolicyIPPoolStaticSubnetRead(d *schema.ResourceData, m interfac
 func resourceNsxtPolicyIPPoolStaticSubnetCreate(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
 	client := ippools.NewIpSubnetsClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 
 	poolPath := d.Get("pool_path").(string)
 	poolID := getPolicyIDFromPath(poolPath)
@@ -209,6 +215,9 @@ func resourceNsxtPolicyIPPoolStaticSubnetCreate(d *schema.ResourceData, m interf
 func resourceNsxtPolicyIPPoolStaticSubnetUpdate(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
 	client := ippools.NewIpSubnetsClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 
 	poolPath := d.Get("pool_path").(string)
 	poolID := getPolicyIDFromPath(poolPath)
@@ -237,6 +246,9 @@ func resourceNsxtPolicyIPPoolStaticSubnetUpdate(d *schema.ResourceData, m interf
 func resourceNsxtPolicyIPPoolStaticSubnetDelete(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
 	client := ippools.NewIpSubnetsClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 
 	poolPath := d.Get("pool_path").(string)
 	poolID := getPolicyIDFromPath(poolPath)

--- a/nsxt/resource_nsxt_policy_ip_pool_static_subnet_test.go
+++ b/nsxt/resource_nsxt_policy_ip_pool_static_subnet_test.go
@@ -195,6 +195,9 @@ func testAccNSXPolicyIPPoolStaticSubnetCheckExists(resourceName string) resource
 	return func(state *terraform.State) error {
 		connector := getPolicyConnector(testAccProvider.Meta().(nsxtClients))
 		client := ippools.NewIpSubnetsClient(testAccGetSessionContext(), connector)
+		if client == nil {
+			return policyResourceNotSupportedError()
+		}
 
 		rs, ok := state.RootModule().Resources[resourceName]
 		if !ok {
@@ -219,6 +222,9 @@ func testAccNSXPolicyIPPoolStaticSubnetCheckExists(resourceName string) resource
 func testAccNSXPolicyIPPoolStaticSubnetCheckDestroy(state *terraform.State) error {
 	connector := getPolicyConnector(testAccProvider.Meta().(nsxtClients))
 	client := ippools.NewIpSubnetsClient(testAccGetSessionContext(), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 
 	for _, rs := range state.RootModule().Resources {
 		if rs.Type != "nsxt_policy_ip_pool_static_subnet" {

--- a/nsxt/resource_nsxt_policy_ip_pool_test.go
+++ b/nsxt/resource_nsxt_policy_ip_pool_test.go
@@ -138,6 +138,9 @@ func testAccNSXPolicyIPPoolCheckExists(resourceName string) resource.TestCheckFu
 	return func(state *terraform.State) error {
 		connector := getPolicyConnector(testAccProvider.Meta().(nsxtClients))
 		client := infra.NewIpPoolsClient(testAccGetSessionContext(), connector)
+		if client == nil {
+			return policyResourceNotSupportedError()
+		}
 
 		rs, ok := state.RootModule().Resources[resourceName]
 		if !ok {
@@ -161,6 +164,9 @@ func testAccNSXPolicyIPPoolCheckExists(resourceName string) resource.TestCheckFu
 func testAccNSXPolicyIPPoolCheckDestroy(state *terraform.State) error {
 	connector := getPolicyConnector(testAccProvider.Meta().(nsxtClients))
 	client := infra.NewIpPoolsClient(testAccGetSessionContext(), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 
 	for _, rs := range state.RootModule().Resources {
 		if rs.Type != "nsxt_policy_ip_pool" {

--- a/nsxt/resource_nsxt_policy_mac_discovery_profile.go
+++ b/nsxt/resource_nsxt_policy_mac_discovery_profile.go
@@ -141,6 +141,9 @@ func resourceNsxtPolicyMacDiscoveryProfile() *schema.Resource {
 func resourceNsxtPolicyMacDiscoveryProfileExists(sessionContext utl.SessionContext, id string, connector client.Connector) (bool, error) {
 	var err error
 	client := infra.NewMacDiscoveryProfilesClient(sessionContext, connector)
+	if client == nil {
+		return false, policyResourceNotSupportedError()
+	}
 	_, err = client.Get(id)
 	if err == nil {
 		return true, nil
@@ -182,6 +185,9 @@ func resourceNsxtPolicyMacDiscoveryProfileCreate(d *schema.ResourceData, m inter
 	log.Printf("[INFO] Creating MacDiscoveryProfile with ID %s", id)
 	boolFalse := false
 	client := infra.NewMacDiscoveryProfilesClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	err = client.Patch(id, obj, &boolFalse)
 	if err != nil {
 		return handleCreateError("MacDiscoveryProfile", id, err)
@@ -202,6 +208,9 @@ func resourceNsxtPolicyMacDiscoveryProfileRead(d *schema.ResourceData, m interfa
 	}
 
 	client := infra.NewMacDiscoveryProfilesClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	obj, err := client.Get(id)
 	if err != nil {
 		return handleReadError(d, "MacDiscoveryProfile", id, err)
@@ -248,6 +257,9 @@ func resourceNsxtPolicyMacDiscoveryProfileUpdate(d *schema.ResourceData, m inter
 	// Update the resource using PATCH
 	boolFalse := false
 	client := infra.NewMacDiscoveryProfilesClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	_, err := client.Update(id, obj, &boolFalse)
 	if err != nil {
 		return handleUpdateError("MacDiscoveryProfile", id, err)
@@ -265,6 +277,9 @@ func resourceNsxtPolicyMacDiscoveryProfileDelete(d *schema.ResourceData, m inter
 	connector := getPolicyConnector(m)
 	boolFalse := false
 	client := infra.NewMacDiscoveryProfilesClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	err := client.Delete(id, &boolFalse)
 
 	if err != nil {

--- a/nsxt/resource_nsxt_policy_nat_rule.go
+++ b/nsxt/resource_nsxt_policy_nat_rule.go
@@ -151,9 +151,15 @@ func resourceNsxtPolicyNATRule() *schema.Resource {
 func deleteNsxtPolicyNATRule(sessionContext utl.SessionContext, connector client.Connector, gwID string, isT0 bool, natType string, ruleID string) error {
 	if isT0 {
 		client := t0nat.NewNatRulesClient(sessionContext, connector)
+		if client == nil {
+			return policyResourceNotSupportedError()
+		}
 		return client.Delete(gwID, natType, ruleID)
 	}
 	client := t1nat.NewNatRulesClient(sessionContext, connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	return client.Delete(gwID, natType, ruleID)
 }
 
@@ -186,9 +192,15 @@ func resourceNsxtPolicyNATRuleDelete(d *schema.ResourceData, m interface{}) erro
 func getNsxtPolicyNATRuleByID(sessionContext utl.SessionContext, connector client.Connector, gwID string, isT0 bool, natType string, ruleID string) (model.PolicyNatRule, error) {
 	if isT0 {
 		client := t0nat.NewNatRulesClient(sessionContext, connector)
+		if client == nil {
+			return model.PolicyNatRule{}, policyResourceNotSupportedError()
+		}
 		return client.Get(gwID, natType, ruleID)
 	}
 	client := t1nat.NewNatRulesClient(sessionContext, connector)
+	if client == nil {
+		return model.PolicyNatRule{}, policyResourceNotSupportedError()
+	}
 	return client.Get(gwID, natType, ruleID)
 }
 
@@ -207,9 +219,15 @@ func patchNsxtPolicyNATRule(sessionContext utl.SessionContext, connector client.
 
 	if isT0 {
 		client := t0nat.NewNatRulesClient(sessionContext, connector)
+		if client == nil {
+			return policyResourceNotSupportedError()
+		}
 		return client.Patch(gwID, natType, *rule.Id, rule)
 	}
 	client := t1nat.NewNatRulesClient(sessionContext, connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	return client.Patch(gwID, natType, *rule.Id, rule)
 }
 
@@ -497,12 +515,18 @@ func resourceNsxtPolicyNATRuleImport(d *schema.ResourceData, m interface{}) ([]*
 	gwID := s[0]
 	connector := getPolicyConnector(m)
 	t0Client := infra.NewTier0sClient(getSessionContext(d, m), connector)
+	if t0Client == nil {
+		return nil, policyResourceNotSupportedError()
+	}
 	t0gw, err := t0Client.Get(gwID)
 	if err != nil {
 		if !isNotFoundError(err) {
 			return nil, err
 		}
 		t1Client := infra.NewTier1sClient(getSessionContext(d, m), connector)
+		if t1Client == nil {
+			return nil, policyResourceNotSupportedError()
+		}
 		t1gw, err := t1Client.Get(gwID)
 		if err != nil {
 			return nil, err

--- a/nsxt/resource_nsxt_policy_parent_security_policy.go
+++ b/nsxt/resource_nsxt_policy_parent_security_policy.go
@@ -63,6 +63,9 @@ func parentSecurityPolicyModelToSchema(d *schema.ResourceData, m interface{}) (*
 		return nil, fmt.Errorf("Error obtaining Security Policy id")
 	}
 	client := domains.NewSecurityPoliciesClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return nil, policyResourceNotSupportedError()
+	}
 	obj, err := client.Get(domainName, id)
 	if err != nil {
 		return nil, err

--- a/nsxt/resource_nsxt_policy_predefined_gateway_policy.go
+++ b/nsxt/resource_nsxt_policy_predefined_gateway_policy.go
@@ -414,6 +414,9 @@ func resourceNsxtPolicyPredefinedGatewayPolicyRead(d *schema.ResourceData, m int
 	domain := getDomainFromResourcePath(path)
 
 	client := domains.NewGatewayPoliciesClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	obj, err := client.Get(domain, id)
 	if err != nil {
 		return handleReadError(d, "Predefined Gateway Policy", id, err)

--- a/nsxt/resource_nsxt_policy_predefined_security_policy.go
+++ b/nsxt/resource_nsxt_policy_predefined_security_policy.go
@@ -336,6 +336,9 @@ func resourceNsxtPolicyPredefinedSecurityPolicyRead(d *schema.ResourceData, m in
 	domain := getDomainFromResourcePath(path)
 
 	client := domains.NewSecurityPoliciesClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	obj, err := client.Get(domain, id)
 	if err != nil {
 		return handleReadError(d, "Predefined Security Policy", id, err)

--- a/nsxt/resource_nsxt_policy_qos_profile.go
+++ b/nsxt/resource_nsxt_policy_qos_profile.go
@@ -66,6 +66,9 @@ func resourceNsxtPolicyQosProfile() *schema.Resource {
 
 func resourceNsxtPolicyQosProfileExists(sessionContext utl.SessionContext, id string, connector client.Connector) (bool, error) {
 	client := infra.NewQosProfilesClient(sessionContext, connector)
+	if client == nil {
+		return false, policyResourceNotSupportedError()
+	}
 	_, err := client.Get(id)
 	if err == nil {
 		return true, nil
@@ -175,6 +178,9 @@ func resourceNsxtPolicyQosProfileCreate(d *schema.ResourceData, m interface{}) e
 	log.Printf("[INFO] Creating QosProfile with ID %s", id)
 	boolFalse := false
 	client := infra.NewQosProfilesClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	err = client.Patch(id, obj, &boolFalse)
 	if err != nil {
 		return handleCreateError("QosProfile", id, err)
@@ -195,6 +201,9 @@ func resourceNsxtPolicyQosProfileRead(d *schema.ResourceData, m interface{}) err
 	}
 
 	client := infra.NewQosProfilesClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	obj, err := client.Get(id)
 	if err != nil {
 		return handleReadError(d, "QosProfile", id, err)
@@ -285,6 +294,9 @@ func resourceNsxtPolicyQosProfileDelete(d *schema.ResourceData, m interface{}) e
 	connector := getPolicyConnector(m)
 	boolFalse := false
 	client := infra.NewQosProfilesClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	err := client.Delete(id, &boolFalse)
 
 	if err != nil {

--- a/nsxt/resource_nsxt_policy_security_policy.go
+++ b/nsxt/resource_nsxt_policy_security_policy.go
@@ -30,12 +30,18 @@ func resourceNsxtPolicySecurityPolicy() *schema.Resource {
 
 func getSecurityPolicyInDomain(sessionContext utl.SessionContext, id string, domainName string, connector client.Connector) (model.SecurityPolicy, error) {
 	client := domains.NewSecurityPoliciesClient(sessionContext, connector)
+	if client == nil {
+		return model.SecurityPolicy{}, policyResourceNotSupportedError()
+	}
 	return client.Get(domainName, id)
 
 }
 
 func resourceNsxtPolicySecurityPolicyExistsInDomain(sessionContext utl.SessionContext, id string, domainName string, connector client.Connector) (bool, error) {
 	client := domains.NewSecurityPoliciesClient(sessionContext, connector)
+	if client == nil {
+		return false, policyResourceNotSupportedError()
+	}
 	_, err := client.Get(domainName, id)
 
 	if err == nil {
@@ -106,6 +112,9 @@ func resourceNsxtPolicySecurityPolicyDelete(d *schema.ResourceData, m interface{
 	connector := getPolicyConnector(m)
 
 	client := domains.NewSecurityPoliciesClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	err := client.Delete(d.Get("domain").(string), id)
 
 	if err != nil {

--- a/nsxt/resource_nsxt_policy_security_policy_rule.go
+++ b/nsxt/resource_nsxt_policy_security_policy_rule.go
@@ -49,6 +49,9 @@ func resourceNsxtPolicySecurityPolicyRuleCreate(d *schema.ResourceData, m interf
 
 	log.Printf("[INFO] Creating Security Policy Rule with ID %s under policy %s", id, policyPath)
 	client := securitypolicies.NewRulesClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	rule := securityPolicyRuleSchemaToModel(d, id)
 	err = client.Patch(domain, policyID, id, rule)
 	if err != nil {
@@ -129,6 +132,9 @@ func resourceNsxtPolicySecurityPolicyRuleExistsPartial(policyPath string) func(s
 
 func resourceNsxtPolicySecurityPolicyRuleExists(sessionContext utl.SessionContext, id string, policyPath string, connector client.Connector) (bool, error) {
 	client := securitypolicies.NewRulesClient(sessionContext, connector)
+	if client == nil {
+		return false, policyResourceNotSupportedError()
+	}
 
 	domain := getDomainFromResourcePath(policyPath)
 	policyID := getPolicyIDFromPath(policyPath)
@@ -162,6 +168,9 @@ func resourceNsxtPolicySecurityPolicyRuleRead(d *schema.ResourceData, m interfac
 	}
 
 	client := securitypolicies.NewRulesClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	rule, err := client.Get(domain, policyID, id)
 	if err != nil {
 		return handleReadError(d, "SecurityPolicyRule", fmt.Sprintf("%s/%s", policyPath, id), err)
@@ -215,6 +224,9 @@ func resourceNsxtPolicySecurityPolicyRuleUpdate(d *schema.ResourceData, m interf
 	policyID := getPolicyIDFromPath(policyPath)
 
 	client := securitypolicies.NewRulesClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	rule := securityPolicyRuleSchemaToModel(d, id)
 	err := client.Patch(domain, policyID, id, rule)
 	if err != nil {
@@ -238,6 +250,9 @@ func resourceNsxtPolicySecurityPolicyRuleDelete(d *schema.ResourceData, m interf
 	policyID := getPolicyIDFromPath(policyPath)
 
 	client := securitypolicies.NewRulesClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	return client.Delete(domain, policyID, id)
 }
 

--- a/nsxt/resource_nsxt_policy_segment_security_profile.go
+++ b/nsxt/resource_nsxt_policy_segment_security_profile.go
@@ -253,6 +253,9 @@ func resourceNsxtPolicySegmentSecurityProfile() *schema.Resource {
 
 func resourceNsxtPolicySegmentSecurityProfileExists(context utl.SessionContext, id string, connector client.Connector) (bool, error) {
 	client := infra.NewSegmentSecurityProfilesClient(context, connector)
+	if client == nil {
+		return false, policyResourceNotSupportedError()
+	}
 	_, err := client.Get(id)
 	if err == nil {
 		return true, nil
@@ -288,6 +291,9 @@ func resourceNsxtPolicySegmentSecurityProfilePatch(d *schema.ResourceData, m int
 
 	log.Printf("[INFO] Sending SegmentSecurityProfile with ID %s", id)
 	client := infra.NewSegmentSecurityProfilesClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	return client.Patch(id, obj, nil)
 }
 
@@ -319,6 +325,9 @@ func resourceNsxtPolicySegmentSecurityProfileRead(d *schema.ResourceData, m inte
 	}
 
 	client := infra.NewSegmentSecurityProfilesClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	obj, err := client.Get(id)
 	if err != nil {
 		return handleReadError(d, "SegmentSecurityProfile", id, err)
@@ -362,6 +371,9 @@ func resourceNsxtPolicySegmentSecurityProfileDelete(d *schema.ResourceData, m in
 
 	connector := getPolicyConnector(m)
 	client := infra.NewSegmentSecurityProfilesClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	err := client.Delete(id, nil)
 
 	if err != nil {

--- a/nsxt/resource_nsxt_policy_service.go
+++ b/nsxt/resource_nsxt_policy_service.go
@@ -423,6 +423,9 @@ func resourceNsxtPolicyServiceGetEntriesFromSchema(d *schema.ResourceData) ([]*d
 
 func resourceNsxtPolicyServiceExists(sessionContext utl.SessionContext, id string, connector client.Connector) (bool, error) {
 	client := infra.NewServicesClient(sessionContext, connector)
+	if client == nil {
+		return false, policyResourceNotSupportedError()
+	}
 	_, err := client.Get(id)
 
 	if err == nil {
@@ -471,6 +474,9 @@ func resourceNsxtPolicyServiceCreate(d *schema.ResourceData, m interface{}) erro
 	log.Printf("[INFO] Creating service with ID %s", id)
 
 	client := infra.NewServicesClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	err = client.Patch(id, obj)
 	if err != nil {
 		return handleCreateError("Service", id, err)
@@ -490,6 +496,9 @@ func resourceNsxtPolicyServiceRead(d *schema.ResourceData, m interface{}) error 
 	}
 
 	client := infra.NewServicesClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	obj, err := client.Get(id)
 	if err != nil {
 		return handleReadError(d, "Service", id, err)
@@ -681,6 +690,9 @@ func resourceNsxtPolicyServiceUpdate(d *schema.ResourceData, m interface{}) erro
 
 	// Update the resource using Update to totally replace the list of entries
 	client := infra.NewServicesClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	_, err := client.Update(id, obj)
 
 	if err != nil {
@@ -699,6 +711,9 @@ func resourceNsxtPolicyServiceDelete(d *schema.ResourceData, m interface{}) erro
 
 	doDelete := func() error {
 		client := infra.NewServicesClient(getSessionContext(d, m), connector)
+		if client == nil {
+			return policyResourceNotSupportedError()
+		}
 		return client.Delete(id)
 	}
 

--- a/nsxt/resource_nsxt_policy_service_test.go
+++ b/nsxt/resource_nsxt_policy_service_test.go
@@ -774,6 +774,9 @@ func testAccNsxtPolicyServiceExists(resourceName string) resource.TestCheckFunc 
 		}
 
 		nsxClient := infra.NewServicesClient(testAccGetSessionContext(), connector)
+		if nsxClient == nil {
+			return policyResourceNotSupportedError()
+		}
 		_, err := nsxClient.Get(resourceID)
 		if err != nil {
 			return fmt.Errorf("Error while retrieving policy service ID %s. Error: %v", resourceID, err)
@@ -793,6 +796,9 @@ func testAccNsxtPolicyServiceCheckDestroy(state *terraform.State, displayName st
 
 		resourceID := rs.Primary.Attributes["id"]
 		nsxClient := infra.NewServicesClient(testAccGetSessionContext(), connector)
+		if nsxClient == nil {
+			return policyResourceNotSupportedError()
+		}
 		_, err := nsxClient.Get(resourceID)
 		if err == nil {
 			return fmt.Errorf("Policy service %s still exists", displayName)

--- a/nsxt/resource_nsxt_policy_spoof_guard_profile.go
+++ b/nsxt/resource_nsxt_policy_spoof_guard_profile.go
@@ -43,6 +43,9 @@ func resourceNsxtPolicySpoofGuardProfile() *schema.Resource {
 
 func resourceNsxtPolicySpoofGuardProfileExists(context utl.SessionContext, id string, connector client.Connector) (bool, error) {
 	client := infra.NewSpoofguardProfilesClient(context, connector)
+	if client == nil {
+		return false, policyResourceNotSupportedError()
+	}
 	_, err := client.Get(id)
 	if err == nil {
 		return true, nil
@@ -72,6 +75,9 @@ func resourceNsxtPolicySpoofGuardProfilePatch(d *schema.ResourceData, m interfac
 
 	log.Printf("[INFO] Patching SpoofGuardProfile with ID %s", id)
 	client := infra.NewSpoofguardProfilesClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	return client.Patch(id, obj, nil)
 }
 
@@ -103,6 +109,9 @@ func resourceNsxtPolicySpoofGuardProfileRead(d *schema.ResourceData, m interface
 	}
 
 	client := infra.NewSpoofguardProfilesClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	obj, err := client.Get(id)
 	if err != nil {
 		return handleReadError(d, "SpoofGuardProfile", id, err)
@@ -143,6 +152,9 @@ func resourceNsxtPolicySpoofGuardProfileDelete(d *schema.ResourceData, m interfa
 
 	connector := getPolicyConnector(m)
 	client := infra.NewSpoofguardProfilesClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	err := client.Delete(id, nil)
 
 	if err != nil {

--- a/nsxt/resource_nsxt_policy_static_route.go
+++ b/nsxt/resource_nsxt_policy_static_route.go
@@ -82,27 +82,45 @@ func resourceNsxtPolicyStaticRoute() *schema.Resource {
 func patchNsxtPolicyStaticRoute(sessionContext utl.SessionContext, connector client.Connector, gwID string, route model.StaticRoutes, isT0 bool) error {
 	if isT0 {
 		routeClient := tier0s.NewStaticRoutesClient(sessionContext, connector)
+		if routeClient == nil {
+			return policyResourceNotSupportedError()
+		}
 		return routeClient.Patch(gwID, *route.Id, route)
 	}
 	routeClient := tier1s.NewStaticRoutesClient(sessionContext, connector)
+	if routeClient == nil {
+		return policyResourceNotSupportedError()
+	}
 	return routeClient.Patch(gwID, *route.Id, route)
 }
 
 func deleteNsxtPolicyStaticRoute(sessionContext utl.SessionContext, connector client.Connector, gwID string, isT0 bool, routeID string) error {
 	if isT0 {
 		routeClient := tier0s.NewStaticRoutesClient(sessionContext, connector)
+		if routeClient == nil {
+			return policyResourceNotSupportedError()
+		}
 		return routeClient.Delete(gwID, routeID)
 	}
 	routeClient := tier1s.NewStaticRoutesClient(sessionContext, connector)
+	if routeClient == nil {
+		return policyResourceNotSupportedError()
+	}
 	return routeClient.Delete(gwID, routeID)
 }
 
 func getNsxtPolicyStaticRouteByID(sessionContext utl.SessionContext, connector client.Connector, gwID string, isT0 bool, routeID string) (model.StaticRoutes, error) {
 	if isT0 {
 		routeClient := tier0s.NewStaticRoutesClient(sessionContext, connector)
+		if routeClient == nil {
+			return model.StaticRoutes{}, policyResourceNotSupportedError()
+		}
 		return routeClient.Get(gwID, routeID)
 	}
 	routeClient := tier1s.NewStaticRoutesClient(sessionContext, connector)
+	if routeClient == nil {
+		return model.StaticRoutes{}, policyResourceNotSupportedError()
+	}
 	return routeClient.Get(gwID, routeID)
 }
 
@@ -353,12 +371,18 @@ func resourceNsxtPolicyStaticRouteImport(d *schema.ResourceData, m interface{}) 
 	gwID := s[0]
 	connector := getPolicyConnector(m)
 	t0Client := infra.NewTier0sClient(getSessionContext(d, m), connector)
+	if t0Client == nil {
+		return nil, policyResourceNotSupportedError()
+	}
 	t0gw, err := t0Client.Get(gwID)
 	if err != nil {
 		if !isNotFoundError(err) {
 			return nil, err
 		}
 		t1Client := infra.NewTier1sClient(getSessionContext(d, m), connector)
+		if t1Client == nil {
+			return nil, policyResourceNotSupportedError()
+		}
 		t1gw, err := t1Client.Get(gwID)
 		if err != nil {
 			return nil, err

--- a/nsxt/resource_nsxt_policy_tier1_gateway.go
+++ b/nsxt/resource_nsxt_policy_tier1_gateway.go
@@ -200,6 +200,9 @@ func getAdvRulesSchema() *schema.Schema {
 
 func listTier1GatewayLocaleServices(context utl.SessionContext, connector client.Connector, gwID string, cursor *string) (model.LocaleServicesListResult, error) {
 	client := tier1s.NewLocaleServicesClient(context, connector)
+	if client == nil {
+		return model.LocaleServicesListResult{}, policyResourceNotSupportedError()
+	}
 	markForDelete := false
 	return client.List(gwID, cursor, &markForDelete, nil, nil, nil, nil)
 }
@@ -212,6 +215,9 @@ func listPolicyTier1GatewayLocaleServices(context utl.SessionContext, connector 
 func getPolicyTier1GatewayLocaleServiceEntry(context utl.SessionContext, gwID string, connector client.Connector) (*model.LocaleServices, error) {
 	// Get the locale services of this Tier1 for the edge-cluster id
 	client := tier1s.NewLocaleServicesClient(context, connector)
+	if client == nil {
+		return nil, policyResourceNotSupportedError()
+	}
 	obj, err := client.Get(gwID, defaultPolicyLocaleServiceID)
 	if err == nil {
 		return &obj, nil
@@ -256,6 +262,9 @@ func resourceNsxtPolicyTier1GatewayReadEdgeCluster(context utl.SessionContext, d
 
 func resourceNsxtPolicyTier1GatewayExists(context utl.SessionContext, id string, connector client.Connector) (bool, error) {
 	client := infra.NewTier1sClient(context, connector)
+	if client == nil {
+		return false, policyResourceNotSupportedError()
+	}
 	_, err := client.Get(id)
 
 	if err == nil {
@@ -531,6 +540,9 @@ func resourceNsxtPolicyTier1GatewayRead(d *schema.ResourceData, m interface{}) e
 
 	context := getSessionContext(d, m)
 	client := infra.NewTier1sClient(context, connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	obj, err := client.Get(id)
 
 	if err != nil {

--- a/nsxt/resource_nsxt_policy_tier1_gateway_interface.go
+++ b/nsxt/resource_nsxt_policy_tier1_gateway_interface.go
@@ -121,6 +121,9 @@ func resourceNsxtPolicyTier1GatewayInterfaceCreate(d *schema.ResourceData, m int
 	} else {
 		var err error
 		client := localeservices.NewInterfacesClient(getSessionContext(d, m), connector)
+		if client == nil {
+			return policyResourceNotSupportedError()
+		}
 		_, err = client.Get(tier1ID, localeServiceID, id)
 
 		if err == nil {
@@ -162,6 +165,9 @@ func resourceNsxtPolicyTier1GatewayInterfaceCreate(d *schema.ResourceData, m int
 	// Create the resource using PATCH
 	log.Printf("[INFO] Creating tier1 interface with ID %s", id)
 	client := localeservices.NewInterfacesClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	err := client.Patch(tier1ID, localeServiceID, id, obj)
 
 	if err != nil {
@@ -207,6 +213,9 @@ func resourceNsxtPolicyTier1GatewayInterfaceRead(d *schema.ResourceData, m inter
 	} else {
 		var err error
 		client := localeservices.NewInterfacesClient(getSessionContext(d, m), connector)
+		if client == nil {
+			return policyResourceNotSupportedError()
+		}
 		obj, err = client.Get(tier1ID, localeServiceID, id)
 		if err != nil {
 			return handleReadError(d, "Tier1 Interface", id, err)
@@ -286,6 +295,9 @@ func resourceNsxtPolicyTier1GatewayInterfaceUpdate(d *schema.ResourceData, m int
 	}
 	var err error
 	client := localeservices.NewInterfacesClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	_, err = client.Update(tier1ID, localeServiceID, id, obj)
 	if err != nil {
 		return handleUpdateError("Tier1 Interface", id, err)
@@ -307,6 +319,9 @@ func resourceNsxtPolicyTier1GatewayInterfaceDelete(d *schema.ResourceData, m int
 
 	var err error
 	client := localeservices.NewInterfacesClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	err = client.Delete(tier1ID, localeServiceID, id)
 	if err != nil {
 		return handleDeleteError("Tier1 Interface", id, err)
@@ -343,6 +358,9 @@ func resourceNsxtPolicyTier1GatewayInterfaceImport(d *schema.ResourceData, m int
 	connector := getPolicyConnector(m)
 	var tier1GW model.Tier1
 	client := infra.NewTier1sClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return nil, policyResourceNotSupportedError()
+	}
 	tier1GW, err = client.Get(gwID)
 	if err != nil {
 		return nil, err

--- a/nsxt/resource_nsxt_policy_tier1_gateway_interface_test.go
+++ b/nsxt/resource_nsxt_policy_tier1_gateway_interface_test.go
@@ -381,6 +381,9 @@ func testAccNsxtPolicyTier1InterfaceExists(resourceName string) resource.TestChe
 		}
 
 		nsxClient := localeservices.NewInterfacesClient(testAccGetSessionContext(), connector)
+		if nsxClient == nil {
+			return policyResourceNotSupportedError()
+		}
 		_, err := nsxClient.Get(gwID, localeServiceID, resourceID)
 
 		if err != nil {
@@ -394,6 +397,9 @@ func testAccNsxtPolicyTier1InterfaceExists(resourceName string) resource.TestChe
 func testAccNsxtPolicyTier1InterfaceCheckDestroy(state *terraform.State, displayName string) error {
 	connector := getPolicyConnector(testAccProvider.Meta().(nsxtClients))
 	client := localeservices.NewInterfacesClient(testAccGetSessionContext(), connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 	for _, rs := range state.RootModule().Resources {
 
 		if rs.Type != "nsxt_policy_tier1_gateway_interface" {

--- a/nsxt/resource_nsxt_policy_vm_tags.go
+++ b/nsxt/resource_nsxt_policy_vm_tags.go
@@ -64,6 +64,9 @@ func resourceNsxtPolicyVMTags() *schema.Resource {
 
 func listAllPolicyVirtualMachines(context utl.SessionContext, connector client.Connector, m interface{}) ([]model.VirtualMachine, error) {
 	client := realizedstate.NewVirtualMachinesClient(context, connector)
+	if client == nil {
+		return nil, policyResourceNotSupportedError()
+	}
 	var results []model.VirtualMachine
 	boolFalse := false
 	var cursor *string
@@ -116,10 +119,16 @@ func listAllPolicySegmentPorts(context utl.SessionContext, connector client.Conn
 	for {
 		if len(gwID) == 0 {
 			client := segments.NewPortsClient(context, connector)
+			if client == nil {
+				return nil, policyResourceNotSupportedError()
+			}
 			ports, err = client.List(segmentID, cursor, &boolFalse, nil, nil, &boolFalse, nil)
 		} else {
 			// fixed segments
 			client := t1_segments.NewPortsClient(context, connector)
+			if client == nil {
+				return nil, policyResourceNotSupportedError()
+			}
 			ports, err = client.List(gwID, segmentID, cursor, &boolFalse, nil, nil, &boolFalse, nil)
 
 		}
@@ -310,10 +319,16 @@ func updateNsxtPolicyVMPortTags(context utl.SessionContext, connector client.Con
 					log.Printf("[DEBUG] Updating port %s with %d tags", *port.Path, len(tags))
 					if len(gwID) == 0 {
 						client := segments.NewPortsClient(context, connector)
+						if client == nil {
+							return policyResourceNotSupportedError()
+						}
 						_, err = client.Update(segmentID, *port.Id, port)
 					} else {
 						// fixed segment
 						client := t1_segments.NewPortsClient(context, connector)
+						if client == nil {
+							return policyResourceNotSupportedError()
+						}
 						_, err = client.Update(gwID, segmentID, *port.Id, port)
 					}
 					if err != nil {

--- a/nsxt/segment_common.go
+++ b/nsxt/segment_common.go
@@ -1172,6 +1172,9 @@ func nsxtPolicySegmentDiscoveryProfileRead(d *schema.ResourceData, m interface{}
 		results = lmResults.(model.SegmentDiscoveryProfileBindingMapListResult)
 	} else {
 		client := segments.NewSegmentDiscoveryProfileBindingMapsClient(getSessionContext(d, m), connector)
+		if client == nil {
+			return policyResourceNotSupportedError()
+		}
 		var err error
 		results, err = client.List(segmentID, nil, nil, nil, nil, nil, nil)
 		if err != nil {
@@ -1213,6 +1216,9 @@ func nsxtPolicySegmentQosProfileRead(d *schema.ResourceData, m interface{}) erro
 		results = lmResults.(model.SegmentQosProfileBindingMapListResult)
 	} else {
 		client := segments.NewSegmentQosProfileBindingMapsClient(getSessionContext(d, m), connector)
+		if client == nil {
+			return policyResourceNotSupportedError()
+		}
 		var err error
 		results, err = client.List(segmentID, nil, nil, nil, nil, nil)
 		if err != nil {
@@ -1255,6 +1261,9 @@ func nsxtPolicySegmentSecurityProfileRead(d *schema.ResourceData, m interface{})
 		results = lmResults.(model.SegmentSecurityProfileBindingMapListResult)
 	} else {
 		client := segments.NewSegmentSecurityProfileBindingMapsClient(getSessionContext(d, m), connector)
+		if client == nil {
+			return policyResourceNotSupportedError()
+		}
 		var err error
 		results, err = client.List(segmentID, nil, nil, nil, nil, nil)
 		if err != nil {
@@ -1316,7 +1325,11 @@ func setSegmentBridgeConfigInSchema(d *schema.ResourceData, obj *model.Segment) 
 
 func nsxtPolicyGetSegment(context utl.SessionContext, connector client.Connector, id string, gwPath string, isFixed bool) (model.Segment, error) {
 	if !isFixed {
-		return infra.NewSegmentsClient(context, connector).Get(id)
+		client := infra.NewSegmentsClient(context, connector)
+		if client == nil {
+			return model.Segment{}, policyResourceNotSupportedError()
+		}
+		return client.Get(id)
 	}
 
 	isT0, gwID := parseGatewayPolicyPath(gwPath)
@@ -1327,7 +1340,11 @@ func nsxtPolicyGetSegment(context utl.SessionContext, connector client.Connector
 		return model.Segment{}, fmt.Errorf("Tier-0 fixed segments are not supported")
 	}
 
-	return tier1s.NewSegmentsClient(context, connector).Get(gwID, id)
+	client := tier1s.NewSegmentsClient(context, connector)
+	if client == nil {
+		return model.Segment{}, policyResourceNotSupportedError()
+	}
+	return client.Get(gwID, id)
 }
 
 func nsxtPolicySegmentRead(d *schema.ResourceData, m interface{}, isVlan bool, isFixed bool) error {
@@ -1522,6 +1539,9 @@ func nsxtPolicySegmentDelete(d *schema.ResourceData, m interface{}, isFixed bool
 				ports = gmPorts
 			} else {
 				portsClient := segments.NewPortsClient(getSessionContext(d, m), connector)
+				if portsClient == nil {
+					return nil, "error", policyResourceNotSupportedError()
+				}
 				lmPorts, err := portsClient.List(id, nil, nil, nil, nil, nil, nil)
 				if err != nil {
 					return lmPorts, "error", logAPIError("Error listing segment ports", err)


### PR DESCRIPTION
When a resource or datasource is defined with an invalid context, e.g with a VPC for a resource with no VPC implementation, the provider crashes as the client creation is not validated.
    
This PR addresses this issue.
