### PR TITLE
Fix read in separate security policy rule resource

### DIFF
--- a/nsxt/policy_utils.go
+++ b/nsxt/policy_utils.go
@@ -165,9 +165,11 @@ func getPathListFromSchema(d *schema.ResourceData, schemaAttrName string) []stri
 }
 
 func setPathListInSchema(d *schema.ResourceData, attrName string, pathList []string) {
-	if !(len(pathList) == 1 && pathList[0] == "ANY") {
-		d.Set(attrName, pathList)
+	if len(pathList) == 1 && pathList[0] == "ANY" {
+		d.Set(attrName, nil)
+		return
 	}
+	d.Set(attrName, pathList)
 }
 
 func getDomainFromResourcePath(rPath string) string {


### PR DESCRIPTION
Before the fix, the code did not respect empty lists for certain attributes, which resulted in non-empty plan.