### PR TITLE
Skip sharing tests for v4.1.0

### DIFF
--- a/nsxt/resource_nsxt_policy_share_test.go
+++ b/nsxt/resource_nsxt_policy_share_test.go
@@ -28,7 +28,7 @@ func TestAccResourceNsxtPolicyShare_basic(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccOnlyLocalManager(t)
-			testAccNSXVersion(t, "4.1.0")
+			testAccNSXVersion(t, "4.1.1")
 		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
@@ -71,7 +71,7 @@ func TestAccResourceNsxtPolicyShare_importBasic(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccOnlyLocalManager(t)
-			testAccNSXVersion(t, "4.1.0")
+			testAccNSXVersion(t, "4.1.1")
 		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {

--- a/nsxt/resource_nsxt_policy_shared_resource_test.go
+++ b/nsxt/resource_nsxt_policy_shared_resource_test.go
@@ -29,7 +29,7 @@ func TestAccResourceNsxtPolicySharedResource_basic(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccOnlyLocalManager(t)
-			testAccNSXVersion(t, "4.1.0")
+			testAccNSXVersion(t, "4.1.1")
 		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
@@ -72,7 +72,7 @@ func TestAccResourceNsxtPolicySharedResource_importBasic(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccOnlyLocalManager(t)
-			testAccNSXVersion(t, "4.1.0")
+			testAccNSXVersion(t, "4.1.1")
 		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {

--- a/website/docs/r/policy_share.html.markdown
+++ b/website/docs/r/policy_share.html.markdown
@@ -9,6 +9,7 @@ description: A resource to configure a Share.
 
 This resource provides a method for the management of a Share.
 This resource is applicable to NSX Policy Manager.
+This resource is supported with NSX 4.1.1 onwards.
 
 ## Example Usage
 

--- a/website/docs/r/policy_shared_resource.html.markdown
+++ b/website/docs/r/policy_shared_resource.html.markdown
@@ -9,6 +9,7 @@ description: A resource to configure a Shared Resource.
 
 This resource provides a method for the management of a Shared Resource.
 This resource is applicable to NSX Policy Manager.
+This resource is supported with NSX 4.1.1 onwards.
 
 ## Example Usage
 


### PR DESCRIPTION
As NSX v4.1.0 sharing API is different than later versions.