### PR TITLE
Add VPC path importer func

### DIFF
--- a/nsxt/policy_utils.go
+++ b/nsxt/policy_utils.go
@@ -382,6 +382,18 @@ func nsxtPolicyPathResourceImporter(d *schema.ResourceData, m interface{}) ([]*s
 	return rd, nil
 }
 
+func nsxtVPCPathResourceImporter(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	rd, err := nsxtPolicyPathResourceImporterHelper(d, m)
+	if err != nil {
+		return rd, err
+	}
+	projectID, vpcID := getContextDataFromSchema(d)
+	if projectID == "" || vpcID == "" {
+		return rd, fmt.Errorf("imported resource policy path should have both project_id and vpc_id fields")
+	}
+	return rd, nil
+}
+
 func nsxtPolicyPathResourceImporterHelper(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
 	importID := d.Id()
 	if isPolicyPath(importID) {

--- a/nsxt/resource_nsxt_vpc_gateway_policy.go
+++ b/nsxt/resource_nsxt_vpc_gateway_policy.go
@@ -22,7 +22,7 @@ func resourceNsxtVPCGatewayPolicy() *schema.Resource {
 		Update: resourceNsxtVPCGatewayPolicyUpdate,
 		Delete: resourceNsxtVPCGatewayPolicyDelete,
 		Importer: &schema.ResourceImporter{
-			State: nsxtPolicyPathResourceImporter,
+			State: nsxtVPCPathResourceImporter,
 		},
 
 		Schema: getPolicyGatewayPolicySchema(false),

--- a/nsxt/resource_nsxt_vpc_group.go
+++ b/nsxt/resource_nsxt_vpc_group.go
@@ -12,7 +12,7 @@ func resourceNsxtVPCGroup() *schema.Resource {
 		Update: resourceNsxtVPCGroupUpdate,
 		Delete: resourceNsxtVPCGroupDelete,
 		Importer: &schema.ResourceImporter{
-			State: nsxtPolicyPathResourceImporter,
+			State: nsxtVPCPathResourceImporter,
 		},
 
 		Schema: getPolicyGroupSchema(false),

--- a/nsxt/resource_nsxt_vpc_security_policy.go
+++ b/nsxt/resource_nsxt_vpc_security_policy.go
@@ -18,7 +18,7 @@ func resourceNsxtVPCSecurityPolicy() *schema.Resource {
 		Update: resourceNsxtVPCSecurityPolicyUpdate,
 		Delete: resourceNsxtVPCSecurityPolicyDelete,
 		Importer: &schema.ResourceImporter{
-			State: nsxtPolicyPathResourceImporter,
+			State: nsxtVPCPathResourceImporter,
 		},
 		Schema: getPolicySecurityPolicySchema(false, true, true, false),
 	}


### PR DESCRIPTION
VPC resources use policy path to import resources into the TF state. This importer func does some validation that the required attributes for a policy resource import do exist.