### PR TITLE
Configure project and VPC at provider level

### DIFF
--- a/api/api_list.yaml
+++ b/api/api_list.yaml
@@ -452,6 +452,9 @@
     - client: github.com/vmware/vsphere-automation-sdk-go/services/nsxt/orgs/projects/infra/domains
       model: github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model
       type: Multitenancy
+    - client: github.com/vmware/vsphere-automation-sdk-go/services/nsxt/orgs/projects/vpcs
+      model: github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model
+      type: VPC
   model_name: SecurityPolicy
   obj_name: SecurityPolicy
   client_name: SecurityPoliciesClient
@@ -986,7 +989,6 @@
     - New
     - Get
     - Delete
-    - List
     - Patch
     - Update
     - List

--- a/api/api_templates.yaml
+++ b/api/api_templates.yaml
@@ -17,7 +17,7 @@ New:
         default:
             return nil
         }
-        return &${model_name}ClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID}
+        return &${model_name}ClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID, VPCID: sessionContext.VPCID}
     }
 Get:
   Convert: |2

--- a/api/infra.go
+++ b/api/infra.go
@@ -29,7 +29,7 @@ func NewInfraClient(sessionContext utl.SessionContext, connector vapiProtocolCli
 	default:
 		return nil
 	}
-	return &InfraClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID}
+	return &InfraClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID, VPCID: sessionContext.VPCID}
 }
 
 func (c InfraClientContext) Get(basePathParam *string, filterParam *string, typeFilterParam *string) (model0.Infra, error) {

--- a/api/infra/context_profiles/attribute.go
+++ b/api/infra/context_profiles/attribute.go
@@ -34,7 +34,7 @@ func NewAttributesClient(sessionContext utl.SessionContext, connector vapiProtoc
 	default:
 		return nil
 	}
-	return &AttributeClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID}
+	return &AttributeClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID, VPCID: sessionContext.VPCID}
 }
 
 func (c AttributeClientContext) List(attributeKeyParam *string, attributeSourceParam *string, cursorParam *string, includeMarkForDeleteObjectsParam *bool, includedFieldsParam *string, pageSizeParam *int64, sortAscendingParam *bool, sortByParam *string) (model0.PolicyContextProfileListResult, error) {

--- a/api/infra/context_profiles/custom_attributes/policy_custom_attributes.go
+++ b/api/infra/context_profiles/custom_attributes/policy_custom_attributes.go
@@ -34,7 +34,7 @@ func NewDefaultClient(sessionContext utl.SessionContext, connector vapiProtocolC
 	default:
 		return nil
 	}
-	return &PolicyCustomAttributesClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID}
+	return &PolicyCustomAttributesClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID, VPCID: sessionContext.VPCID}
 }
 
 func (c PolicyCustomAttributesClientContext) Create(policyCustomAttributesParam model0.PolicyCustomAttributes, actionParam string) error {

--- a/api/infra/dhcp_relay_config.go
+++ b/api/infra/dhcp_relay_config.go
@@ -34,7 +34,7 @@ func NewDhcpRelayConfigsClient(sessionContext utl.SessionContext, connector vapi
 	default:
 		return nil
 	}
-	return &DhcpRelayConfigClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID}
+	return &DhcpRelayConfigClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID, VPCID: sessionContext.VPCID}
 }
 
 func (c DhcpRelayConfigClientContext) Get(dhcpRelayConfigIdParam string) (model0.DhcpRelayConfig, error) {

--- a/api/infra/dhcp_server_config.go
+++ b/api/infra/dhcp_server_config.go
@@ -34,7 +34,7 @@ func NewDhcpServerConfigsClient(sessionContext utl.SessionContext, connector vap
 	default:
 		return nil
 	}
-	return &DhcpServerConfigClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID}
+	return &DhcpServerConfigClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID, VPCID: sessionContext.VPCID}
 }
 
 func (c DhcpServerConfigClientContext) Get(dhcpServerConfigIdParam string) (model0.DhcpServerConfig, error) {

--- a/api/infra/domains/gateway_policy.go
+++ b/api/infra/domains/gateway_policy.go
@@ -34,7 +34,7 @@ func NewGatewayPoliciesClient(sessionContext utl.SessionContext, connector vapiP
 	default:
 		return nil
 	}
-	return &GatewayPolicyClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID}
+	return &GatewayPolicyClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID, VPCID: sessionContext.VPCID}
 }
 
 func (c GatewayPolicyClientContext) Get(domainIdParam string, gatewayPolicyIdParam string) (model0.GatewayPolicy, error) {

--- a/api/infra/domains/group.go
+++ b/api/infra/domains/group.go
@@ -34,7 +34,7 @@ func NewGroupsClient(sessionContext utl.SessionContext, connector vapiProtocolCl
 	default:
 		return nil
 	}
-	return &GroupClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID}
+	return &GroupClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID, VPCID: sessionContext.VPCID}
 }
 
 func (c GroupClientContext) Get(domainIdParam string, groupIdParam string) (model0.Group, error) {

--- a/api/infra/domains/groups/policy_firewall_flood_protection_profile_binding_map.go
+++ b/api/infra/domains/groups/policy_firewall_flood_protection_profile_binding_map.go
@@ -34,7 +34,7 @@ func NewFirewallFloodProtectionProfileBindingMapsClient(sessionContext utl.Sessi
 	default:
 		return nil
 	}
-	return &PolicyFirewallFloodProtectionProfileBindingMapClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID}
+	return &PolicyFirewallFloodProtectionProfileBindingMapClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID, VPCID: sessionContext.VPCID}
 }
 
 func (c PolicyFirewallFloodProtectionProfileBindingMapClientContext) Get(domainIdParam string, groupIdParam string, firewallFloodProtectionProfileBindingMapIdParam string) (model0.PolicyFirewallFloodProtectionProfileBindingMap, error) {

--- a/api/infra/domains/ids_security_policy.go
+++ b/api/infra/domains/ids_security_policy.go
@@ -29,7 +29,7 @@ func NewIntrusionServicePoliciesClient(sessionContext utl.SessionContext, connec
 	default:
 		return nil
 	}
-	return &IdsSecurityPolicyClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID}
+	return &IdsSecurityPolicyClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID, VPCID: sessionContext.VPCID}
 }
 
 func (c IdsSecurityPolicyClientContext) Get(domainIdParam string, policyIdParam string) (model0.IdsSecurityPolicy, error) {

--- a/api/infra/domains/security_policies/rule.go
+++ b/api/infra/domains/security_policies/rule.go
@@ -34,7 +34,7 @@ func NewRulesClient(sessionContext utl.SessionContext, connector vapiProtocolCli
 	default:
 		return nil
 	}
-	return &RuleClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID}
+	return &RuleClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID, VPCID: sessionContext.VPCID}
 }
 
 func (c RuleClientContext) Get(domainIdParam string, securityPolicyIdParam string, ruleIdParam string) (model0.Rule, error) {

--- a/api/infra/domains/security_policy.go
+++ b/api/infra/domains/security_policy.go
@@ -11,6 +11,7 @@ import (
 	client0 "github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/domains"
 	model0 "github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 	client2 "github.com/vmware/vsphere-automation-sdk-go/services/nsxt/orgs/projects/infra/domains"
+	client3 "github.com/vmware/vsphere-automation-sdk-go/services/nsxt/orgs/projects/vpcs"
 
 	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
 )
@@ -31,10 +32,13 @@ func NewSecurityPoliciesClient(sessionContext utl.SessionContext, connector vapi
 	case utl.Multitenancy:
 		client = client2.NewSecurityPoliciesClient(connector)
 
+	case utl.VPC:
+		client = client3.NewSecurityPoliciesClient(connector)
+
 	default:
 		return nil
 	}
-	return &SecurityPolicyClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID}
+	return &SecurityPolicyClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID, VPCID: sessionContext.VPCID}
 }
 
 func (c SecurityPolicyClientContext) Get(domainIdParam string, securityPolicyIdParam string) (model0.SecurityPolicy, error) {
@@ -67,6 +71,13 @@ func (c SecurityPolicyClientContext) Get(domainIdParam string, securityPolicyIdP
 			return obj, err
 		}
 
+	case utl.VPC:
+		client := c.Client.(client3.SecurityPoliciesClient)
+		obj, err = client.Get(utl.DefaultOrgID, c.ProjectID, c.VPCID, securityPolicyIdParam)
+		if err != nil {
+			return obj, err
+		}
+
 	default:
 		return obj, errors.New("invalid infrastructure for model")
 	}
