### PR TITLE
Fix set IP block visibility on READ if NSX version too low

### DIFF
--- a/nsxt/resource_nsxt_policy_ip_block.go
+++ b/nsxt/resource_nsxt_policy_ip_block.go
@@ -92,7 +92,9 @@ func resourceNsxtPolicyIPBlockRead(d *schema.ResourceData, m interface{}) error 
 	d.Set("path", block.Path)
 	d.Set("revision", block.Revision)
 	d.Set("cidr", block.Cidr)
-	d.Set("visibility", block.Visibility)
+	if util.NsxVersionHigherOrEqual("4.2.0") {
+		d.Set("visibility", block.Visibility)
+	}
 
 	return nil
 }


### PR DESCRIPTION
This change fixes setting policy IP block visibility on READ if NSX is below 4.2, where the value will always be nil. This will cause tf to always show diff if the resource spec has non-empty value.

Closes #1227 