### PR TITLE
Rename VPC data source tests

### DIFF
--- a/nsxt/data_source_nsxt_vpc_test.go
+++ b/nsxt/data_source_nsxt_vpc_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/orgs/projects"
 )
 
-func TestAccDataSourceNsxtVPC_basic_multitenancy(t *testing.T) {
+func TestAccDataSourceNsxtVPC_basic(t *testing.T) {
 	name := getAccTestDataSourceName()
 	testResourceName := "data.nsxt_vpc.test"
 


### PR DESCRIPTION
VPC data source tests were prefixed with "multitenancy" but as there is a VPC test job, they could run there instead.