@@ -93,6 +104,10 @@ func (c SecurityPolicyClientContext) Patch(domainIdParam string, securityPolicyI
 	case utl.Multitenancy:
 		client := c.Client.(client2.SecurityPoliciesClient)
 		err = client.Patch(utl.DefaultOrgID, c.ProjectID, domainIdParam, securityPolicyIdParam, securityPolicyParam)
+
+	case utl.VPC:
+		client := c.Client.(client3.SecurityPoliciesClient)
+		err = client.Patch(utl.DefaultOrgID, c.ProjectID, c.VPCID, securityPolicyIdParam, securityPolicyParam)
 
 	default:
 		err = errors.New("invalid infrastructure for model")
@@ -130,6 +145,10 @@ func (c SecurityPolicyClientContext) Update(domainIdParam string, securityPolicy
 		client := c.Client.(client2.SecurityPoliciesClient)
 		obj, err = client.Update(utl.DefaultOrgID, c.ProjectID, domainIdParam, securityPolicyIdParam, securityPolicyParam)
 
+	case utl.VPC:
+		client := c.Client.(client3.SecurityPoliciesClient)
+		obj, err = client.Update(utl.DefaultOrgID, c.ProjectID, c.VPCID, securityPolicyIdParam, securityPolicyParam)
+
 	default:
 		err = errors.New("invalid infrastructure for model")
 	}
@@ -152,6 +171,10 @@ func (c SecurityPolicyClientContext) Delete(domainIdParam string, securityPolicy
 	case utl.Multitenancy:
 		client := c.Client.(client2.SecurityPoliciesClient)
 		err = client.Delete(utl.DefaultOrgID, c.ProjectID, domainIdParam, securityPolicyIdParam)
+
+	case utl.VPC:
+		client := c.Client.(client3.SecurityPoliciesClient)
+		err = client.Delete(utl.DefaultOrgID, c.ProjectID, c.VPCID, securityPolicyIdParam)
 
 	default:
 		err = errors.New("invalid infrastructure for model")
@@ -184,6 +207,10 @@ func (c SecurityPolicyClientContext) List(domainIdParam string, cursorParam *str
 	case utl.Multitenancy:
 		client := c.Client.(client2.SecurityPoliciesClient)
 		obj, err = client.List(utl.DefaultOrgID, c.ProjectID, domainIdParam, cursorParam, includeMarkForDeleteObjectsParam, includeRuleCountParam, includedFieldsParam, pageSizeParam, sortAscendingParam, sortByParam)
+
+	case utl.VPC:
+		client := c.Client.(client3.SecurityPoliciesClient)
+		obj, err = client.List(utl.DefaultOrgID, c.ProjectID, c.VPCID, cursorParam, includeMarkForDeleteObjectsParam, includeRuleCountParam, includedFieldsParam, pageSizeParam, sortAscendingParam, sortByParam)
 
 	default:
 		err = errors.New("invalid infrastructure for model")

--- a/api/infra/flood_protection_profiles_client.go
+++ b/api/infra/flood_protection_profiles_client.go
@@ -35,7 +35,7 @@ func NewFloodProtectionProfilesClient(sessionContext utl.SessionContext, connect
 	default:
 		return nil
 	}
-	return &StructValueClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID}
+	return &StructValueClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID, VPCID: sessionContext.VPCID}
 }
 
 func (c StructValueClientContext) Get(floodProtectionProfileIdParam string) (*model0.StructValue, error) {

--- a/api/infra/gateway_qos_profile.go
+++ b/api/infra/gateway_qos_profile.go
@@ -34,7 +34,7 @@ func NewGatewayQosProfilesClient(sessionContext utl.SessionContext, connector va
 	default:
 		return nil
 	}
-	return &GatewayQosProfileClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID}
+	return &GatewayQosProfileClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID, VPCID: sessionContext.VPCID}
 }
 
 func (c GatewayQosProfileClientContext) Get(qosProfileIdParam string) (model0.GatewayQosProfile, error) {

--- a/api/infra/ip_address_block.go
+++ b/api/infra/ip_address_block.go
@@ -29,7 +29,7 @@ func NewIpBlocksClient(sessionContext utl.SessionContext, connector vapiProtocol
 	default:
 		return nil
 	}
-	return &IpAddressBlockClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID}
+	return &IpAddressBlockClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID, VPCID: sessionContext.VPCID}
 }
 
 func (c IpAddressBlockClientContext) Get(ipBlockIdParam string, ignoreIpblockUsageParam *bool) (model0.IpAddressBlock, error) {

--- a/api/infra/ip_address_pool.go
+++ b/api/infra/ip_address_pool.go
@@ -29,7 +29,7 @@ func NewIpPoolsClient(sessionContext utl.SessionContext, connector vapiProtocolC
 	default:
 		return nil
 	}
-	return &IpAddressPoolClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID}
+	return &IpAddressPoolClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID, VPCID: sessionContext.VPCID}
 }
 
 func (c IpAddressPoolClientContext) Get(ipPoolIdParam string) (model0.IpAddressPool, error) {

--- a/api/infra/ip_discovery_profile.go
+++ b/api/infra/ip_discovery_profile.go
@@ -34,7 +34,7 @@ func NewIpDiscoveryProfilesClient(sessionContext utl.SessionContext, connector v
 	default:
 		return nil
 	}
-	return &IPDiscoveryProfileClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID}
+	return &IPDiscoveryProfileClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID, VPCID: sessionContext.VPCID}
 }
 
 func (c IPDiscoveryProfileClientContext) Get(ipDiscoveryProfileIdParam string) (model0.IPDiscoveryProfile, error) {

--- a/api/infra/ip_pools/ip_address_allocation.go
+++ b/api/infra/ip_pools/ip_address_allocation.go
@@ -29,7 +29,7 @@ func NewIpAllocationsClient(sessionContext utl.SessionContext, connector vapiPro
 	default:
 		return nil
 	}
-	return &IpAddressAllocationClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID}
+	return &IpAddressAllocationClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID, VPCID: sessionContext.VPCID}
 }
 
 func (c IpAddressAllocationClientContext) Get(ipPoolIdParam string, ipAllocationIdParam string) (model0.IpAddressAllocation, error) {

--- a/api/infra/ip_pools/ip_subnets_client.go
+++ b/api/infra/ip_pools/ip_subnets_client.go
@@ -30,7 +30,7 @@ func NewIpSubnetsClient(sessionContext utl.SessionContext, connector vapiProtoco
 	default:
 		return nil
 	}
-	return &StructValueClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID}
+	return &StructValueClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID, VPCID: sessionContext.VPCID}
 }
 
 func (c StructValueClientContext) Get(ipPoolIdParam string, ipSubnetIdParam string) (*model0.StructValue, error) {

--- a/api/infra/ipv6_dad_profile.go
+++ b/api/infra/ipv6_dad_profile.go
@@ -34,7 +34,7 @@ func NewIpv6DadProfilesClient(sessionContext utl.SessionContext, connector vapiP
 	default:
 		return nil
 	}
-	return &Ipv6DadProfileClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID}
+	return &Ipv6DadProfileClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID, VPCID: sessionContext.VPCID}
 }
 
 func (c Ipv6DadProfileClientContext) Get(dadProfileIdParam string) (model0.Ipv6DadProfile, error) {

--- a/api/infra/ipv6_ndra_profile.go
+++ b/api/infra/ipv6_ndra_profile.go
@@ -34,7 +34,7 @@ func NewIpv6NdraProfilesClient(sessionContext utl.SessionContext, connector vapi
 	default:
 		return nil
 	}
-	return &Ipv6NdraProfileClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID}
+	return &Ipv6NdraProfileClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID, VPCID: sessionContext.VPCID}
 }
 
 func (c Ipv6NdraProfileClientContext) Get(ndraProfileIdParam string) (model0.Ipv6NdraProfile, error) {

--- a/api/infra/mac_discovery_profile.go
+++ b/api/infra/mac_discovery_profile.go
@@ -34,7 +34,7 @@ func NewMacDiscoveryProfilesClient(sessionContext utl.SessionContext, connector 
 	default:
 		return nil
 	}
-	return &MacDiscoveryProfileClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID}
+	return &MacDiscoveryProfileClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID, VPCID: sessionContext.VPCID}
 }
 
 func (c MacDiscoveryProfileClientContext) Get(macDiscoveryProfileIdParam string) (model0.MacDiscoveryProfile, error) {

--- a/api/infra/policy_context_profile.go
+++ b/api/infra/policy_context_profile.go
@@ -34,7 +34,7 @@ func NewContextProfilesClient(sessionContext utl.SessionContext, connector vapiP
 	default:
 		return nil
 	}
-	return &PolicyContextProfileClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID}
+	return &PolicyContextProfileClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID, VPCID: sessionContext.VPCID}
 }
 
 func (c PolicyContextProfileClientContext) Get(contextProfileIdParam string) (model0.PolicyContextProfile, error) {

--- a/api/infra/policy_dns_forwarder_zone.go
+++ b/api/infra/policy_dns_forwarder_zone.go
@@ -34,7 +34,7 @@ func NewDnsForwarderZonesClient(sessionContext utl.SessionContext, connector vap
 	default:
 		return nil
 	}
-	return &PolicyDnsForwarderZoneClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID}
+	return &PolicyDnsForwarderZoneClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID, VPCID: sessionContext.VPCID}
 }
 
 func (c PolicyDnsForwarderZoneClientContext) Get(dnsForwarderZoneIdParam string) (model0.PolicyDnsForwarderZone, error) {

--- a/api/infra/qos_profile.go
+++ b/api/infra/qos_profile.go
@@ -34,7 +34,7 @@ func NewQosProfilesClient(sessionContext utl.SessionContext, connector vapiProto
 	default:
 		return nil
 	}
-	return &QosProfileClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID}
+	return &QosProfileClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID, VPCID: sessionContext.VPCID}
 }
 
 func (c QosProfileClientContext) Get(qosProfileIdParam string) (model0.QosProfile, error) {

--- a/api/infra/realized_state/realized_entity.go
+++ b/api/infra/realized_state/realized_entity.go
@@ -34,7 +34,7 @@ func NewRealizedEntitiesClient(sessionContext utl.SessionContext, connector vapi
 	default:
 		return nil
 	}
-	return &RealizedEntityClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID}
+	return &RealizedEntityClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID, VPCID: sessionContext.VPCID}
 }
 
 func (c RealizedEntityClientContext) List(intentPathParam string, sitePathParam *string) (model0.GenericPolicyRealizedResourceListResult, error) {

--- a/api/infra/realized_state/virtual_machine.go
+++ b/api/infra/realized_state/virtual_machine.go
@@ -29,7 +29,7 @@ func NewVirtualMachinesClient(sessionContext utl.SessionContext, connector vapiP
 	default:
 		return nil
 	}
-	return &VirtualMachineClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID}
+	return &VirtualMachineClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID, VPCID: sessionContext.VPCID}
 }
 
 func (c VirtualMachineClientContext) List(cursorParam *string, enforcementPointPathParam *string, includeMarkForDeleteObjectsParam *bool, includedFieldsParam *string, pageSizeParam *int64, sortAscendingParam *bool, sortByParam *string) (model0.VirtualMachineListResult, error) {

--- a/api/infra/segment.go
+++ b/api/infra/segment.go
@@ -34,7 +34,7 @@ func NewSegmentsClient(sessionContext utl.SessionContext, connector vapiProtocol
 	default:
 		return nil
 	}
-	return &SegmentClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID}
+	return &SegmentClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID, VPCID: sessionContext.VPCID}
 }
 
 func (c SegmentClientContext) Get(segmentIdParam string) (model0.Segment, error) {

--- a/api/infra/segment_security_profile.go
+++ b/api/infra/segment_security_profile.go
@@ -34,7 +34,7 @@ func NewSegmentSecurityProfilesClient(sessionContext utl.SessionContext, connect
 	default:
 		return nil
 	}
-	return &SegmentSecurityProfileClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID}
+	return &SegmentSecurityProfileClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID, VPCID: sessionContext.VPCID}
 }
 
 func (c SegmentSecurityProfileClientContext) Get(segmentSecurityProfileIdParam string) (model0.SegmentSecurityProfile, error) {

--- a/api/infra/segments/dhcp_static_binding_config.go
+++ b/api/infra/segments/dhcp_static_binding_config.go
@@ -35,7 +35,7 @@ func NewDhcpStaticBindingConfigsClient(sessionContext utl.SessionContext, connec
 	default:
 		return nil
 	}
-	return &StructValueClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID}
+	return &StructValueClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID, VPCID: sessionContext.VPCID}
 }
 
 func (c StructValueClientContext) Get(segmentIdParam string, bindingIdParam string) (*model0.StructValue, error) {

--- a/api/infra/segments/segment_configuration_state.go
+++ b/api/infra/segments/segment_configuration_state.go
@@ -34,7 +34,7 @@ func NewStateClient(sessionContext utl.SessionContext, connector vapiProtocolCli
 	default:
 		return nil
 	}
-	return &SegmentConfigurationStateClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID}
+	return &SegmentConfigurationStateClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID, VPCID: sessionContext.VPCID}
 }
 
 func (c SegmentConfigurationStateClientContext) Get(segmentsIdParam string, cursorParam *string, edgePathParam *string, enforcementPointPathParam *string, includeMarkForDeleteObjectsParam *bool, includedFieldsParam *string, pageSizeParam *int64, sortAscendingParam *bool, sortByParam *string, sourceParam *string, statsTypeParam *string, transportNodeIdParam *string) (model0.SegmentConfigurationState, error) {

--- a/api/infra/segments/segment_discovery_profile_binding_map.go
+++ b/api/infra/segments/segment_discovery_profile_binding_map.go
@@ -29,7 +29,7 @@ func NewSegmentDiscoveryProfileBindingMapsClient(sessionContext utl.SessionConte
 	default:
 		return nil
 	}
-	return &SegmentDiscoveryProfileBindingMapClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID}
+	return &SegmentDiscoveryProfileBindingMapClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID, VPCID: sessionContext.VPCID}
 }
 
 func (c SegmentDiscoveryProfileBindingMapClientContext) Get(infraSegmentIdParam string, segmentDiscoveryProfileBindingMapIdParam string) (model0.SegmentDiscoveryProfileBindingMap, error) {

--- a/api/infra/segments/segment_port.go
+++ b/api/infra/segments/segment_port.go
@@ -29,7 +29,7 @@ func NewPortsClient(sessionContext utl.SessionContext, connector vapiProtocolCli
 	default:
 		return nil
 	}
-	return &SegmentPortClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID}
+	return &SegmentPortClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID, VPCID: sessionContext.VPCID}
 }
 
 func (c SegmentPortClientContext) Get(segmentIdParam string, portIdParam string) (model0.SegmentPort, error) {

--- a/api/infra/segments/segment_qos_profile_binding_map.go
+++ b/api/infra/segments/segment_qos_profile_binding_map.go
@@ -29,7 +29,7 @@ func NewSegmentQosProfileBindingMapsClient(sessionContext utl.SessionContext, co
 	default:
 		return nil
 	}
-	return &SegmentQosProfileBindingMapClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID}
+	return &SegmentQosProfileBindingMapClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID, VPCID: sessionContext.VPCID}
 }
 
 func (c SegmentQosProfileBindingMapClientContext) Get(segmentIdParam string, segmentQosProfileBindingMapIdParam string) (model0.SegmentQosProfileBindingMap, error) {

--- a/api/infra/segments/segment_security_profile_binding_map.go
+++ b/api/infra/segments/segment_security_profile_binding_map.go
@@ -29,7 +29,7 @@ func NewSegmentSecurityProfileBindingMapsClient(sessionContext utl.SessionContex
 	default:
 		return nil
 	}
-	return &SegmentSecurityProfileBindingMapClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID}
+	return &SegmentSecurityProfileBindingMapClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID, VPCID: sessionContext.VPCID}
 }
 
 func (c SegmentSecurityProfileBindingMapClientContext) Get(segmentIdParam string, segmentSecurityProfileBindingMapIdParam string) (model0.SegmentSecurityProfileBindingMap, error) {

--- a/api/infra/service.go
+++ b/api/infra/service.go
@@ -34,7 +34,7 @@ func NewServicesClient(sessionContext utl.SessionContext, connector vapiProtocol
 	default:
 		return nil
 	}
-	return &ServiceClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID}
+	return &ServiceClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID, VPCID: sessionContext.VPCID}
 }
 
 func (c ServiceClientContext) Get(serviceIdParam string) (model0.Service, error) {

--- a/api/infra/settings/firewall/security/intrusion_services/ids_profile.go
+++ b/api/infra/settings/firewall/security/intrusion_services/ids_profile.go
@@ -29,7 +29,7 @@ func NewProfilesClient(sessionContext utl.SessionContext, connector vapiProtocol
 	default:
 		return nil
 	}
-	return &IdsProfileClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID}
+	return &IdsProfileClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID, VPCID: sessionContext.VPCID}
 }
 
 func (c IdsProfileClientContext) Get(profileIdParam string) (model0.IdsProfile, error) {

--- a/api/infra/settings/firewall/security/policy_exclude_list.go
+++ b/api/infra/settings/firewall/security/policy_exclude_list.go
@@ -30,7 +30,7 @@ func NewExcludeListClient(sessionContext utl.SessionContext, connector vapiProto
 	default:
 		return nil
 	}
-	return &PolicyExcludeListClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID}
+	return &PolicyExcludeListClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID, VPCID: sessionContext.VPCID}
 }
 
 func (c PolicyExcludeListClientContext) Get() (model0.PolicyExcludeList, error) {

--- a/api/infra/spoof_guard_profile.go
+++ b/api/infra/spoof_guard_profile.go
@@ -34,7 +34,7 @@ func NewSpoofguardProfilesClient(sessionContext utl.SessionContext, connector va
 	default:
 		return nil
 	}
-	return &SpoofGuardProfileClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID}
+	return &SpoofGuardProfileClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID, VPCID: sessionContext.VPCID}
 }
 
 func (c SpoofGuardProfileClientContext) Get(spoofguardProfileIdParam string) (model0.SpoofGuardProfile, error) {

--- a/api/infra/tier0.go
+++ b/api/infra/tier0.go
@@ -30,7 +30,7 @@ func NewTier0sClient(sessionContext utl.SessionContext, connector vapiProtocolCl
 	default:
 		return nil
 	}
-	return &Tier0ClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID}
+	return &Tier0ClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID, VPCID: sessionContext.VPCID}
 }
 
 func (c Tier0ClientContext) Get(tier0IdParam string) (model0.Tier0, error) {

--- a/api/infra/tier1.go
+++ b/api/infra/tier1.go
@@ -34,7 +34,7 @@ func NewTier1sClient(sessionContext utl.SessionContext, connector vapiProtocolCl
 	default:
 		return nil
 	}
-	return &Tier1ClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID}
+	return &Tier1ClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID, VPCID: sessionContext.VPCID}
 }
 
 func (c Tier1ClientContext) Get(tier1IdParam string) (model0.Tier1, error) {

--- a/api/infra/tier_0s/flood_protection_profile_binding_map.go
+++ b/api/infra/tier_0s/flood_protection_profile_binding_map.go
@@ -30,7 +30,7 @@ func NewFloodProtectionProfileBindingsClient(sessionContext utl.SessionContext, 
 	default:
 		return nil
 	}
-	return &FloodProtectionProfileBindingMapClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID}
+	return &FloodProtectionProfileBindingMapClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID, VPCID: sessionContext.VPCID}
 }
 
 func (c FloodProtectionProfileBindingMapClientContext) Get(tier0IdParam string, floodProtectionProfileBindingIdParam string) (model0.FloodProtectionProfileBindingMap, error) {

--- a/api/infra/tier_0s/locale_services.go
+++ b/api/infra/tier_0s/locale_services.go
@@ -30,7 +30,7 @@ func NewLocaleServicesClient(sessionContext utl.SessionContext, connector vapiPr
 	default:
 		return nil
 	}
-	return &LocaleServicesClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID}
+	return &LocaleServicesClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID, VPCID: sessionContext.VPCID}
 }
 
 func (c LocaleServicesClientContext) Get(tier0IdParam string, localeServicesIdParam string) (model0.LocaleServices, error) {

--- a/api/infra/tier_0s/locale_services/flood_protection_profile_binding_map.go
+++ b/api/infra/tier_0s/locale_services/flood_protection_profile_binding_map.go
@@ -30,7 +30,7 @@ func NewFloodProtectionProfileBindingsClient(sessionContext utl.SessionContext, 
 	default:
 		return nil
 	}
-	return &FloodProtectionProfileBindingMapClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID}
+	return &FloodProtectionProfileBindingMapClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID, VPCID: sessionContext.VPCID}
 }
 
 func (c FloodProtectionProfileBindingMapClientContext) Get(tier0IdParam string, localeServicesIdParam string, floodProtectionProfileBindingIdParam string) (model0.FloodProtectionProfileBindingMap, error) {

--- a/api/infra/tier_0s/nat/policy_nat_rule.go
+++ b/api/infra/tier_0s/nat/policy_nat_rule.go
@@ -30,7 +30,7 @@ func NewNatRulesClient(sessionContext utl.SessionContext, connector vapiProtocol
 	default:
 		return nil
 	}
-	return &PolicyNatRuleClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID}
+	return &PolicyNatRuleClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID, VPCID: sessionContext.VPCID}
 }
 
 func (c PolicyNatRuleClientContext) Get(tier0IdParam string, natIdParam string, natRuleIdParam string) (model0.PolicyNatRule, error) {

--- a/api/infra/tier_0s/policy_dns_forwarder.go
+++ b/api/infra/tier_0s/policy_dns_forwarder.go
@@ -30,7 +30,7 @@ func NewDnsForwarderClient(sessionContext utl.SessionContext, connector vapiProt
 	default:
 		return nil
 	}
-	return &PolicyDnsForwarderClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID}
+	return &PolicyDnsForwarderClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID, VPCID: sessionContext.VPCID}
 }
 
 func (c PolicyDnsForwarderClientContext) Get(tier0IdParam string) (model0.PolicyDnsForwarder, error) {

--- a/api/infra/tier_0s/static_routes.go
+++ b/api/infra/tier_0s/static_routes.go
@@ -30,7 +30,7 @@ func NewStaticRoutesClient(sessionContext utl.SessionContext, connector vapiProt
 	default:
 		return nil
 	}
-	return &StaticRoutesClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID}
+	return &StaticRoutesClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID, VPCID: sessionContext.VPCID}
 }
 
 func (c StaticRoutesClientContext) Get(tier0IdParam string, routeIdParam string) (model0.StaticRoutes, error) {

--- a/api/infra/tier_1s/flood_protection_profile_binding_map.go
+++ b/api/infra/tier_1s/flood_protection_profile_binding_map.go
@@ -34,7 +34,7 @@ func NewFloodProtectionProfileBindingsClient(sessionContext utl.SessionContext, 
 	default:
 		return nil
 	}
-	return &FloodProtectionProfileBindingMapClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID}
+	return &FloodProtectionProfileBindingMapClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID, VPCID: sessionContext.VPCID}
 }
 
 func (c FloodProtectionProfileBindingMapClientContext) Get(tier1IdParam string, floodProtectionProfileBindingIdParam string) (model0.FloodProtectionProfileBindingMap, error) {

--- a/api/infra/tier_1s/locale_services.go
+++ b/api/infra/tier_1s/locale_services.go
@@ -34,7 +34,7 @@ func NewLocaleServicesClient(sessionContext utl.SessionContext, connector vapiPr
 	default:
 		return nil
 	}
-	return &LocaleServicesClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID}
+	return &LocaleServicesClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID, VPCID: sessionContext.VPCID}
 }
 
 func (c LocaleServicesClientContext) Get(tier1IdParam string, localeServicesIdParam string) (model0.LocaleServices, error) {

--- a/api/infra/tier_1s/locale_services/flood_protection_profile_binding_map.go
+++ b/api/infra/tier_1s/locale_services/flood_protection_profile_binding_map.go
@@ -34,7 +34,7 @@ func NewFloodProtectionProfileBindingsClient(sessionContext utl.SessionContext, 
 	default:
 		return nil
 	}
-	return &FloodProtectionProfileBindingMapClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID}
+	return &FloodProtectionProfileBindingMapClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID, VPCID: sessionContext.VPCID}
 }
 
 func (c FloodProtectionProfileBindingMapClientContext) Get(tier1IdParam string, localeServicesIdParam string, floodProtectionProfileBindingIdParam string) (model0.FloodProtectionProfileBindingMap, error) {

--- a/api/infra/tier_1s/locale_services/tier1_interface.go
+++ b/api/infra/tier_1s/locale_services/tier1_interface.go
@@ -34,7 +34,7 @@ func NewInterfacesClient(sessionContext utl.SessionContext, connector vapiProtoc
 	default:
 		return nil
 	}
-	return &Tier1InterfaceClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID}
+	return &Tier1InterfaceClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID, VPCID: sessionContext.VPCID}
 }
 
 func (c Tier1InterfaceClientContext) Get(tier1IdParam string, localeServicesIdParam string, interfaceIdParam string) (model0.Tier1Interface, error) {

--- a/api/infra/tier_1s/nat/policy_nat_rule.go
+++ b/api/infra/tier_1s/nat/policy_nat_rule.go
@@ -34,7 +34,7 @@ func NewNatRulesClient(sessionContext utl.SessionContext, connector vapiProtocol
 	default:
 		return nil
 	}
-	return &PolicyNatRuleClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID}
+	return &PolicyNatRuleClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID, VPCID: sessionContext.VPCID}
 }
 
 func (c PolicyNatRuleClientContext) Get(tier1IdParam string, natIdParam string, natRuleIdParam string) (model0.PolicyNatRule, error) {

--- a/api/infra/tier_1s/policy_dns_forwarder.go
+++ b/api/infra/tier_1s/policy_dns_forwarder.go
@@ -34,7 +34,7 @@ func NewDnsForwarderClient(sessionContext utl.SessionContext, connector vapiProt
 	default:
 		return nil
 	}
-	return &PolicyDnsForwarderClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID}
+	return &PolicyDnsForwarderClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID, VPCID: sessionContext.VPCID}
 }
 
 func (c PolicyDnsForwarderClientContext) Get(tier1IdParam string) (model0.PolicyDnsForwarder, error) {

--- a/api/infra/tier_1s/segment.go
+++ b/api/infra/tier_1s/segment.go
@@ -34,7 +34,7 @@ func NewSegmentsClient(sessionContext utl.SessionContext, connector vapiProtocol
 	default:
 		return nil
 	}
-	return &SegmentClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID}
+	return &SegmentClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID, VPCID: sessionContext.VPCID}
 }
 
 func (c SegmentClientContext) Get(tier1IdParam string, segmentIdParam string) (model0.Segment, error) {

--- a/api/infra/tier_1s/segments/dhcp_static_binding_config.go
+++ b/api/infra/tier_1s/segments/dhcp_static_binding_config.go
@@ -35,7 +35,7 @@ func NewDhcpStaticBindingConfigsClient(sessionContext utl.SessionContext, connec
 	default:
 		return nil
 	}
-	return &StructValueClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID}
+	return &StructValueClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID, VPCID: sessionContext.VPCID}
 }
 
 func (c StructValueClientContext) Get(tier1IdParam string, segmentIdParam string, bindingIdParam string) (*model0.StructValue, error) {

--- a/api/infra/tier_1s/segments/segment_port.go
+++ b/api/infra/tier_1s/segments/segment_port.go
@@ -29,7 +29,7 @@ func NewPortsClient(sessionContext utl.SessionContext, connector vapiProtocolCli
 	default:
 		return nil
 	}
-	return &SegmentPortClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID}
+	return &SegmentPortClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID, VPCID: sessionContext.VPCID}
 }
 
 func (c SegmentPortClientContext) List(tier1IdParam string, segmentIdParam string, cursorParam *string, includeMarkForDeleteObjectsParam *bool, includedFieldsParam *string, pageSizeParam *int64, sortAscendingParam *bool, sortByParam *string) (model0.SegmentPortListResult, error) {

--- a/api/infra/tier_1s/static_routes.go
+++ b/api/infra/tier_1s/static_routes.go
@@ -34,7 +34,7 @@ func NewStaticRoutesClient(sessionContext utl.SessionContext, connector vapiProt
 	default:
 		return nil
 	}
-	return &StaticRoutesClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID}
+	return &StaticRoutesClientContext{Client: client, ClientType: sessionContext.ClientType, ProjectID: sessionContext.ProjectID, VPCID: sessionContext.VPCID}
 }
 
 func (c StaticRoutesClientContext) Get(tier1IdParam string, routeIdParam string) (model0.StaticRoutes, error) {

--- a/api/utl/api_util.go
+++ b/api/utl/api_util.go
@@ -11,16 +11,19 @@ const (
 	Global       = 0
 	Local        = 1
 	Multitenancy = 2
+	VPC          = 3
 )
 
 type SessionContext struct {
 	ClientType ClientType
 	ProjectID  string
+	VPCID      string
 }
 type ClientContext struct {
 	Client     interface{}
 	ClientType ClientType
 	ProjectID  string
+	VPCID      string
 }
 
 func ConvertModelBindingType(obj interface{}, sourceType bindings.BindingType, destType bindings.BindingType) (interface{}, error) {

--- a/api/utl_file_template.yaml
+++ b/api/utl_file_template.yaml
@@ -15,11 +15,13 @@
   type SessionContext struct {
       ClientType ClientType
       ProjectID string
+      VPCID     string
   }
   type ClientContext struct {
       Client     interface{}
       ClientType ClientType
       ProjectID  string
+      VPCID      string
   }
   
   func ConvertModelBindingType(obj interface{}, sourceType bindings.BindingType, destType bindings.BindingType) (interface{}, error) {

--- a/nsxt/data_source_nsxt_policy_bfd_profile.go
+++ b/nsxt/data_source_nsxt_policy_bfd_profile.go
@@ -23,7 +23,11 @@ func dataSourceNsxtPolicyBfdProfile() *schema.Resource {
 func dataSourceNsxtPolicyBfdProfileRead(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
 
-	_, err := policyDataSourceResourceRead(d, connector, getSessionContext(d, m), "BfdProfile", nil)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	_, err = policyDataSourceResourceRead(d, connector, context, "BfdProfile", nil)
 	if err != nil {
 		return err
 	}

--- a/nsxt/data_source_nsxt_policy_bridge_profile.go
+++ b/nsxt/data_source_nsxt_policy_bridge_profile.go
@@ -23,7 +23,11 @@ func dataSourceNsxtPolicyBridgeProfile() *schema.Resource {
 func dataSourceNsxtPolicyBridgeProfileRead(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
 
-	_, err := policyDataSourceResourceRead(d, connector, getSessionContext(d, m), "L2BridgeEndpointProfile", nil)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	_, err = policyDataSourceResourceRead(d, connector, context, "L2BridgeEndpointProfile", nil)
 	if err != nil {
 		return err
 	}

--- a/nsxt/data_source_nsxt_policy_certificate.go
+++ b/nsxt/data_source_nsxt_policy_certificate.go
@@ -23,7 +23,11 @@ func dataSourceNsxtPolicyCertificate() *schema.Resource {
 func dataSourceNsxtPolicyCertificateRead(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
 
-	_, err := policyDataSourceResourceRead(d, connector, getSessionContext(d, m), "TlsCertificate", nil)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	_, err = policyDataSourceResourceRead(d, connector, context, "TlsCertificate", nil)
 	if err != nil {
 		return err
 	}

--- a/nsxt/data_source_nsxt_policy_context_profile.go
+++ b/nsxt/data_source_nsxt_policy_context_profile.go
@@ -22,7 +22,11 @@ func dataSourceNsxtPolicyContextProfile() *schema.Resource {
 }
 
 func dataSourceNsxtPolicyContextProfileRead(d *schema.ResourceData, m interface{}) error {
-	_, err := policyDataSourceResourceRead(d, getPolicyConnector(m), getSessionContext(d, m), "PolicyContextProfile", nil)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	_, err = policyDataSourceResourceRead(d, getPolicyConnector(m), context, "PolicyContextProfile", nil)
 	if err != nil {
 		return err
 	}

--- a/nsxt/data_source_nsxt_policy_context_profile.go
+++ b/nsxt/data_source_nsxt_policy_context_profile.go
@@ -16,7 +16,7 @@ func dataSourceNsxtPolicyContextProfile() *schema.Resource {
 			"display_name": getDataSourceDisplayNameSchema(),
 			"description":  getDataSourceDescriptionSchema(),
 			"path":         getPathSchema(),
-			"context":      getContextSchema(false, false),
+			"context":      getContextSchema(false, false, false),
 		},
 	}
 }

--- a/nsxt/data_source_nsxt_policy_context_profile_test.go
+++ b/nsxt/data_source_nsxt_policy_context_profile_test.go
@@ -83,7 +83,7 @@ func TestAccDataSourceNsxtPolicyContextProfile_multitenancyProvider(t *testing.T
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccOnlyMultitenancy(t)
+			testAccOnlyMultitenancyProvider(t)
 		},
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
@@ -111,7 +111,7 @@ func testAccNsxtPolicyContextProfileMultitenancyTemplate(name string, withContex
 	if withContext {
 		context = testAccNsxtPolicyMultitenancyContext()
 	}
-	return fmt.Sprintf(`
+	s := fmt.Sprintf(`
 resource "nsxt_policy_context_profile" "test" {
 %s
   display_name = "%s"
@@ -133,4 +133,5 @@ data "nsxt_policy_context_profile" "test" {
 %s
   display_name = nsxt_policy_context_profile.test.display_name
 }`, context, name, context)
+	return s
 }

--- a/nsxt/data_source_nsxt_policy_context_profile_test.go
+++ b/nsxt/data_source_nsxt_policy_context_profile_test.go
@@ -65,7 +65,30 @@ func TestAccDataSourceNsxtPolicyContextProfile_multitenancy(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNsxtPolicyContextProfileMultitenancyTemplate(name),
+				Config: testAccNsxtPolicyContextProfileMultitenancyTemplate(name, true),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(testResourceName, "display_name", name),
+					resource.TestCheckResourceAttrSet(testResourceName, "description"),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceNsxtPolicyContextProfile_multitenancyProvider(t *testing.T) {
+	name := getAccTestResourceName()
+	testResourceName := "data.nsxt_policy_context_profile.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccOnlyMultitenancy(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyContextProfileMultitenancyTemplate(name, false),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(testResourceName, "display_name", name),
 					resource.TestCheckResourceAttrSet(testResourceName, "description"),
@@ -83,8 +106,11 @@ data "nsxt_policy_context_profile" "test" {
 }`, name)
 }
 
-func testAccNsxtPolicyContextProfileMultitenancyTemplate(name string) string {
-	context := testAccNsxtPolicyMultitenancyContext()
+func testAccNsxtPolicyContextProfileMultitenancyTemplate(name string, withContext bool) string {
+	context := ""
+	if withContext {
+		context = testAccNsxtPolicyMultitenancyContext()
+	}
 	return fmt.Sprintf(`
 resource "nsxt_policy_context_profile" "test" {
 %s

--- a/nsxt/data_source_nsxt_policy_dhcp_server.go
+++ b/nsxt/data_source_nsxt_policy_dhcp_server.go
@@ -24,7 +24,11 @@ func dataSourceNsxtPolicyDhcpServer() *schema.Resource {
 func dataSourceNsxtPolicyDhcpServerRead(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
 
-	_, err := policyDataSourceResourceRead(d, connector, getSessionContext(d, m), "DhcpServerConfig", nil)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	_, err = policyDataSourceResourceRead(d, connector, context, "DhcpServerConfig", nil)
 	if err != nil {
 		return err
 	}

--- a/nsxt/data_source_nsxt_policy_dhcp_server.go
+++ b/nsxt/data_source_nsxt_policy_dhcp_server.go
@@ -16,7 +16,7 @@ func dataSourceNsxtPolicyDhcpServer() *schema.Resource {
 			"display_name": getDataSourceExtendedDisplayNameSchema(),
 			"description":  getDataSourceDescriptionSchema(),
 			"path":         getPathSchema(),
-			"context":      getContextSchema(false, false),
+			"context":      getContextSchema(false, false, false),
 		},
 	}
 }

--- a/nsxt/data_source_nsxt_policy_dhcp_server_test.go
+++ b/nsxt/data_source_nsxt_policy_dhcp_server_test.go
@@ -21,6 +21,13 @@ func TestAccDataSourceNsxtPolicyDhcpServer_multitenancy(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceNsxtPolicyDhcpServer_multitenancyProvider(t *testing.T) {
+	testAccDataSourceNsxtPolicyDhcpServerBasic(t, false, func() {
+		testAccPreCheck(t)
+		testAccOnlyMultitenancyProvider(t)
+	})
+}
+
 func testAccDataSourceNsxtPolicyDhcpServerBasic(t *testing.T, withContext bool, preCheck func()) {
 	name := getAccTestDataSourceName()
 	testResourceName := "data.nsxt_policy_dhcp_server.test"

--- a/nsxt/data_source_nsxt_policy_distributed_flood_protection_profile.go
+++ b/nsxt/data_source_nsxt_policy_distributed_flood_protection_profile.go
@@ -16,7 +16,7 @@ func dataSourceNsxtPolicyDistributedFloodProtectionProfile() *schema.Resource {
 			"display_name": getDataSourceExtendedDisplayNameSchema(),
 			"description":  getDataSourceDescriptionSchema(),
 			"path":         getPathSchema(),
-			"context":      getContextSchema(false, false),
+			"context":      getContextSchema(false, false, false),
 		},
 	}
 }

--- a/nsxt/data_source_nsxt_policy_distributed_flood_protection_profile.go
+++ b/nsxt/data_source_nsxt_policy_distributed_flood_protection_profile.go
@@ -24,7 +24,11 @@ func dataSourceNsxtPolicyDistributedFloodProtectionProfile() *schema.Resource {
 func dataSourceNsxtPolicyDistributedFloodProtectionProfileRead(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
 
-	_, err := policyDataSourceResourceRead(d, connector, getSessionContext(d, m), "DistributedFloodProtectionProfile", nil)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	_, err = policyDataSourceResourceRead(d, connector, context, "DistributedFloodProtectionProfile", nil)
 	if err != nil {
 		return err
 	}

--- a/nsxt/data_source_nsxt_policy_edge_cluster.go
+++ b/nsxt/data_source_nsxt_policy_edge_cluster.go
@@ -41,7 +41,11 @@ func dataSourceNsxtPolicyEdgeClusterRead(d *schema.ResourceData, m interface{}) 
 		query := make(map[string]string)
 		globalPolicyEnforcementPointPath := getGlobalPolicyEnforcementPointPath(m, &objSitePath)
 		query["parent_path"] = globalPolicyEnforcementPointPath
-		_, err := policyDataSourceResourceReadWithValidation(d, getPolicyConnector(m), getSessionContext(d, m), "PolicyEdgeCluster", query, false)
+		context, err := getSessionContext(d, m)
+		if err != nil {
+			return err
+		}
+		_, err = policyDataSourceResourceReadWithValidation(d, getPolicyConnector(m), context, "PolicyEdgeCluster", query, false)
 		if err != nil {
 			return err
 		}
@@ -50,7 +54,11 @@ func dataSourceNsxtPolicyEdgeClusterRead(d *schema.ResourceData, m interface{}) 
 
 	// Local manager
 	connector := getPolicyConnector(m)
-	_, err := policyDataSourceResourceRead(d, connector, getSessionContext(d, m), "PolicyEdgeCluster", nil)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	_, err = policyDataSourceResourceRead(d, connector, context, "PolicyEdgeCluster", nil)
 	if err != nil {
 		return err
 	}

--- a/nsxt/data_source_nsxt_policy_edge_node.go
+++ b/nsxt/data_source_nsxt_policy_edge_node.go
@@ -50,7 +50,11 @@ func dataSourceNsxtPolicyEdgeNodeRead(d *schema.ResourceData, m interface{}) err
 		if memberIndexSet {
 			query["member_index"] = strconv.Itoa(memberIndex.(int))
 		}
-		obj, err := policyDataSourceResourceReadWithValidation(d, getPolicyConnector(m), getSessionContext(d, m), "PolicyEdgeNode", query, false)
+		context, err := getSessionContext(d, m)
+		if err != nil {
+			return err
+		}
+		obj, err := policyDataSourceResourceReadWithValidation(d, getPolicyConnector(m), context, "PolicyEdgeNode", query, false)
 		if err != nil {
 			return err
 		}

--- a/nsxt/data_source_nsxt_policy_gateway_dns_forwarder.go
+++ b/nsxt/data_source_nsxt_policy_gateway_dns_forwarder.go
@@ -19,7 +19,7 @@ func dataSourceNsxtPolicyGatewayDNSForwarder() *schema.Resource {
 			"description":  getDataSourceDescriptionSchema(),
 			"path":         getPathSchema(),
 			"gateway_path": getPolicyPathSchema(false, false, "Gateway path"),
-			"context":      getContextSchema(false, false),
+			"context":      getContextSchema(false, false, false),
 		},
 	}
 }

--- a/nsxt/data_source_nsxt_policy_gateway_dns_forwarder.go
+++ b/nsxt/data_source_nsxt_policy_gateway_dns_forwarder.go
@@ -32,7 +32,11 @@ func dataSourceNsxtPolicyGatewayDNSForwarderRead(d *schema.ResourceData, m inter
 	if len(gwPath) > 0 {
 		query["parent_path"] = fmt.Sprintf("%s*", gwPath)
 	}
-	_, err := policyDataSourceResourceReadWithValidation(d, connector, getSessionContext(d, m), "PolicyDnsForwarder", query, false)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	_, err = policyDataSourceResourceReadWithValidation(d, connector, context, "PolicyDnsForwarder", query, false)
 	if err != nil {
 		return err
 	}

--- a/nsxt/data_source_nsxt_policy_gateway_flood_protection_profile.go
+++ b/nsxt/data_source_nsxt_policy_gateway_flood_protection_profile.go
@@ -24,7 +24,11 @@ func dataSourceNsxtPolicyGatewayFloodProtectionProfile() *schema.Resource {
 func dataSourceNsxtPolicyGatewayFloodProtectionProfileRead(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
 
-	_, err := policyDataSourceResourceRead(d, connector, getSessionContext(d, m), "GatewayFloodProtectionProfile", nil)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	_, err = policyDataSourceResourceRead(d, connector, context, "GatewayFloodProtectionProfile", nil)
 	if err != nil {
 		return err
 	}

--- a/nsxt/data_source_nsxt_policy_gateway_flood_protection_profile.go
+++ b/nsxt/data_source_nsxt_policy_gateway_flood_protection_profile.go
@@ -16,7 +16,7 @@ func dataSourceNsxtPolicyGatewayFloodProtectionProfile() *schema.Resource {
 			"display_name": getDataSourceExtendedDisplayNameSchema(),
 			"description":  getDataSourceDescriptionSchema(),
 			"path":         getPathSchema(),
-			"context":      getContextSchema(false, false),
+			"context":      getContextSchema(false, false, false),
 		},
 	}
 }

--- a/nsxt/data_source_nsxt_policy_gateway_interface_realization.go
+++ b/nsxt/data_source_nsxt_policy_gateway_interface_realization.go
@@ -22,7 +22,7 @@ func dataSourceNsxtPolicyGatewayInterfaceRealization() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"id":      getDataSourceIDSchema(),
-			"context": getContextSchema(false, false),
+			"context": getContextSchema(false, false, false),
 			"gateway_path": {
 				Type:         schema.TypeString,
 				Description:  "The path for the gateway",

--- a/nsxt/data_source_nsxt_policy_gateway_interface_realization.go
+++ b/nsxt/data_source_nsxt_policy_gateway_interface_realization.go
@@ -72,7 +72,11 @@ func dataSourceNsxtPolicyGatewayInterfaceRealization() *schema.Resource {
 
 func dataSourceNsxtPolicyGatewayInterfaceRealizationRead(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
-	client := realizedstate.NewRealizedEntitiesClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := realizedstate.NewRealizedEntitiesClient(context, connector)
 
 	id := d.Get("id").(string)
 	gatewayPath := d.Get("gateway_path").(string)
@@ -154,7 +158,7 @@ func dataSourceNsxtPolicyGatewayInterfaceRealizationRead(d *schema.ResourceData,
 		MinTimeout: 1 * time.Second,
 		Delay:      time.Duration(delay) * time.Second,
 	}
-	_, err := stateConf.WaitForState()
+	_, err = stateConf.WaitForState()
 	if err != nil {
 		return fmt.Errorf("Failed to get gateway interface realization information for %s: %v", gatewayPath, err)
 	}

--- a/nsxt/data_source_nsxt_policy_gateway_locale_service.go
+++ b/nsxt/data_source_nsxt_policy_gateway_locale_service.go
@@ -28,7 +28,7 @@ func dataSourceNsxtPolicyGatewayLocaleService() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 			},
-			"context": getContextSchema(false, false),
+			"context": getContextSchema(false, false, false),
 		},
 	}
 }

--- a/nsxt/data_source_nsxt_policy_gateway_locale_service.go
+++ b/nsxt/data_source_nsxt_policy_gateway_locale_service.go
@@ -39,7 +39,11 @@ func dataSourceNsxtPolicyGatewayLocaleServiceRead(d *schema.ResourceData, m inte
 	gwPath := d.Get("gateway_path").(string)
 	query := make(map[string]string)
 	query["parent_path"] = gwPath
-	obj, err := policyDataSourceResourceReadWithValidation(d, connector, getSessionContext(d, m), "LocaleServices", query, false)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	obj, err := policyDataSourceResourceReadWithValidation(d, connector, context, "LocaleServices", query, false)
 
 	if err != nil {
 		return err

--- a/nsxt/data_source_nsxt_policy_gateway_locale_service_test.go
+++ b/nsxt/data_source_nsxt_policy_gateway_locale_service_test.go
@@ -88,6 +88,13 @@ func TestAccDataSourceNsxtPolicyGatewayLocaleService_multitenancy(t *testing.T) 
 	})
 }
 
+func TestAccDataSourceNsxtPolicyGatewayLocaleService_multitenancyProvider(t *testing.T) {
+	testAccDataSourceNsxtPolicyGatewayLocaleServiceDefault(t, false, func() {
+		testAccPreCheck(t)
+		testAccOnlyMultitenancyProvider(t)
+	})
+}
+
 func testAccNsxtPolicyGatewayLocaleServiceTemplate(name string, withContext bool) string {
 	context := ""
 	if withContext {

--- a/nsxt/data_source_nsxt_policy_gateway_policy.go
+++ b/nsxt/data_source_nsxt_policy_gateway_policy.go
@@ -74,7 +74,10 @@ func dataSourceNsxtPolicyGatewayPolicyRead(d *schema.ResourceData, m interface{}
 
 	category := d.Get("category").(string)
 	domain := d.Get("domain").(string)
-	context := getSessionContext(d, m)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
 	if isPolicyGlobalManager(m) {
 		query := make(map[string]string)
 		query["parent_path"] = "*/" + domain

--- a/nsxt/data_source_nsxt_policy_gateway_policy.go
+++ b/nsxt/data_source_nsxt_policy_gateway_policy.go
@@ -30,7 +30,7 @@ func dataSourceNsxtPolicyGatewayPolicy() *schema.Resource {
 			"description":  getDataSourceDescriptionSchema(),
 			"path":         getPathSchema(),
 			"domain":       getDataSourceDomainNameSchema(),
-			"context":      getContextSchema(false, false),
+			"context":      getContextSchema(false, false, false),
 			"category": {
 				Type:         schema.TypeString,
 				Description:  "Category",

--- a/nsxt/data_source_nsxt_policy_gateway_policy_test.go
+++ b/nsxt/data_source_nsxt_policy_gateway_policy_test.go
@@ -22,6 +22,13 @@ func TestAccDataSourceNsxtPolicyGatewayPolicy_multitenancy(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceNsxtPolicyGatewayPolicy_multitenancyProvider(t *testing.T) {
+	testAccDataSourceNsxtPolicyGatewayPolicyBasic(t, false, func() {
+		testAccPreCheck(t)
+		testAccOnlyMultitenancyProvider(t)
+	})
+}
+
 func testAccDataSourceNsxtPolicyGatewayPolicyBasic(t *testing.T, withContext bool, preCheck func()) {
 	name := getAccTestDataSourceName()
 	category := "LocalGatewayRules"

--- a/nsxt/data_source_nsxt_policy_gateway_prefix_list.go
+++ b/nsxt/data_source_nsxt_policy_gateway_prefix_list.go
@@ -31,7 +31,11 @@ func dataSourceNsxtPolicyGatewayPrefixListRead(d *schema.ResourceData, m interfa
 	if len(gwPath) > 0 {
 		query["parent_path"] = fmt.Sprintf("%s*", gwPath)
 	}
-	_, err := policyDataSourceResourceReadWithValidation(d, connector, getSessionContext(d, m), "PrefixList", query, false)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	_, err = policyDataSourceResourceReadWithValidation(d, connector, context, "PrefixList", query, false)
 	if err != nil {
 		return err
 	}

--- a/nsxt/data_source_nsxt_policy_gateway_qos_profile.go
+++ b/nsxt/data_source_nsxt_policy_gateway_qos_profile.go
@@ -16,7 +16,7 @@ func dataSourceNsxtPolicyGatewayQosProfile() *schema.Resource {
 			"display_name": getDataSourceDisplayNameSchema(),
 			"description":  getDataSourceDescriptionSchema(),
 			"path":         getPathSchema(),
-			"context":      getContextSchema(false, false),
+			"context":      getContextSchema(false, false, false),
 		},
 	}
 }

--- a/nsxt/data_source_nsxt_policy_gateway_qos_profile.go
+++ b/nsxt/data_source_nsxt_policy_gateway_qos_profile.go
@@ -22,7 +22,11 @@ func dataSourceNsxtPolicyGatewayQosProfile() *schema.Resource {
 }
 
 func dataSourceNsxtPolicyGatewayQosProfileRead(d *schema.ResourceData, m interface{}) error {
-	_, err := policyDataSourceResourceRead(d, getPolicyConnector(m), getSessionContext(d, m), "GatewayQosProfile", nil)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	_, err = policyDataSourceResourceRead(d, getPolicyConnector(m), context, "GatewayQosProfile", nil)
 	if err != nil {
 		return err
 	}

--- a/nsxt/data_source_nsxt_policy_gateway_qos_profile_test.go
+++ b/nsxt/data_source_nsxt_policy_gateway_qos_profile_test.go
@@ -30,6 +30,13 @@ func TestAccDataSourceNsxtPolicyGatewayQosProfile_multitenancy(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceNsxtPolicyGatewayQosProfile_multitenancyProvider(t *testing.T) {
+	testAccDataSourceNsxtPolicyGatewayQosProfileBasic(t, false, func() {
+		testAccPreCheck(t)
+		testAccOnlyMultitenancyProvider(t)
+	})
+}
+
 func testAccDataSourceNsxtPolicyGatewayQosProfileBasic(t *testing.T, withContext bool, preCheck func()) {
 	name := getAccTestDataSourceName()
 	testResourceName := "data.nsxt_policy_gateway_qos_profile.test"

--- a/nsxt/data_source_nsxt_policy_gateway_route_map.go
+++ b/nsxt/data_source_nsxt_policy_gateway_route_map.go
@@ -31,7 +31,11 @@ func dataSourceNsxtPolicyGatewayRouteMapRead(d *schema.ResourceData, m interface
 	if len(gwPath) > 0 {
 		query["parent_path"] = fmt.Sprintf("%s*", gwPath)
 	}
-	_, err := policyDataSourceResourceReadWithValidation(d, connector, getSessionContext(d, m), "Tier0RouteMap", query, false)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	_, err = policyDataSourceResourceReadWithValidation(d, connector, context, "Tier0RouteMap", query, false)
 	if err != nil {
 		return err
 	}

--- a/nsxt/data_source_nsxt_policy_group.go
+++ b/nsxt/data_source_nsxt_policy_group.go
@@ -17,7 +17,7 @@ func dataSourceNsxtPolicyGroup() *schema.Resource {
 			"description":  getDataSourceDescriptionSchema(),
 			"path":         getPathSchema(),
 			"domain":       getDomainNameSchema(),
-			"context":      getContextSchema(false, false),
+			"context":      getContextSchema(false, false, false),
 		},
 	}
 }

--- a/nsxt/data_source_nsxt_policy_group.go
+++ b/nsxt/data_source_nsxt_policy_group.go
@@ -26,7 +26,11 @@ func dataSourceNsxtPolicyGroupRead(d *schema.ResourceData, m interface{}) error 
 	domain := d.Get("domain").(string)
 	query := make(map[string]string)
 	query["parent_path"] = "*/" + domain
-	_, err := policyDataSourceResourceRead(d, getPolicyConnector(m), getSessionContext(d, m), "Group", query)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	_, err = policyDataSourceResourceRead(d, getPolicyConnector(m), context, "Group", query)
 	if err != nil {
 		return err
 	}

--- a/nsxt/data_source_nsxt_policy_group_test.go
+++ b/nsxt/data_source_nsxt_policy_group_test.go
@@ -27,6 +27,13 @@ func TestAccDataSourceNsxtPolicyGroup_multitenancy(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceNsxtPolicyGroup_multitenancyProvider(t *testing.T) {
+	testAccDataSourceNsxtPolicyGroupBasic(t, false, func() {
+		testAccPreCheck(t)
+		testAccOnlyMultitenancyProvider(t)
+	})
+}
+
 func testAccDataSourceNsxtPolicyGroupBasic(t *testing.T, withContext bool, preCheck func()) {
 	name := getAccTestDataSourceName()
 	domain := "default"

--- a/nsxt/data_source_nsxt_policy_host_transport_node.go
+++ b/nsxt/data_source_nsxt_policy_host_transport_node.go
@@ -28,7 +28,11 @@ func dataSourceNsxtPolicyHostTransportNode() *schema.Resource {
 }
 
 func dataSourceNsxtPolicyHostTransportNodeRead(d *schema.ResourceData, m interface{}) error {
-	obj, err := policyDataSourceResourceRead(d, getPolicyConnector(m), getSessionContext(d, m), "HostTransportNode", nil)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	obj, err := policyDataSourceResourceRead(d, getPolicyConnector(m), context, "HostTransportNode", nil)
 	if err != nil {
 		return err
 	}

--- a/nsxt/data_source_nsxt_policy_host_transport_node_profile.go
+++ b/nsxt/data_source_nsxt_policy_host_transport_node_profile.go
@@ -21,7 +21,11 @@ func dataSourceNsxtPolicyHostTransportNodeProfile() *schema.Resource {
 }
 
 func dataSourceNsxtPolicyHostTransportNodeProfileRead(d *schema.ResourceData, m interface{}) error {
-	_, err := policyDataSourceResourceRead(d, getPolicyConnector(m), getSessionContext(d, m), "PolicyHostTransportNodeProfile", nil)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	_, err = policyDataSourceResourceRead(d, getPolicyConnector(m), context, "PolicyHostTransportNodeProfile", nil)
 	if err != nil {
 		return err
 	}

--- a/nsxt/data_source_nsxt_policy_intrusion_service_profile.go
+++ b/nsxt/data_source_nsxt_policy_intrusion_service_profile.go
@@ -28,7 +28,11 @@ func dataSourceNsxtPolicyIntrusionServiceProfileRead(d *schema.ResourceData, m i
 		return localManagerOnlyError()
 	}
 
-	_, err := policyDataSourceResourceRead(d, connector, getSessionContext(d, m), "IdsProfile", nil)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	_, err = policyDataSourceResourceRead(d, connector, context, "IdsProfile", nil)
 	if err != nil {
 		return err
 	}

--- a/nsxt/data_source_nsxt_policy_intrusion_service_profile.go
+++ b/nsxt/data_source_nsxt_policy_intrusion_service_profile.go
@@ -16,7 +16,7 @@ func dataSourceNsxtPolicyIntrusionServiceProfile() *schema.Resource {
 			"display_name": getDataSourceExtendedDisplayNameSchema(),
 			"description":  getDataSourceDescriptionSchema(),
 			"path":         getPathSchema(),
-			"context":      getContextSchema(false, false),
+			"context":      getContextSchema(false, false, false),
 		},
 	}
 }

--- a/nsxt/data_source_nsxt_policy_intrusion_service_profile_test.go
+++ b/nsxt/data_source_nsxt_policy_intrusion_service_profile_test.go
@@ -49,6 +49,13 @@ func TestAccDataSourceNsxtPolicyIntrusionServiceProfile_multitenancy(t *testing.
 	})
 }
 
+func TestAccDataSourceNsxtPolicyIntrusionServiceProfile_multitenancyProvider(t *testing.T) {
+	testAccDataSourceNsxtPolicyIntrusionServiceProfileBasic(t, false, func() {
+		testAccPreCheck(t)
+		testAccOnlyMultitenancyProvider(t)
+	})
+}
+
 func testAccDataSourceNsxtPolicyIntrusionServiceProfileBasic(t *testing.T, withContext bool, preCheck func()) {
 	name := getAccTestResourceName()
 	testResourceName := "data.nsxt_policy_intrusion_service_profile.test"

--- a/nsxt/data_source_nsxt_policy_ip_block.go
+++ b/nsxt/data_source_nsxt_policy_ip_block.go
@@ -22,7 +22,7 @@ func dataSourceNsxtPolicyIPBlock() *schema.Resource {
 			"display_name": getDataSourceDisplayNameSchema(),
 			"description":  getDataSourceDescriptionSchema(),
 			"path":         getPathSchema(),
-			"context":      getContextSchema(false, false),
+			"context":      getContextSchema(false, false, false),
 		},
 	}
 }

--- a/nsxt/data_source_nsxt_policy_ip_block.go
+++ b/nsxt/data_source_nsxt_policy_ip_block.go
@@ -29,7 +29,11 @@ func dataSourceNsxtPolicyIPBlock() *schema.Resource {
 
 func dataSourceNsxtPolicyIPBlockRead(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
-	client := infra.NewIpBlocksClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := infra.NewIpBlocksClient(context, connector)
 
 	objID := d.Get("id").(string)
 	objName := d.Get("display_name").(string)

--- a/nsxt/data_source_nsxt_policy_ip_block_test.go
+++ b/nsxt/data_source_nsxt_policy_ip_block_test.go
@@ -29,6 +29,13 @@ func TestAccDataSourceNsxtPolicyIpBlock_multitenancy(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceNsxtPolicyIpBlock_multitenancyProvider(t *testing.T) {
+	testAccDataSourceNsxtPolicyIPBlockBasic(t, false, func() {
+		testAccPreCheck(t)
+		testAccOnlyMultitenancyProvider(t)
+	})
+}
+
 func testAccDataSourceNsxtPolicyIPBlockBasic(t *testing.T, withContext bool, preCheck func()) {
 	name := getAccTestDataSourceName()
 	testResourceName := "data.nsxt_policy_ip_block.test"

--- a/nsxt/data_source_nsxt_policy_ip_discovery_profile.go
+++ b/nsxt/data_source_nsxt_policy_ip_discovery_profile.go
@@ -16,7 +16,7 @@ func dataSourceNsxtPolicyIPDiscoveryProfile() *schema.Resource {
 			"display_name": getDataSourceDisplayNameSchema(),
 			"description":  getDataSourceDescriptionSchema(),
 			"path":         getPathSchema(),
-			"context":      getContextSchema(false, false),
+			"context":      getContextSchema(false, false, false),
 		},
 	}
 }

--- a/nsxt/data_source_nsxt_policy_ip_discovery_profile.go
+++ b/nsxt/data_source_nsxt_policy_ip_discovery_profile.go
@@ -22,7 +22,11 @@ func dataSourceNsxtPolicyIPDiscoveryProfile() *schema.Resource {
 }
 
 func dataSourceNsxtPolicyIPDiscoveryProfileRead(d *schema.ResourceData, m interface{}) error {
-	_, err := policyDataSourceResourceRead(d, getPolicyConnector(m), getSessionContext(d, m), "IPDiscoveryProfile", nil)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	_, err = policyDataSourceResourceRead(d, getPolicyConnector(m), context, "IPDiscoveryProfile", nil)
 	if err != nil {
 		return err
 	}

--- a/nsxt/data_source_nsxt_policy_ip_pool.go
+++ b/nsxt/data_source_nsxt_policy_ip_pool.go
@@ -30,7 +30,11 @@ func dataSourceNsxtPolicyIPPool() *schema.Resource {
 }
 
 func dataSourceNsxtPolicyIPPoolRead(d *schema.ResourceData, m interface{}) error {
-	obj, err := policyDataSourceResourceRead(d, getPolicyConnector(m), getSessionContext(d, m), "IpAddressPool", nil)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	obj, err := policyDataSourceResourceRead(d, getPolicyConnector(m), context, "IpAddressPool", nil)
 	if err != nil {
 		return err
 	}

--- a/nsxt/data_source_nsxt_policy_ip_pool.go
+++ b/nsxt/data_source_nsxt_policy_ip_pool.go
@@ -19,7 +19,7 @@ func dataSourceNsxtPolicyIPPool() *schema.Resource {
 			"display_name": getDataSourceDisplayNameSchema(),
 			"description":  getDataSourceDescriptionSchema(),
 			"path":         getPathSchema(),
-			"context":      getContextSchema(false, false),
+			"context":      getContextSchema(false, false, false),
 			"realized_id": {
 				Type:        schema.TypeString,
 				Description: "The ID of the realized resource",

--- a/nsxt/data_source_nsxt_policy_ip_pool_test.go
+++ b/nsxt/data_source_nsxt_policy_ip_pool_test.go
@@ -28,6 +28,13 @@ func TestAccDataSourceNsxtPolicyIpPool_multitenancy(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceNsxtPolicyIpPool_multitenancyProvider(t *testing.T) {
+	testAccDataSourceNsxtPolicyIPPoolBasic(t, false, func() {
+		testAccPreCheck(t)
+		testAccOnlyMultitenancyProvider(t)
+	})
+}
+
 func testAccDataSourceNsxtPolicyIPPoolBasic(t *testing.T, withContext bool, preCheck func()) {
 	name := getAccTestDataSourceName()
 	testResourceName := "data.nsxt_policy_ip_pool.test"

--- a/nsxt/data_source_nsxt_policy_ipsec_vpn_local_endpoint.go
+++ b/nsxt/data_source_nsxt_policy_ipsec_vpn_local_endpoint.go
@@ -49,7 +49,11 @@ func dataSourceNsxtPolicyIPSecVpnLocalEndpointRead(d *schema.ResourceData, m int
 		}
 		query["parent_path"] = fmt.Sprintf("%s*", servicePath)
 	}
-	objInt, err := policyDataSourceResourceReadWithValidation(d, connector, getSessionContext(d, m), "IPSecVpnLocalEndpoint", query, false)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	objInt, err := policyDataSourceResourceReadWithValidation(d, connector, context, "IPSecVpnLocalEndpoint", query, false)
 	if err != nil {
 		return err
 	}

--- a/nsxt/data_source_nsxt_policy_ipsec_vpn_service.go
+++ b/nsxt/data_source_nsxt_policy_ipsec_vpn_service.go
@@ -31,7 +31,11 @@ func dataSourceNsxtPolicyIPSecVpnServiceRead(d *schema.ResourceData, m interface
 	if len(gwPath) > 0 {
 		query["parent_path"] = fmt.Sprintf("%s*", gwPath)
 	}
-	_, err := policyDataSourceResourceReadWithValidation(d, connector, getSessionContext(d, m), "IPSecVpnService", query, false)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	_, err = policyDataSourceResourceReadWithValidation(d, connector, context, "IPSecVpnService", query, false)
 	if err != nil {
 		return err
 	}

--- a/nsxt/data_source_nsxt_policy_ipv6_dad_profile.go
+++ b/nsxt/data_source_nsxt_policy_ipv6_dad_profile.go
@@ -16,7 +16,7 @@ func dataSourceNsxtPolicyIpv6DadProfile() *schema.Resource {
 			"display_name": getDataSourceDisplayNameSchema(),
 			"description":  getDataSourceDescriptionSchema(),
 			"path":         getPathSchema(),
-			"context":      getContextSchema(false, false),
+			"context":      getContextSchema(false, false, false),
 		},
 	}
 }

--- a/nsxt/data_source_nsxt_policy_ipv6_dad_profile.go
+++ b/nsxt/data_source_nsxt_policy_ipv6_dad_profile.go
@@ -22,7 +22,11 @@ func dataSourceNsxtPolicyIpv6DadProfile() *schema.Resource {
 }
 
 func dataSourceNsxtPolicyIpv6DadProfileRead(d *schema.ResourceData, m interface{}) error {
-	_, err := policyDataSourceResourceRead(d, getPolicyConnector(m), getSessionContext(d, m), "Ipv6DadProfile", nil)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	_, err = policyDataSourceResourceRead(d, getPolicyConnector(m), context, "Ipv6DadProfile", nil)
 	if err != nil {
 		return err
 	}

--- a/nsxt/data_source_nsxt_policy_ipv6_dad_profile_test.go
+++ b/nsxt/data_source_nsxt_policy_ipv6_dad_profile_test.go
@@ -27,6 +27,13 @@ func TestAccDataSourceNsxtPolicyIpv6DadProfile_multitenancy(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceNsxtPolicyIpv6DadProfile_multitenancyProvider(t *testing.T) {
+	testAccDataSourceNsxtPolicyIpv6DadProfileBasic(t, false, func() {
+		testAccPreCheck(t)
+		testAccOnlyMultitenancyProvider(t)
+	})
+}
+
 func testAccDataSourceNsxtPolicyIpv6DadProfileBasic(t *testing.T, withContext bool, preCheck func()) {
 	name := getAccTestDataSourceName()
 	testResourceName := "data.nsxt_policy_ipv6_dad_profile.test"

--- a/nsxt/data_source_nsxt_policy_ipv6_ndra_profile.go
+++ b/nsxt/data_source_nsxt_policy_ipv6_ndra_profile.go
@@ -22,7 +22,11 @@ func dataSourceNsxtPolicyIpv6NdraProfile() *schema.Resource {
 }
 
 func dataSourceNsxtPolicyIpv6NdraProfileRead(d *schema.ResourceData, m interface{}) error {
-	_, err := policyDataSourceResourceRead(d, getPolicyConnector(m), getSessionContext(d, m), "Ipv6NdraProfile", nil)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	_, err = policyDataSourceResourceRead(d, getPolicyConnector(m), context, "Ipv6NdraProfile", nil)
 	if err != nil {
 		return err
 	}

--- a/nsxt/data_source_nsxt_policy_ipv6_ndra_profile.go
+++ b/nsxt/data_source_nsxt_policy_ipv6_ndra_profile.go
@@ -16,7 +16,7 @@ func dataSourceNsxtPolicyIpv6NdraProfile() *schema.Resource {
 			"display_name": getDataSourceDisplayNameSchema(),
 			"description":  getDataSourceDescriptionSchema(),
 			"path":         getPathSchema(),
-			"context":      getContextSchema(false, false),
+			"context":      getContextSchema(false, false, false),
 		},
 	}
 }

--- a/nsxt/data_source_nsxt_policy_ipv6_ndra_profile_test.go
+++ b/nsxt/data_source_nsxt_policy_ipv6_ndra_profile_test.go
@@ -27,6 +27,13 @@ func TestAccDataSourceNsxtPolicyIpv6NdraProfile_multitenancy(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceNsxtPolicyIpv6NdraProfile_multitenancyProvider(t *testing.T) {
+	testAccDataSourceNsxtPolicyIpv6NdraProfileBasic(t, false, func() {
+		testAccPreCheck(t)
+		testAccOnlyMultitenancyProvider(t)
+	})
+}
+
 func testAccDataSourceNsxtPolicyIpv6NdraProfileBasic(t *testing.T, withContext bool, preCheck func()) {
 	name := getAccTestDataSourceName()
 	testResourceName := "data.nsxt_policy_ipv6_ndra_profile.test"

--- a/nsxt/data_source_nsxt_policy_l2_vpn_service.go
+++ b/nsxt/data_source_nsxt_policy_l2_vpn_service.go
@@ -31,7 +31,11 @@ func dataSourceNsxtPolicyL2VpnServiceRead(d *schema.ResourceData, m interface{})
 	if len(gwPath) > 0 {
 		query["parent_path"] = fmt.Sprintf("%s*", gwPath)
 	}
-	_, err := policyDataSourceResourceReadWithValidation(d, connector, getSessionContext(d, m), "L2VPNService", query, false)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	_, err = policyDataSourceResourceReadWithValidation(d, connector, context, "L2VPNService", query, false)
 	if err != nil {
 		return err
 	}

--- a/nsxt/data_source_nsxt_policy_lb_service.go
+++ b/nsxt/data_source_nsxt_policy_lb_service.go
@@ -23,7 +23,11 @@ func dataSourceNsxtPolicyLbService() *schema.Resource {
 func dataSourceNsxtPolicyLbServiceRead(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
 
-	_, err := policyDataSourceResourceRead(d, connector, getSessionContext(d, m), "LBService", nil)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	_, err = policyDataSourceResourceRead(d, connector, context, "LBService", nil)
 	if err != nil {
 		return err
 	}

--- a/nsxt/data_source_nsxt_policy_mac_discovery_profile.go
+++ b/nsxt/data_source_nsxt_policy_mac_discovery_profile.go
@@ -16,7 +16,7 @@ func dataSourceNsxtPolicyMacDiscoveryProfile() *schema.Resource {
 			"display_name": getDataSourceDisplayNameSchema(),
 			"description":  getDataSourceDescriptionSchema(),
 			"path":         getPathSchema(),
-			"context":      getContextSchema(false, false),
+			"context":      getContextSchema(false, false, false),
 		},
 	}
 }

--- a/nsxt/data_source_nsxt_policy_mac_discovery_profile.go
+++ b/nsxt/data_source_nsxt_policy_mac_discovery_profile.go
@@ -22,7 +22,11 @@ func dataSourceNsxtPolicyMacDiscoveryProfile() *schema.Resource {
 }
 
 func dataSourceNsxtPolicyMacDiscoveryProfileRead(d *schema.ResourceData, m interface{}) error {
-	_, err := policyDataSourceResourceRead(d, getPolicyConnector(m), getSessionContext(d, m), "MacDiscoveryProfile", nil)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	_, err = policyDataSourceResourceRead(d, getPolicyConnector(m), context, "MacDiscoveryProfile", nil)
 	if err != nil {
 		return err
 	}

--- a/nsxt/data_source_nsxt_policy_mac_discovery_profile_test.go
+++ b/nsxt/data_source_nsxt_policy_mac_discovery_profile_test.go
@@ -64,7 +64,29 @@ func TestAccDataSourceNsxtPolicyMacDiscoveryProfile_multitenancy(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNsxtPolicyMacDiscoveryProfileMultitenancyTemplate(name),
+				Config: testAccNsxtPolicyMacDiscoveryProfileMultitenancyTemplate(name, true),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(testResourceName, "display_name", name),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceNsxtPolicyMacDiscoveryProfile_multitenancyProvider(t *testing.T) {
+	name := getAccTestResourceName()
+	testResourceName := "data.nsxt_policy_mac_discovery_profile.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccOnlyMultitenancyProvider(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyMacDiscoveryProfileMultitenancyTemplate(name, false),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(testResourceName, "display_name", name),
 					resource.TestCheckResourceAttrSet(testResourceName, "path"),
@@ -81,8 +103,11 @@ data "nsxt_policy_mac_discovery_profile" "test" {
 }`, name)
 }
 
-func testAccNsxtPolicyMacDiscoveryProfileMultitenancyTemplate(name string) string {
-	context := testAccNsxtPolicyMultitenancyContext()
+func testAccNsxtPolicyMacDiscoveryProfileMultitenancyTemplate(name string, withContext bool) string {
+	context := ""
+	if withContext {
+		context = testAccNsxtPolicyMultitenancyContext()
+	}
 	return fmt.Sprintf(`
 resource "nsxt_policy_mac_discovery_profile" "test" {
 %s

--- a/nsxt/data_source_nsxt_policy_qos_profile.go
+++ b/nsxt/data_source_nsxt_policy_qos_profile.go
@@ -22,7 +22,11 @@ func dataSourceNsxtPolicyQosProfile() *schema.Resource {
 }
 
 func dataSourceNsxtPolicyQosProfileRead(d *schema.ResourceData, m interface{}) error {
-	_, err := policyDataSourceResourceRead(d, getPolicyConnector(m), getSessionContext(d, m), "QoSProfile", nil)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	_, err = policyDataSourceResourceRead(d, getPolicyConnector(m), context, "QoSProfile", nil)
 	if err != nil {
 		return err
 	}

--- a/nsxt/data_source_nsxt_policy_qos_profile.go
+++ b/nsxt/data_source_nsxt_policy_qos_profile.go
@@ -16,7 +16,7 @@ func dataSourceNsxtPolicyQosProfile() *schema.Resource {
 			"display_name": getDataSourceDisplayNameSchema(),
 			"description":  getDataSourceDescriptionSchema(),
 			"path":         getPathSchema(),
-			"context":      getContextSchema(false, false),
+			"context":      getContextSchema(false, false, false),
 		},
 	}
 }

--- a/nsxt/data_source_nsxt_policy_qos_profile_test.go
+++ b/nsxt/data_source_nsxt_policy_qos_profile_test.go
@@ -27,6 +27,13 @@ func TestAccDataSourceNsxtPolicyQosProfile_multitenancy(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceNsxtPolicyQosProfile_multitenancyProvider(t *testing.T) {
+	testAccDataSourceNsxtPolicyQosProfileBasic(t, false, func() {
+		testAccPreCheck(t)
+		testAccOnlyMultitenancyProvider(t)
+	})
+}
+
 func testAccDataSourceNsxtPolicyQosProfileBasic(t *testing.T, withContext bool, preCheck func()) {
 	name := getAccTestDataSourceName()
 	testResourceName := "data.nsxt_policy_qos_profile.test"

--- a/nsxt/data_source_nsxt_policy_realization_info.go
+++ b/nsxt/data_source_nsxt_policy_realization_info.go
@@ -27,7 +27,7 @@ func dataSourceNsxtPolicyRealizationInfo() *schema.Resource {
 				Required:     true,
 				ValidateFunc: validatePolicyPath(),
 			},
-			"context": getContextSchema(false, false),
+			"context": getContextSchema(false, false, false),
 			"entity_type": {
 				Type:        schema.TypeString,
 				Description: "The entity type of the realized resource",

--- a/nsxt/data_source_nsxt_policy_realization_info.go
+++ b/nsxt/data_source_nsxt_policy_realization_info.go
@@ -79,6 +79,11 @@ func dataSourceNsxtPolicyRealizationInfoRead(d *schema.ResourceData, m interface
 	delay := d.Get("delay").(int)
 	timeout := d.Get("timeout").(int)
 
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+
 	// Site is mandatory got GM and irrelevant else
 	if !isPolicyGlobalManager(m) && objSitePath != "" {
 		return globalManagerOnlyError()
@@ -104,7 +109,7 @@ func dataSourceNsxtPolicyRealizationInfoRead(d *schema.ResourceData, m interface
 
 			var realizationError error
 			var realizationResult model.GenericPolicyRealizedResourceListResult
-			client := realizedstate.NewRealizedEntitiesClient(getSessionContext(d, m), connector)
+			client := realizedstate.NewRealizedEntitiesClient(context, connector)
 			realizationResult, realizationError = client.List(path, nil)
 			state := "UNKNOWN"
 			if realizationError == nil {
@@ -146,7 +151,7 @@ func dataSourceNsxtPolicyRealizationInfoRead(d *schema.ResourceData, m interface
 		MinTimeout: 1 * time.Second,
 		Delay:      time.Duration(delay) * time.Second,
 	}
-	_, err := stateConf.WaitForState()
+	_, err = stateConf.WaitForState()
 	if err != nil {
 		return fmt.Errorf("Failed to get realization information for %s: %v", path, err)
 	}

--- a/nsxt/data_source_nsxt_policy_realization_info_test.go
+++ b/nsxt/data_source_nsxt_policy_realization_info_test.go
@@ -25,6 +25,13 @@ func TestAccDataSourceNsxtPolicyRealizationInfo_tier1DataSource_multitenancy(t *
 	})
 }
 
+func TestAccDataSourceNsxtPolicyRealizationInfo_tier1DataSource_multitenancyProvider(t *testing.T) {
+	testAccDataSourceNsxtPolicyRealizationInfoTier1DataSource(t, false, func() {
+		testAccPreCheck(t)
+		testAccOnlyMultitenancyProvider(t)
+	})
+}
+
 func testAccDataSourceNsxtPolicyRealizationInfoTier1DataSource(t *testing.T, withContext bool, preCheck func()) {
 	resourceDataType := "nsxt_policy_tier1_gateway"
 	resourceName := getAccTestDataSourceName()
@@ -114,6 +121,14 @@ func TestAccDataSourceNsxtPolicyRealizationInfo_tier1Resource_multitenancy(t *te
 		testAccPreCheck(t)
 		testAccNSXVersion(t, "3.0.0")
 		testAccOnlyMultitenancy(t)
+	})
+}
+
+func TestAccDataSourceNsxtPolicyRealizationInfo_tier1Resource_multitenancyProvider(t *testing.T) {
+	testAccDataSourceNsxtPolicyRealizationInfoTier1Resource(t, false, func() {
+		testAccPreCheck(t)
+		testAccNSXVersion(t, "3.0.0")
+		testAccOnlyMultitenancyProvider(t)
 	})
 }
 

--- a/nsxt/data_source_nsxt_policy_security_policy.go
+++ b/nsxt/data_source_nsxt_policy_security_policy.go
@@ -25,7 +25,7 @@ func dataSourceNsxtPolicySecurityPolicy() *schema.Resource {
 			"display_name": getDataSourceDisplayNameSchema(),
 			"description":  getDataSourceDescriptionSchema(),
 			"path":         getPathSchema(),
-			"context":      getContextSchema(false, false),
+			"context":      getContextSchema(false, false, false),
 			"domain":       getDataSourceDomainNameSchema(),
 			"is_default": {
 				Type:        schema.TypeBool,

--- a/nsxt/data_source_nsxt_policy_security_policy.go
+++ b/nsxt/data_source_nsxt_policy_security_policy.go
@@ -82,7 +82,10 @@ func dataSourceNsxtPolicySecurityPolicyRead(d *schema.ResourceData, m interface{
 	objName := d.Get("display_name").(string)
 
 	var obj model.SecurityPolicy
-	context := getSessionContext(d, m)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
 	if objID != "" {
 		// Get by id
 		client := domains.NewSecurityPoliciesClient(context, connector)

--- a/nsxt/data_source_nsxt_policy_security_policy_test.go
+++ b/nsxt/data_source_nsxt_policy_security_policy_test.go
@@ -24,6 +24,13 @@ func TestAccDataSourceNsxtPolicySecurityPolicy_multitenancy(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceNsxtPolicySecurityPolicy_multitenancyProvider(t *testing.T) {
+	testAccDataSourceNsxtPolicySecurityPolicyBasic(t, false, func() {
+		testAccPreCheck(t)
+		testAccOnlyMultitenancyProvider(t)
+	})
+}
+
 func testAccDataSourceNsxtPolicySecurityPolicyBasic(t *testing.T, withContext bool, preCheck func()) {
 	name := getAccTestDataSourceName()
 	category := "Application"

--- a/nsxt/data_source_nsxt_policy_segment.go
+++ b/nsxt/data_source_nsxt_policy_segment.go
@@ -24,7 +24,11 @@ func dataSourceNsxtPolicySegment() *schema.Resource {
 func dataSourceNsxtPolicySegmentRead(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
 
-	_, err := policyDataSourceResourceRead(d, connector, getSessionContext(d, m), "Segment", nil)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	_, err = policyDataSourceResourceRead(d, connector, context, "Segment", nil)
 	if err != nil {
 		return err
 	}

--- a/nsxt/data_source_nsxt_policy_segment.go
+++ b/nsxt/data_source_nsxt_policy_segment.go
@@ -16,7 +16,7 @@ func dataSourceNsxtPolicySegment() *schema.Resource {
 			"display_name": getDataSourceExtendedDisplayNameSchema(),
 			"description":  getDataSourceDescriptionSchema(),
 			"path":         getPathSchema(),
-			"context":      getContextSchema(false, false),
+			"context":      getContextSchema(false, false, false),
 		},
 	}
 }

--- a/nsxt/data_source_nsxt_policy_segment_realization.go
+++ b/nsxt/data_source_nsxt_policy_segment_realization.go
@@ -46,7 +46,10 @@ func dataSourceNsxtPolicySegmentRealization() *schema.Resource {
 func dataSourceNsxtPolicySegmentRealizationRead(d *schema.ResourceData, m interface{}) error {
 	// Read the realization info by the path, and wait till it is valid
 	connector := getPolicyConnector(m)
-	context := getSessionContext(d, m)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
 	commonProviderConfig := getCommonProviderConfig(m)
 
 	// Get the realization info of this resource
@@ -91,7 +94,7 @@ func dataSourceNsxtPolicySegmentRealizationRead(d *schema.ResourceData, m interf
 		MinTimeout: 1 * time.Second,
 		Delay:      1 * time.Second,
 	}
-	_, err := stateConf.WaitForState()
+	_, err = stateConf.WaitForState()
 	if err != nil {
 		return fmt.Errorf("Failed to get realization information for %s: %v", path, err)
 	}

--- a/nsxt/data_source_nsxt_policy_segment_realization.go
+++ b/nsxt/data_source_nsxt_policy_segment_realization.go
@@ -22,7 +22,7 @@ func dataSourceNsxtPolicySegmentRealization() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"id":      getDataSourceIDSchema(),
-			"context": getContextSchema(false, false),
+			"context": getContextSchema(false, false, false),
 			"path": {
 				Type:         schema.TypeString,
 				Description:  "The path for the policy segment",

--- a/nsxt/data_source_nsxt_policy_segment_realization_test.go
+++ b/nsxt/data_source_nsxt_policy_segment_realization_test.go
@@ -52,6 +52,13 @@ func TestAccDataSourceNsxtPolicySegmentRealization_multitenancy(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceNsxtPolicySegmentRealization_multitenancyProvider(t *testing.T) {
+	testAccDataSourceNsxtPolicySegmentRealization(t, false, false, func() {
+		testAccPreCheck(t)
+		testAccOnlyMultitenancyProvider(t)
+	})
+}
+
 func testAccNsxtPolicySegmentRealizationTemplate(vlan, withContext bool) string {
 	resource := "nsxt_policy_segment"
 	tz := getOverlayTransportZoneName()

--- a/nsxt/data_source_nsxt_policy_segment_security_profile.go
+++ b/nsxt/data_source_nsxt_policy_segment_security_profile.go
@@ -22,7 +22,11 @@ func dataSourceNsxtPolicySegmentSecurityProfile() *schema.Resource {
 }
 
 func dataSourceNsxtPolicySegmentSecurityProfileRead(d *schema.ResourceData, m interface{}) error {
-	_, err := policyDataSourceResourceRead(d, getPolicyConnector(m), getSessionContext(d, m), "SegmentSecurityProfile", nil)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	_, err = policyDataSourceResourceRead(d, getPolicyConnector(m), context, "SegmentSecurityProfile", nil)
 	if err != nil {
 		return err
 	}

--- a/nsxt/data_source_nsxt_policy_segment_security_profile.go
+++ b/nsxt/data_source_nsxt_policy_segment_security_profile.go
@@ -16,7 +16,7 @@ func dataSourceNsxtPolicySegmentSecurityProfile() *schema.Resource {
 			"display_name": getDataSourceDisplayNameSchema(),
 			"description":  getDataSourceDescriptionSchema(),
 			"path":         getPathSchema(),
-			"context":      getContextSchema(false, false),
+			"context":      getContextSchema(false, false, false),
 		},
 	}
 }

--- a/nsxt/data_source_nsxt_policy_segment_test.go
+++ b/nsxt/data_source_nsxt_policy_segment_test.go
@@ -28,6 +28,13 @@ func TestAccDataSourceNsxtPolicySegment_multitenancy(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceNsxtPolicySegment_multitenancyProvider(t *testing.T) {
+	testAccDataSourceNsxtPolicySegmentBasic(t, false, func() {
+		testAccPreCheck(t)
+		testAccOnlyMultitenancyProvider(t)
+	})
+}
+
 func testAccDataSourceNsxtPolicySegmentBasic(t *testing.T, withContext bool, preCheck func()) {
 	name := getAccTestDataSourceName()
 	testResourceName := "data.nsxt_policy_segment.test"

--- a/nsxt/data_source_nsxt_policy_service.go
+++ b/nsxt/data_source_nsxt_policy_service.go
@@ -16,7 +16,7 @@ func dataSourceNsxtPolicyService() *schema.Resource {
 			"display_name": getDataSourceDisplayNameSchema(),
 			"description":  getDataSourceDescriptionSchema(),
 			"path":         getPathSchema(),
-			"context":      getContextSchema(false, false),
+			"context":      getContextSchema(false, false, false),
 		},
 	}
 }

--- a/nsxt/data_source_nsxt_policy_service.go
+++ b/nsxt/data_source_nsxt_policy_service.go
@@ -22,7 +22,11 @@ func dataSourceNsxtPolicyService() *schema.Resource {
 }
 
 func dataSourceNsxtPolicyServiceRead(d *schema.ResourceData, m interface{}) error {
-	_, err := policyDataSourceResourceRead(d, getPolicyConnector(m), getSessionContext(d, m), "Service", nil)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	_, err = policyDataSourceResourceRead(d, getPolicyConnector(m), context, "Service", nil)
 	if err != nil {
 		return err
 	}

--- a/nsxt/data_source_nsxt_policy_site.go
+++ b/nsxt/data_source_nsxt_policy_site.go
@@ -25,7 +25,11 @@ func dataSourceNsxtPolicySiteRead(d *schema.ResourceData, m interface{}) error {
 		return globalManagerOnlyError()
 	}
 
-	_, err := policyDataSourceResourceRead(d, getPolicyConnector(m), getSessionContext(d, m), "Site", nil)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	_, err = policyDataSourceResourceRead(d, getPolicyConnector(m), context, "Site", nil)
 	if err != nil {
 		return err
 	}

--- a/nsxt/data_source_nsxt_policy_spoofguard_profile.go
+++ b/nsxt/data_source_nsxt_policy_spoofguard_profile.go
@@ -22,7 +22,11 @@ func dataSourceNsxtPolicySpoofGuardProfile() *schema.Resource {
 }
 
 func dataSourceNsxtPolicySpoofGuardProfileRead(d *schema.ResourceData, m interface{}) error {
-	_, err := policyDataSourceResourceRead(d, getPolicyConnector(m), getSessionContext(d, m), "SpoofGuardProfile", nil)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	_, err = policyDataSourceResourceRead(d, getPolicyConnector(m), context, "SpoofGuardProfile", nil)
 	if err != nil {
 		return err
 	}

--- a/nsxt/data_source_nsxt_policy_spoofguard_profile.go
+++ b/nsxt/data_source_nsxt_policy_spoofguard_profile.go
@@ -16,7 +16,7 @@ func dataSourceNsxtPolicySpoofGuardProfile() *schema.Resource {
 			"display_name": getDataSourceDisplayNameSchema(),
 			"description":  getDataSourceDescriptionSchema(),
 			"path":         getPathSchema(),
-			"context":      getContextSchema(false, false),
+			"context":      getContextSchema(false, false, false),
 		},
 	}
 }

--- a/nsxt/data_source_nsxt_policy_tier0_gateway.go
+++ b/nsxt/data_source_nsxt_policy_tier0_gateway.go
@@ -36,7 +36,11 @@ func dataSourceNsxtPolicyTier0Gateway() *schema.Resource {
 
 func dataSourceNsxtPolicyTier0GatewayRead(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
-	obj, err := policyDataSourceResourceRead(d, connector, getSessionContext(d, m), "Tier0", nil)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	obj, err := policyDataSourceResourceRead(d, connector, context, "Tier0", nil)
 	if err != nil {
 		return err
 	}
@@ -51,7 +55,7 @@ func dataSourceNsxtPolicyTier0GatewayRead(d *schema.ResourceData, m interface{})
 			return errors[0]
 		}
 		gw := dataValue.(model.Tier0)
-		err := resourceNsxtPolicyTier0GatewayReadEdgeCluster(getSessionContext(d, m), d, connector)
+		err := resourceNsxtPolicyTier0GatewayReadEdgeCluster(context, d, connector)
 		if err != nil {
 			return fmt.Errorf("failed to get Tier0 %s locale-services: %v", *gw.Id, err)
 		}

--- a/nsxt/data_source_nsxt_policy_tier1_gateway.go
+++ b/nsxt/data_source_nsxt_policy_tier1_gateway.go
@@ -26,7 +26,7 @@ func dataSourceNsxtPolicyTier1Gateway() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 			},
-			"context": getContextSchema(false, false),
+			"context": getContextSchema(false, false, false),
 		},
 	}
 }

--- a/nsxt/data_source_nsxt_policy_tier1_gateway.go
+++ b/nsxt/data_source_nsxt_policy_tier1_gateway.go
@@ -33,7 +33,11 @@ func dataSourceNsxtPolicyTier1Gateway() *schema.Resource {
 
 func dataSourceNsxtPolicyTier1GatewayRead(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
-	obj, err := policyDataSourceResourceRead(d, connector, getSessionContext(d, m), "Tier1", nil)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	obj, err := policyDataSourceResourceRead(d, connector, context, "Tier1", nil)
 	if err != nil {
 		return err
 	}
@@ -48,7 +52,7 @@ func dataSourceNsxtPolicyTier1GatewayRead(d *schema.ResourceData, m interface{})
 			return errors[0]
 		}
 		tier1 := dataValue.(model.Tier1)
-		err := resourceNsxtPolicyTier1GatewayReadEdgeCluster(getSessionContext(d, m), d, connector)
+		err := resourceNsxtPolicyTier1GatewayReadEdgeCluster(context, d, connector)
 		if err != nil {
 			return fmt.Errorf("failed to get Tier1 %s locale-services: %v", *tier1.Id, err)
 		}

--- a/nsxt/data_source_nsxt_policy_tier1_gateway_test.go
+++ b/nsxt/data_source_nsxt_policy_tier1_gateway_test.go
@@ -27,6 +27,13 @@ func TestAccDataSourceNsxtPolicyTier1Gateway_multitenancy(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceNsxtPolicyTier1Gateway_multitenancyProvider(t *testing.T) {
+	testAccDataSourceNsxtPolicyTier1GatewayBasic(t, false, func() {
+		testAccPreCheck(t)
+		testAccOnlyMultitenancyProvider(t)
+	})
+}
+
 func testAccDataSourceNsxtPolicyTier1GatewayBasic(t *testing.T, withContext bool, preCheck func()) {
 	routerName := getAccTestDataSourceName()
 	testResourceName := "data.nsxt_policy_tier1_gateway.test"

--- a/nsxt/data_source_nsxt_policy_transport_zone.go
+++ b/nsxt/data_source_nsxt_policy_transport_zone.go
@@ -76,7 +76,11 @@ func dataSourceNsxtPolicyTransportZoneRead(d *schema.ResourceData, m interface{}
 		if isDefault {
 			query["is_default"] = "true"
 		}
-		obj, err := policyDataSourceResourceReadWithValidation(d, getPolicyConnector(m), getSessionContext(d, m), "PolicyTransportZone", query, false)
+		context, err := getSessionContext(d, m)
+		if err != nil {
+			return err
+		}
+		obj, err := policyDataSourceResourceReadWithValidation(d, getPolicyConnector(m), context, "PolicyTransportZone", query, false)
 		if err != nil {
 			return err
 		}

--- a/nsxt/data_source_nsxt_policy_uplink_host_switch_profile.go
+++ b/nsxt/data_source_nsxt_policy_uplink_host_switch_profile.go
@@ -26,7 +26,11 @@ func dataSourceNsxtUplinkHostSwitchProfile() *schema.Resource {
 func dataSourceNsxtUplinkHostSwitchProfileRead(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
 
-	_, err := policyDataSourceResourceReadWithValidation(d, connector, getSessionContext(d, m), infra.HostSwitchProfiles_LIST_HOSTSWITCH_PROFILE_TYPE_POLICYUPLINKHOSTSWITCHPROFILE, nil, false)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	_, err = policyDataSourceResourceReadWithValidation(d, connector, context, infra.HostSwitchProfiles_LIST_HOSTSWITCH_PROFILE_TYPE_POLICYUPLINKHOSTSWITCHPROFILE, nil, false)
 	if err == nil {
 		return nil
 	}

--- a/nsxt/data_source_nsxt_policy_vm.go
+++ b/nsxt/data_source_nsxt_policy_vm.go
@@ -46,7 +46,10 @@ func dataSourceNsxtPolicyVMIDRead(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
 
 	objID := getNsxtPolicyVMIDFromSchema(d)
-	context := getSessionContext(d, m)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
 	if objID != "" {
 		vmObj, err := findNsxtPolicyVMByID(context, connector, objID, m)
 		if err != nil {

--- a/nsxt/data_source_nsxt_policy_vm.go
+++ b/nsxt/data_source_nsxt_policy_vm.go
@@ -26,7 +26,7 @@ func dataSourceNsxtPolicyVM() *schema.Resource {
 			"external_id":  getDataSourceStringSchema("External ID of the Virtual Machine"),
 			"bios_id":      getDataSourceStringSchema("BIOS UUID of the Virtual Machine"),
 			"instance_id":  getDataSourceStringSchema("Instance UUID of the Virtual Machine"),
-			"context":      getContextSchema(false, false),
+			"context":      getContextSchema(false, false, false),
 		},
 	}
 }

--- a/nsxt/data_source_nsxt_policy_vm_test.go
+++ b/nsxt/data_source_nsxt_policy_vm_test.go
@@ -27,6 +27,14 @@ func TestAccDataSourceNsxtPolicyVM_multitenancy(t *testing.T) {
 		testAccEnvDefined(t, "NSXT_TEST_VM_NAME")
 	})
 }
+func TestAccDataSourceNsxtPolicyVM_multitenancyProvider(t *testing.T) {
+	testAccDataSourceNsxtPolicyVMBasic(t, false, func() {
+		testAccPreCheck(t)
+		testAccOnlyMultitenancyProvider(t)
+		testAccEnvDefined(t, "NSXT_TEST_VM_ID")
+		testAccEnvDefined(t, "NSXT_TEST_VM_NAME")
+	})
+}
 func testAccDataSourceNsxtPolicyVMBasic(t *testing.T, withContext bool, preCheck func()) {
 	testResourceName := "data.nsxt_policy_vm.test"
 

--- a/nsxt/data_source_nsxt_policy_vms.go
+++ b/nsxt/data_source_nsxt_policy_vms.go
@@ -71,7 +71,11 @@ func dataSourceNsxtPolicyVMsRead(d *schema.ResourceData, m interface{}) error {
 	osPrefix := d.Get("guest_os").(string)
 	vmMap := make(map[string]interface{})
 
-	allVMs, err := listAllPolicyVirtualMachines(getSessionContext(d, m), connector, m)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	allVMs, err := listAllPolicyVirtualMachines(context, connector, m)
 	if err != nil {
 		return fmt.Errorf("Error reading Virtual Machines: %v", err)
 	}

--- a/nsxt/data_source_nsxt_policy_vms.go
+++ b/nsxt/data_source_nsxt_policy_vms.go
@@ -58,7 +58,7 @@ func dataSourceNsxtPolicyVMs() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
-			"context": getContextSchema(false, false),
+			"context": getContextSchema(false, false, false),
 		},
 	}
 }

--- a/nsxt/data_source_nsxt_policy_vms_test.go
+++ b/nsxt/data_source_nsxt_policy_vms_test.go
@@ -19,9 +19,17 @@ func TestAccDataSourceNsxtPolicyVMs_basic(t *testing.T) {
 }
 
 func TestAccDataSourceNsxtPolicyVMs_multitenancy(t *testing.T) {
-	testAccDataSourceNsxtPolicyVMsBasic(t, false, func() {
+	testAccDataSourceNsxtPolicyVMsBasic(t, true, func() {
 		testAccPreCheck(t)
 		testAccOnlyMultitenancy(t)
+		testAccEnvDefined(t, "NSXT_TEST_VM_NAME")
+	})
+}
+
+func TestAccDataSourceNsxtPolicyVMs_multitenancyProvider(t *testing.T) {
+	testAccDataSourceNsxtPolicyVMsBasic(t, false, func() {
+		testAccPreCheck(t)
+		testAccOnlyMultitenancyProvider(t)
 		testAccEnvDefined(t, "NSXT_TEST_VM_NAME")
 	})
 }

--- a/nsxt/data_source_nsxt_policy_vpc.go
+++ b/nsxt/data_source_nsxt_policy_vpc.go
@@ -27,7 +27,11 @@ func dataSourceNsxtPolicyVPC() *schema.Resource {
 }
 
 func dataSourceNsxtPolicyVPCRead(d *schema.ResourceData, m interface{}) error {
-	obj, err := policyDataSourceResourceRead(d, getPolicyConnector(m), getSessionContext(d, m), "Vpc", nil)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	obj, err := policyDataSourceResourceRead(d, getPolicyConnector(m), context, "Vpc", nil)
 	if err != nil {
 		return err
 	}

--- a/nsxt/data_source_nsxt_policy_vpc.go
+++ b/nsxt/data_source_nsxt_policy_vpc.go
@@ -17,7 +17,7 @@ func dataSourceNsxtPolicyVPC() *schema.Resource {
 			"display_name": getDataSourceDisplayNameSchema(),
 			"description":  getDataSourceDescriptionSchema(),
 			"path":         getPathSchema(),
-			"context":      getContextSchema(true, false),
+			"context":      getContextSchema(true, false, false),
 			"short_id": {
 				Type:     schema.TypeString,
 				Optional: true,

--- a/nsxt/data_source_nsxt_policy_vtep_ha_host_switch_profile.go
+++ b/nsxt/data_source_nsxt_policy_vtep_ha_host_switch_profile.go
@@ -26,7 +26,11 @@ func dataSourceNsxtVtepHAHostSwitchProfile() *schema.Resource {
 func dataSourceNsxtVtepHAHostSwitchProfileRead(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
 
-	_, err := policyDataSourceResourceReadWithValidation(d, connector, getSessionContext(d, m), infra.HostSwitchProfiles_LIST_HOSTSWITCH_PROFILE_TYPE_POLICYVTEPHAHOSTSWITCHPROFILE, nil, false)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	_, err = policyDataSourceResourceReadWithValidation(d, connector, context, infra.HostSwitchProfiles_LIST_HOSTSWITCH_PROFILE_TYPE_POLICYVTEPHAHOSTSWITCHPROFILE, nil, false)
 	if err == nil {
 		return nil
 	}

--- a/nsxt/policy_common.go
+++ b/nsxt/policy_common.go
@@ -298,7 +298,7 @@ func getSecurityPolicyAndGatewayRuleSchema(scopeRequired bool, isIds bool, nsxID
 		}
 		// Using computed context here, because context is required for consistency and
 		// if it's not provided it can be derived from policy_path.
-		ruleSchema["context"] = getContextSchema(false, true)
+		ruleSchema["context"] = getContextSchema(false, true, false)
 	} else {
 		ruleSchema["sequence_number"] = &schema.Schema{
 			Type:        schema.TypeInt,
@@ -328,7 +328,7 @@ func getPolicySecurityPolicySchema(isIds, withContext, withRule bool) map[string
 		"description":  getDescriptionSchema(),
 		"revision":     getRevisionSchema(),
 		"tag":          getTagsSchema(),
-		"context":      getContextSchema(false, false),
+		"context":      getContextSchema(false, false, false),
 		"domain":       getDomainNameSchema(),
 		"category": {
 			Type:         schema.TypeString,

--- a/nsxt/policy_utils.go
+++ b/nsxt/policy_utils.go
@@ -308,11 +308,12 @@ func nsxtPolicyPathResourceImporterHelper(d *schema.ResourceData, m interface{})
 			}
 			// pathSegs[2] should contain the organization. Once we support multiple organization, it should be
 			// assigned into the context as well
-			contexts := make([]interface{}, 1)
 			ctxMap := make(map[string]interface{})
 			ctxMap["project_id"] = pathSegs[4]
-			contexts[0] = ctxMap
-			d.Set("context", contexts)
+			if pathSegs[5] == "vpcs" {
+				ctxMap["vpc_id"] = pathSegs[6]
+			}
+			d.Set("context", []interface{}{ctxMap})
 			d.SetId(pathSegs[len(pathSegs)-1])
 		}
 		return []*schema.ResourceData{d}, nil

--- a/nsxt/policy_utils.go
+++ b/nsxt/policy_utils.go
@@ -34,7 +34,11 @@ func getOrGenerateID2(d *schema.ResourceData, m interface{}, presenceChecker fun
 		return newUUID(), nil
 	}
 
-	exists, err := presenceChecker(getSessionContext(d, m), id, connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return "", err
+	}
+	exists, err := presenceChecker(context, id, connector)
 	if err != nil {
 		return "", err
 	}

--- a/nsxt/resource_nsxt_policy_bgp_config.go
+++ b/nsxt/resource_nsxt_policy_bgp_config.go
@@ -142,7 +142,10 @@ func resourceNsxtPolicyBgpConfigToStruct(d *schema.ResourceData, isVRF bool) (*m
 func resourceNsxtPolicyBgpConfigCreate(d *schema.ResourceData, m interface{}) error {
 	// This is not a create operation on NSX, since BGP config us auto created
 	connector := getPolicyConnector(m)
-	context := getSessionContext(d, m)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
 
 	gwPath := d.Get("gateway_path").(string)
 	isT0, gwID := parseGatewayPolicyPath(gwPath)

--- a/nsxt/resource_nsxt_policy_context_profile.go
+++ b/nsxt/resource_nsxt_policy_context_profile.go
@@ -61,7 +61,7 @@ func resourceNsxtPolicyContextProfile() *schema.Resource {
 			"description":  getDescriptionSchema(),
 			"revision":     getRevisionSchema(),
 			"tag":          getTagsSchema(),
-			"context":      getContextSchema(false, false),
+			"context":      getContextSchema(false, false, false),
 			"app_id":       getContextProfilePolicyAppIDAttributesSchema(),
 			"custom_url":   getContextProfilePolicyCustomURLAttributesSchema(),
 			"domain_name":  getContextProfilePolicyOtherAttributesSchema(),

--- a/nsxt/resource_nsxt_policy_context_profile.go
+++ b/nsxt/resource_nsxt_policy_context_profile.go
@@ -187,7 +187,10 @@ func resourceNsxtPolicyContextProfileExists(sessionContext utl.SessionContext, i
 
 func resourceNsxtPolicyContextProfileCreate(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
-	context := getSessionContext(d, m)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
 	// Initialize resource Id and verify this ID is not yet used
 	id, err := getOrGenerateID2(d, m, resourceNsxtPolicyContextProfileExists)
 	if err != nil {
@@ -245,7 +248,11 @@ func resourceNsxtPolicyContextProfileRead(d *schema.ResourceData, m interface{})
 		return fmt.Errorf("Error obtaining ContextProfile ID")
 	}
 
-	client := infra.NewContextProfilesClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := infra.NewContextProfilesClient(context, connector)
 	obj, err := client.Get(id)
 	if err != nil {
 		return handleReadError(d, "ContextProfile", id, err)
@@ -264,7 +271,10 @@ func resourceNsxtPolicyContextProfileRead(d *schema.ResourceData, m interface{})
 
 func resourceNsxtPolicyContextProfileUpdate(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
-	context := getSessionContext(d, m)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
 	id := d.Id()
 	if id == "" {
 		return fmt.Errorf("Error obtaining ContextProfile ID")
@@ -274,7 +284,6 @@ func resourceNsxtPolicyContextProfileUpdate(d *schema.ResourceData, m interface{
 	displayName := d.Get("display_name").(string)
 	description := d.Get("description").(string)
 	attributesStructList := make([]model.PolicyAttributes, 0)
-	var err error
 	for key := range attributeKeyMap {
 		attributes := d.Get(key).(*schema.Set).List()
 		err := checkAttributesValid(context, attributes, m, key)
@@ -316,7 +325,11 @@ func resourceNsxtPolicyContextProfileDelete(d *schema.ResourceData, m interface{
 	connector := getPolicyConnector(m)
 	var err error
 	force := true
-	client := infra.NewContextProfilesClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := infra.NewContextProfilesClient(context, connector)
 	err = client.Delete(id, &force, nil)
 	if err != nil {
 		return handleDeleteError("ContextProfile", id, err)

--- a/nsxt/resource_nsxt_policy_context_profile_custom_attribute.go
+++ b/nsxt/resource_nsxt_policy_context_profile_custom_attribute.go
@@ -103,7 +103,11 @@ func resourceNsxtPolicyContextProfileCustomAttributeRead(d *schema.ResourceData,
 	log.Printf("[INFO] Reading ContextProfileCustomAttribute with ID %s", d.Id())
 
 	connector := getPolicyConnector(m)
-	exists, err := resourceNsxtPolicyContextProfileCustomAttributeExists(getSessionContext(d, m), id, connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	exists, err := resourceNsxtPolicyContextProfileCustomAttributeExists(context, id, connector)
 	if err != nil {
 		return err
 	}
@@ -132,7 +136,11 @@ func resourceNsxtPolicyContextProfileCustomAttributeCreate(d *schema.ResourceDat
 	}
 
 	// PATCH the resource
-	client := infra.NewDefaultClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := infra.NewDefaultClient(context, connector)
 	err = client.Create(obj, "add")
 	if err != nil {
 		return handleCreateError("ContextProfileCustomAttribute", attribute, err)
@@ -165,7 +173,11 @@ func resourceNsxtPolicyContextProfileCustomAttributeDelete(d *schema.ResourceDat
 	}
 
 	// PATCH the resource
-	client := infra.NewDefaultClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := infra.NewDefaultClient(context, connector)
 	err = client.Create(obj, "remove")
 
 	if err != nil {

--- a/nsxt/resource_nsxt_policy_context_profile_custom_attribute.go
+++ b/nsxt/resource_nsxt_policy_context_profile_custom_attribute.go
@@ -42,7 +42,7 @@ func resourceNsxtPolicyContextProfileCustomAttribute() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"context": getContextSchema(false, false),
+			"context": getContextSchema(false, false, false),
 			"key": {
 				Type:         schema.TypeString,
 				Description:  "Key for attribute",

--- a/nsxt/resource_nsxt_policy_context_profile_custom_attribute_test.go
+++ b/nsxt/resource_nsxt_policy_context_profile_custom_attribute_test.go
@@ -30,6 +30,13 @@ func TestAccResourceNsxtPolicyContextProfileCustomAttribute_multitenancy(t *test
 	})
 }
 
+func TestAccResourceNsxtPolicyContextProfileCustomAttribute_multitenancyProvider(t *testing.T) {
+	testAccResourceNsxtPolicyContextProfileCustomAttributeBasic(t, false, func() {
+		testAccPreCheck(t)
+		testAccOnlyMultitenancyProvider(t)
+	})
+}
+
 func testAccResourceNsxtPolicyContextProfileCustomAttributeBasic(t *testing.T, withContext bool, preCheck func()) {
 	testResourceName := "nsxt_policy_context_profile_custom_attribute.test"
 

--- a/nsxt/resource_nsxt_policy_context_profile_test.go
+++ b/nsxt/resource_nsxt_policy_context_profile_test.go
@@ -30,6 +30,13 @@ func TestAccResourceNsxtPolicyContextProfile_multitenancy(t *testing.T) {
 	})
 }
 
+func TestAccResourceNsxtPolicyContextProfile_multitenancyProvider(t *testing.T) {
+	testAccResourceNsxtPolicyContextProfileBasic(t, false, func() {
+		testAccPreCheck(t)
+		testAccOnlyMultitenancyProvider(t)
+	})
+}
+
 func testAccResourceNsxtPolicyContextProfileBasic(t *testing.T, withContext bool, preCheck func()) {
 	name := getAccTestResourceName()
 	updatedName := getAccTestResourceName()
@@ -154,6 +161,31 @@ func TestAccResourceNsxtPolicyContextProfile_importBasic_multitenancy(t *testing
 		Steps: []resource.TestStep{
 			{
 				Config: testAccNsxtPolicyContextProfileTemplate(name, attributes, true),
+			},
+			{
+				ResourceName:      testResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccResourceNsxtPolicyImportIDRetriever(testResourceName),
+			},
+		},
+	})
+}
+
+func TestAccResourceNsxtPolicyContextProfile_importBasic_multitenancyProvider(t *testing.T) {
+	name := getAccTestResourceName()
+	testResourceName := "nsxt_policy_context_profile.test"
+	attributes := testAccNsxtPolicyContextProfileAttributeDomainNameTemplate(testSystemDomainName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t); testAccOnlyMultitenancyProvider(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyContextProfileCheckDestroy(state, name)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyContextProfileTemplate(name, attributes, false),
 			},
 			{
 				ResourceName:      testResourceName,

--- a/nsxt/resource_nsxt_policy_dhcp_relay.go
+++ b/nsxt/resource_nsxt_policy_dhcp_relay.go
@@ -62,7 +62,11 @@ func resourceNsxtPolicyDhcpRelayConfigExists(sessionContext utl.SessionContext, 
 
 func resourceNsxtPolicyDhcpRelayConfigCreate(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
-	client := infra.NewDhcpRelayConfigsClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := infra.NewDhcpRelayConfigsClient(context, connector)
 
 	if client == nil {
 		return policyResourceNotSupportedError()
@@ -101,7 +105,11 @@ func resourceNsxtPolicyDhcpRelayConfigCreate(d *schema.ResourceData, m interface
 
 func resourceNsxtPolicyDhcpRelayConfigRead(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
-	client := infra.NewDhcpRelayConfigsClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := infra.NewDhcpRelayConfigsClient(context, connector)
 
 	if client == nil {
 		return policyResourceNotSupportedError()
@@ -131,7 +139,11 @@ func resourceNsxtPolicyDhcpRelayConfigRead(d *schema.ResourceData, m interface{}
 
 func resourceNsxtPolicyDhcpRelayConfigUpdate(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
-	client := infra.NewDhcpRelayConfigsClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := infra.NewDhcpRelayConfigsClient(context, connector)
 	if client == nil {
 		return policyResourceNotSupportedError()
 	}
@@ -157,7 +169,7 @@ func resourceNsxtPolicyDhcpRelayConfigUpdate(d *schema.ResourceData, m interface
 		Revision:        &revision,
 	}
 
-	_, err := client.Update(id, obj)
+	_, err = client.Update(id, obj)
 	if err != nil {
 		return handleUpdateError("DhcpRelayConfig", id, err)
 	}
@@ -172,12 +184,16 @@ func resourceNsxtPolicyDhcpRelayConfigDelete(d *schema.ResourceData, m interface
 	}
 
 	connector := getPolicyConnector(m)
-	client := infra.NewDhcpRelayConfigsClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := infra.NewDhcpRelayConfigsClient(context, connector)
 	if client == nil {
 		return policyResourceNotSupportedError()
 	}
 
-	err := client.Delete(id)
+	err = client.Delete(id)
 	if err != nil {
 		return handleDeleteError("DhcpRelayConfig", id, err)
 	}

--- a/nsxt/resource_nsxt_policy_dhcp_relay.go
+++ b/nsxt/resource_nsxt_policy_dhcp_relay.go
@@ -32,7 +32,7 @@ func resourceNsxtPolicyDhcpRelayConfig() *schema.Resource {
 			"description":  getDescriptionSchema(),
 			"revision":     getRevisionSchema(),
 			"tag":          getTagsSchema(),
-			"context":      getContextSchema(false, false),
+			"context":      getContextSchema(false, false, false),
 			"server_addresses": {
 				Type:     schema.TypeList,
 				Required: true,

--- a/nsxt/resource_nsxt_policy_dhcp_relay_test.go
+++ b/nsxt/resource_nsxt_policy_dhcp_relay_test.go
@@ -36,6 +36,13 @@ func TestAccResourceNsxtPolicyDhcpRelayConfig_multitenancy(t *testing.T) {
 	})
 }
 
+func TestAccResourceNsxtPolicyDhcpRelayConfig_multitenancyProvider(t *testing.T) {
+	testAccResourceNsxtPolicyDhcpRelayConfigBasic(t, false, func() {
+		testAccPreCheck(t)
+		testAccOnlyMultitenancyProvider(t)
+	})
+}
+
 // NOTE: Realization is not tested here. Relay config is only realized when segment uses it.
 func testAccResourceNsxtPolicyDhcpRelayConfigBasic(t *testing.T, withContext bool, preCheck func()) {
 	testResourceName := "nsxt_policy_dhcp_relay.test"
@@ -126,6 +133,30 @@ func TestAccResourceNsxtPolicyDhcpRelayConfig_importBasic_multitenancy(t *testin
 		Steps: []resource.TestStep{
 			{
 				Config: testAccNsxtPolicyDhcpRelayConfigMinimalistic(true),
+			},
+			{
+				ResourceName:      testResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccResourceNsxtPolicyImportIDRetriever(testResourceName),
+			},
+		},
+	})
+}
+
+func TestAccResourceNsxtPolicyDhcpRelayConfig_importBasic_multitenancyProvider(t *testing.T) {
+	name := getAccTestResourceName()
+	testResourceName := "nsxt_policy_dhcp_relay.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t); testAccOnlyMultitenancyProvider(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyDhcpRelayConfigCheckDestroy(state, name)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyDhcpRelayConfigMinimalistic(false),
 			},
 			{
 				ResourceName:      testResourceName,

--- a/nsxt/resource_nsxt_policy_dhcp_server.go
+++ b/nsxt/resource_nsxt_policy_dhcp_server.go
@@ -33,7 +33,7 @@ func resourceNsxtPolicyDhcpServer() *schema.Resource {
 			"description":       getDescriptionSchema(),
 			"revision":          getRevisionSchema(),
 			"tag":               getTagsSchema(),
-			"context":           getContextSchema(false, false),
+			"context":           getContextSchema(false, false, false),
 			"edge_cluster_path": getPolicyPathSchema(false, false, "Edge Cluster path"),
 			"lease_time": {
 				Type:         schema.TypeInt,

--- a/nsxt/resource_nsxt_policy_dhcp_server.go
+++ b/nsxt/resource_nsxt_policy_dhcp_server.go
@@ -124,7 +124,11 @@ func resourceNsxtPolicyDhcpServerCreate(d *schema.ResourceData, m interface{}) e
 
 	// Create the resource using PATCH
 	log.Printf("[INFO] Creating DhcpServer with ID %s", id)
-	client := infra.NewDhcpServerConfigsClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := infra.NewDhcpServerConfigsClient(context, connector)
 	err = client.Patch(id, resourceNsxtPolicyDhcpServerSchemaToModel(d))
 	if err != nil {
 		return handleCreateError("DhcpServer", id, err)
@@ -144,7 +148,11 @@ func resourceNsxtPolicyDhcpServerRead(d *schema.ResourceData, m interface{}) err
 		return fmt.Errorf("Error obtaining DhcpServer ID")
 	}
 
-	client := infra.NewDhcpServerConfigsClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := infra.NewDhcpServerConfigsClient(context, connector)
 	obj, err := client.Get(id)
 	if err != nil {
 		return handleReadError(d, "DhcpServer", id, err)
@@ -167,7 +175,11 @@ func resourceNsxtPolicyDhcpServerRead(d *schema.ResourceData, m interface{}) err
 
 func resourceNsxtPolicyDhcpServerUpdate(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
-	client := infra.NewDhcpServerConfigsClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := infra.NewDhcpServerConfigsClient(context, connector)
 	if client == nil {
 		return policyResourceNotSupportedError()
 	}
@@ -178,7 +190,7 @@ func resourceNsxtPolicyDhcpServerUpdate(d *schema.ResourceData, m interface{}) e
 	}
 
 	// Update the resource using PATCH
-	err := client.Patch(id, resourceNsxtPolicyDhcpServerSchemaToModel(d))
+	err = client.Patch(id, resourceNsxtPolicyDhcpServerSchemaToModel(d))
 	if err != nil {
 		return handleUpdateError("DhcpServer", id, err)
 	}
@@ -194,7 +206,11 @@ func resourceNsxtPolicyDhcpServerDelete(d *schema.ResourceData, m interface{}) e
 
 	var err error
 	connector := getPolicyConnector(m)
-	client := infra.NewDhcpServerConfigsClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := infra.NewDhcpServerConfigsClient(context, connector)
 	err = client.Delete(id)
 
 	if err != nil {

--- a/nsxt/resource_nsxt_policy_dhcp_server_test.go
+++ b/nsxt/resource_nsxt_policy_dhcp_server_test.go
@@ -38,6 +38,13 @@ func TestAccResourceNsxtPolicyDhcpServer_multitenancy(t *testing.T) {
 	})
 }
 
+func TestAccResourceNsxtPolicyDhcpServer_multitenancyProvider(t *testing.T) {
+	testAccResourceNsxtPolicyDhcpServerBasic(t, false, func() {
+		testAccPreCheck(t)
+		testAccOnlyMultitenancyProvider(t)
+	})
+}
+
 func testAccResourceNsxtPolicyDhcpServerBasic(t *testing.T, withContext bool, preCheck func()) {
 	testResourceName := "nsxt_policy_dhcp_server.test"
 
@@ -135,6 +142,30 @@ func TestAccResourceNsxtPolicyDhcpServer_importBasic_multitenancy(t *testing.T) 
 		Steps: []resource.TestStep{
 			{
 				Config: testAccNsxtPolicyDhcpServerMinimalistic(true),
+			},
+			{
+				ResourceName:      testResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccResourceNsxtPolicyImportIDRetriever(testResourceName),
+			},
+		},
+	})
+}
+
+func TestAccResourceNsxtPolicyDhcpServer_importBasic_multitenancyProvider(t *testing.T) {
+	name := getAccTestResourceName()
+	testResourceName := "nsxt_policy_dhcp_server.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t); testAccOnlyMultitenancyProvider(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyDhcpServerCheckDestroy(state, name)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyDhcpServerMinimalistic(false),
 			},
 			{
 				ResourceName:      testResourceName,

--- a/nsxt/resource_nsxt_policy_dhcp_v4_static_binding.go
+++ b/nsxt/resource_nsxt_policy_dhcp_v4_static_binding.go
@@ -132,7 +132,10 @@ func policyDhcpV4StaticBindingConvertAndPatch(d *schema.ResourceData, segmentPat
 	}
 
 	connector := getPolicyConnector(m)
-	context := getSessionContext(d, m)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
 
 	converter := bindings.NewTypeConverter()
 
@@ -225,7 +228,10 @@ func resourceNsxtPolicyDhcpV4StaticBindingRead(d *schema.ResourceData, m interfa
 		return fmt.Errorf("This resource is not applicable to segment %s", segmentPath)
 	}
 
-	context := getSessionContext(d, m)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
 	if context.ClientType == utl.Global && gwID != "" {
 		return fmt.Errorf("This resource is not applicable to segment on Global Manager %s", segmentPath)
 	}
@@ -305,8 +311,10 @@ func resourceNsxtPolicyDhcpStaticBindingDelete(d *schema.ResourceData, m interfa
 	_, gwID, segmentID := parseSegmentPolicyPath(segmentPath)
 
 	connector := getPolicyConnector(m)
-	context := getSessionContext(d, m)
-	var err error
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
 	if gwID == "" {
 		// infra segment
 		client := segments.NewDhcpStaticBindingConfigsClient(context, connector)

--- a/nsxt/resource_nsxt_policy_dhcp_v4_static_binding.go
+++ b/nsxt/resource_nsxt_policy_dhcp_v4_static_binding.go
@@ -38,7 +38,7 @@ func resourceNsxtPolicyDhcpV4StaticBinding() *schema.Resource {
 			"description":  getDescriptionSchema(),
 			"revision":     getRevisionSchema(),
 			"tag":          getTagsSchema(),
-			"context":      getContextSchema(false, false),
+			"context":      getContextSchema(false, false, false),
 			"segment_path": getPolicyPathSchema(true, true, "segment path"),
 			"gateway_address": {
 				Type:         schema.TypeString,

--- a/nsxt/resource_nsxt_policy_dhcp_v4_static_binding_test.go
+++ b/nsxt/resource_nsxt_policy_dhcp_v4_static_binding_test.go
@@ -60,6 +60,13 @@ func TestAccResourceNsxtPolicyDhcpV4StaticBinding_multitenancy(t *testing.T) {
 	})
 }
 
+func TestAccResourceNsxtPolicyDhcpV4StaticBinding_multitenancyProvider(t *testing.T) {
+	testAccResourceNsxtPolicyDhcpV4StaticBindingBasic(t, false, false, func() {
+		testAccPreCheck(t)
+		testAccOnlyMultitenancyProvider(t)
+	})
+}
+
 func TestAccResourceNsxtPolicyDhcpV4StaticBinding_fixedSegment(t *testing.T) {
 	testAccResourceNsxtPolicyDhcpV4StaticBindingBasic(t, true, false, func() {
 		testAccPreCheck(t)
@@ -72,6 +79,13 @@ func TestAccResourceNsxtPolicyDhcpV4StaticBinding_fixedSegment_multitenancy(t *t
 	testAccResourceNsxtPolicyDhcpV4StaticBindingBasic(t, true, true, func() {
 		testAccPreCheck(t)
 		testAccOnlyMultitenancy(t)
+	})
+}
+
+func TestAccResourceNsxtPolicyDhcpV4StaticBinding_fixedSegment_multitenancyProvider(t *testing.T) {
+	testAccResourceNsxtPolicyDhcpV4StaticBindingBasic(t, true, false, func() {
+		testAccPreCheck(t)
+		testAccOnlyMultitenancyProvider(t)
 	})
 }
 
@@ -171,6 +185,29 @@ func TestAccResourceNsxtPolicyDhcpV4StaticBinding_importBasic_multitenancy(t *te
 		Steps: []resource.TestStep{
 			{
 				Config: testAccNsxtPolicyDhcpV4StaticBindingMinimalistic(false, true),
+			},
+			{
+				ResourceName:      testAccPolicyDhcpV4StaticBindingResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccResourceNsxtPolicyImportIDRetriever(testAccPolicyDhcpV4StaticBindingResourceName),
+			},
+		},
+	})
+}
+
+func TestAccResourceNsxtPolicyDhcpV4StaticBinding_importBasic_multitenancyProvider(t *testing.T) {
+	name := getAccTestResourceName()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t); testAccOnlyMultitenancyProvider(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyDhcpV4StaticBindingCheckDestroy(state, name)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyDhcpV4StaticBindingMinimalistic(false, false),
 			},
 			{
 				ResourceName:      testAccPolicyDhcpV4StaticBindingResourceName,

--- a/nsxt/resource_nsxt_policy_dhcp_v6_static_binding.go
+++ b/nsxt/resource_nsxt_policy_dhcp_v6_static_binding.go
@@ -125,7 +125,10 @@ func policyDhcpV6StaticBindingConvertAndPatch(d *schema.ResourceData, segmentPat
 	if isT0 {
 		return fmt.Errorf("This resource is not applicable to segment %s", segmentPath)
 	}
-	context := getSessionContext(d, m)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
 
 	if isPolicyGlobalManager(m) && gwID != "" {
 		return fmt.Errorf("This resource is not applicable to segment on Global Manager %s", segmentPath)
@@ -185,7 +188,10 @@ func resourceNsxtPolicyDhcpV6StaticBindingRead(d *schema.ResourceData, m interfa
 	converter := bindings.NewTypeConverter()
 	var err error
 	var dhcpObj *data.StructValue
-	context := getSessionContext(d, m)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
 
 	if gwID == "" {
 		// infra segment

--- a/nsxt/resource_nsxt_policy_dhcp_v6_static_binding.go
+++ b/nsxt/resource_nsxt_policy_dhcp_v6_static_binding.go
@@ -34,7 +34,7 @@ func resourceNsxtPolicyDhcpV6StaticBinding() *schema.Resource {
 			"description":  getDescriptionSchema(),
 			"revision":     getRevisionSchema(),
 			"tag":          getTagsSchema(),
-			"context":      getContextSchema(false, false),
+			"context":      getContextSchema(false, false, false),
 			"segment_path": getPolicyPathSchema(true, true, "segment path"),
 			"dns_nameservers": {
 				Type:        schema.TypeList,

--- a/nsxt/resource_nsxt_policy_dhcp_v6_static_binding_test.go
+++ b/nsxt/resource_nsxt_policy_dhcp_v6_static_binding_test.go
@@ -53,6 +53,13 @@ func TestAccResourceNsxtPolicyDhcpV6StaticBinding_multitenancy(t *testing.T) {
 	})
 }
 
+func TestAccResourceNsxtPolicyDhcpV6StaticBinding_multitenancyProvider(t *testing.T) {
+	testAccResourceNsxtPolicyDhcpV6StaticBindingBasic(t, false, false, func() {
+		testAccPreCheck(t)
+		testAccOnlyMultitenancyProvider(t)
+	})
+}
+
 func TestAccResourceNsxtPolicyDhcpV6StaticBinding_fixed(t *testing.T) {
 	testAccResourceNsxtPolicyDhcpV6StaticBindingBasic(t, true, false, func() {
 		testAccPreCheck(t)
@@ -65,6 +72,13 @@ func TestAccResourceNsxtPolicyDhcpV6StaticBinding_fixed_multitenancy(t *testing.
 	testAccResourceNsxtPolicyDhcpV6StaticBindingBasic(t, true, true, func() {
 		testAccPreCheck(t)
 		testAccOnlyMultitenancy(t)
+	})
+}
+
+func TestAccResourceNsxtPolicyDhcpV6StaticBinding_fixed_multitenancyProvider(t *testing.T) {
+	testAccResourceNsxtPolicyDhcpV6StaticBindingBasic(t, true, false, func() {
+		testAccPreCheck(t)
+		testAccOnlyMultitenancyProvider(t)
 	})
 }
 
@@ -178,6 +192,29 @@ func TestAccResourceNsxtPolicyDhcpV6StaticBinding_importBasic_multitenancy(t *te
 		Steps: []resource.TestStep{
 			{
 				Config: testAccNsxtPolicyDhcpV6StaticBindingMinimalistic(false, true),
+			},
+			{
+				ResourceName:      testAccPolicyDhcpV6StaticBindingResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccResourceNsxtPolicyImportIDRetriever(testAccPolicyDhcpV6StaticBindingResourceName),
+			},
+		},
+	})
+}
+
+func TestAccResourceNsxtPolicyDhcpV6StaticBinding_importBasic_multitenancyProvider(t *testing.T) {
+	name := getAccTestResourceName()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t); testAccOnlyMultitenancyProvider(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyDhcpV6StaticBindingCheckDestroy(state, name)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyDhcpV6StaticBindingMinimalistic(false, false),
 			},
 			{
 				ResourceName:      testAccPolicyDhcpV6StaticBindingResourceName,

--- a/nsxt/resource_nsxt_policy_distributed_flood_protection_profile.go
+++ b/nsxt/resource_nsxt_policy_distributed_flood_protection_profile.go
@@ -141,7 +141,11 @@ func resourceNsxtPolicyDistributedFloodProtectionProfilePatch(d *schema.Resource
 	profileStruct := profileValue.(*data.StructValue)
 
 	log.Printf("[INFO] Patching DistributedFloodProtectionProfile with ID %s", id)
-	client := infra.NewFloodProtectionProfilesClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := infra.NewFloodProtectionProfilesClient(context, connector)
 	return client.Patch(id, profileStruct, nil)
 }
 
@@ -173,7 +177,11 @@ func resourceNsxtPolicyDistributedFloodProtectionProfileRead(d *schema.ResourceD
 		return fmt.Errorf("Error obtaining FloodProtectionProfile ID")
 	}
 
-	client := infra.NewFloodProtectionProfilesClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := infra.NewFloodProtectionProfilesClient(context, connector)
 	dpffData, err := client.Get(id)
 	if err != nil {
 		return handleReadError(d, "FloodProtectionProfile", id, err)
@@ -224,8 +232,12 @@ func resourceNsxtPolicyFloodProtectionProfileDelete(d *schema.ResourceData, m in
 	}
 
 	connector := getPolicyConnector(m)
-	client := infra.NewFloodProtectionProfilesClient(getSessionContext(d, m), connector)
-	err := client.Delete(id, nil)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := infra.NewFloodProtectionProfilesClient(context, connector)
+	err = client.Delete(id, nil)
 	if err != nil {
 		return handleDeleteError("FloodProtectionProfile", id, err)
 	}

--- a/nsxt/resource_nsxt_policy_distributed_flood_protection_profile.go
+++ b/nsxt/resource_nsxt_policy_distributed_flood_protection_profile.go
@@ -39,7 +39,7 @@ func getFloodProtectionProfile() map[string]*schema.Schema {
 		"description":  getDescriptionSchema(),
 		"revision":     getRevisionSchema(),
 		"tag":          getTagsSchema(),
-		"context":      getContextSchema(false, false),
+		"context":      getContextSchema(false, false, false),
 		"icmp_active_flow_limit": {
 			Type:         schema.TypeInt,
 			Description:  "Active ICMP connections limit",

--- a/nsxt/resource_nsxt_policy_distributed_flood_protection_profile_binding.go
+++ b/nsxt/resource_nsxt_policy_distributed_flood_protection_profile_binding.go
@@ -30,7 +30,7 @@ func resourceNsxtPolicyDistributedFloodProtectionProfileBinding() *schema.Resour
 			"description":  getDescriptionSchema(),
 			"revision":     getRevisionSchema(),
 			"tag":          getTagsSchema(),
-			"context":      getContextSchema(false, false),
+			"context":      getContextSchema(false, false, false),
 			"profile_path": {
 				Type:         schema.TypeString,
 				Description:  "The path of the flood protection profile",

--- a/nsxt/resource_nsxt_policy_distributed_flood_protection_profile_binding.go
+++ b/nsxt/resource_nsxt_policy_distributed_flood_protection_profile_binding.go
@@ -55,7 +55,11 @@ func resourceNsxtPolicyDistributedFloodProtectionProfileBinding() *schema.Resour
 
 func resourceNsxtPolicyDistributedFloodProtectionProfileBindingPatch(d *schema.ResourceData, m interface{}, id string, isCreate bool) error {
 	connector := getPolicyConnector(m)
-	bindingClient := groups.NewFirewallFloodProtectionProfileBindingMapsClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	bindingClient := groups.NewFirewallFloodProtectionProfileBindingMapsClient(context, connector)
 
 	displayName := d.Get("display_name").(string)
 	description := d.Get("description").(string)
@@ -105,7 +109,11 @@ func resourceNsxtPolicyDistributedFloodProtectionProfileBindingCreate(d *schema.
 	}
 
 	groupPath := d.Get("group_path").(string)
-	exist, err := resourceNsxtPolicyDistributedFloodProtectionProfileBindingExists(getSessionContext(d, m), getPolicyConnector(m), groupPath, id)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	exist, err := resourceNsxtPolicyDistributedFloodProtectionProfileBindingExists(context, getPolicyConnector(m), groupPath, id)
 	if err != nil {
 		return err
 	}
@@ -131,7 +139,11 @@ func resourceNsxtPolicyDistributedFloodProtectionProfileBindingRead(d *schema.Re
 	}
 
 	connector := getPolicyConnector(m)
-	bindingClient := groups.NewFirewallFloodProtectionProfileBindingMapsClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	bindingClient := groups.NewFirewallFloodProtectionProfileBindingMapsClient(context, connector)
 
 	groupPath := d.Get("group_path").(string)
 	domain := getDomainFromResourcePath(groupPath)
@@ -168,13 +180,17 @@ func resourceNsxtPolicyDistributedFloodProtectionProfileBindingDelete(d *schema.
 	}
 
 	connector := getPolicyConnector(m)
-	bindingClient := groups.NewFirewallFloodProtectionProfileBindingMapsClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	bindingClient := groups.NewFirewallFloodProtectionProfileBindingMapsClient(context, connector)
 
 	groupPath := d.Get("group_path").(string)
 	domain := getDomainFromResourcePath(groupPath)
 	groupID := getPolicyIDFromPath(groupPath)
 
-	err := bindingClient.Delete(domain, groupID, id)
+	err = bindingClient.Delete(domain, groupID, id)
 	if err != nil {
 		return handleDeleteError("FloodProtectionProfileBinding", id, err)
 	}

--- a/nsxt/resource_nsxt_policy_distributed_flood_protection_profile_binding_test.go
+++ b/nsxt/resource_nsxt_policy_distributed_flood_protection_profile_binding_test.go
@@ -37,6 +37,13 @@ func TestAccResourceNsxtPolicyDistributedFloodProtectionProfileBinding_multitena
 	})
 }
 
+func TestAccResourceNsxtPolicyDistributedFloodProtectionProfileBinding_multitenancyProvider(t *testing.T) {
+	testAccResourceNsxtPolicyDistributedFloodProtectionProfileBindingBasic(t, false, func() {
+		testAccPreCheck(t)
+		testAccOnlyMultitenancyProvider(t)
+	})
+}
+
 func testAccResourceNsxtPolicyDistributedFloodProtectionProfileBindingBasic(t *testing.T, withContext bool, preCheck func()) {
 	testResourceName := "nsxt_policy_distributed_flood_protection_profile_binding.test"
 	if withContext {
@@ -96,6 +103,13 @@ func TestAccResourceNsxtPolicyDistributedFloodProtectionProfileBinding_importBas
 	testAccResourceNsxtPolicyDistributedFloodProtectionProfileBindingImportBasic(t, true, func() {
 		testAccPreCheck(t)
 		testAccOnlyMultitenancy(t)
+	})
+}
+
+func TestAccResourceNsxtPolicyDistributedFloodProtectionProfileBinding_importBasic_multitenancyProvider(t *testing.T) {
+	testAccResourceNsxtPolicyDistributedFloodProtectionProfileBindingImportBasic(t, false, func() {
+		testAccPreCheck(t)
+		testAccOnlyMultitenancyProvider(t)
 	})
 }
 

--- a/nsxt/resource_nsxt_policy_distributed_flood_protection_profile_test.go
+++ b/nsxt/resource_nsxt_policy_distributed_flood_protection_profile_test.go
@@ -70,6 +70,13 @@ func TestAccResourceNsxtPolicyDistributedFloodProtectionProfile_multitenancy(t *
 	})
 }
 
+func TestAccResourceNsxtPolicyDistributedFloodProtectionProfile_multitenancyProvider(t *testing.T) {
+	testAccResourceNsxtPolicyDistributedFloodProtectionProfileBasic(t, false, func() {
+		testAccPreCheck(t)
+		testAccOnlyMultitenancyProvider(t)
+	})
+}
+
 func testAccResourceNsxtPolicyDistributedFloodProtectionProfileBasic(t *testing.T, withContext bool, preCheck func()) {
 	testResourceName := "nsxt_policy_distributed_flood_protection_profile.test"
 	if withContext {
@@ -137,6 +144,13 @@ func TestAccResourceNsxtPolicyDistributedFloodProtectionProfile_importBasic_mult
 	testAccResourceNsxtPolicyDistributedFloodProtectionProfileImportBasic(t, true, func() {
 		testAccPreCheck(t)
 		testAccOnlyMultitenancy(t)
+	})
+}
+
+func TestAccResourceNsxtPolicyDistributedFloodProtectionProfile_importBasic_multitenancyProvider(t *testing.T) {
+	testAccResourceNsxtPolicyDistributedFloodProtectionProfileImportBasic(t, false, func() {
+		testAccPreCheck(t)
+		testAccOnlyMultitenancyProvider(t)
 	})
 }
 

--- a/nsxt/resource_nsxt_policy_dns_forwarder_zone.go
+++ b/nsxt/resource_nsxt_policy_dns_forwarder_zone.go
@@ -93,7 +93,11 @@ func policyDNSForwarderZonePatch(id string, d *schema.ResourceData, m interface{
 	}
 
 	// Create the resource using PATCH
-	client := infra.NewDnsForwarderZonesClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := infra.NewDnsForwarderZonesClient(context, connector)
 	return client.Patch(id, obj)
 }
 
@@ -127,7 +131,11 @@ func resourceNsxtPolicyDNSForwarderZoneRead(d *schema.ResourceData, m interface{
 		return fmt.Errorf("Error obtaining Dns Forwarder Zone ID")
 	}
 
-	client := infra.NewDnsForwarderZonesClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := infra.NewDnsForwarderZonesClient(context, connector)
 	obj, err := client.Get(id)
 	if err != nil {
 		return handleReadError(d, "Dns Forwarder Zone", id, err)
@@ -171,8 +179,12 @@ func resourceNsxtPolicyDNSForwarderZoneDelete(d *schema.ResourceData, m interfac
 	}
 
 	connector := getPolicyConnector(m)
-	client := infra.NewDnsForwarderZonesClient(getSessionContext(d, m), connector)
-	err := client.Delete(id)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := infra.NewDnsForwarderZonesClient(context, connector)
+	err = client.Delete(id)
 
 	if err != nil {
 		return handleDeleteError("Dns Forwarder Zone", id, err)

--- a/nsxt/resource_nsxt_policy_dns_forwarder_zone.go
+++ b/nsxt/resource_nsxt_policy_dns_forwarder_zone.go
@@ -33,7 +33,7 @@ func resourceNsxtPolicyDNSForwarderZone() *schema.Resource {
 			"description":      getDescriptionSchema(),
 			"revision":         getRevisionSchema(),
 			"tag":              getTagsSchema(),
-			"context":          getContextSchema(false, false),
+			"context":          getContextSchema(false, false, false),
 			"dns_domain_names": getDomainNamesSchema(),
 			"source_ip": {
 				Type:         schema.TypeString,

--- a/nsxt/resource_nsxt_policy_dns_forwarder_zone_test.go
+++ b/nsxt/resource_nsxt_policy_dns_forwarder_zone_test.go
@@ -40,6 +40,13 @@ func TestAccResourceNsxtPolicyDNSForwarderZone_multitenancy(t *testing.T) {
 	})
 }
 
+func TestAccResourceNsxtPolicyDNSForwarderZone_multitenancyProvider(t *testing.T) {
+	testAccResourceNsxtPolicyDNSForwarderZoneBasic(t, false, func() {
+		testAccPreCheck(t)
+		testAccOnlyMultitenancyProvider(t)
+	})
+}
+
 func testAccResourceNsxtPolicyDNSForwarderZoneBasic(t *testing.T, withContext bool, preCheck func()) {
 	testResourceName := "nsxt_policy_dns_forwarder_zone.test"
 
@@ -139,6 +146,30 @@ func TestAccResourceNsxtPolicyDNSForwarderZone_importBasic_multitenancy(t *testi
 		Steps: []resource.TestStep{
 			{
 				Config: testAccNsxtPolicyDNSForwarderZoneMinimalistic(true),
+			},
+			{
+				ResourceName:      testResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccResourceNsxtPolicyImportIDRetriever(testResourceName),
+			},
+		},
+	})
+}
+
+func TestAccResourceNsxtPolicyDNSForwarderZone_importBasic_multitenancyProvider(t *testing.T) {
+	name := getAccTestResourceName()
+	testResourceName := "nsxt_policy_dns_forwarder_zone.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t); testAccOnlyMultitenancyProvider(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyDNSForwarderZoneCheckDestroy(state, name)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyDNSForwarderZoneMinimalistic(false),
 			},
 			{
 				ResourceName:      testResourceName,

--- a/nsxt/resource_nsxt_policy_domain.go
+++ b/nsxt/resource_nsxt_policy_domain.go
@@ -200,7 +200,11 @@ func resourceNsxtPolicyDomainCreate(d *schema.ResourceData, m interface{}) error
 
 	// Create the resource using PATCH
 	log.Printf("[INFO] Creating Domain with ID %s", id)
-	err = policyInfraPatch(getSessionContext(d, m), infraStruct, getPolicyConnector(m), false)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	err = policyInfraPatch(context, infraStruct, getPolicyConnector(m), false)
 	if err != nil {
 		return handleCreateError("Domain", id, err)
 	}
@@ -297,7 +301,11 @@ func resourceNsxtPolicyDomainUpdate(d *schema.ResourceData, m interface{}) error
 		ResourceType: &infraType,
 	}
 
-	err = policyInfraPatch(getSessionContext(d, m), infraStruct, getPolicyConnector(m), false)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	err = policyInfraPatch(context, infraStruct, getPolicyConnector(m), false)
 	if err != nil {
 		return handleUpdateError("Domain", id, err)
 	}

--- a/nsxt/resource_nsxt_policy_firewall_exclude_list_member.go
+++ b/nsxt/resource_nsxt_policy_firewall_exclude_list_member.go
@@ -65,8 +65,12 @@ func resourceNsxtPolicyFirewallExcludeListMemberCreate(d *schema.ResourceData, m
 	doUpdate := func() error {
 		var obj model.PolicyExcludeList
 
-		client := security.NewExcludeListClient(getSessionContext(d, m), connector)
-		obj, err := client.Get()
+		context, err := getSessionContext(d, m)
+		if err != nil {
+			return err
+		}
+		client := security.NewExcludeListClient(context, connector)
+		obj, err = client.Get()
 		if isNotFoundError(err) {
 			obj = model.PolicyExcludeList{
 				Members: []string{member},
@@ -100,7 +104,11 @@ func resourceNsxtPolicyFirewallExcludeListMemberRead(d *schema.ResourceData, m i
 	connector := getPolicyConnector(m)
 	member := d.Id()
 
-	client := security.NewExcludeListClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := security.NewExcludeListClient(context, connector)
 	obj, err := client.Get()
 	if err != nil {
 		return handleReadError(d, "PolicyFirewallExcludeListMember", member, err)
@@ -119,8 +127,12 @@ func resourceNsxtPolicyFirewallExcludeListMemberDelete(d *schema.ResourceData, m
 	doUpdate := func() error {
 		var obj model.PolicyExcludeList
 
-		client := security.NewExcludeListClient(getSessionContext(d, m), connector)
-		obj, err := client.Get()
+		context, err := getSessionContext(d, m)
+		if err != nil {
+			return err
+		}
+		client := security.NewExcludeListClient(context, connector)
+		obj, err = client.Get()
 		if isNotFoundError(err) {
 			return nil
 		} else if err != nil {

--- a/nsxt/resource_nsxt_policy_fixed_segment_test.go
+++ b/nsxt/resource_nsxt_policy_fixed_segment_test.go
@@ -57,6 +57,29 @@ func TestAccResourceNsxtPolicyFixedSegment_basicImport_multitenancy(t *testing.T
 	})
 }
 
+func TestAccResourceNsxtPolicyFixedSegment_basicImport_multitenancyProvider(t *testing.T) {
+	name := getAccTestResourceName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t); testAccOnlyMultitenancyProvider(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyFixedSegmentCheckDestroy(state, name)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyFixedSegmentImportTemplate("", name, false),
+			},
+			{
+				ResourceName:      testAccPolicyFixedSegmentResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccResourceNsxtPolicyImportIDRetriever(testAccPolicyFixedSegmentResourceName),
+			},
+		},
+	})
+}
+
 func TestAccResourceNsxtPolicyFixedSegment_basicUpdate(t *testing.T) {
 	testAccResourceNsxtPolicyFixedSegmentBasicUpdate(t, false, func() {
 		testAccPreCheck(t)
@@ -67,6 +90,13 @@ func TestAccResourceNsxtPolicyFixedSegment_multitenancy(t *testing.T) {
 	testAccResourceNsxtPolicyFixedSegmentBasicUpdate(t, true, func() {
 		testAccPreCheck(t)
 		testAccOnlyMultitenancy(t)
+	})
+}
+
+func TestAccResourceNsxtPolicyFixedSegment_multitenancyProvider(t *testing.T) {
+	testAccResourceNsxtPolicyFixedSegmentBasicUpdate(t, false, func() {
+		testAccPreCheck(t)
+		testAccOnlyMultitenancyProvider(t)
 	})
 }
 

--- a/nsxt/resource_nsxt_policy_gateway_dns_forwarder.go
+++ b/nsxt/resource_nsxt_policy_gateway_dns_forwarder.go
@@ -42,7 +42,7 @@ func resourceNsxtPolicyGatewayDNSForwarder() *schema.Resource {
 			"description":  getDescriptionSchema(),
 			"revision":     getRevisionSchema(),
 			"tag":          getTagsSchema(),
-			"context":      getContextSchema(false, false),
+			"context":      getContextSchema(false, false, false),
 			"gateway_path": getPolicyPathSchema(true, true, "Policy path for the Gateway"),
 			"listener_ip": {
 				Type:         schema.TypeString,

--- a/nsxt/resource_nsxt_policy_gateway_dns_forwarder.go
+++ b/nsxt/resource_nsxt_policy_gateway_dns_forwarder.go
@@ -98,7 +98,10 @@ func resourceNsxtPolicyGatewayDNSForwarderRead(d *schema.ResourceData, m interfa
 		return fmt.Errorf("gateway_path is not valid")
 	}
 
-	context := getSessionContext(d, m)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
 	if isT0 && context.ClientType == utl.Multitenancy {
 		return handleMultitenancyTier0Error()
 	}
@@ -173,7 +176,10 @@ func resourceNsxtPolicyGatewayDNSForwarderCreate(d *schema.ResourceData, m inter
 
 	// Verify DNS forwarder is not yet defined for this Gateway
 	var err error
-	context := getSessionContext(d, m)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
 
 	if isT0 && context.ClientType == utl.Multitenancy {
 		return handleMultitenancyTier0Error()
@@ -212,12 +218,15 @@ func resourceNsxtPolicyGatewayDNSForwarderUpdate(d *schema.ResourceData, m inter
 		return fmt.Errorf("gateway_path is not valid")
 	}
 
-	context := getSessionContext(d, m)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
 	if isT0 && context.ClientType == utl.Multitenancy {
 		return handleMultitenancyTier0Error()
 	}
 	log.Printf("[INFO] Updating Gateway Dns Forwarder with ID %s", gwID)
-	err := patchNsxtPolicyGatewayDNSForwarder(context, connector, d, gwID, isT0)
+	err = patchNsxtPolicyGatewayDNSForwarder(context, connector, d, gwID, isT0)
 	if err != nil {
 		return handleUpdateError("Gateway Dns Forwarder", gwID, err)
 	}
@@ -235,7 +244,10 @@ func resourceNsxtPolicyGatewayDNSForwarderDelete(d *schema.ResourceData, m inter
 	}
 
 	var err error
-	context := getSessionContext(d, m)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
 	if isT0 && context.ClientType == utl.Multitenancy {
 		return handleMultitenancyTier0Error()
 	}

--- a/nsxt/resource_nsxt_policy_gateway_dns_forwarder_test.go
+++ b/nsxt/resource_nsxt_policy_gateway_dns_forwarder_test.go
@@ -57,6 +57,13 @@ func TestAccResourceNsxtPolicyGatewayDNSForwarder_tier1_multitenancy(t *testing.
 	})
 }
 
+func TestAccResourceNsxtPolicyGatewayDNSForwarder_tier1_multitenancyProvider(t *testing.T) {
+	testAccResourceNsxtPolicyGatewayDNSForwarder(t, false, false, func() {
+		testAccPreCheck(t)
+		testAccOnlyMultitenancyProvider(t)
+	})
+}
+
 func testAccResourceNsxtPolicyGatewayDNSForwarder(t *testing.T, isT0 bool, withContext bool, preCheck func()) {
 	resourceName := testAccResourcePolicyGatewayDNSForwarderName
 	resource.Test(t, resource.TestCase{
@@ -145,6 +152,27 @@ func TestAccResourceNsxtPolicyGatewayDNSForwarder_importTier1_multitenancy(t *te
 		Steps: []resource.TestStep{
 			{
 				Config: testAccNsxtPolicyGatewayDNSForwarderMinimalistic(false, true),
+			},
+			{
+				ResourceName:      testAccResourcePolicyGatewayDNSForwarderName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccNSXPolicyGatewayDNSForwarderImporterGetID,
+			},
+		},
+	})
+}
+
+func TestAccResourceNsxtPolicyGatewayDNSForwarder_importTier1_multitenancyProvider(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t); testAccOnlyMultitenancyProvider(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyGatewayDNSForwarderCheckDestroy(state, accTestPolicyGatewayDNSForwarderCreateAttributes["display_name"])
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyGatewayDNSForwarderMinimalistic(false, false),
 			},
 			{
 				ResourceName:      testAccResourcePolicyGatewayDNSForwarderName,

--- a/nsxt/resource_nsxt_policy_gateway_flood_protection_profile.go
+++ b/nsxt/resource_nsxt_policy_gateway_flood_protection_profile.go
@@ -83,7 +83,11 @@ func resourceNsxtPolicyGatewayFloodProtectionProfilePatch(d *schema.ResourceData
 	profileStruct := profileValue.(*data.StructValue)
 
 	log.Printf("[INFO] Patching GatewayFloodProtectionProfile with ID %s", id)
-	client := infra.NewFloodProtectionProfilesClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := infra.NewFloodProtectionProfilesClient(context, connector)
 	return client.Patch(id, profileStruct, nil)
 }
 
@@ -115,7 +119,11 @@ func resourceNsxtPolicyGatewayFloodProtectionProfileRead(d *schema.ResourceData,
 		return fmt.Errorf("Error obtaining FloodProtectionProfile ID")
 	}
 
-	client := infra.NewFloodProtectionProfilesClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := infra.NewFloodProtectionProfilesClient(context, connector)
 	gpffData, err := client.Get(id)
 	if err != nil {
 		return handleReadError(d, "GatewayFloodProtectionProfile", id, err)

--- a/nsxt/resource_nsxt_policy_gateway_flood_protection_profile_binding.go
+++ b/nsxt/resource_nsxt_policy_gateway_flood_protection_profile_binding.go
@@ -95,12 +95,17 @@ func resourceNsxtPolicyGatewayFloodProtectionProfileBindingPatch(d *schema.Resou
 	if err != nil {
 		return err
 	}
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+
 	if tier0ID != "" {
 		if localeServiceID == "" {
-			bindingClient := tier0s.NewFloodProtectionProfileBindingsClient(getSessionContext(d, m), connector)
+			bindingClient := tier0s.NewFloodProtectionProfileBindingsClient(context, connector)
 			err = bindingClient.Patch(tier0ID, id, obj)
 		} else {
-			bindingClient := t0localeservices.NewFloodProtectionProfileBindingsClient(getSessionContext(d, m), connector)
+			bindingClient := t0localeservices.NewFloodProtectionProfileBindingsClient(context, connector)
 			err = bindingClient.Patch(tier0ID, localeServiceID, id, obj)
 		}
 		if err != nil {
@@ -108,10 +113,10 @@ func resourceNsxtPolicyGatewayFloodProtectionProfileBindingPatch(d *schema.Resou
 		}
 	} else if tier1ID != "" {
 		if localeServiceID == "" {
-			bindingClient := tier1s.NewFloodProtectionProfileBindingsClient(getSessionContext(d, m), connector)
+			bindingClient := tier1s.NewFloodProtectionProfileBindingsClient(context, connector)
 			err = bindingClient.Patch(tier1ID, id, obj)
 		} else {
-			bindingClient := t1localeservices.NewFloodProtectionProfileBindingsClient(getSessionContext(d, m), connector)
+			bindingClient := t1localeservices.NewFloodProtectionProfileBindingsClient(context, connector)
 			err = bindingClient.Patch(tier1ID, localeServiceID, id, obj)
 		}
 	}
@@ -166,7 +171,11 @@ func resourceNsxtPolicyGatewayFloodProtectionProfileBindingCreate(d *schema.Reso
 	id := "default"
 	parentPath := d.Get("parent_path").(string)
 
-	exist, err := resourceNsxtPolicyGatewayFloodProtectionProfileBindingExists(getSessionContext(d, m), getPolicyConnector(m), parentPath, id)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	exist, err := resourceNsxtPolicyGatewayFloodProtectionProfileBindingExists(context, getPolicyConnector(m), parentPath, id)
 	if err != nil {
 		return err
 	}
@@ -194,7 +203,11 @@ func resourceNsxtPolicyGatewayFloodProtectionProfileBindingRead(d *schema.Resour
 	}
 
 	parentPath := d.Get("parent_path").(string)
-	binding, err := resourceNsxtPolicyGatewayFloodProtectionProfileBindingGet(getSessionContext(d, m), connector, parentPath, id)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	binding, err := resourceNsxtPolicyGatewayFloodProtectionProfileBindingGet(context, connector, parentPath, id)
 	if err != nil {
 		return handleReadError(d, "GatewayFloodProtectionProfileBinding", id, err)
 	}
@@ -247,12 +260,16 @@ func resourceNsxtPolicyGatewayFloodProtectionProfileBindingDelete(d *schema.Reso
 		return err
 	}
 
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
 	if tier0ID != "" {
 		if localeServiceID == "" {
-			bindingClient := tier0s.NewFloodProtectionProfileBindingsClient(getSessionContext(d, m), connector)
+			bindingClient := tier0s.NewFloodProtectionProfileBindingsClient(context, connector)
 			err = bindingClient.Delete(tier0ID, id)
 		} else {
-			bindingClient := t0localeservices.NewFloodProtectionProfileBindingsClient(getSessionContext(d, m), connector)
+			bindingClient := t0localeservices.NewFloodProtectionProfileBindingsClient(context, connector)
 			err = bindingClient.Delete(tier0ID, localeServiceID, id)
 		}
 		if err != nil {
@@ -260,10 +277,10 @@ func resourceNsxtPolicyGatewayFloodProtectionProfileBindingDelete(d *schema.Reso
 		}
 	} else if tier1ID != "" {
 		if localeServiceID == "" {
-			bindingClient := tier1s.NewFloodProtectionProfileBindingsClient(getSessionContext(d, m), connector)
+			bindingClient := tier1s.NewFloodProtectionProfileBindingsClient(context, connector)
 			err = bindingClient.Delete(tier1ID, id)
 		} else {
-			bindingClient := t1localeservices.NewFloodProtectionProfileBindingsClient(getSessionContext(d, m), connector)
+			bindingClient := t1localeservices.NewFloodProtectionProfileBindingsClient(context, connector)
 			err = bindingClient.Delete(tier1ID, localeServiceID, id)
 		}
 	}

--- a/nsxt/resource_nsxt_policy_gateway_flood_protection_profile_binding.go
+++ b/nsxt/resource_nsxt_policy_gateway_flood_protection_profile_binding.go
@@ -33,7 +33,7 @@ func resourceNsxtPolicyGatewayFloodProtectionProfileBinding() *schema.Resource {
 			"description":  getDescriptionSchema(),
 			"revision":     getRevisionSchema(),
 			"tag":          getTagsSchema(),
-			"context":      getContextSchema(false, false),
+			"context":      getContextSchema(false, false, false),
 			"profile_path": {
 				Type:         schema.TypeString,
 				Description:  "The path of the flood protection profile",

--- a/nsxt/resource_nsxt_policy_gateway_flood_protection_profile_binding_test.go
+++ b/nsxt/resource_nsxt_policy_gateway_flood_protection_profile_binding_test.go
@@ -74,6 +74,13 @@ func TestAccResourceNsxtPolicyT1GatewayFloodProtectionProfileBinding_multitenanc
 	}, "tier1")
 }
 
+func TestAccResourceNsxtPolicyT1GatewayFloodProtectionProfileBinding_multitenancyProvider(t *testing.T) {
+	testAccResourceNsxtPolicyGatewayFloodProtectionProfileBindingBasic(t, false, func() {
+		testAccPreCheck(t)
+		testAccOnlyMultitenancyProvider(t)
+	}, "tier1")
+}
+
 func testAccResourceNsxtPolicyGatewayFloodProtectionProfileBindingBasic(t *testing.T, withContext bool, preCheck func(), parent string) {
 	testResourceName := "nsxt_policy_gateway_flood_protection_profile_binding.test"
 	if withContext {
@@ -131,6 +138,13 @@ func TestAccResourceNsxtPolicyGatewayFloodProtectionProfileBinding_importBasic_m
 	testAccResourceNsxtPolicyGatewayFloodProtectionProfileBindingImportBasic(t, true, func() {
 		testAccPreCheck(t)
 		testAccOnlyMultitenancy(t)
+	}, "tier1")
+}
+
+func TestAccResourceNsxtPolicyGatewayFloodProtectionProfileBinding_importBasic_multitenancyProvider(t *testing.T) {
+	testAccResourceNsxtPolicyGatewayFloodProtectionProfileBindingImportBasic(t, false, func() {
+		testAccPreCheck(t)
+		testAccOnlyMultitenancyProvider(t)
 	}, "tier1")
 }
 

--- a/nsxt/resource_nsxt_policy_gateway_flood_protection_profile_test.go
+++ b/nsxt/resource_nsxt_policy_gateway_flood_protection_profile_test.go
@@ -68,6 +68,13 @@ func TestAccResourceNsxtPolicyGatewayFloodProtectionProfile_multitenancy(t *test
 	})
 }
 
+func TestAccResourceNsxtPolicyGatewayFloodProtectionProfile_multitenancyProvider(t *testing.T) {
+	testAccResourceNsxtPolicyGatewayFloodProtectionProfileBasic(t, false, func() {
+		testAccPreCheck(t)
+		testAccOnlyMultitenancyProvider(t)
+	})
+}
+
 func testAccResourceNsxtPolicyGatewayFloodProtectionProfileBasic(t *testing.T, withContext bool, preCheck func()) {
 	testResourceName := "nsxt_policy_gateway_flood_protection_profile.test"
 	if withContext {
@@ -133,6 +140,13 @@ func TestAccResourceNsxtPolicyGatewayFloodProtectionProfile_importBasic_multiten
 	testAccResourceNsxtPolicyGatewayFloodProtectionProfileImportBasic(t, true, func() {
 		testAccPreCheck(t)
 		testAccOnlyMultitenancy(t)
+	})
+}
+
+func TestAccResourceNsxtPolicyGatewayFloodProtectionProfile_importBasic_multitenancyProvider(t *testing.T) {
+	testAccResourceNsxtPolicyGatewayFloodProtectionProfileImportBasic(t, false, func() {
+		testAccPreCheck(t)
+		testAccOnlyMultitenancyProvider(t)
 	})
 }
 

--- a/nsxt/resource_nsxt_policy_gateway_policy.go
+++ b/nsxt/resource_nsxt_policy_gateway_policy.go
@@ -166,7 +166,11 @@ func policyGatewayPolicyBuildAndPatch(d *schema.ResourceData, m interface{}, con
 		obj.Children = policyChildren
 	}
 
-	return gatewayPolicyInfraPatch(getSessionContext(d, m), obj, domain, m)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	return gatewayPolicyInfraPatch(context, obj, domain, m)
 }
 
 func resourceNsxtPolicyGatewayPolicyCreate(d *schema.ResourceData, m interface{}) error {
@@ -197,7 +201,11 @@ func resourceNsxtPolicyGatewayPolicyRead(d *schema.ResourceData, m interface{}) 
 		return fmt.Errorf("Error obtaining Gateway Policy ID")
 	}
 
-	obj, err := getGatewayPolicyInDomain(getSessionContext(d, m), id, d.Get("domain").(string), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	obj, err := getGatewayPolicyInDomain(context, id, d.Get("domain").(string), connector)
 	if err != nil {
 		return handleReadError(d, "Gateway Policy", id, err)
 	}
@@ -244,8 +252,12 @@ func resourceNsxtPolicyGatewayPolicyDelete(d *schema.ResourceData, m interface{}
 	}
 
 	connector := getPolicyConnector(m)
-	client := domains.NewGatewayPoliciesClient(getSessionContext(d, m), connector)
-	err := client.Delete(d.Get("domain").(string), id)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := domains.NewGatewayPoliciesClient(context, connector)
+	err = client.Delete(d.Get("domain").(string), id)
 	if err != nil {
 		return handleDeleteError("Gateway Policy", id, err)
 	}

--- a/nsxt/resource_nsxt_policy_gateway_policy_test.go
+++ b/nsxt/resource_nsxt_policy_gateway_policy_test.go
@@ -24,6 +24,13 @@ func TestAccResourceNsxtPolicyGatewayPolicy_multitenancy(t *testing.T) {
 	})
 }
 
+func TestAccResourceNsxtPolicyGatewayPolicy_multitenancyProvider(t *testing.T) {
+	testAccResourceNsxtPolicyGatewayPolicyBasic(t, false, func() {
+		testAccPreCheck(t)
+		testAccOnlyMultitenancyProvider(t)
+	})
+}
+
 func testAccResourceNsxtPolicyGatewayPolicyBasic(t *testing.T, withContext bool, preCheck func()) {
 	name := getAccTestResourceName()
 	updatedName := getAccTestResourceName()
@@ -242,6 +249,30 @@ func TestAccResourceNsxtPolicyGatewayPolicy_importBasic_multitenancy(t *testing.
 		Steps: []resource.TestStep{
 			{
 				Config: testAccNsxtPolicyGatewayPolicyBasic(name, "import", true),
+			},
+			{
+				ResourceName:      testResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccResourceNsxtPolicyImportIDRetriever(testResourceName),
+			},
+		},
+	})
+}
+
+func TestAccResourceNsxtPolicyGatewayPolicy_importBasic_multitenancyProvider(t *testing.T) {
+	name := getAccTestResourceName()
+	testResourceName := "nsxt_policy_gateway_policy.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t); testAccOnlyMultitenancyProvider(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyGatewayPolicyCheckDestroy(state, name, defaultDomain)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyGatewayPolicyBasic(name, "import", false),
 			},
 			{
 				ResourceName:      testResourceName,

--- a/nsxt/resource_nsxt_policy_gateway_redistribution_config.go
+++ b/nsxt/resource_nsxt_policy_gateway_redistribution_config.go
@@ -86,7 +86,11 @@ func policyGatewayRedistributionConfigPatch(d *schema.ResourceData, m interface{
 	}
 
 	doPatch := func() error {
-		client := tier0s.NewLocaleServicesClient(getSessionContext(d, m), connector)
+		context, err := getSessionContext(d, m)
+		if err != nil {
+			return err
+		}
+		client := tier0s.NewLocaleServicesClient(context, connector)
 		return client.Patch(gwID, localeServiceID, serviceStruct)
 	}
 	// since redistribution config is not a separate API endpoint, but sub-clause of Tier0,
@@ -105,7 +109,10 @@ func resourceNsxtPolicyGatewayRedistributionConfigCreate(d *schema.ResourceData,
 	}
 
 	localeServiceID := ""
-	context := getSessionContext(d, m)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
 	if isPolicyGlobalManager(m) {
 		if sitePath == "" {
 			return attributeRequiredGlobalManagerError("site_path", "nsxt_policy_gateway_redistribution_config")
@@ -133,7 +140,7 @@ func resourceNsxtPolicyGatewayRedistributionConfigCreate(d *schema.ResourceData,
 	}
 
 	id := newUUID()
-	err := policyGatewayRedistributionConfigPatch(d, m, gwID, localeServiceID)
+	err = policyGatewayRedistributionConfigPatch(d, m, gwID, localeServiceID)
 	if err != nil {
 		return handleCreateError("Tier0 Redistribution Config", id, err)
 	}
@@ -155,7 +162,11 @@ func resourceNsxtPolicyGatewayRedistributionConfigRead(d *schema.ResourceData, m
 		return fmt.Errorf("Error obtaining Tier0 Gateway id or Locale Service id")
 	}
 
-	client := tier0s.NewLocaleServicesClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := tier0s.NewLocaleServicesClient(context, connector)
 	obj, err := client.Get(gwID, localeServiceID)
 	if err != nil {
 		return handleReadError(d, "Tier0 Redistribution Config", id, err)
@@ -206,7 +217,11 @@ func resourceNsxtPolicyGatewayRedistributionConfigDelete(d *schema.ResourceData,
 
 	// Update the locale service with empty Redistribution config using get/post
 	doUpdate := func() error {
-		client := tier0s.NewLocaleServicesClient(getSessionContext(d, m), connector)
+		context, err := getSessionContext(d, m)
+		if err != nil {
+			return err
+		}
+		client := tier0s.NewLocaleServicesClient(context, connector)
 		obj, err := client.Get(gwID, localeServiceID)
 		if err != nil {
 			return err
@@ -236,7 +251,11 @@ func resourceNsxtPolicyGatewayRedistributionConfigImport(d *schema.ResourceData,
 	gwID := s[0]
 	localeServiceID := s[1]
 	connector := getPolicyConnector(m)
-	client := tier0s.NewLocaleServicesClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return nil, err
+	}
+	client := tier0s.NewLocaleServicesClient(context, connector)
 	obj, err := client.Get(gwID, localeServiceID)
 	if err != nil || obj.RouteRedistributionConfig == nil {
 		return nil, fmt.Errorf("Failed to retrieve redistribution config for locale service %s on gateway %s", localeServiceID, gwID)

--- a/nsxt/resource_nsxt_policy_group.go
+++ b/nsxt/resource_nsxt_policy_group.go
@@ -101,7 +101,7 @@ func resourceNsxtPolicyGroup() *schema.Resource {
 			"description":  getDescriptionSchema(),
 			"revision":     getRevisionSchema(),
 			"tag":          getTagsSchema(),
-			"context":      getContextSchema(false, false),
+			"context":      getContextSchema(false, false, false),
 			"domain":       getDomainNameSchema(),
 			"group_type": {
 				Type:         schema.TypeString,

--- a/nsxt/resource_nsxt_policy_group.go
+++ b/nsxt/resource_nsxt_policy_group.go
@@ -879,7 +879,11 @@ func resourceNsxtPolicyGroupCreate(d *schema.ResourceData, m interface{}) error 
 		obj.GroupType = groupTypes
 	}
 
-	client := domains.NewGroupsClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := domains.NewGroupsClient(context, connector)
 	err = client.Patch(d.Get("domain").(string), id, obj)
 
 	// Create the resource using PATCH
@@ -901,7 +905,11 @@ func resourceNsxtPolicyGroupRead(d *schema.ResourceData, m interface{}) error {
 	if id == "" {
 		return fmt.Errorf("Error obtaining Group ID")
 	}
-	client := domains.NewGroupsClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := domains.NewGroupsClient(context, connector)
 	obj, err := client.Get(domainName, id)
 	if err != nil {
 		return handleReadError(d, "Group", id, err)
@@ -992,7 +1000,11 @@ func resourceNsxtPolicyGroupUpdate(d *schema.ResourceData, m interface{}) error 
 		obj.GroupType = groupTypes
 	}
 
-	client := domains.NewGroupsClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := domains.NewGroupsClient(context, connector)
 
 	// Update the resource using PATCH
 	err = client.Patch(d.Get("domain").(string), id, obj)
@@ -1014,7 +1026,11 @@ func resourceNsxtPolicyGroupDelete(d *schema.ResourceData, m interface{}) error 
 	failIfSubtreeExists := false
 
 	doDelete := func() error {
-		client := domains.NewGroupsClient(getSessionContext(d, m), connector)
+		context, err := getSessionContext(d, m)
+		if err != nil {
+			return err
+		}
+		client := domains.NewGroupsClient(context, connector)
 		return client.Delete(d.Get("domain").(string), id, &failIfSubtreeExists, &forceDelete)
 	}
 

--- a/nsxt/resource_nsxt_policy_group_test.go
+++ b/nsxt/resource_nsxt_policy_group_test.go
@@ -56,6 +56,30 @@ func TestAccResourceNsxtPolicyGroup_basicImport_multitenancy(t *testing.T) {
 	})
 }
 
+func TestAccResourceNsxtPolicyGroup_basicImport_multitenancyProvider(t *testing.T) {
+	name := getAccTestResourceName()
+	testResourceName := "nsxt_policy_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t); testAccOnlyMultitenancyProvider(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyGroupCheckDestroy(state, name, defaultDomain)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyGroupIPAddressImportTemplate(name, false),
+			},
+			{
+				ResourceName:      testResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccResourceNsxtPolicyImportIDRetriever(testResourceName),
+			},
+		},
+	})
+}
+
 func TestAccResourceNsxtPolicyGroup_addressCriteria(t *testing.T) {
 	testAccResourceNsxtPolicyGroupAddressCriteria(t, false, func() {
 		testAccPreCheck(t)
@@ -66,6 +90,13 @@ func TestAccResourceNsxtPolicyGroup_addressCriteria_multitenancy(t *testing.T) {
 	testAccResourceNsxtPolicyGroupAddressCriteria(t, true, func() {
 		testAccPreCheck(t)
 		testAccOnlyMultitenancy(t)
+	})
+}
+
+func TestAccResourceNsxtPolicyGroup_addressCriteria_multitenancyProvider(t *testing.T) {
+	testAccResourceNsxtPolicyGroupAddressCriteria(t, false, func() {
+		testAccPreCheck(t)
+		testAccOnlyMultitenancyProvider(t)
 	})
 }
 

--- a/nsxt/resource_nsxt_policy_intrusion_service_policy.go
+++ b/nsxt/resource_nsxt_policy_intrusion_service_policy.go
@@ -284,7 +284,11 @@ func updateIdsSecurityPolicy(id string, d *schema.ResourceData, m interface{}) e
 		obj.Children = childRules
 	}
 
-	return idsPolicyInfraPatch(getSessionContext(d, m), obj, domain, m)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	return idsPolicyInfraPatch(context, obj, domain, m)
 }
 
 func idsPolicyInfraPatch(context utl.SessionContext, policy model.IdsSecurityPolicy, domain string, m interface{}) error {
@@ -309,7 +313,11 @@ func idsPolicyInfraPatch(context utl.SessionContext, policy model.IdsSecurityPol
 func resourceNsxtPolicyIntrusionServicePolicyCreate(d *schema.ResourceData, m interface{}) error {
 
 	// Initialize resource Id and verify this ID is not yet used
-	id, err := getOrGenerateID2(d, m, resourceNsxtPolicyIntrusionServicePolicyExistsPartial(getSessionContext(d, m), d.Get("domain").(string)))
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	id, err := getOrGenerateID2(d, m, resourceNsxtPolicyIntrusionServicePolicyExistsPartial(context, d.Get("domain").(string)))
 	if err != nil {
 		return err
 	}
@@ -334,7 +342,11 @@ func resourceNsxtPolicyIntrusionServicePolicyRead(d *schema.ResourceData, m inte
 	if id == "" {
 		return fmt.Errorf("Error obtaining Intrusion Service Policy id")
 	}
-	client := domains.NewIntrusionServicePoliciesClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := domains.NewIntrusionServicePoliciesClient(context, connector)
 	obj, err := client.Get(domainName, id)
 	if err != nil {
 		return handleReadError(d, "Intrusion Service Policy", id, err)
@@ -378,8 +390,12 @@ func resourceNsxtPolicyIntrusionServicePolicyDelete(d *schema.ResourceData, m in
 
 	connector := getPolicyConnector(m)
 
-	client := domains.NewIntrusionServicePoliciesClient(getSessionContext(d, m), connector)
-	err := client.Delete(d.Get("domain").(string), id)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := domains.NewIntrusionServicePoliciesClient(context, connector)
+	err = client.Delete(d.Get("domain").(string), id)
 
 	if err != nil {
 		return handleDeleteError("Intrusion Service Policy", id, err)

--- a/nsxt/resource_nsxt_policy_intrusion_service_policy_test.go
+++ b/nsxt/resource_nsxt_policy_intrusion_service_policy_test.go
@@ -29,6 +29,13 @@ func TestAccResourceNsxtPolicyIntrusionServicePolicy_multitenancy(t *testing.T) 
 	})
 }
 
+func TestAccResourceNsxtPolicyIntrusionServicePolicy_multitenancyProvider(t *testing.T) {
+	testAccResourceNsxtPolicyIntrusionServicePolicyBasic(t, false, func() {
+		testAccPreCheck(t)
+		testAccOnlyMultitenancyProvider(t)
+	})
+}
+
 func testAccResourceNsxtPolicyIntrusionServicePolicyBasic(t *testing.T, withContext bool, preCheck func()) {
 	name := getAccTestResourceName()
 	updatedName := getAccTestResourceName()
@@ -216,6 +223,13 @@ func TestAccResourceNsxtPolicyIntrusionServicePolicy_importBasic_multitenancy(t 
 	testAccResourceNsxtPolicyIntrusionServicePolicyImportBasic(t, true, func() {
 		testAccPreCheck(t)
 		testAccOnlyMultitenancy(t)
+	})
+}
+
+func TestAccResourceNsxtPolicyIntrusionServicePolicy_importBasic_multitenancyProvider(t *testing.T) {
+	testAccResourceNsxtPolicyIntrusionServicePolicyImportBasic(t, false, func() {
+		testAccPreCheck(t)
+		testAccOnlyMultitenancyProvider(t)
 	})
 }
 

--- a/nsxt/resource_nsxt_policy_intrusion_service_profile.go
+++ b/nsxt/resource_nsxt_policy_intrusion_service_profile.go
@@ -373,7 +373,11 @@ func resourceNsxtPolicyIntrusionServiceProfileCreate(d *schema.ResourceData, m i
 
 	// Create the resource using PATCH
 	log.Printf("[INFO] Creating Intrusion Service Profile with ID %s", id)
-	client := services.NewProfilesClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := services.NewProfilesClient(context, connector)
 	err = client.Patch(id, obj)
 	if err != nil {
 		return handleCreateError("Ids Profile", id, err)
@@ -393,7 +397,11 @@ func resourceNsxtPolicyIntrusionServiceProfileRead(d *schema.ResourceData, m int
 		return fmt.Errorf("Error obtaining Ids Profile ID")
 	}
 
-	client := services.NewProfilesClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := services.NewProfilesClient(context, connector)
 	obj, err := client.Get(id)
 	if err != nil {
 		return handleReadError(d, "Ids Profile", id, err)
@@ -449,7 +457,11 @@ func resourceNsxtPolicyIntrusionServiceProfileUpdate(d *schema.ResourceData, m i
 
 	// Create the resource using PATCH
 	log.Printf("[INFO] Update Intrusion Service Profile with ID %s", id)
-	client := services.NewProfilesClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := services.NewProfilesClient(context, connector)
 	err = client.Patch(id, obj)
 	if err != nil {
 		return handleUpdateError("Ids Profile", id, err)
@@ -468,8 +480,11 @@ func resourceNsxtPolicyIntrusionServiceProfileDelete(d *schema.ResourceData, m i
 	}
 
 	connector := getPolicyConnector(m)
-	var err error
-	client := services.NewProfilesClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := services.NewProfilesClient(context, connector)
 	err = client.Delete(id)
 
 	if err != nil {

--- a/nsxt/resource_nsxt_policy_intrusion_service_profile.go
+++ b/nsxt/resource_nsxt_policy_intrusion_service_profile.go
@@ -56,7 +56,7 @@ func resourceNsxtPolicyIntrusionServiceProfile() *schema.Resource {
 			"description":  getDescriptionSchema(),
 			"revision":     getRevisionSchema(),
 			"tag":          getTagsSchema(),
-			"context":      getContextSchema(false, false),
+			"context":      getContextSchema(false, false, false),
 			"criteria": {
 				Type:        schema.TypeList,
 				Description: "Filtering criteria for the IDS Profile",

--- a/nsxt/resource_nsxt_policy_intrusion_service_profile_test.go
+++ b/nsxt/resource_nsxt_policy_intrusion_service_profile_test.go
@@ -26,6 +26,13 @@ func TestAccResourceNsxtPolicyIntrusionServiceProfile_multitenancy(t *testing.T)
 	})
 }
 
+func TestAccResourceNsxtPolicyIntrusionServiceProfile_multitenancyProvider(t *testing.T) {
+	testAccResourceNsxtPolicyIntrusionServiceProfileBasic(t, false, func() {
+		testAccPreCheck(t)
+		testAccOnlyMultitenancyProvider(t)
+	})
+}
+
 func testAccResourceNsxtPolicyIntrusionServiceProfileBasic(t *testing.T, withContext bool, preCheck func()) {
 	name := getAccTestResourceName()
 	updatedName := getAccTestResourceName()
@@ -104,6 +111,13 @@ func TestAccResourceNsxtPolicyIntrusionServiceProfile_importBasic_multitenancy(t
 	testAccResourceNsxtPolicyIntrusionServiceProfileImportBasic(t, true, func() {
 		testAccPreCheck(t)
 		testAccOnlyMultitenancy(t)
+	})
+}
+
+func TestAccResourceNsxtPolicyIntrusionServiceProfile_importBasic_multitenancyProvider(t *testing.T) {
+	testAccResourceNsxtPolicyIntrusionServiceProfileImportBasic(t, false, func() {
+		testAccPreCheck(t)
+		testAccOnlyMultitenancyProvider(t)
 	})
 }
 

--- a/nsxt/resource_nsxt_policy_ip_address_allocation.go
+++ b/nsxt/resource_nsxt_policy_ip_address_allocation.go
@@ -77,8 +77,11 @@ func resourceNsxtPolicyIPAddressAllocationExists(sessionContext utl.SessionConte
 
 func resourceNsxtPolicyIPAddressAllocationCreate(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
-	sessionContext := getSessionContext(d, m)
-	client := ippools.NewIpAllocationsClient(sessionContext, connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := ippools.NewIpAllocationsClient(context, connector)
 
 	if client == nil {
 		return policyResourceNotSupportedError()
@@ -92,7 +95,7 @@ func resourceNsxtPolicyIPAddressAllocationCreate(d *schema.ResourceData, m inter
 		id = uuid.String()
 	}
 
-	exists, err := resourceNsxtPolicyIPAddressAllocationExists(sessionContext, poolID, id, connector)
+	exists, err := resourceNsxtPolicyIPAddressAllocationExists(context, poolID, id, connector)
 	if err != nil {
 		return err
 	}
@@ -130,7 +133,11 @@ func resourceNsxtPolicyIPAddressAllocationCreate(d *schema.ResourceData, m inter
 
 func resourceNsxtPolicyIPAddressAllocationRead(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
-	client := ippools.NewIpAllocationsClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := ippools.NewIpAllocationsClient(context, connector)
 
 	if client == nil {
 		return policyResourceNotSupportedError()
@@ -182,7 +189,11 @@ func resourceNsxtPolicyIPAddressAllocationRead(d *schema.ResourceData, m interfa
 
 func resourceNsxtPolicyIPAddressAllocationUpdate(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
-	client := ippools.NewIpAllocationsClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := ippools.NewIpAllocationsClient(context, connector)
 
 	if client == nil {
 		return policyResourceNotSupportedError()
@@ -206,7 +217,7 @@ func resourceNsxtPolicyIPAddressAllocationUpdate(d *schema.ResourceData, m inter
 
 	// Update the resource using PATCH
 	log.Printf("[INFO] Updating IPAddressAllocation with ID %s", id)
-	err := client.Patch(poolID, id, obj)
+	err = client.Patch(poolID, id, obj)
 	if err != nil {
 		return handleUpdateError("IPAddressAllocation", id, err)
 	}
@@ -216,7 +227,11 @@ func resourceNsxtPolicyIPAddressAllocationUpdate(d *schema.ResourceData, m inter
 
 func resourceNsxtPolicyIPAddressAllocationDelete(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
-	client := ippools.NewIpAllocationsClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := ippools.NewIpAllocationsClient(context, connector)
 	if client == nil {
 		return policyResourceNotSupportedError()
 	}
@@ -228,7 +243,7 @@ func resourceNsxtPolicyIPAddressAllocationDelete(d *schema.ResourceData, m inter
 
 	poolID := getPolicyIDFromPath(d.Get("pool_path").(string))
 
-	err := client.Delete(poolID, id)
+	err = client.Delete(poolID, id)
 	if err != nil {
 		return handleDeleteError("IPAddressAllocation", id, err)
 	}
@@ -260,7 +275,11 @@ func resourceNsxtPolicyIPAddressAllocationImport(d *schema.ResourceData, m inter
 
 	poolID := s[0]
 	connector := getPolicyConnector(m)
-	client := infra.NewIpPoolsClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return nil, err
+	}
+	client := infra.NewIpPoolsClient(context, connector)
 
 	pool, err := client.Get(poolID)
 	if err != nil {

--- a/nsxt/resource_nsxt_policy_ip_address_allocation.go
+++ b/nsxt/resource_nsxt_policy_ip_address_allocation.go
@@ -39,7 +39,7 @@ func resourceNsxtPolicyIPAddressAllocation() *schema.Resource {
 			"description":  getDescriptionSchema(),
 			"revision":     getRevisionSchema(),
 			"tag":          getTagsSchema(),
-			"context":      getContextSchema(false, false),
+			"context":      getContextSchema(false, false, false),
 			"pool_path":    getPolicyPathSchema(true, true, "The path of the IP Pool for this allocation"),
 			"allocation_ip": {
 				Type:         schema.TypeString,

--- a/nsxt/resource_nsxt_policy_ip_address_allocation_test.go
+++ b/nsxt/resource_nsxt_policy_ip_address_allocation_test.go
@@ -42,6 +42,13 @@ func TestAccResourceNsxtPolicyIPAddressAllocation_multitenancy(t *testing.T) {
 	})
 }
 
+func TestAccResourceNsxtPolicyIPAddressAllocation_multitenancyProvider(t *testing.T) {
+	testAccResourceNsxtPolicyIPAddressAllocationBasic(t, false, func() {
+		testAccPreCheck(t)
+		testAccOnlyMultitenancyProvider(t)
+	})
+}
+
 func testAccResourceNsxtPolicyIPAddressAllocationBasic(t *testing.T, withContext bool, preCheck func()) {
 	testResourceName := "nsxt_policy_ip_address_allocation.test"
 
@@ -191,6 +198,34 @@ func TestAccResourceNsxtPolicyIPAddressAllocation_importBasic_multitenancy(t *te
 		},
 	})
 }
+
+func TestAccResourceNsxtPolicyIPAddressAllocation_importBasic_multitenancyProvider(t *testing.T) {
+	name := accTestPolicyIPAddressAllocationUpdateAttributes["display_name"]
+	testResourceName := "nsxt_policy_ip_address_allocation.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t); testAccOnlyMultitenancyProvider(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyIPAddressAllocationCheckDestroy(state, name)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyIPAddressAllocationTemplate(true, false),
+			},
+			{
+				ResourceName:      testResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccResourceNsxtPolicyImportIDRetriever(testResourceName),
+			},
+			{
+				Config: testAccNsxtPolicyIPAddressAllocationDependenciesTemplate(true),
+			},
+		},
+	})
+}
+
 func testAccNSXPolicyIPAddressAllocationImporterGetID(s *terraform.State) (string, error) {
 	rs, ok := s.RootModule().Resources["nsxt_policy_ip_address_allocation.test"]
 	if !ok {

--- a/nsxt/resource_nsxt_policy_ip_block.go
+++ b/nsxt/resource_nsxt_policy_ip_block.go
@@ -39,7 +39,7 @@ func resourceNsxtPolicyIPBlock() *schema.Resource {
 			"description":  getDescriptionSchema(),
 			"revision":     getRevisionSchema(),
 			"tag":          getTagsSchema(),
-			"context":      getContextSchema(false, false),
+			"context":      getContextSchema(false, false, false),
 			"cidr": {
 				Type:         schema.TypeString,
 				Description:  "Network address and the prefix length which will be associated with a layer-2 broadcast domain",

--- a/nsxt/resource_nsxt_policy_ip_block.go
+++ b/nsxt/resource_nsxt_policy_ip_block.go
@@ -73,7 +73,11 @@ func resourceNsxtPolicyIPBlockExists(sessionContext utl.SessionContext, id strin
 
 func resourceNsxtPolicyIPBlockRead(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
-	client := infra.NewIpBlocksClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := infra.NewIpBlocksClient(context, connector)
 
 	id := d.Id()
 	if id == "" {
@@ -99,7 +103,11 @@ func resourceNsxtPolicyIPBlockRead(d *schema.ResourceData, m interface{}) error 
 
 func resourceNsxtPolicyIPBlockCreate(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
-	client := infra.NewIpBlocksClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := infra.NewIpBlocksClient(context, connector)
 
 	id, err := getOrGenerateID2(d, m, resourceNsxtPolicyIPBlockExists)
 	if err != nil {
@@ -135,7 +143,11 @@ func resourceNsxtPolicyIPBlockCreate(d *schema.ResourceData, m interface{}) erro
 
 func resourceNsxtPolicyIPBlockUpdate(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
-	client := infra.NewIpBlocksClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := infra.NewIpBlocksClient(context, connector)
 
 	id := d.Id()
 	if id == "" {
@@ -162,7 +174,7 @@ func resourceNsxtPolicyIPBlockUpdate(d *schema.ResourceData, m interface{}) erro
 		obj.Visibility = &visibility
 	}
 
-	_, err := client.Update(id, obj)
+	_, err = client.Update(id, obj)
 	if err != nil {
 		return handleUpdateError("IP Block", id, err)
 	}
@@ -177,8 +189,12 @@ func resourceNsxtPolicyIPBlockDelete(d *schema.ResourceData, m interface{}) erro
 	}
 
 	connector := getPolicyConnector(m)
-	client := infra.NewIpBlocksClient(getSessionContext(d, m), connector)
-	err := client.Delete(id)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := infra.NewIpBlocksClient(context, connector)
+	err = client.Delete(id)
 	if err != nil {
 		return handleDeleteError("IP Block", id, err)
 	}

--- a/nsxt/resource_nsxt_policy_ip_block_test.go
+++ b/nsxt/resource_nsxt_policy_ip_block_test.go
@@ -63,6 +63,13 @@ func TestAccResourceNsxtPolicyIPBlock_multitenancy(t *testing.T) {
 	})
 }
 
+func TestAccResourceNsxtPolicyIPBlock_multitenancyProvider(t *testing.T) {
+	testAccResourceNsxtPolicyIPBlockBasic(t, false, false, func() {
+		testAccPreCheck(t)
+		testAccOnlyMultitenancyProvider(t)
+	})
+}
+
 func testAccResourceNsxtPolicyIPBlockBasic(t *testing.T, withContext bool, withVisibility bool, preCheck func()) {
 	name := getAccTestResourceName()
 	testResourceName := "nsxt_policy_ip_block.test"
@@ -165,6 +172,30 @@ func TestAccResourceNsxtPolicyIPBlock_importBasic_multitenancy(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccNSXPolicyIPBlockCreateMinimalTemplate(name, "192.191.1.0/24", true, false),
+			},
+			{
+				ResourceName:      testResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccResourceNsxtPolicyImportIDRetriever(testResourceName),
+			},
+		},
+	})
+}
+
+func TestAccResourceNsxtPolicyIPBlock_importBasic_multitenancyProvider(t *testing.T) {
+	name := getAccTestResourceName()
+	testResourceName := "nsxt_policy_ip_block.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t); testAccOnlyMultitenancyProvider(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNSXPolicyIPBlockCheckDestroy(state)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNSXPolicyIPBlockCreateMinimalTemplate(name, "192.191.1.0/24", false, false),
 			},
 			{
 				ResourceName:      testResourceName,

--- a/nsxt/resource_nsxt_policy_ip_discovery_profile.go
+++ b/nsxt/resource_nsxt_policy_ip_discovery_profile.go
@@ -33,7 +33,7 @@ func resourceNsxtPolicyIPDiscoveryProfile() *schema.Resource {
 			"description":  getDescriptionSchema(),
 			"revision":     getRevisionSchema(),
 			"tag":          getTagsSchema(),
-			"context":      getContextSchema(false, false),
+			"context":      getContextSchema(false, false, false),
 			"arp_nd_binding_timeout": {
 				Type:         schema.TypeInt,
 				Description:  "ARP and ND cache timeout (in minutes)",

--- a/nsxt/resource_nsxt_policy_ip_discovery_profile.go
+++ b/nsxt/resource_nsxt_policy_ip_discovery_profile.go
@@ -182,7 +182,11 @@ func resourceNsxtPolicyIPDiscoveryProfileCreate(d *schema.ResourceData, m interf
 	// Create the resource using PATCH
 	log.Printf("[INFO] Creating IPDiscoveryProfile with ID %s", id)
 	boolFalse := false
-	client := infra.NewIpDiscoveryProfilesClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := infra.NewIpDiscoveryProfilesClient(context, connector)
 	err = client.Patch(id, obj, &boolFalse)
 	if err != nil {
 		return handleCreateError("IPDiscoveryProfile", id, err)
@@ -202,7 +206,11 @@ func resourceNsxtPolicyIPDiscoveryProfileRead(d *schema.ResourceData, m interfac
 		return fmt.Errorf("Error obtaining IPDiscoveryProfile ID")
 	}
 
-	client := infra.NewIpDiscoveryProfilesClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := infra.NewIpDiscoveryProfilesClient(context, connector)
 	obj, err := client.Get(id)
 	if err != nil {
 		return handleReadError(d, "IPDiscoveryProfile", id, err)
@@ -232,7 +240,11 @@ func resourceNsxtPolicyIPDiscoveryProfileRead(d *schema.ResourceData, m interfac
 
 func resourceNsxtPolicyIPDiscoveryProfileUpdate(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
-	client := infra.NewIpDiscoveryProfilesClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := infra.NewIpDiscoveryProfilesClient(context, connector)
 	if client == nil {
 		return policyResourceNotSupportedError()
 	}
@@ -248,7 +260,7 @@ func resourceNsxtPolicyIPDiscoveryProfileUpdate(d *schema.ResourceData, m interf
 	// Create the resource using PATCH
 	log.Printf("[INFO] Updating IPDiscoveryProfile with ID %s", id)
 	boolFalse := false
-	err := client.Patch(id, obj, &boolFalse)
+	err = client.Patch(id, obj, &boolFalse)
 	if err != nil {
 		return handleUpdateError("IPDiscoveryProfile", id, err)
 	}
@@ -266,7 +278,11 @@ func resourceNsxtPolicyIPDiscoveryProfileDelete(d *schema.ResourceData, m interf
 	connector := getPolicyConnector(m)
 	boolFalse := false
 
-	client := infra.NewIpDiscoveryProfilesClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := infra.NewIpDiscoveryProfilesClient(context, connector)
 	err = client.Delete(id, &boolFalse)
 
 	if err != nil {

--- a/nsxt/resource_nsxt_policy_ip_discovery_profile_test.go
+++ b/nsxt/resource_nsxt_policy_ip_discovery_profile_test.go
@@ -56,6 +56,13 @@ func TestAccResourceNsxtPolicyIPDiscoveryProfile_multitenancy(t *testing.T) {
 	})
 }
 
+func TestAccResourceNsxtPolicyIPDiscoveryProfile_multitenancyProvider(t *testing.T) {
+	testAccResourceNsxtPolicyIPDiscoveryProfileBasic(t, false, func() {
+		testAccPreCheck(t)
+		testAccOnlyMultitenancyProvider(t)
+	})
+}
+
 func testAccResourceNsxtPolicyIPDiscoveryProfileBasic(t *testing.T, withContext bool, preCheck func()) {
 	testResourceName := "nsxt_policy_ip_discovery_profile.test"
 
@@ -176,6 +183,30 @@ func TestAccResourceNsxtPolicyIPDiscoveryProfile_importBasic_multitenancy(t *tes
 		Steps: []resource.TestStep{
 			{
 				Config: testAccNsxtPolicyIPDiscoveryProfileMinimalistic(true),
+			},
+			{
+				ResourceName:      testResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccResourceNsxtPolicyImportIDRetriever(testResourceName),
+			},
+		},
+	})
+}
+
+func TestAccResourceNsxtPolicyIPDiscoveryProfile_importBasic_multitenancyProvider(t *testing.T) {
+	name := getAccTestResourceName()
+	testResourceName := "nsxt_policy_ip_discovery_profile.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t); testAccOnlyMultitenancyProvider(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyIPDiscoveryProfileCheckDestroy(state, name)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyIPDiscoveryProfileMinimalistic(false),
 			},
 			{
 				ResourceName:      testResourceName,

--- a/nsxt/resource_nsxt_policy_ip_pool.go
+++ b/nsxt/resource_nsxt_policy_ip_pool.go
@@ -59,7 +59,11 @@ func resourceNsxtPolicyIPPoolExists(sessionContext utl.SessionContext, id string
 
 func resourceNsxtPolicyIPPoolRead(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
-	client := infra.NewIpPoolsClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := infra.NewIpPoolsClient(context, connector)
 
 	id := d.Id()
 	if id == "" {
@@ -89,7 +93,11 @@ func resourceNsxtPolicyIPPoolRead(d *schema.ResourceData, m interface{}) error {
 
 func resourceNsxtPolicyIPPoolCreate(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
-	client := infra.NewIpPoolsClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := infra.NewIpPoolsClient(context, connector)
 
 	id, err := getOrGenerateID2(d, m, resourceNsxtPolicyIPPoolExists)
 	if err != nil {
@@ -120,7 +128,11 @@ func resourceNsxtPolicyIPPoolCreate(d *schema.ResourceData, m interface{}) error
 
 func resourceNsxtPolicyIPPoolUpdate(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
-	client := infra.NewIpPoolsClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := infra.NewIpPoolsClient(context, connector)
 
 	id := d.Id()
 	if id == "" {
@@ -139,7 +151,7 @@ func resourceNsxtPolicyIPPoolUpdate(d *schema.ResourceData, m interface{}) error
 	}
 
 	log.Printf("[INFO] Updating IP Pool with ID %s", id)
-	err := client.Patch(id, obj)
+	err = client.Patch(id, obj)
 	if err != nil {
 		return handleUpdateError("IP Pool", id, err)
 	}
@@ -151,7 +163,11 @@ func resourceNsxtPolicyIPPoolUpdate(d *schema.ResourceData, m interface{}) error
 
 func resourceNsxtPolicyIPPoolDelete(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
-	client := infra.NewIpPoolsClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := infra.NewIpPoolsClient(context, connector)
 
 	id := d.Id()
 	if id == "" {
@@ -159,7 +175,7 @@ func resourceNsxtPolicyIPPoolDelete(d *schema.ResourceData, m interface{}) error
 	}
 
 	log.Printf("[INFO] Deleting IP Pool with ID %s", id)
-	err := client.Delete(id)
+	err = client.Delete(id)
 	if err != nil {
 		return handleDeleteError("IP Pool", id, err)
 	}

--- a/nsxt/resource_nsxt_policy_ip_pool.go
+++ b/nsxt/resource_nsxt_policy_ip_pool.go
@@ -32,7 +32,7 @@ func resourceNsxtPolicyIPPool() *schema.Resource {
 			"description":  getDescriptionSchema(),
 			"revision":     getRevisionSchema(),
 			"tag":          getTagsSchema(),
-			"context":      getContextSchema(false, false),
+			"context":      getContextSchema(false, false, false),
 			"realized_id": {
 				Type:        schema.TypeString,
 				Description: "The ID of the realized resource",

--- a/nsxt/resource_nsxt_policy_ip_pool_block_subnet.go
+++ b/nsxt/resource_nsxt_policy_ip_pool_block_subnet.go
@@ -40,7 +40,7 @@ func resourceNsxtPolicyIPPoolBlockSubnet() *schema.Resource {
 			"description":  getDescriptionSchema(),
 			"revision":     getRevisionSchema(),
 			"tag":          getTagsSchema(),
-			"context":      getContextSchema(false, false),
+			"context":      getContextSchema(false, false, false),
 			"auto_assign_gateway": {
 				Type:        schema.TypeBool,
 				Description: "If true, the first IP in the range will be reserved for gateway",

--- a/nsxt/resource_nsxt_policy_ip_pool_block_subnet.go
+++ b/nsxt/resource_nsxt_policy_ip_pool_block_subnet.go
@@ -92,7 +92,11 @@ func resourceNsxtPolicyIPPoolBlockSubnetSchemaToStructValue(d *schema.ResourceDa
 
 func resourceNsxtPolicyIPPoolBlockSubnetRead(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
-	client := ippools.NewIpSubnetsClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := ippools.NewIpSubnetsClient(context, connector)
 	converter := bindings.NewTypeConverter()
 
 	poolPath := d.Get("pool_path").(string)
@@ -135,7 +139,11 @@ func resourceNsxtPolicyIPPoolBlockSubnetRead(d *schema.ResourceData, m interface
 
 func resourceNsxtPolicyIPPoolBlockSubnetCreate(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
-	client := ippools.NewIpSubnetsClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := ippools.NewIpSubnetsClient(context, connector)
 
 	poolPath := d.Get("pool_path").(string)
 	poolID := getPolicyIDFromPath(poolPath)
@@ -170,7 +178,11 @@ func resourceNsxtPolicyIPPoolBlockSubnetCreate(d *schema.ResourceData, m interfa
 
 func resourceNsxtPolicyIPPoolBlockSubnetUpdate(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
-	client := ippools.NewIpSubnetsClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := ippools.NewIpSubnetsClient(context, connector)
 
 	poolPath := d.Get("pool_path").(string)
 	poolID := getPolicyIDFromPath(poolPath)
@@ -198,7 +210,11 @@ func resourceNsxtPolicyIPPoolBlockSubnetUpdate(d *schema.ResourceData, m interfa
 
 func resourceNsxtPolicyIPPoolBlockSubnetDelete(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
-	client := ippools.NewIpSubnetsClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := ippools.NewIpSubnetsClient(context, connector)
 
 	poolPath := d.Get("pool_path").(string)
 	poolID := getPolicyIDFromPath(poolPath)
@@ -209,12 +225,12 @@ func resourceNsxtPolicyIPPoolBlockSubnetDelete(d *schema.ResourceData, m interfa
 	}
 
 	log.Printf("[INFO] Deleting Block Subnet with ID %s", id)
-	err := client.Delete(poolID, id, nil)
+	err = client.Delete(poolID, id, nil)
 	if err != nil {
 		return handleDeleteError("Block Subnet", id, err)
 	}
 
-	return resourceNsxtPolicyIPPoolBlockSubnetVerifyDelete(getSessionContext(d, m), d, connector)
+	return resourceNsxtPolicyIPPoolBlockSubnetVerifyDelete(context, d, connector)
 }
 
 // NOTE: This will not be needed when IPAM is handled by NSXT Policy
@@ -275,7 +291,11 @@ func resourceNsxtPolicyIPPoolSubnetImport(d *schema.ResourceData, m interface{})
 
 	poolID := s[0]
 	connector := getPolicyConnector(m)
-	client := infra.NewIpPoolsClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return nil, err
+	}
+	client := infra.NewIpPoolsClient(context, connector)
 
 	pool, err := client.Get(poolID)
 	if err != nil {

--- a/nsxt/resource_nsxt_policy_ip_pool_block_subnet_test.go
+++ b/nsxt/resource_nsxt_policy_ip_pool_block_subnet_test.go
@@ -62,6 +62,13 @@ func TestAccResourceNsxtPolicyIPPoolBlockSubnet_multitenancy(t *testing.T) {
 	})
 }
 
+func TestAccResourceNsxtPolicyIPPoolBlockSubnet_multitenancyProvider(t *testing.T) {
+	testAccResourceNsxtPolicyIPPoolBlockSubnetBasic(t, false, func() {
+		testAccPreCheck(t)
+		testAccOnlyMultitenancyProvider(t)
+	})
+}
+
 func testAccResourceNsxtPolicyIPPoolBlockSubnetBasic(t *testing.T, withContext bool, preCheck func()) {
 	poolName := getAccTestResourceName()
 	name := getAccTestResourceName()
@@ -156,6 +163,34 @@ func TestAccResourceNsxtPolicyIPPoolBlockSubnet_importBasic_multitenancy(t *test
 		Steps: []resource.TestStep{
 			{
 				Config: testAccNSXPolicyIPPoolBlockSubnetCreateTemplate(poolName, name, true),
+			},
+			{
+				ResourceName:      testResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccResourceNsxtPolicyImportIDRetriever(testResourceName),
+			},
+			{
+				Config: testAccNSXPolicyIPPoolBlockSubnetIPBlockTemplate(true),
+			},
+		},
+	})
+}
+
+func TestAccResourceNsxtPolicyIPPoolBlockSubnet_importBasic_multitenancyProvider(t *testing.T) {
+	poolName := getAccTestResourceName()
+	name := getAccTestResourceName()
+	testResourceName := "nsxt_policy_ip_pool_block_subnet.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t); testAccOnlyMultitenancyProvider(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNSXPolicyIPPoolBlockSubnetCheckDestroy(state)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNSXPolicyIPPoolBlockSubnetCreateTemplate(poolName, name, false),
 			},
 			{
 				ResourceName:      testResourceName,

--- a/nsxt/resource_nsxt_policy_ip_pool_static_subnet.go
+++ b/nsxt/resource_nsxt_policy_ip_pool_static_subnet.go
@@ -31,7 +31,7 @@ func resourceNsxtPolicyIPPoolStaticSubnet() *schema.Resource {
 			"description":      getDescriptionSchema(),
 			"revision":         getRevisionSchema(),
 			"tag":              getTagsSchema(),
-			"context":          getContextSchema(false, false),
+			"context":          getContextSchema(false, false, false),
 			"pool_path":        getPolicyPathSchema(true, true, "Policy path to the IP Pool for this Subnet"),
 			"allocation_range": getAllocationRangeListSchema(true, "A collection of IPv4 or IPv6 IP ranges"),
 			"cidr": {

--- a/nsxt/resource_nsxt_policy_ip_pool_static_subnet.go
+++ b/nsxt/resource_nsxt_policy_ip_pool_static_subnet.go
@@ -120,7 +120,11 @@ func resourceNsxtPolicyIPPoolStaticSubnetSchemaToStructValue(d *schema.ResourceD
 
 func resourceNsxtPolicyIPPoolStaticSubnetRead(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
-	client := ippools.NewIpSubnetsClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := ippools.NewIpSubnetsClient(context, connector)
 	converter := bindings.NewTypeConverter()
 
 	poolPath := d.Get("pool_path").(string)
@@ -173,7 +177,11 @@ func resourceNsxtPolicyIPPoolStaticSubnetRead(d *schema.ResourceData, m interfac
 
 func resourceNsxtPolicyIPPoolStaticSubnetCreate(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
-	client := ippools.NewIpSubnetsClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := ippools.NewIpSubnetsClient(context, connector)
 
 	poolPath := d.Get("pool_path").(string)
 	poolID := getPolicyIDFromPath(poolPath)
@@ -208,7 +216,11 @@ func resourceNsxtPolicyIPPoolStaticSubnetCreate(d *schema.ResourceData, m interf
 
 func resourceNsxtPolicyIPPoolStaticSubnetUpdate(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
-	client := ippools.NewIpSubnetsClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := ippools.NewIpSubnetsClient(context, connector)
 
 	poolPath := d.Get("pool_path").(string)
 	poolID := getPolicyIDFromPath(poolPath)
@@ -236,7 +248,11 @@ func resourceNsxtPolicyIPPoolStaticSubnetUpdate(d *schema.ResourceData, m interf
 
 func resourceNsxtPolicyIPPoolStaticSubnetDelete(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
-	client := ippools.NewIpSubnetsClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := ippools.NewIpSubnetsClient(context, connector)
 
 	poolPath := d.Get("pool_path").(string)
 	poolID := getPolicyIDFromPath(poolPath)
@@ -247,7 +263,7 @@ func resourceNsxtPolicyIPPoolStaticSubnetDelete(d *schema.ResourceData, m interf
 	}
 
 	log.Printf("[INFO] Deleting Static Subnet with ID %s", id)
-	err := client.Delete(poolID, id, nil)
+	err = client.Delete(poolID, id, nil)
 	if err != nil {
 		return handleDeleteError("Static Subnet", id, err)
 	}

--- a/nsxt/resource_nsxt_policy_ip_pool_static_subnet_test.go
+++ b/nsxt/resource_nsxt_policy_ip_pool_static_subnet_test.go
@@ -59,6 +59,13 @@ func TestAccResourceNsxtPolicyIPPoolStaticSubnet_multitenancy(t *testing.T) {
 	})
 }
 
+func TestAccResourceNsxtPolicyIPPoolStaticSubnet_multitenancyProvider(t *testing.T) {
+	testAccResourceNsxtPolicyIPPoolStaticSubnetBasic(t, false, func() {
+		testAccPreCheck(t)
+		testAccOnlyMultitenancyProvider(t)
+	})
+}
+
 func testAccResourceNsxtPolicyIPPoolStaticSubnetBasic(t *testing.T, withContext bool, preCheck func()) {
 	name := getAccTestResourceName()
 	updatedName := getAccTestResourceName()
@@ -163,6 +170,30 @@ func TestAccResourceNsxtPolicyIPPoolStaticSubnet_import_basic_multitenancy(t *te
 		Steps: []resource.TestStep{
 			{
 				Config: testAccNSXPolicyIPPoolStaticSubnetCreateTemplate(name, true),
+			},
+			{
+				ResourceName:      testResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccResourceNsxtPolicyImportIDRetriever(testResourceName),
+			},
+		},
+	})
+}
+
+func TestAccResourceNsxtPolicyIPPoolStaticSubnet_import_basic_multitenancyProvider(t *testing.T) {
+	name := getAccTestResourceName()
+	testResourceName := "nsxt_policy_ip_pool_static_subnet.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t); testAccOnlyMultitenancyProvider(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNSXPolicyIPPoolStaticSubnetCheckDestroy(state)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNSXPolicyIPPoolStaticSubnetCreateTemplate(name, false),
 			},
 			{
 				ResourceName:      testResourceName,

--- a/nsxt/resource_nsxt_policy_ip_pool_test.go
+++ b/nsxt/resource_nsxt_policy_ip_pool_test.go
@@ -51,6 +51,13 @@ func TestAccResourceNsxtPolicyIPPool_multitenancy(t *testing.T) {
 	})
 }
 
+func TestAccResourceNsxtPolicyIPPool_multitenancyProvider(t *testing.T) {
+	testAccResourceNsxtPolicyIPPoolBasic(t, false, func() {
+		testAccPreCheck(t)
+		testAccOnlyMultitenancyProvider(t)
+	})
+}
+
 func testAccResourceNsxtPolicyIPPoolBasic(t *testing.T, withContext bool, preCheck func()) {
 	name := getAccTestResourceName()
 	updatedName := getAccTestResourceName()
@@ -123,6 +130,30 @@ func TestAccResourceNsxtPolicyIPPool_importBasic_multitenancy(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccNSXPolicyIPPoolCreateTemplate(name, true),
+			},
+			{
+				ResourceName:      testResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccResourceNsxtPolicyImportIDRetriever(testResourceName),
+			},
+		},
+	})
+}
+
+func TestAccResourceNsxtPolicyIPPool_importBasic_multitenancyProvider(t *testing.T) {
+	name := getAccTestResourceName()
+	testResourceName := "nsxt_policy_ip_pool.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t); testAccOnlyMultitenancyProvider(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNSXPolicyIPPoolCheckDestroy(state)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNSXPolicyIPPoolCreateTemplate(name, false),
 			},
 			{
 				ResourceName:      testResourceName,

--- a/nsxt/resource_nsxt_policy_mac_discovery_profile.go
+++ b/nsxt/resource_nsxt_policy_mac_discovery_profile.go
@@ -30,7 +30,7 @@ var macDiscoveryProfileSchema = map[string]*metadata.ExtendedSchema{
 	"description":  metadata.GetExtendedSchema(getDescriptionSchema()),
 	"revision":     metadata.GetExtendedSchema(getRevisionSchema()),
 	"tag":          metadata.GetExtendedSchema(getTagsSchema()),
-	"context":      metadata.GetExtendedSchema(getContextSchema(false, false)),
+	"context":      metadata.GetExtendedSchema(getContextSchema(false, false, false)),
 	"mac_change_enabled": {
 		Schema: schema.Schema{
 			Type:     schema.TypeBool,

--- a/nsxt/resource_nsxt_policy_mac_discovery_profile.go
+++ b/nsxt/resource_nsxt_policy_mac_discovery_profile.go
@@ -181,7 +181,11 @@ func resourceNsxtPolicyMacDiscoveryProfileCreate(d *schema.ResourceData, m inter
 	// Create the resource using PATCH
 	log.Printf("[INFO] Creating MacDiscoveryProfile with ID %s", id)
 	boolFalse := false
-	client := infra.NewMacDiscoveryProfilesClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := infra.NewMacDiscoveryProfilesClient(context, connector)
 	err = client.Patch(id, obj, &boolFalse)
 	if err != nil {
 		return handleCreateError("MacDiscoveryProfile", id, err)
@@ -201,7 +205,11 @@ func resourceNsxtPolicyMacDiscoveryProfileRead(d *schema.ResourceData, m interfa
 		return fmt.Errorf("Error obtaining MacDiscoveryProfile ID")
 	}
 
-	client := infra.NewMacDiscoveryProfilesClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := infra.NewMacDiscoveryProfilesClient(context, connector)
 	obj, err := client.Get(id)
 	if err != nil {
 		return handleReadError(d, "MacDiscoveryProfile", id, err)
@@ -247,8 +255,12 @@ func resourceNsxtPolicyMacDiscoveryProfileUpdate(d *schema.ResourceData, m inter
 
 	// Update the resource using PATCH
 	boolFalse := false
-	client := infra.NewMacDiscoveryProfilesClient(getSessionContext(d, m), connector)
-	_, err := client.Update(id, obj, &boolFalse)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := infra.NewMacDiscoveryProfilesClient(context, connector)
+	_, err = client.Update(id, obj, &boolFalse)
 	if err != nil {
 		return handleUpdateError("MacDiscoveryProfile", id, err)
 	}
@@ -264,8 +276,12 @@ func resourceNsxtPolicyMacDiscoveryProfileDelete(d *schema.ResourceData, m inter
 
 	connector := getPolicyConnector(m)
 	boolFalse := false
-	client := infra.NewMacDiscoveryProfilesClient(getSessionContext(d, m), connector)
-	err := client.Delete(id, &boolFalse)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := infra.NewMacDiscoveryProfilesClient(context, connector)
+	err = client.Delete(id, &boolFalse)
 
 	if err != nil {
 		return handleDeleteError("MacDiscoveryProfile", id, err)

--- a/nsxt/resource_nsxt_policy_mac_discovery_profile_test.go
+++ b/nsxt/resource_nsxt_policy_mac_discovery_profile_test.go
@@ -34,6 +34,14 @@ func TestAccResourceNsxtPolicyMacDiscoveryProfile_multitenancy(t *testing.T) {
 	})
 }
 
+func TestAccResourceNsxtPolicyMacDiscoveryProfile_multitenancyProvider(t *testing.T) {
+	testAccResourceNsxtPolicyMacDiscoveryProfileBasic(t, false, func() {
+		testAccPreCheck(t)
+		testAccNSXVersion(t, "3.0.0")
+		testAccOnlyMultitenancyProvider(t)
+	})
+}
+
 func getMacDiscoveryProfileTestCheckFunc(testResourceName string, create bool) []resource.TestCheckFunc {
 	displayName := createDisplayName
 	if !create {
@@ -159,6 +167,30 @@ func TestAccResourceNsxtPolicyMacDiscoveryProfile_importBasic_multitenancy(t *te
 		Steps: []resource.TestStep{
 			{
 				Config: testAccNsxtPolicyMacDiscoveryProfileMinimalistic(true),
+			},
+			{
+				ResourceName:      testResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccResourceNsxtPolicyImportIDRetriever(testResourceName),
+			},
+		},
+	})
+}
+
+func TestAccResourceNsxtPolicyMacDiscoveryProfile_importBasic_multitenancyProvider(t *testing.T) {
+	name := getAccTestResourceName()
+	testResourceName := "nsxt_policy_mac_discovery_profile.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t); testAccOnlyMultitenancyProvider(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyMacDiscoveryProfileCheckDestroy(state, name)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyMacDiscoveryProfileMinimalistic(false),
 			},
 			{
 				ResourceName:      testResourceName,

--- a/nsxt/resource_nsxt_policy_nat_rule.go
+++ b/nsxt/resource_nsxt_policy_nat_rule.go
@@ -57,7 +57,7 @@ func resourceNsxtPolicyNATRule() *schema.Resource {
 			"description":  getDescriptionSchema(),
 			"revision":     getRevisionSchema(),
 			"tag":          getTagsSchema(),
-			"context":      getContextSchema(false, false),
+			"context":      getContextSchema(false, false, false),
 			"gateway_path": getPolicyGatewayPathSchema(),
 			"action": {
 				Type:         schema.TypeString,

--- a/nsxt/resource_nsxt_policy_nat_rule_test.go
+++ b/nsxt/resource_nsxt_policy_nat_rule_test.go
@@ -61,6 +61,13 @@ func TestAccResourceNsxtPolicyNATRule_basicT1_multitenancy(t *testing.T) {
 	})
 }
 
+func TestAccResourceNsxtPolicyNATRule_basicT1_multitenancyProvider(t *testing.T) {
+	testAccResourceNsxtPolicyNATRuleBasicT1(t, false, func() {
+		testAccPreCheck(t)
+		testAccOnlyMultitenancyProvider(t)
+	})
+}
+
 func testAccResourceNsxtPolicyNATRuleBasicT1(t *testing.T, withContext bool, preCheck func()) {
 	name := getAccTestResourceName()
 	updateName := getAccTestResourceName()
@@ -295,6 +302,30 @@ func TestAccResourceNsxtPolicyNATRule_basicT1Import_multitenancy(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccNsxtPolicyNATRuleTier1CreateTemplate(name, action, testAccResourcePolicyNATRuleSourceNet, testAccResourcePolicyNATRuleDestNet, testAccResourcePolicyNATRuleTransNet, true),
+			},
+			{
+				ResourceName:      testAccResourcePolicyNATRuleName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccResourceNsxtPolicyImportIDRetriever(testAccResourcePolicyNATRuleName),
+			},
+		},
+	})
+}
+
+func TestAccResourceNsxtPolicyNATRule_basicT1Import_multitenancyProvider(t *testing.T) {
+	name := getAccTestResourceName()
+	action := model.PolicyNatRule_ACTION_DNAT
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t); testAccOnlyMultitenancyProvider(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyNATRuleCheckDestroy(state, name, false)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyNATRuleTier1CreateTemplate(name, action, testAccResourcePolicyNATRuleSourceNet, testAccResourcePolicyNATRuleDestNet, testAccResourcePolicyNATRuleTransNet, false),
 			},
 			{
 				ResourceName:      testAccResourcePolicyNATRuleName,

--- a/nsxt/resource_nsxt_policy_ospf_config.go
+++ b/nsxt/resource_nsxt_policy_ospf_config.go
@@ -142,7 +142,11 @@ func resourceNsxtPolicyOspfConfigCreate(d *schema.ResourceData, m interface{}) e
 		return fmt.Errorf("Tier0 Gateway path expected, got %s", gwPath)
 	}
 
-	localeService, err := getPolicyTier0GatewayLocaleServiceWithEdgeCluster(getSessionContext(d, m), gwID, connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	localeService, err := getPolicyTier0GatewayLocaleServiceWithEdgeCluster(context, gwID, connector)
 	if err != nil {
 		return fmt.Errorf("Tier0 Gateway path with configured edge cluster expected, got %s", gwPath)
 	}

--- a/nsxt/resource_nsxt_policy_parent_security_policy.go
+++ b/nsxt/resource_nsxt_policy_parent_security_policy.go
@@ -62,7 +62,11 @@ func parentSecurityPolicyModelToSchema(d *schema.ResourceData, m interface{}) (*
 	if id == "" {
 		return nil, fmt.Errorf("Error obtaining Security Policy id")
 	}
-	client := domains.NewSecurityPoliciesClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return nil, err
+	}
+	client := domains.NewSecurityPoliciesClient(context, connector)
 	obj, err := client.Get(domainName, id)
 	if err != nil {
 		return nil, err

--- a/nsxt/resource_nsxt_policy_parent_security_policy_test.go
+++ b/nsxt/resource_nsxt_policy_parent_security_policy_test.go
@@ -24,6 +24,13 @@ func TestAccResourceNsxtPolicyParentSecurityPolicy_multitenancy(t *testing.T) {
 	})
 }
 
+func TestAccResourceNsxtPolicyParentSecurityPolicy_multitenancyProvider(t *testing.T) {
+	testAccResourceNsxtPolicyParentSecurityPolicyBasic(t, false, func() {
+		testAccPreCheck(t)
+		testAccOnlyMultitenancyProvider(t)
+	})
+}
+
 func testAccResourceNsxtPolicyParentSecurityPolicyBasic(t *testing.T, withContext bool, preCheck func()) {
 	testResourceName := "nsxt_policy_parent_security_policy.test"
 
@@ -107,6 +114,33 @@ func TestAccResourceNsxtPolicyParentSecurityPolicy_importBasic_multitenancy(t *t
 		Steps: []resource.TestStep{
 			{
 				Config: testAccNsxtPolicyParentSecurityPolicyTemplate(true, name, "true", "1", "true"),
+			},
+			{
+				ResourceName:      testResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccResourceNsxtPolicyImportIDRetriever(testResourceName),
+			},
+		},
+	})
+}
+
+func TestAccResourceNsxtPolicyParentSecurityPolicy_importBasic_multitenancyProvider(t *testing.T) {
+	name := getAccTestResourceName()
+	testResourceName := "nsxt_policy_parent_security_policy.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccOnlyMultitenancyProvider(t)
+		},
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicySecurityPolicyCheckDestroy(state, name, defaultDomain)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyParentSecurityPolicyTemplate(false, name, "true", "1", "true"),
 			},
 			{
 				ResourceName:      testResourceName,

--- a/nsxt/resource_nsxt_policy_predefined_gateway_policy.go
+++ b/nsxt/resource_nsxt_policy_predefined_gateway_policy.go
@@ -293,7 +293,11 @@ func updatePolicyPredefinedGatewayPolicy(id string, d *schema.ResourceData, m in
 		return fmt.Errorf("Failed to extract domain from Gateway Policy path %s", path)
 	}
 
-	predefinedPolicy, err := getGatewayPolicyInDomain(getSessionContext(d, m), id, domain, connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	predefinedPolicy, err := getGatewayPolicyInDomain(context, id, domain, connector)
 	if err != nil {
 		return err
 	}
@@ -376,7 +380,10 @@ func updatePolicyPredefinedGatewayPolicy(id string, d *schema.ResourceData, m in
 		predefinedPolicy.Children = childRules
 	}
 
-	err = gatewayPolicyInfraPatch(getSessionContext(d, m), predefinedPolicy, domain, m)
+	if err != nil {
+		return err
+	}
+	err = gatewayPolicyInfraPatch(context, predefinedPolicy, domain, m)
 	if err != nil {
 		return handleUpdateError("Predefined Gateway Policy", id, err)
 	}
@@ -413,7 +420,11 @@ func resourceNsxtPolicyPredefinedGatewayPolicyRead(d *schema.ResourceData, m int
 	path := d.Get("path").(string)
 	domain := getDomainFromResourcePath(path)
 
-	client := domains.NewGatewayPoliciesClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := domains.NewGatewayPoliciesClient(context, connector)
 	obj, err := client.Get(domain, id)
 	if err != nil {
 		return handleReadError(d, "Predefined Gateway Policy", id, err)
@@ -465,7 +476,11 @@ func resourceNsxtPolicyPredefinedGatewayPolicyDelete(d *schema.ResourceData, m i
 	path := d.Get("path").(string)
 	domain := getDomainFromResourcePath(path)
 
-	predefinedPolicy, err := getGatewayPolicyInDomain(getSessionContext(d, m), id, domain, getPolicyConnector(m))
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	predefinedPolicy, err := getGatewayPolicyInDomain(context, id, domain, getPolicyConnector(m))
 	if err != nil {
 		return err
 	}
@@ -475,7 +490,7 @@ func resourceNsxtPolicyPredefinedGatewayPolicyDelete(d *schema.ResourceData, m i
 		return fmt.Errorf("Failed to revert Predefined Gateway Policy %s: %s", id, err)
 	}
 
-	err = gatewayPolicyInfraPatch(getSessionContext(d, m), revertedPolicy, domain, m)
+	err = gatewayPolicyInfraPatch(context, revertedPolicy, domain, m)
 	if err != nil {
 		return handleUpdateError("Predefined Gateway Policy", id, err)
 	}

--- a/nsxt/resource_nsxt_policy_predefined_gateway_policy.go
+++ b/nsxt/resource_nsxt_policy_predefined_gateway_policy.go
@@ -42,7 +42,7 @@ func getPolicyPredefinedGatewayPolicySchema() map[string]*schema.Schema {
 		"rule":         getSecurityPolicyAndGatewayRulesSchema(true, false, false),
 		"default_rule": getGatewayPolicyDefaultRulesSchema(),
 		"revision":     getRevisionSchema(),
-		"context":      getContextSchema(false, false),
+		"context":      getContextSchema(false, false, false),
 	}
 }
 

--- a/nsxt/resource_nsxt_policy_predefined_security_policy.go
+++ b/nsxt/resource_nsxt_policy_predefined_security_policy.go
@@ -219,7 +219,11 @@ func updatePolicyPredefinedSecurityPolicy(id string, d *schema.ResourceData, m i
 		return fmt.Errorf("Failed to extract domain from Security Policy path %s", path)
 	}
 
-	predefinedPolicy, err := getSecurityPolicyInDomain(getSessionContext(d, m), id, domain, connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	predefinedPolicy, err := getSecurityPolicyInDomain(context, id, domain, connector)
 	if err != nil {
 		return err
 	}
@@ -298,7 +302,10 @@ func updatePolicyPredefinedSecurityPolicy(id string, d *schema.ResourceData, m i
 		predefinedPolicy.Children = childRules
 	}
 
-	err = securityPolicyInfraPatch(getSessionContext(d, m), predefinedPolicy, domain, m)
+	if err != nil {
+		return err
+	}
+	err = securityPolicyInfraPatch(context, predefinedPolicy, domain, m)
 	if err != nil {
 		return handleUpdateError("Predefined Security Policy", id, err)
 	}
@@ -335,7 +342,11 @@ func resourceNsxtPolicyPredefinedSecurityPolicyRead(d *schema.ResourceData, m in
 	path := d.Get("path").(string)
 	domain := getDomainFromResourcePath(path)
 
-	client := domains.NewSecurityPoliciesClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := domains.NewSecurityPoliciesClient(context, connector)
 	obj, err := client.Get(domain, id)
 	if err != nil {
 		return handleReadError(d, "Predefined Security Policy", id, err)
@@ -386,7 +397,10 @@ func resourceNsxtPolicyPredefinedSecurityPolicyDelete(d *schema.ResourceData, m 
 
 	path := d.Get("path").(string)
 	domain := getDomainFromResourcePath(path)
-	context := getSessionContext(d, m)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
 
 	predefinedPolicy, err := getSecurityPolicyInDomain(context, id, domain, getPolicyConnector(m))
 	if err != nil {

--- a/nsxt/resource_nsxt_policy_predefined_security_policy.go
+++ b/nsxt/resource_nsxt_policy_predefined_security_policy.go
@@ -39,7 +39,7 @@ func getSecurityPolicyDefaultRulesSchema() *schema.Schema {
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"nsx_id":  getComputedNsxIDSchema(),
-				"context": getContextSchema(false, false),
+				"context": getContextSchema(false, false, false),
 				"scope": {
 					Type:        schema.TypeString,
 					Description: "Scope for this rule",
@@ -85,7 +85,7 @@ func getPolicyPredefinedSecurityPolicySchema() map[string]*schema.Schema {
 		"rule":         getSecurityPolicyAndGatewayRulesSchema(false, false, false),
 		"default_rule": getSecurityPolicyDefaultRulesSchema(),
 		"revision":     getRevisionSchema(),
-		"context":      getContextSchema(false, false),
+		"context":      getContextSchema(false, false, false),
 	}
 }
 

--- a/nsxt/resource_nsxt_policy_predefined_security_policy_test.go
+++ b/nsxt/resource_nsxt_policy_predefined_security_policy_test.go
@@ -25,6 +25,13 @@ func TestAccResourceNsxtPolicyPredefinedSecurityPolicy_multitenancy(t *testing.T
 	})
 }
 
+func TestAccResourceNsxtPolicyPredefinedSecurityPolicy_multitenancyProvider(t *testing.T) {
+	testAccResourceNsxtPolicyPredefinedSecurityPolicyBasic(t, false, func() {
+		testAccPreCheck(t)
+		testAccOnlyMultitenancyProvider(t)
+	})
+}
+
 func testAccResourceNsxtPolicyPredefinedSecurityPolicyBasic(t *testing.T, withContext bool, preCheck func()) {
 	testResourceName := "nsxt_policy_predefined_security_policy.test"
 	description1 := "test 1"

--- a/nsxt/resource_nsxt_policy_qos_profile.go
+++ b/nsxt/resource_nsxt_policy_qos_profile.go
@@ -174,7 +174,11 @@ func resourceNsxtPolicyQosProfileCreate(d *schema.ResourceData, m interface{}) e
 	// Create the resource using PATCH
 	log.Printf("[INFO] Creating QosProfile with ID %s", id)
 	boolFalse := false
-	client := infra.NewQosProfilesClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := infra.NewQosProfilesClient(context, connector)
 	err = client.Patch(id, obj, &boolFalse)
 	if err != nil {
 		return handleCreateError("QosProfile", id, err)
@@ -194,7 +198,11 @@ func resourceNsxtPolicyQosProfileRead(d *schema.ResourceData, m interface{}) err
 		return fmt.Errorf("Error obtaining QosProfile ID")
 	}
 
-	client := infra.NewQosProfilesClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := infra.NewQosProfilesClient(context, connector)
 	obj, err := client.Get(id)
 	if err != nil {
 		return handleReadError(d, "QosProfile", id, err)
@@ -222,7 +230,11 @@ func resourceNsxtPolicyQosProfileRead(d *schema.ResourceData, m interface{}) err
 
 func resourceNsxtPolicyQosProfileUpdate(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
-	client := infra.NewQosProfilesClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := infra.NewQosProfilesClient(context, connector)
 	if client == nil {
 		return policyResourceNotSupportedError()
 	}
@@ -267,7 +279,7 @@ func resourceNsxtPolicyQosProfileUpdate(d *schema.ResourceData, m interface{}) e
 	// Create the resource using PATCH
 	log.Printf("[INFO] Updating QosProfile with ID %s", id)
 	boolFalse := false
-	err := client.Patch(id, obj, &boolFalse)
+	err = client.Patch(id, obj, &boolFalse)
 	if err != nil {
 		d.Partial(true)
 		return handleUpdateError("QosProfile", id, err)
@@ -284,8 +296,12 @@ func resourceNsxtPolicyQosProfileDelete(d *schema.ResourceData, m interface{}) e
 
 	connector := getPolicyConnector(m)
 	boolFalse := false
-	client := infra.NewQosProfilesClient(getSessionContext(d, m), connector)
-	err := client.Delete(id, &boolFalse)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := infra.NewQosProfilesClient(context, connector)
+	err = client.Delete(id, &boolFalse)
 
 	if err != nil {
 		return handleDeleteError("QosProfile", id, err)

--- a/nsxt/resource_nsxt_policy_qos_profile.go
+++ b/nsxt/resource_nsxt_policy_qos_profile.go
@@ -37,7 +37,7 @@ func resourceNsxtPolicyQosProfile() *schema.Resource {
 			"description":  getDescriptionSchema(),
 			"revision":     getRevisionSchema(),
 			"tag":          getTagsSchema(),
-			"context":      getContextSchema(false, false),
+			"context":      getContextSchema(false, false, false),
 			"class_of_service": {
 				Type:         schema.TypeInt,
 				Description:  "Class of service",

--- a/nsxt/resource_nsxt_policy_qos_profile_test.go
+++ b/nsxt/resource_nsxt_policy_qos_profile_test.go
@@ -24,6 +24,13 @@ func TestAccResourceNsxtPolicyQosProfile_multitenancy(t *testing.T) {
 	})
 }
 
+func TestAccResourceNsxtPolicyQosProfile_multitenancyProvider(t *testing.T) {
+	testAccResourceNsxtPolicyQosProfileBasic(t, false, func() {
+		testAccPreCheck(t)
+		testAccOnlyMultitenancyProvider(t)
+	})
+}
+
 func testAccResourceNsxtPolicyQosProfileBasic(t *testing.T, withContext bool, preCheck func()) {
 	name := getAccTestResourceName()
 	updatedName := getAccTestResourceName()
@@ -147,6 +154,29 @@ func TestAccResourceNsxtPolicyQosProfile_importBasic_multitenancy(t *testing.T) 
 		Steps: []resource.TestStep{
 			{
 				Config: testAccNSXPolicyQosProfileCreateTemplateTrivial(name, true),
+			},
+			{
+				ResourceName:      testResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccResourceNsxtPolicyImportIDRetriever(testResourceName),
+			},
+		},
+	})
+}
+
+func TestAccResourceNsxtPolicyQosProfile_importBasic_multitenancyProvider(t *testing.T) {
+	name := getAccTestResourceName()
+	testResourceName := "nsxt_policy_qos_profile.test"
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t); testAccOnlyMultitenancyProvider(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNSXPolicyQosProfileCheckDestroy(state, name)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNSXPolicyQosProfileCreateTemplateTrivial(name, false),
 			},
 			{
 				ResourceName:      testResourceName,

--- a/nsxt/resource_nsxt_policy_security_policy.go
+++ b/nsxt/resource_nsxt_policy_security_policy.go
@@ -82,7 +82,11 @@ func policySecurityPolicyBuildAndPatch(d *schema.ResourceData, m interface{}, id
 	}
 
 	log.Printf("[INFO] Using selective H-API for policy with ID %s", id)
-	return securityPolicyInfraPatch(getSessionContext(d, m), obj, domain, m)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	return securityPolicyInfraPatch(context, obj, domain, m)
 }
 
 func resourceNsxtPolicySecurityPolicyCreate(d *schema.ResourceData, m interface{}) error {
@@ -105,8 +109,12 @@ func resourceNsxtPolicySecurityPolicyDelete(d *schema.ResourceData, m interface{
 
 	connector := getPolicyConnector(m)
 
-	client := domains.NewSecurityPoliciesClient(getSessionContext(d, m), connector)
-	err := client.Delete(d.Get("domain").(string), id)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := domains.NewSecurityPoliciesClient(context, connector)
+	err = client.Delete(d.Get("domain").(string), id)
 
 	if err != nil {
 		return handleDeleteError("Security Policy", id, err)

--- a/nsxt/resource_nsxt_policy_security_policy_rule.go
+++ b/nsxt/resource_nsxt_policy_security_policy_rule.go
@@ -62,7 +62,7 @@ func resourceNsxtPolicySecurityPolicyRuleCreate(d *schema.ResourceData, m interf
 }
 
 func setSecurityPolicyRuleContext(d *schema.ResourceData, projectID string) error {
-	providedProjectID := getProjectIDFromSchema(d)
+	providedProjectID, _ := getContextDataFromSchema(d)
 	if providedProjectID == "" {
 		contexts := make([]interface{}, 1)
 		ctxMap := make(map[string]interface{})

--- a/nsxt/resource_nsxt_policy_security_policy_rule.go
+++ b/nsxt/resource_nsxt_policy_security_policy_rule.go
@@ -43,7 +43,7 @@ func resourceNsxtPolicySecurityPolicyRuleCreate(d *schema.ResourceData, m interf
 		return err
 	}
 
-	if err := setSecurityPolicyRuleContext(d, projectID); err != nil {
+	if err := setSecurityPolicyRuleContext(d, m, projectID); err != nil {
 		return handleCreateError("SecurityPolicyRule", fmt.Sprintf("%s/%s", policyPath, id), err)
 	}
 
@@ -61,8 +61,8 @@ func resourceNsxtPolicySecurityPolicyRuleCreate(d *schema.ResourceData, m interf
 	return resourceNsxtPolicySecurityPolicyRuleRead(d, m)
 }
 
-func setSecurityPolicyRuleContext(d *schema.ResourceData, projectID string) error {
-	providedProjectID, _ := getContextDataFromSchema(d)
+func setSecurityPolicyRuleContext(d *schema.ResourceData, m interface{}, projectID string) error {
+	providedProjectID, _ := getContextDataFromSchema(d, m)
 	if providedProjectID == "" {
 		contexts := make([]interface{}, 1)
 		ctxMap := make(map[string]interface{})
@@ -157,7 +157,7 @@ func resourceNsxtPolicySecurityPolicyRuleRead(d *schema.ResourceData, m interfac
 	domain := getDomainFromResourcePath(policyPath)
 	policyID := getPolicyIDFromPath(policyPath)
 
-	if err := setSecurityPolicyRuleContext(d, projectID); err != nil {
+	if err := setSecurityPolicyRuleContext(d, m, projectID); err != nil {
 		return handleReadError(d, "SecurityPolicyRule", fmt.Sprintf("%s/%s", policyPath, id), err)
 	}
 

--- a/nsxt/resource_nsxt_policy_security_policy_rule.go
+++ b/nsxt/resource_nsxt_policy_security_policy_rule.go
@@ -48,7 +48,11 @@ func resourceNsxtPolicySecurityPolicyRuleCreate(d *schema.ResourceData, m interf
 	}
 
 	log.Printf("[INFO] Creating Security Policy Rule with ID %s under policy %s", id, policyPath)
-	client := securitypolicies.NewRulesClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := securitypolicies.NewRulesClient(context, connector)
 	rule := securityPolicyRuleSchemaToModel(d, id)
 	err = client.Patch(domain, policyID, id, rule)
 	if err != nil {
@@ -62,7 +66,10 @@ func resourceNsxtPolicySecurityPolicyRuleCreate(d *schema.ResourceData, m interf
 }
 
 func setSecurityPolicyRuleContext(d *schema.ResourceData, m interface{}, projectID string) error {
-	providedProjectID, _ := getContextDataFromSchema(d, m)
+	providedProjectID, _, err := getContextDataFromSchema(d, m)
+	if err != nil {
+		return err
+	}
 	if providedProjectID == "" {
 		contexts := make([]interface{}, 1)
 		ctxMap := make(map[string]interface{})
@@ -161,7 +168,11 @@ func resourceNsxtPolicySecurityPolicyRuleRead(d *schema.ResourceData, m interfac
 		return handleReadError(d, "SecurityPolicyRule", fmt.Sprintf("%s/%s", policyPath, id), err)
 	}
 
-	client := securitypolicies.NewRulesClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := securitypolicies.NewRulesClient(context, connector)
 	rule, err := client.Get(domain, policyID, id)
 	if err != nil {
 		return handleReadError(d, "SecurityPolicyRule", fmt.Sprintf("%s/%s", policyPath, id), err)
@@ -214,9 +225,13 @@ func resourceNsxtPolicySecurityPolicyRuleUpdate(d *schema.ResourceData, m interf
 	domain := getDomainFromResourcePath(policyPath)
 	policyID := getPolicyIDFromPath(policyPath)
 
-	client := securitypolicies.NewRulesClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := securitypolicies.NewRulesClient(context, connector)
 	rule := securityPolicyRuleSchemaToModel(d, id)
-	err := client.Patch(domain, policyID, id, rule)
+	err = client.Patch(domain, policyID, id, rule)
 	if err != nil {
 		return handleUpdateError("SecurityPolicyRule", fmt.Sprintf("%s/%s", policyPath, id), err)
 	}
@@ -237,7 +252,11 @@ func resourceNsxtPolicySecurityPolicyRuleDelete(d *schema.ResourceData, m interf
 	domain := getDomainFromResourcePath(policyPath)
 	policyID := getPolicyIDFromPath(policyPath)
 
-	client := securitypolicies.NewRulesClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := securitypolicies.NewRulesClient(context, connector)
 	return client.Delete(domain, policyID, id)
 }
 

--- a/nsxt/resource_nsxt_policy_security_policy_rule_test.go
+++ b/nsxt/resource_nsxt_policy_security_policy_rule_test.go
@@ -24,6 +24,13 @@ func TestAccResourceNsxtPolicySecurityPolicyRule_multitenancy(t *testing.T) {
 	})
 }
 
+func TestAccResourceNsxtPolicySecurityPolicyRule_multitenancyProvider(t *testing.T) {
+	testAccResourceNsxtPolicySecurityPolicyRuleBasic(t, false, func() {
+		testAccPreCheck(t)
+		testAccOnlyMultitenancyProvider(t)
+	})
+}
+
 func testAccResourceNsxtPolicySecurityPolicyRuleBasic(t *testing.T, withContext bool, preCheck func()) {
 	policyResourceName := "nsxt_policy_parent_security_policy.policy1"
 	policyName := getAccTestResourceName()
@@ -180,6 +187,34 @@ func TestAccResourceNsxtPolicySecurityPolicyRule_importBasic_multitenancy(t *tes
 		Steps: []resource.TestStep{
 			{
 				Config: testAccNsxtPolicySecurityPolicyRuleDeps(true, "policyName", "true") +
+					testAccNsxtPolicySecurityPolicyRuleTemplate("test", name, "ALLOW", "IN", "IPV4", "1"),
+			},
+			{
+				ResourceName:      testResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccResourceNsxtPolicyImportIDRetriever(testResourceName),
+			},
+		},
+	})
+}
+
+func TestAccResourceNsxtPolicySecurityPolicyRule_importBasic_multitenancyProvider(t *testing.T) {
+	name := getAccTestResourceName()
+	testResourceName := "nsxt_policy_security_policy_rule.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccOnlyMultitenancyProvider(t)
+		},
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicySecurityPolicyCheckDestroy(state, name, defaultDomain)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicySecurityPolicyRuleDeps(false, "policyName", "true") +
 					testAccNsxtPolicySecurityPolicyRuleTemplate("test", name, "ALLOW", "IN", "IPV4", "1"),
 			},
 			{

--- a/nsxt/resource_nsxt_policy_security_policy_test.go
+++ b/nsxt/resource_nsxt_policy_security_policy_test.go
@@ -24,6 +24,13 @@ func TestAccResourceNsxtPolicySecurityPolicy_multitenancy(t *testing.T) {
 	})
 }
 
+func TestAccResourceNsxtPolicySecurityPolicy_multitenancyProvider(t *testing.T) {
+	testAccResourceNsxtPolicySecurityPolicyBasic(t, false, func() {
+		testAccPreCheck(t)
+		testAccOnlyMultitenancyProvider(t)
+	})
+}
+
 func testAccResourceNsxtPolicySecurityPolicyBasic(t *testing.T, withContext bool, preCheck func()) {
 	name := getAccTestResourceName()
 	updatedName := getAccTestResourceName()

--- a/nsxt/resource_nsxt_policy_segment_security_profile.go
+++ b/nsxt/resource_nsxt_policy_segment_security_profile.go
@@ -287,7 +287,11 @@ func resourceNsxtPolicySegmentSecurityProfilePatch(d *schema.ResourceData, m int
 	}
 
 	log.Printf("[INFO] Sending SegmentSecurityProfile with ID %s", id)
-	client := infra.NewSegmentSecurityProfilesClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := infra.NewSegmentSecurityProfilesClient(context, connector)
 	return client.Patch(id, obj, nil)
 }
 
@@ -318,7 +322,11 @@ func resourceNsxtPolicySegmentSecurityProfileRead(d *schema.ResourceData, m inte
 		return fmt.Errorf("Error obtaining SegmentSecurityProfile ID")
 	}
 
-	client := infra.NewSegmentSecurityProfilesClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := infra.NewSegmentSecurityProfilesClient(context, connector)
 	obj, err := client.Get(id)
 	if err != nil {
 		return handleReadError(d, "SegmentSecurityProfile", id, err)
@@ -361,8 +369,12 @@ func resourceNsxtPolicySegmentSecurityProfileDelete(d *schema.ResourceData, m in
 	}
 
 	connector := getPolicyConnector(m)
-	client := infra.NewSegmentSecurityProfilesClient(getSessionContext(d, m), connector)
-	err := client.Delete(id, nil)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := infra.NewSegmentSecurityProfilesClient(context, connector)
+	err = client.Delete(id, nil)
 
 	if err != nil {
 		return handleDeleteError("SegmentSecurityProfile", id, err)

--- a/nsxt/resource_nsxt_policy_segment_security_profile.go
+++ b/nsxt/resource_nsxt_policy_segment_security_profile.go
@@ -25,7 +25,7 @@ var segmentSecurityProfileSchema = map[string]*metadata.ExtendedSchema{
 	"description":  metadata.GetExtendedSchema(getDescriptionSchema()),
 	"revision":     metadata.GetExtendedSchema(getRevisionSchema()),
 	"tag":          metadata.GetExtendedSchema(getTagsSchema()),
-	"context":      metadata.GetExtendedSchema(getContextSchema(false, false)),
+	"context":      metadata.GetExtendedSchema(getContextSchema(false, false, false)),
 	"bpdu_filter_allow": {
 		Schema: schema.Schema{
 			Type: schema.TypeSet,

--- a/nsxt/resource_nsxt_policy_segment_security_profile_test.go
+++ b/nsxt/resource_nsxt_policy_segment_security_profile_test.go
@@ -60,6 +60,13 @@ func TestAccResourceNsxtPolicySegmentSecurityProfile_multitenancy(t *testing.T) 
 	})
 }
 
+func TestAccResourceNsxtPolicySegmentSecurityProfile_multitenancyProvider(t *testing.T) {
+	testAccResourceNsxtPolicySegmentSecurityProfileBasic(t, false, func() {
+		testAccPreCheck(t)
+		testAccOnlyMultitenancyProvider(t)
+	})
+}
+
 func testAccResourceNsxtPolicySegmentSecurityProfileBasic(t *testing.T, withContext bool, preCheck func()) {
 	testResourceName := "nsxt_policy_segment_security_profile.test"
 
@@ -167,7 +174,7 @@ func TestAccResourceNsxtPolicySegmentSecurityProfile_importBasic_multitenancy(t 
 	testResourceName := "nsxt_policy_segment_security_profile.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccOnlyMultitenancy(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNsxtPolicySegmentSecurityProfileCheckDestroy(state, name)
@@ -175,6 +182,30 @@ func TestAccResourceNsxtPolicySegmentSecurityProfile_importBasic_multitenancy(t 
 		Steps: []resource.TestStep{
 			{
 				Config: testAccNsxtPolicySegmentSecurityProfileMinimalistic(true),
+			},
+			{
+				ResourceName:      testResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccResourceNsxtPolicyImportIDRetriever(testResourceName),
+			},
+		},
+	})
+}
+
+func TestAccResourceNsxtPolicySegmentSecurityProfile_importBasic_multitenancyProvider(t *testing.T) {
+	name := getAccTestResourceName()
+	testResourceName := "nsxt_policy_segment_security_profile.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t); testAccOnlyMultitenancyProvider(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicySegmentSecurityProfileCheckDestroy(state, name)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicySegmentSecurityProfileMinimalistic(false),
 			},
 			{
 				ResourceName:      testResourceName,

--- a/nsxt/resource_nsxt_policy_segment_test.go
+++ b/nsxt/resource_nsxt_policy_segment_test.go
@@ -59,6 +59,30 @@ func TestAccResourceNsxtPolicySegment_basicImport_multitenancy(t *testing.T) {
 	})
 }
 
+func TestAccResourceNsxtPolicySegment_basicImport_multitenancyProvider(t *testing.T) {
+	name := getAccTestResourceName()
+	testResourceName := "nsxt_policy_segment.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t); testAccOnlyMultitenancyProvider(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicySegmentCheckDestroy(state, name)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicySegmentImportTemplate("", name, false),
+			},
+			{
+				ResourceName:      testResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccResourceNsxtPolicyImportIDRetriever(testResourceName),
+			},
+		},
+	})
+}
+
 func TestAccResourceNsxtPolicySegment_basicUpdate(t *testing.T) {
 	name := getAccTestResourceName()
 	updatedName := getAccTestResourceName()
@@ -210,6 +234,13 @@ func TestAccResourceNsxtPolicySegment_noTransportZone_multitenancy(t *testing.T)
 	testAccResourceNsxtPolicySegmentNoTransportZone(t, true, func() {
 		testAccPreCheck(t)
 		testAccOnlyMultitenancy(t)
+	})
+}
+
+func TestAccResourceNsxtPolicySegment_noTransportZone_multitenancyProvider(t *testing.T) {
+	testAccResourceNsxtPolicySegmentNoTransportZone(t, false, func() {
+		testAccPreCheck(t)
+		testAccOnlyMultitenancyProvider(t)
 	})
 }
 

--- a/nsxt/resource_nsxt_policy_service.go
+++ b/nsxt/resource_nsxt_policy_service.go
@@ -36,7 +36,7 @@ func resourceNsxtPolicyService() *schema.Resource {
 			"description":  getDescriptionSchema(),
 			"revision":     getRevisionSchema(),
 			"tag":          getTagsSchema(),
-			"context":      getContextSchema(false, false),
+			"context":      getContextSchema(false, false, false),
 
 			"icmp_entry": {
 				Type:        schema.TypeSet,

--- a/nsxt/resource_nsxt_policy_service.go
+++ b/nsxt/resource_nsxt_policy_service.go
@@ -470,7 +470,11 @@ func resourceNsxtPolicyServiceCreate(d *schema.ResourceData, m interface{}) erro
 	// Create the resource using PATCH
 	log.Printf("[INFO] Creating service with ID %s", id)
 
-	client := infra.NewServicesClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := infra.NewServicesClient(context, connector)
 	err = client.Patch(id, obj)
 	if err != nil {
 		return handleCreateError("Service", id, err)
@@ -489,7 +493,11 @@ func resourceNsxtPolicyServiceRead(d *schema.ResourceData, m interface{}) error 
 		return fmt.Errorf("Error obtaining service id")
 	}
 
-	client := infra.NewServicesClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := infra.NewServicesClient(context, connector)
 	obj, err := client.Get(id)
 	if err != nil {
 		return handleReadError(d, "Service", id, err)
@@ -680,8 +688,12 @@ func resourceNsxtPolicyServiceUpdate(d *schema.ResourceData, m interface{}) erro
 	}
 
 	// Update the resource using Update to totally replace the list of entries
-	client := infra.NewServicesClient(getSessionContext(d, m), connector)
-	_, err := client.Update(id, obj)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := infra.NewServicesClient(context, connector)
+	_, err = client.Update(id, obj)
 
 	if err != nil {
 		return handleUpdateError("Service", id, err)
@@ -698,7 +710,11 @@ func resourceNsxtPolicyServiceDelete(d *schema.ResourceData, m interface{}) erro
 	connector := getPolicyConnector(m)
 
 	doDelete := func() error {
-		client := infra.NewServicesClient(getSessionContext(d, m), connector)
+		context, err := getSessionContext(d, m)
+		if err != nil {
+			return err
+		}
+		client := infra.NewServicesClient(context, connector)
 		return client.Delete(id)
 	}
 

--- a/nsxt/resource_nsxt_policy_service_test.go
+++ b/nsxt/resource_nsxt_policy_service_test.go
@@ -26,6 +26,13 @@ func TestAccResourceNsxtPolicyService_icmp_multitenancy(t *testing.T) {
 	})
 }
 
+func TestAccResourceNsxtPolicyService_icmp_multitenancyProvider(t *testing.T) {
+	testAccResourceNsxtPolicyServiceIcmp(t, false, func() {
+		testAccPreCheck(t)
+		testAccOnlyMultitenancyProvider(t)
+	})
+}
+
 func testAccResourceNsxtPolicyServiceIcmp(t *testing.T, withContext bool, preCheck func()) {
 	name := getAccTestResourceName()
 	updateName := getAccTestResourceName()
@@ -747,6 +754,30 @@ func TestAccResourceNsxtPolicyService_importBasic_multitenancy(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccNsxtPolicyIcmpTypeServiceCreateNoTypeCodeTemplate(name, "ICMPv4", true),
+			},
+			{
+				ResourceName:      testResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccResourceNsxtPolicyImportIDRetriever(testResourceName),
+			},
+		},
+	})
+}
+
+func TestAccResourceNsxtPolicyService_importBasic_multitenancyProvider(t *testing.T) {
+	name := getAccTestResourceName()
+	testResourceName := "nsxt_policy_service.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t); testAccOnlyMultitenancyProvider(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyServiceCheckDestroy(state, name)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyIcmpTypeServiceCreateNoTypeCodeTemplate(name, "ICMPv4", false),
 			},
 			{
 				ResourceName:      testResourceName,

--- a/nsxt/resource_nsxt_policy_spoof_guard_profile.go
+++ b/nsxt/resource_nsxt_policy_spoof_guard_profile.go
@@ -32,7 +32,7 @@ func resourceNsxtPolicySpoofGuardProfile() *schema.Resource {
 			"description":  getDescriptionSchema(),
 			"revision":     getRevisionSchema(),
 			"tag":          getTagsSchema(),
-			"context":      getContextSchema(false, false),
+			"context":      getContextSchema(false, false, false),
 			"address_binding_allowlist": {
 				Type:     schema.TypeBool,
 				Optional: true,

--- a/nsxt/resource_nsxt_policy_spoof_guard_profile.go
+++ b/nsxt/resource_nsxt_policy_spoof_guard_profile.go
@@ -71,7 +71,11 @@ func resourceNsxtPolicySpoofGuardProfilePatch(d *schema.ResourceData, m interfac
 	}
 
 	log.Printf("[INFO] Patching SpoofGuardProfile with ID %s", id)
-	client := infra.NewSpoofguardProfilesClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := infra.NewSpoofguardProfilesClient(context, connector)
 	return client.Patch(id, obj, nil)
 }
 
@@ -102,7 +106,11 @@ func resourceNsxtPolicySpoofGuardProfileRead(d *schema.ResourceData, m interface
 		return fmt.Errorf("Error obtaining SpoofGuardProfile ID")
 	}
 
-	client := infra.NewSpoofguardProfilesClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := infra.NewSpoofguardProfilesClient(context, connector)
 	obj, err := client.Get(id)
 	if err != nil {
 		return handleReadError(d, "SpoofGuardProfile", id, err)
@@ -142,8 +150,12 @@ func resourceNsxtPolicySpoofGuardProfileDelete(d *schema.ResourceData, m interfa
 	}
 
 	connector := getPolicyConnector(m)
-	client := infra.NewSpoofguardProfilesClient(getSessionContext(d, m), connector)
-	err := client.Delete(id, nil)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := infra.NewSpoofguardProfilesClient(context, connector)
+	err = client.Delete(id, nil)
 
 	if err != nil {
 		return handleDeleteError("SpoofGuardProfile", id, err)

--- a/nsxt/resource_nsxt_policy_spoof_guard_profile_test.go
+++ b/nsxt/resource_nsxt_policy_spoof_guard_profile_test.go
@@ -36,6 +36,13 @@ func TestAccResourceNsxtPolicySpoofGuardProfile_multitenancy(t *testing.T) {
 	})
 }
 
+func TestAccResourceNsxtPolicySpoofGuardProfile_multitenancyProvider(t *testing.T) {
+	testAccResourceNsxtPolicySpoofGuardProfileBasic(t, false, func() {
+		testAccPreCheck(t)
+		testAccOnlyMultitenancyProvider(t)
+	})
+}
+
 func testAccResourceNsxtPolicySpoofGuardProfileBasic(t *testing.T, withContext bool, preCheck func()) {
 	testResourceName := "nsxt_policy_spoof_guard_profile.test"
 
@@ -125,6 +132,30 @@ func TestAccResourceNsxtPolicySpoofGuardProfile_importBasic_multitenancy(t *test
 		Steps: []resource.TestStep{
 			{
 				Config: testAccNsxtPolicySpoofGuardProfileMinimalistic(true),
+			},
+			{
+				ResourceName:      testResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccResourceNsxtPolicyImportIDRetriever(testResourceName),
+			},
+		},
+	})
+}
+
+func TestAccResourceNsxtPolicySpoofGuardProfile_importBasic_multitenancyProvider(t *testing.T) {
+	name := getAccTestResourceName()
+	testResourceName := "nsxt_policy_spoof_guard_profile.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t); testAccOnlyMultitenancyProvider(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicySpoofGuardProfileCheckDestroy(state, name)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicySpoofGuardProfileMinimalistic(false),
 			},
 			{
 				ResourceName:      testResourceName,

--- a/nsxt/resource_nsxt_policy_static_route.go
+++ b/nsxt/resource_nsxt_policy_static_route.go
@@ -37,7 +37,7 @@ func resourceNsxtPolicyStaticRoute() *schema.Resource {
 			"description":  getDescriptionSchema(),
 			"revision":     getRevisionSchema(),
 			"tag":          getTagsSchema(),
-			"context":      getContextSchema(false, false),
+			"context":      getContextSchema(false, false, false),
 			"gateway_path": getPolicyGatewayPathSchema(),
 			"network": {
 				Type:         schema.TypeString,

--- a/nsxt/resource_nsxt_policy_static_route_test.go
+++ b/nsxt/resource_nsxt_policy_static_route_test.go
@@ -84,6 +84,13 @@ func TestAccResourceNsxtPolicyStaticRoute_basicT1_multitenancy(t *testing.T) {
 	})
 }
 
+func TestAccResourceNsxtPolicyStaticRoute_basicT1_multitenancyProvider(t *testing.T) {
+	testAccResourceNsxtPolicyStaticRouteBasicT1(t, false, func() {
+		testAccPreCheck(t)
+		testAccOnlyMultitenancyProvider(t)
+	})
+}
+
 func testAccResourceNsxtPolicyStaticRouteBasicT1(t *testing.T, withContext bool, preCheck func()) {
 	name := getAccTestResourceName()
 	updateName := getAccTestResourceName()
@@ -201,6 +208,30 @@ func TestAccResourceNsxtPolicyStaticRoute_basicT1Import_multitenancy(t *testing.
 		Steps: []resource.TestStep{
 			{
 				Config: testAccNsxtPolicyStaticRouteTier1CreateTemplate(name, network, true),
+			},
+			{
+				ResourceName:      testAccResourcePolicyStaticRouteName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccResourceNsxtPolicyImportIDRetriever(testAccResourcePolicyStaticRouteName),
+			},
+		},
+	})
+}
+
+func TestAccResourceNsxtPolicyStaticRoute_basicT1Import_multitenancyProvider(t *testing.T) {
+	name := getAccTestResourceName()
+	network := "14.1.1.0/24"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t); testAccOnlyMultitenancyProvider(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyStaticRouteCheckDestroy(state, name)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyStaticRouteTier1CreateTemplate(name, network, false),
 			},
 			{
 				ResourceName:      testAccResourcePolicyStaticRouteName,

--- a/nsxt/resource_nsxt_policy_tier0_gateway_interface.go
+++ b/nsxt/resource_nsxt_policy_tier0_gateway_interface.go
@@ -248,7 +248,10 @@ func resourceNsxtPolicyTier0GatewayInterfaceCreate(d *schema.ResourceData, m int
 	}
 
 	localeServiceID := ""
-	context := getSessionContext(d, m)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
 	if isPolicyGlobalManager(m) {
 		enablePIM := d.Get("enable_pim").(bool)
 		if enablePIM {
@@ -330,7 +333,7 @@ func resourceNsxtPolicyTier0GatewayInterfaceCreate(d *schema.ResourceData, m int
 		obj.EdgePath = &edgePath
 	}
 
-	err := gatewayInterfaceVersionDepenantSet(d, m, &obj)
+	err = gatewayInterfaceVersionDepenantSet(d, m, &obj)
 	if err != nil {
 		return handleCreateError("Tier0 Interface", id, err)
 	}

--- a/nsxt/resource_nsxt_policy_tier1_gateway.go
+++ b/nsxt/resource_nsxt_policy_tier1_gateway.go
@@ -502,7 +502,11 @@ func resourceNsxtPolicyTier1GatewayCreate(d *schema.ResourceData, m interface{})
 		return err
 	}
 
-	obj, err := policyTier1GatewayResourceToInfraStruct(getSessionContext(d, m), d, connector, id)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	obj, err := policyTier1GatewayResourceToInfraStruct(context, d, connector, id)
 
 	if err != nil {
 		return err
@@ -510,7 +514,7 @@ func resourceNsxtPolicyTier1GatewayCreate(d *schema.ResourceData, m interface{})
 
 	// Create the resource using PATCH
 	log.Printf("[INFO] Using H-API to create Tier1 with ID %s", id)
-	err = policyInfraPatch(getSessionContext(d, m), obj, connector, false)
+	err = policyInfraPatch(context, obj, connector, false)
 	if err != nil {
 		return handleCreateError("Tier1", id, err)
 	}
@@ -529,7 +533,10 @@ func resourceNsxtPolicyTier1GatewayRead(d *schema.ResourceData, m interface{}) e
 		return fmt.Errorf("Error obtaining Tier1 id")
 	}
 
-	context := getSessionContext(d, m)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
 	client := infra.NewTier1sClient(context, connector)
 	obj, err := client.Get(id)
 
@@ -652,13 +659,17 @@ func resourceNsxtPolicyTier1GatewayUpdate(d *schema.ResourceData, m interface{})
 		return fmt.Errorf("Error obtaining Tier1 id")
 	}
 
-	obj, err := policyTier1GatewayResourceToInfraStruct(getSessionContext(d, m), d, connector, id)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	obj, err := policyTier1GatewayResourceToInfraStruct(context, d, connector, id)
 	if err != nil {
 		return err
 	}
 
 	log.Printf("[INFO] Using H-API to update Tier1 with ID %s", id)
-	err = policyInfraPatch(getSessionContext(d, m), obj, connector, true)
+	err = policyInfraPatch(context, obj, connector, true)
 	if err != nil {
 		return handleUpdateError("Tier1", id, err)
 	}
@@ -697,7 +708,11 @@ func resourceNsxtPolicyTier1GatewayDelete(d *schema.ResourceData, m interface{})
 	}
 
 	log.Printf("[DEBUG] Using H-API to delete Tier1 with ID %s", id)
-	err := policyInfraPatch(getSessionContext(d, m), obj, getPolicyConnector(m), false)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	err = policyInfraPatch(context, obj, getPolicyConnector(m), false)
 	if err != nil {
 		return handleDeleteError("Tier1", id, err)
 	}

--- a/nsxt/resource_nsxt_policy_tier1_gateway.go
+++ b/nsxt/resource_nsxt_policy_tier1_gateway.go
@@ -144,7 +144,7 @@ func resourceNsxtPolicyTier1Gateway() *schema.Resource {
 				ValidateFunc: validation.StringInSlice(t1TypeValues, false),
 				Optional:     true,
 			},
-			"context": getContextSchema(false, false),
+			"context": getContextSchema(false, false, false),
 		},
 	}
 }

--- a/nsxt/resource_nsxt_policy_tier1_gateway_interface.go
+++ b/nsxt/resource_nsxt_policy_tier1_gateway_interface.go
@@ -38,7 +38,7 @@ func resourceNsxtPolicyTier1GatewayInterface() *schema.Resource {
 			"description":            getDescriptionSchema(),
 			"revision":               getRevisionSchema(),
 			"tag":                    getTagsSchema(),
-			"context":                getContextSchema(false, false),
+			"context":                getContextSchema(false, false, false),
 			"gateway_path":           getPolicyPathSchema(true, true, "Policy path for tier1 gateway"),
 			"segment_path":           getPolicyPathSchema(true, true, "Policy path for connected segment"),
 			"subnets":                getGatewayInterfaceSubnetsSchema(),

--- a/nsxt/resource_nsxt_policy_tier1_gateway_interface.go
+++ b/nsxt/resource_nsxt_policy_tier1_gateway_interface.go
@@ -88,7 +88,10 @@ func resourceNsxtPolicyTier1GatewayInterfaceCreate(d *schema.ResourceData, m int
 	sitePath := d.Get("site_path").(string)
 	tier1ID := getPolicyIDFromPath(tier1Path)
 	localeServiceID := ""
-	context := getSessionContext(d, m)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
 	if isPolicyGlobalManager(m) {
 		if sitePath == "" {
 			return attributeRequiredGlobalManagerError("site_path", "nsxt_policy_tier1_gateway_interface")
@@ -120,7 +123,7 @@ func resourceNsxtPolicyTier1GatewayInterfaceCreate(d *schema.ResourceData, m int
 		id = newUUID()
 	} else {
 		var err error
-		client := localeservices.NewInterfacesClient(getSessionContext(d, m), connector)
+		client := localeservices.NewInterfacesClient(context, connector)
 		_, err = client.Get(tier1ID, localeServiceID, id)
 
 		if err == nil {
@@ -161,8 +164,8 @@ func resourceNsxtPolicyTier1GatewayInterfaceCreate(d *schema.ResourceData, m int
 
 	// Create the resource using PATCH
 	log.Printf("[INFO] Creating tier1 interface with ID %s", id)
-	client := localeservices.NewInterfacesClient(getSessionContext(d, m), connector)
-	err := client.Patch(tier1ID, localeServiceID, id, obj)
+	client := localeservices.NewInterfacesClient(context, connector)
+	err = client.Patch(tier1ID, localeServiceID, id, obj)
 
 	if err != nil {
 		return handleCreateError("Tier1 Interface", id, err)
@@ -206,7 +209,11 @@ func resourceNsxtPolicyTier1GatewayInterfaceRead(d *schema.ResourceData, m inter
 		d.Set("site_path", sitePath)
 	} else {
 		var err error
-		client := localeservices.NewInterfacesClient(getSessionContext(d, m), connector)
+		context, err := getSessionContext(d, m)
+		if err != nil {
+			return err
+		}
+		client := localeservices.NewInterfacesClient(context, connector)
 		obj, err = client.Get(tier1ID, localeServiceID, id)
 		if err != nil {
 			return handleReadError(d, "Tier1 Interface", id, err)
@@ -285,7 +292,11 @@ func resourceNsxtPolicyTier1GatewayInterfaceUpdate(d *schema.ResourceData, m int
 		obj.UrpfMode = &urpfMode
 	}
 	var err error
-	client := localeservices.NewInterfacesClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := localeservices.NewInterfacesClient(context, connector)
 	_, err = client.Update(tier1ID, localeServiceID, id, obj)
 	if err != nil {
 		return handleUpdateError("Tier1 Interface", id, err)
@@ -306,7 +317,11 @@ func resourceNsxtPolicyTier1GatewayInterfaceDelete(d *schema.ResourceData, m int
 	}
 
 	var err error
-	client := localeservices.NewInterfacesClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	client := localeservices.NewInterfacesClient(context, connector)
 	err = client.Delete(tier1ID, localeServiceID, id)
 	if err != nil {
 		return handleDeleteError("Tier1 Interface", id, err)
@@ -342,7 +357,11 @@ func resourceNsxtPolicyTier1GatewayInterfaceImport(d *schema.ResourceData, m int
 	gwID := s[0]
 	connector := getPolicyConnector(m)
 	var tier1GW model.Tier1
-	client := infra.NewTier1sClient(getSessionContext(d, m), connector)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return nil, err
+	}
+	client := infra.NewTier1sClient(context, connector)
 	tier1GW, err = client.Get(gwID)
 	if err != nil {
 		return nil, err

--- a/nsxt/resource_nsxt_policy_tier1_gateway_interface_test.go
+++ b/nsxt/resource_nsxt_policy_tier1_gateway_interface_test.go
@@ -29,6 +29,13 @@ func TestAccResourceNsxtPolicyTier1GatewayInterface_multitenancy(t *testing.T) {
 	})
 }
 
+func TestAccResourceNsxtPolicyTier1GatewayInterface_multitenancyProvider(t *testing.T) {
+	testAccResourceNsxtPolicyTier1GatewayInterfaceBasic(t, false, func() {
+		testAccPreCheck(t)
+		testAccOnlyMultitenancyProvider(t)
+	})
+}
+
 func testAccResourceNsxtPolicyTier1GatewayInterfaceBasic(t *testing.T, withContext bool, preCheck func()) {
 	name := getAccTestResourceName()
 	updatedName := getAccTestResourceName()
@@ -351,6 +358,31 @@ func TestAccResourceNsxtPolicyTier1GatewayInterface_importBasic_multitenancy(t *
 		Steps: []resource.TestStep{
 			{
 				Config: testAccNsxtPolicyTier1InterfaceThinTemplate(name, subnet, true),
+			},
+			{
+				ResourceName:      testResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccResourceNsxtPolicyImportIDRetriever(testResourceName),
+			},
+		},
+	})
+}
+
+func TestAccResourceNsxtPolicyTier1GatewayInterface_importBasic_multitenancyProvider(t *testing.T) {
+	name := getAccTestResourceName()
+	testResourceName := "nsxt_policy_tier1_gateway_interface.test"
+	subnet := "1.1.12.2/24"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t); testAccOnlyMultitenancyProvider(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyTier1InterfaceCheckDestroy(state, name)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyTier1InterfaceThinTemplate(name, subnet, false),
 			},
 			{
 				ResourceName:      testResourceName,

--- a/nsxt/resource_nsxt_policy_tier1_gateway_test.go
+++ b/nsxt/resource_nsxt_policy_tier1_gateway_test.go
@@ -24,6 +24,13 @@ func TestAccResourceNsxtPolicyTier1Gateway_multitenancy(t *testing.T) {
 	})
 }
 
+func TestAccResourceNsxtPolicyTier1Gateway_multitenancyProvider(t *testing.T) {
+	testAccResourceNsxtPolicyTier1GatewayBasic(t, false, func() {
+		testAccPreCheck(t)
+		testAccOnlyMultitenancyProvider(t)
+	})
+}
+
 func testAccResourceNsxtPolicyTier1GatewayBasic(t *testing.T, withContext bool, preCheck func()) {
 	name := getAccTestResourceName()
 	updateName := getAccTestResourceName()
@@ -483,6 +490,31 @@ func TestAccResourceNsxtPolicyTier1Gateway_importBasic_multitenancy(t *testing.T
 		Steps: []resource.TestStep{
 			{
 				Config: testAccNsxtPolicyTier1ImportTemplate(name, failoverMode, true),
+			},
+			{
+				ResourceName:      testResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccResourceNsxtPolicyImportIDRetriever(testResourceName),
+			},
+		},
+	})
+}
+
+func TestAccResourceNsxtPolicyTier1Gateway_importBasic_multitenancyProvider(t *testing.T) {
+	name := getAccTestResourceName()
+	testResourceName := "nsxt_policy_tier1_gateway.test"
+	failoverMode := "PREEMPTIVE"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t); testAccOnlyMultitenancyProvider(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyTier1CheckDestroy(state, name)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyTier1ImportTemplate(name, failoverMode, false),
 			},
 			{
 				ResourceName:      testResourceName,

--- a/nsxt/resource_nsxt_policy_vlan_segment_test.go
+++ b/nsxt/resource_nsxt_policy_vlan_segment_test.go
@@ -55,6 +55,30 @@ func TestAccResourceNsxtPolicyVlanSegment_basicImport_multitenancy(t *testing.T)
 	})
 }
 
+func TestAccResourceNsxtPolicyVlanSegment_basicImport_multitenancyProvider(t *testing.T) {
+	name := getAccTestResourceName()
+	testResourceName := "nsxt_policy_vlan_segment.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t); testAccOnlyMultitenancyProvider(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicySegmentCheckDestroy(state, name)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyVlanSegmentImportTemplate(name, false),
+			},
+			{
+				ResourceName:      testResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccResourceNsxtPolicyImportIDRetriever(testResourceName),
+			},
+		},
+	})
+}
+
 func TestAccResourceNsxtPolicyVlanSegment_basicUpdate(t *testing.T) {
 	testAccResourceNsxtPolicyVlanSegmentBasicUpdate(t, false, func() {
 		testAccPreCheck(t)
@@ -65,6 +89,13 @@ func TestAccResourceNsxtPolicyVlanSegment_multitenancy(t *testing.T) {
 	testAccResourceNsxtPolicyVlanSegmentBasicUpdate(t, true, func() {
 		testAccPreCheck(t)
 		testAccOnlyMultitenancy(t)
+	})
+}
+
+func TestAccResourceNsxtPolicyVlanSegment_multitenancyProvider(t *testing.T) {
+	testAccResourceNsxtPolicyVlanSegmentBasicUpdate(t, false, func() {
+		testAccPreCheck(t)
+		testAccOnlyMultitenancyProvider(t)
 	})
 }
 

--- a/nsxt/resource_nsxt_policy_vm_tags.go
+++ b/nsxt/resource_nsxt_policy_vm_tags.go
@@ -57,7 +57,7 @@ func resourceNsxtPolicyVMTags() *schema.Resource {
 					},
 				},
 			},
-			"context": getContextSchema(false, false),
+			"context": getContextSchema(false, false, false),
 		},
 	}
 }

--- a/nsxt/resource_nsxt_policy_vm_tags.go
+++ b/nsxt/resource_nsxt_policy_vm_tags.go
@@ -335,7 +335,10 @@ func setPolicyVMPortTagsInSchema(d *schema.ResourceData, m interface{}, external
 	if err != nil {
 		return err
 	}
-	context := getSessionContext(d, m)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
 
 	portTags := d.Get("port").([]interface{})
 	var actualPortTags []map[string]interface{}
@@ -376,7 +379,11 @@ func resourceNsxtPolicyVMTagsRead(d *schema.ResourceData, m interface{}) error {
 		return fmt.Errorf("Error obtaining Virtual Machine ID")
 	}
 
-	vm, err := findNsxtPolicyVMByID(getSessionContext(d, m), connector, vmID, m)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
+	vm, err := findNsxtPolicyVMByID(context, connector, vmID, m)
 	if err != nil {
 		d.SetId("")
 		log.Printf("[ERROR] Cannot find VM with ID %s, skip reading VM tag", vmID)
@@ -396,7 +403,10 @@ func resourceNsxtPolicyVMTagsRead(d *schema.ResourceData, m interface{}) error {
 func resourceNsxtPolicyVMTagsCreate(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
 	instanceID := d.Get("instance_id").(string)
-	context := getSessionContext(d, m)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
 
 	vm, err := findNsxtPolicyVMByID(context, connector, instanceID, m)
 	if err != nil {
@@ -439,7 +449,10 @@ func resourceNsxtPolicyVMTagsUpdate(d *schema.ResourceData, m interface{}) error
 func resourceNsxtPolicyVMTagsDelete(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
 	instanceID := d.Get("instance_id").(string)
-	context := getSessionContext(d, m)
+	context, err := getSessionContext(d, m)
+	if err != nil {
+		return err
+	}
 
 	vm, err := findNsxtPolicyVMByID(context, connector, instanceID, m)
 

--- a/nsxt/resource_nsxt_policy_vm_tags_test.go
+++ b/nsxt/resource_nsxt_policy_vm_tags_test.go
@@ -27,6 +27,14 @@ func TestAccResourceNsxtPolicyVMTags_multitenancy(t *testing.T) {
 	})
 }
 
+func TestAccResourceNsxtPolicyVMTags_multitenancyProvider(t *testing.T) {
+	testAccResourceNsxtPolicyVMTagsBasic(t, false, func() {
+		testAccPreCheck(t)
+		testAccOnlyMultitenancyProvider(t)
+		testAccEnvDefined(t, "NSXT_TEST_VM_ID")
+	})
+}
+
 func testAccResourceNsxtPolicyVMTagsBasic(t *testing.T, withContext bool, preCheck func()) {
 	vmID := getTestVMID()
 	testResourceName := "nsxt_policy_vm_tags.test"
@@ -137,6 +145,35 @@ func TestAccResourceNsxtPolicyVMTags_import_basic_multitenancy(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccNSXPolicyVMTagsCreateTemplate(vmID, true),
+			},
+			{
+				ResourceName:            testResourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"instance_id"},
+				ImportStateIdFunc:       testAccResourceNsxtPolicyImportIDRetriever(testResourceName),
+			},
+		},
+	})
+}
+
+func TestAccResourceNsxtPolicyVMTags_import_basic_multitenancyProvider(t *testing.T) {
+	vmID := getTestVMID()
+	testResourceName := "nsxt_policy_vm_tags.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccEnvDefined(t, "NSXT_TEST_VM_ID")
+			testAccOnlyMultitenancyProvider(t)
+		},
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNSXPolicyVMTagsCheckDestroy(state)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNSXPolicyVMTagsCreateTemplate(vmID, false),
 			},
 			{
 				ResourceName:            testResourceName,

--- a/nsxt/segment_common.go
+++ b/nsxt/segment_common.go
@@ -267,7 +267,7 @@ func getPolicyCommonSegmentSchema(vlanRequired bool, isFixed bool) map[string]*s
 		"revision":     getRevisionSchema(),
 		"tag":          getTagsSchema(),
 		"ignore_tags":  getIgnoreTagsSchema(),
-		"context":      getContextSchema(false, false),
+		"context":      getContextSchema(false, false, false),
 		"advanced_config": {
 			Type:        schema.TypeList,
 			Description: "Advanced segment configuration",

--- a/nsxt/utils.go
+++ b/nsxt/utils.go
@@ -681,10 +681,6 @@ func handlePagination(lister func(*paginationInfo) error) (int64, error) {
 }
 
 func getContextSchema(isRequired, isComputed, isVPC bool) *schema.Schema {
-	return getContextExtendedSchema(isRequired, isComputed, isVPC, false)
-}
-
-func getContextExtendedSchema(isRequired, isComputed, isVPC, isProvider bool) *schema.Schema {
 	elemSchema := map[string]*schema.Schema{
 		"project_id": {
 			Type:         schema.TypeString,
@@ -702,10 +698,6 @@ func getContextExtendedSchema(isRequired, isComputed, isVPC, isProvider bool) *s
 			ForceNew:     true,
 			ValidateFunc: validation.StringIsNotWhiteSpace,
 		}
-	}
-	if isProvider {
-		elemSchema["project_id"].DefaultFunc = schema.EnvDefaultFunc("NSXT_PROVIDER_PROJECT_ID", false)
-		elemSchema["vpc_id"].DefaultFunc = schema.EnvDefaultFunc("NSXT_PROVIDER_VPC_ID", false)
 	}
 	return &schema.Schema{
 		Type:        schema.TypeList,

--- a/nsxt/utils.go
+++ b/nsxt/utils.go
@@ -680,7 +680,25 @@ func handlePagination(lister func(*paginationInfo) error) (int64, error) {
 	return total, nil
 }
 
-func getContextSchema(isRequired, isComputed bool) *schema.Schema {
+func getContextSchema(isRequired, isComputed, isVPC bool) *schema.Schema {
+	elemSchema := map[string]*schema.Schema{
+		"project_id": {
+			Type:         schema.TypeString,
+			Description:  "Id of the project which the resource belongs to.",
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.StringIsNotWhiteSpace,
+		},
+	}
+	if isVPC {
+		elemSchema["vpc_id"] = &schema.Schema{
+			Type:         schema.TypeString,
+			Description:  "Id of the VPC which the resource belongs to.",
+			Optional:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.StringIsNotWhiteSpace,
+		}
+	}
 	return &schema.Schema{
 		Type:        schema.TypeList,
 		Description: "Resource context",
@@ -690,15 +708,7 @@ func getContextSchema(isRequired, isComputed bool) *schema.Schema {
 		MaxItems:    1,
 		ForceNew:    true,
 		Elem: &schema.Resource{
-			Schema: map[string]*schema.Schema{
-				"project_id": {
-					Type:         schema.TypeString,
-					Description:  "Id of the project which the resource belongs to.",
-					Required:     true,
-					ForceNew:     true,
-					ValidateFunc: validation.StringIsNotWhiteSpace,
-				},
-			},
+			Schema: elemSchema,
 		},
 	}
 }

--- a/nsxt/utils.go
+++ b/nsxt/utils.go
@@ -681,6 +681,10 @@ func handlePagination(lister func(*paginationInfo) error) (int64, error) {
 }
 
 func getContextSchema(isRequired, isComputed, isVPC bool) *schema.Schema {
+	return getContextExtendedSchema(isRequired, isComputed, isVPC, false)
+}
+
+func getContextExtendedSchema(isRequired, isComputed, isVPC, isProvider bool) *schema.Schema {
 	elemSchema := map[string]*schema.Schema{
 		"project_id": {
 			Type:         schema.TypeString,
@@ -698,6 +702,10 @@ func getContextSchema(isRequired, isComputed, isVPC bool) *schema.Schema {
 			ForceNew:     true,
 			ValidateFunc: validation.StringIsNotWhiteSpace,
 		}
+	}
+	if isProvider {
+		elemSchema["project_id"].DefaultFunc = schema.EnvDefaultFunc("NSXT_PROVIDER_PROJECT_ID", false)
+		elemSchema["vpc_id"].DefaultFunc = schema.EnvDefaultFunc("NSXT_PROVIDER_VPC_ID", false)
 	}
 	return &schema.Schema{
 		Type:        schema.TypeList,

--- a/nsxt/utils_test.go
+++ b/nsxt/utils_test.go
@@ -243,6 +243,10 @@ func testAccIsMultitenancy() bool {
 	return os.Getenv("NSXT_PROJECT_ID") != ""
 }
 
+func testAccIsMultitenancyProvider() bool {
+	return os.Getenv("NSXT_PROVIDER_PROJECT_ID") != ""
+}
+
 func testAccIsVPC() bool {
 	return os.Getenv("NSXT_VPC_PROJECT_ID") != "" && os.Getenv("NSXT_VPC_ID") != ""
 }
@@ -319,6 +323,13 @@ func testAccOnlyMultitenancy(t *testing.T) {
 	testAccNSXVersion(t, "4.1.0")
 	if !testAccIsMultitenancy() {
 		t.Skipf("This test requires a multitenancy environment")
+	}
+}
+
+func testAccOnlyMultitenancyProvider(t *testing.T) {
+	testAccNSXVersion(t, "4.1.0")
+	if !testAccIsMultitenancyProvider() {
+		t.Skipf("This test requires a multitenancy environment with provider configuration")
 	}
 }
 

--- a/nsxt/utils_test.go
+++ b/nsxt/utils_test.go
@@ -243,15 +243,29 @@ func testAccIsMultitenancy() bool {
 	return os.Getenv("NSXT_PROJECT_ID") != ""
 }
 
+func testAccIsVPC() bool {
+	return os.Getenv("NSXT_VPC_PROJECT_ID") != "" && os.Getenv("NSXT_VPC_ID") != ""
+}
+
 func testAccIsFabric() bool {
 	return os.Getenv("NSXT_TEST_FABRIC") != ""
 }
 
 func testAccGetSessionContext() tf_api.SessionContext {
-	return tf_api.SessionContext{ProjectID: os.Getenv("NSXT_PROJECT_ID"), ClientType: testAccIsGlobalManager2()}
+	clientType := testAccIsGlobalManager2()
+	projectID := os.Getenv("NSXT_PROJECT_ID")
+	vpcID := ""
+	if clientType == tf_api.VPC {
+		projectID = os.Getenv("NSXT_VPC_PROJECT_ID")
+		vpcID = os.Getenv("NSXT_VPC_ID")
+	}
+	return tf_api.SessionContext{ProjectID: projectID, ClientType: clientType, VPCID: vpcID}
 }
 
 func testAccIsGlobalManager2() tf_api.ClientType {
+	if testAccIsVPC() {
+		return tf_api.VPC
+	}
 	if os.Getenv("NSXT_PROJECT_ID") != "" {
 		return tf_api.Multitenancy
 	}
@@ -677,6 +691,16 @@ func testAccNsxtPolicyResourceCheckDestroy(context tf_api.SessionContext, state 
 }
 
 func testAccNsxtPolicyMultitenancyContext() string {
+	if testAccIsVPC() {
+		projectID := os.Getenv("NSXT_VPC_PROJECT_ID")
+		vpcID := os.Getenv("NSXT_VPC_ID")
+		return fmt.Sprintf(`
+  context {
+    project_id = "%s"
+    vpc_id     = "%s"
+  }
+`, projectID, vpcID)
+	}
 	projectID := os.Getenv("NSXT_PROJECT_ID")
 	if projectID != "" {
 		return fmt.Sprintf(`

--- a/tools/api-wrapper-generator.py
+++ b/tools/api-wrapper-generator.py
@@ -76,6 +76,9 @@ def api_func_call_setup(api, subs_dict):
     arg_list = get_arglist(g[2])
     if subs_dict['type'] == "Multitenancy":
         arg_list = ['utl.DefaultOrgID', 'c.ProjectID'] + arg_list
+    elif subs_dict['type'] == "VPC":
+        arg_list = ['utl.DefaultOrgID', 'c.ProjectID', 'c.VPCID'] + arg_list
+        arg_list.remove('domainIdParam')
     return '%s(%s)' % (g[1], ', '.join(arg_list))
 
 
@@ -88,6 +91,9 @@ def patch_func_call_setup(api, subs_dict):
                 arg_list[n] = 'gmObj.(%s.%s)' % (subs_dict['model_import'], subs_dict['model_name'])
     elif subs_dict['type'] == "Multitenancy":
         arg_list = ['utl.DefaultOrgID', 'c.ProjectID'] + arg_list
+    elif subs_dict['type'] == "VPC":
+        arg_list = ['utl.DefaultOrgID', 'c.ProjectID', 'c.VPCID'] + arg_list
+        arg_list.remove('domainIdParam')
     return '%s(%s)' % (g[1], ', '.join(arg_list))
 
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -251,6 +251,9 @@ The following arguments are used to configure the VMware NSX-T Provider:
   for VMC environments, and is not supported with deprecated NSX manager resources and
   data sources. Note - this setting is useful when NSX manager is not yet available at 
   time of provider evaluation, and not recommended to be turned on otherwise.
+* `context` - (Optional) The context which the object belongs to
+  * `project_id` - (Optional) The ID of the project which the object belongs to
+  * `vpc_id` - (Optional) The ID of the VPC which the object belongs to
 
 ## NSX Logical Networking
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -251,9 +251,8 @@ The following arguments are used to configure the VMware NSX-T Provider:
   for VMC environments, and is not supported with deprecated NSX manager resources and
   data sources. Note - this setting is useful when NSX manager is not yet available at 
   time of provider evaluation, and not recommended to be turned on otherwise.
-* `context` - (Optional) The context which the object belongs to
-  * `project_id` - (Optional) The ID of the project which the object belongs to
-  * `vpc_id` - (Optional) The ID of the VPC which the object belongs to
+* `project_id` - (Optional) ID of the project which the plan executes in its context.
+* `vpc_id` - (Optional) ID of the VPC which the plan executes in its context.
 
 ## NSX Logical Networking
 


### PR DESCRIPTION
Allow configuration of the attributes above in the provider globally for the whole context, instead of the resource level.
