### PR TITLE
[WIP] Skip attribute processing when no values is assigned in schema

### DIFF
--- a/nsxt/metadata/metadata.go
+++ b/nsxt/metadata/metadata.go
@@ -306,7 +306,12 @@ func SchemaToStruct(elem reflect.Value, d *schema.ResourceData, metadata map[str
 			if len(parent) > 0 {
 				value = parentMap[key].(string)
 			} else {
-				value = d.Get(key).(string)
+				v, exists := d.GetOk(key)
+				if !exists {
+					logger.Printf("[TRACE] %s skip key %s as no values is assigned", ctx, key)
+					continue
+				}
+				value = v.(string)
 			}
 			if item.Metadata.OmitIfEmpty && value == "" {
 				logger.Printf("[TRACE] %s skip key %s since its empty and OmitIfEmpty is true", ctx, key)
@@ -320,7 +325,12 @@ func SchemaToStruct(elem reflect.Value, d *schema.ResourceData, metadata map[str
 			if len(parent) > 0 {
 				value = parentMap[key].(bool)
 			} else {
-				value = d.Get(key).(bool)
+				v, exists := d.GetOk(key)
+				if !exists {
+					logger.Printf("[TRACE] %s skip key %s as no values is assigned", ctx, key)
+					continue
+				}
+				value = v.(bool)
 			}
 			logger.Printf("[TRACE] %s assigning bool %v to %s", ctx, value, key)
 			elem.FieldByName(item.Metadata.SdkFieldName).Set(reflect.ValueOf(&value))
@@ -330,7 +340,12 @@ func SchemaToStruct(elem reflect.Value, d *schema.ResourceData, metadata map[str
 			if len(parent) > 0 {
 				value = int64(parentMap[key].(int))
 			} else {
-				value = int64(d.Get(key).(int))
+				v, exists := d.GetOk(key)
+				if !exists {
+					logger.Printf("[TRACE] %s skip key %s as no values is assigned", ctx, key)
+					continue
+				}
+				value = int64(v.(int))
 			}
 			logger.Printf("[TRACE] %s assigning int %v to %s", ctx, value, key)
 			elem.FieldByName(item.Metadata.SdkFieldName).Set(reflect.ValueOf(&value))

--- a/nsxt/metadata/metadata_test.go
+++ b/nsxt/metadata/metadata_test.go
@@ -628,9 +628,9 @@ func TestSchemaToStruct(t *testing.T) {
 	})
 
 	t.Run("Zero values", func(t *testing.T) {
-		assert.Equal(t, "", *obj.StringFieldNil)
-		assert.Equal(t, false, *obj.BoolFieldNil)
-		assert.Equal(t, int64(0), *obj.IntFieldNil)
+		assert.Equal(t, (*string)(nil), obj.StringFieldNil)
+		assert.Equal(t, (*bool)(nil), obj.BoolFieldNil)
+		assert.Equal(t, (*int64)(nil), obj.IntFieldNil)
 	})
 
 	t.Run("Nested struct", func(t *testing.T) {


### PR DESCRIPTION
When a value is not assigned to the schema for some attribute, using  d.Get("attr_name").(type) will return a zero or a null string.

That would break when this value is not allowed by NSX and usually we protect against this with an if statement which would assign this attribute a value only when it's set in the schema. With required attributes that cannot happen as NSX will check that a value is assigned prior to the Create() call.