### PR TITLE
Remove display_name from ldap resource

### DIFF
--- a/nsxt/resource_nsxt_policy_ldap_identity_source.go
+++ b/nsxt/resource_nsxt_policy_ldap_identity_source.go
@@ -35,11 +35,15 @@ func resourceNsxtPolicyLdapIdentitySource() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"nsx_id":       getNsxIDSchema(),
-			"display_name": getDataSourceDisplayNameSchema(),
-			"description":  getDataSourceDescriptionSchema(),
-			"revision":     getRevisionSchema(),
-			"tag":          getTagsSchema(),
+			"nsx_id": {
+				Type:        schema.TypeString,
+				Description: "NSX ID for this resource",
+				Required:    true,
+				ForceNew:    true,
+			},
+			"description": getDescriptionSchema(),
+			"revision":    getRevisionSchema(),
+			"tag":         getTagsSchema(),
 			"type": {
 				Type:         schema.TypeString,
 				Description:  "Indicates the type of LDAP server",
@@ -196,7 +200,6 @@ func resourceNsxtPolicyLdapIdentitySourceProbeAndUpdate(d *schema.ResourceData, 
 	converter := bindings.NewTypeConverter()
 	serverType := d.Get("type").(string)
 
-	displayName := d.Get("display_name").(string)
 	description := d.Get("description").(string)
 	revision := int64(d.Get("revision").(int))
 	tags := getPolicyTagsFromSchema(d)
@@ -209,7 +212,6 @@ func resourceNsxtPolicyLdapIdentitySourceProbeAndUpdate(d *schema.ResourceData, 
 	var errs []error
 	if serverType == activeDirectoryType {
 		obj := nsxModel.ActiveDirectoryIdentitySource{
-			DisplayName:            &displayName,
 			Description:            &description,
 			Revision:               &revision,
 			Tags:                   tags,
@@ -222,7 +224,6 @@ func resourceNsxtPolicyLdapIdentitySourceProbeAndUpdate(d *schema.ResourceData, 
 		dataValue, errs = converter.ConvertToVapi(obj, nsxModel.ActiveDirectoryIdentitySourceBindingType())
 	} else if serverType == openLdapType {
 		obj := nsxModel.OpenLdapIdentitySource{
-			DisplayName:            &displayName,
 			Description:            &description,
 			Revision:               &revision,
 			Tags:                   tags,
@@ -315,7 +316,6 @@ func resourceNsxtPolicyLdapIdentitySourceRead(d *schema.ResourceData, m interfac
 	passwordMap := getLdapServerPasswordMap(d)
 
 	d.Set("nsx_id", id)
-	d.Set("display_name", ldapObj.DisplayName)
 	d.Set("description", ldapObj.Description)
 	d.Set("revision", ldapObj.Revision)
 	setPolicyTagsInSchema(d, ldapObj.Tags)

--- a/nsxt/resource_nsxt_policy_ldap_identity_source_test.go
+++ b/nsxt/resource_nsxt_policy_ldap_identity_source_test.go
@@ -12,13 +12,13 @@ import (
 )
 
 var accTestPolicyLdapIdentitySourceCreateAttributes = map[string]string{
-	"display_name": getAccTestResourceName(),
-	"description":  "terraform created",
+	"nsx_id":      getAccTestResourceName(),
+	"description": "terraform created",
 }
 
 var accTestPolicyLdapIdentitySourceUpdateAttributes = map[string]string{
-	"display_name": getAccTestResourceName(),
-	"description":  "terraform updated",
+	"nsx_id":      getAccTestResourceName(),
+	"description": "terraform updated",
 }
 
 func TestAccResourceNsxtPolicyLdapIdentitySource_basic(t *testing.T) {
@@ -38,7 +38,7 @@ func TestAccResourceNsxtPolicyLdapIdentitySource_basic(t *testing.T) {
 		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNsxtPolicyLdapIdentitySourceCheckDestroy(state, accTestPolicyLdapIdentitySourceUpdateAttributes["display_name"])
+			return testAccNsxtPolicyLdapIdentitySourceCheckDestroy(state, accTestPolicyLdapIdentitySourceUpdateAttributes["nsx_id"])
 		},
 		Steps: []resource.TestStep{
 			{
@@ -46,8 +46,7 @@ func TestAccResourceNsxtPolicyLdapIdentitySource_basic(t *testing.T) {
 					ldapType, getTestLdapDomain(), getTestLdapBaseDN(), getTestLdapUser(), getTestLdapPassword(),
 					getTestLdapURL(), getTestLdapCert()),
 				Check: resource.ComposeTestCheckFunc(
-					testAccNsxtPolicyLdapIdentitySourceExists(accTestPolicyLdapIdentitySourceCreateAttributes["display_name"], testResourceName),
-					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestPolicyLdapIdentitySourceCreateAttributes["display_name"]),
+					testAccNsxtPolicyLdapIdentitySourceExists(accTestPolicyLdapIdentitySourceCreateAttributes["nsx_id"], testResourceName),
 					resource.TestCheckResourceAttr(testResourceName, "description", accTestPolicyLdapIdentitySourceCreateAttributes["description"]),
 					resource.TestCheckResourceAttr(testResourceName, "type", ldapType),
 					resource.TestCheckResourceAttr(testResourceName, "domain_name", getTestLdapDomain()),
@@ -59,7 +58,7 @@ func TestAccResourceNsxtPolicyLdapIdentitySource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(testResourceName, "ldap_server.0.certificates.#", "1"),
 					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
 
-					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
+					resource.TestCheckResourceAttr(testResourceName, "nsx_id", accTestPolicyLdapIdentitySourceCreateAttributes["nsx_id"]),
 					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
 				),
 			},
@@ -68,8 +67,7 @@ func TestAccResourceNsxtPolicyLdapIdentitySource_basic(t *testing.T) {
 					ldapType, getTestLdapDomain(), getTestLdapBaseDN(), getTestLdapUser(), getTestLdapPassword(),
 					getTestLdapURL(), getTestLdapCert()),
 				Check: resource.ComposeTestCheckFunc(
-					testAccNsxtPolicyLdapIdentitySourceExists(accTestPolicyLdapIdentitySourceUpdateAttributes["display_name"], testResourceName),
-					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestPolicyLdapIdentitySourceUpdateAttributes["display_name"]),
+					testAccNsxtPolicyLdapIdentitySourceExists(accTestPolicyLdapIdentitySourceUpdateAttributes["nsx_id"], testResourceName),
 					resource.TestCheckResourceAttr(testResourceName, "description", accTestPolicyLdapIdentitySourceUpdateAttributes["description"]),
 					resource.TestCheckResourceAttr(testResourceName, "type", ldapType),
 					resource.TestCheckResourceAttr(testResourceName, "domain_name", getTestLdapDomain()),
@@ -81,7 +79,6 @@ func TestAccResourceNsxtPolicyLdapIdentitySource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(testResourceName, "ldap_server.0.certificates.#", "1"),
 					resource.TestCheckResourceAttr(testResourceName, "tag.#", "0"),
 
-					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
 					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
 				),
 			},
@@ -106,7 +103,7 @@ func TestAccResourceNsxtPolicyLdapIdentitySource_import_basic(t *testing.T) {
 		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNsxtPolicyLdapIdentitySourceCheckDestroy(state, accTestPolicyLdapIdentitySourceCreateAttributes["display_name"])
+			return testAccNsxtPolicyLdapIdentitySourceCheckDestroy(state, accTestPolicyLdapIdentitySourceCreateAttributes["nsx_id"])
 		},
 		Steps: []resource.TestStep{
 			{
@@ -175,7 +172,7 @@ func testAccNsxtPolicyLdapIdentitySourceCreate(serverType, domainName, baseDn, b
 	attrMap := accTestPolicyLdapIdentitySourceCreateAttributes
 	return fmt.Sprintf(`
 resource "nsxt_policy_ldap_identity_source" "test" {
-    display_name = "%s"
+    nsx_id       = "%s"
     description  = "%s"
     type         = "%s"
     domain_name  = "%s"
@@ -197,14 +194,14 @@ resource "nsxt_policy_ldap_identity_source" "test" {
         scope = "scope1"
         tag = "tag1"
     }
-}`, attrMap["display_name"], attrMap["description"], serverType, domainName, baseDn, bindUser, bindPwd, url, cert)
+}`, attrMap["nsx_id"], attrMap["description"], serverType, domainName, baseDn, bindUser, bindPwd, url, cert)
 }
 
 func testAccNsxtPolicyLdapIdentitySourceUpdate(serverType, domainName, baseDn, bindUser, bindPwd, url, cert string) string {
 	attrMap := accTestPolicyLdapIdentitySourceUpdateAttributes
 	return fmt.Sprintf(`
 resource "nsxt_policy_ldap_identity_source" "test" {
-    display_name = "%s"
+    nsx_id       = "%s"
     description  = "%s"
     type         = "%s"
     domain_name  = "%s"
@@ -221,5 +218,5 @@ resource "nsxt_policy_ldap_identity_source" "test" {
             ,
         ]
     }
-}`, attrMap["display_name"], attrMap["description"], serverType, domainName, baseDn, bindUser, bindPwd, url, cert)
+}`, attrMap["nsx_id"], attrMap["description"], serverType, domainName, baseDn, bindUser, bindPwd, url, cert)
 }

--- a/website/docs/r/policy_ldap_identity_source.html.markdown
+++ b/website/docs/r/policy_ldap_identity_source.html.markdown
@@ -13,11 +13,11 @@ This resource provides a method for the management of LDAP identity sources.
 
 ```hcl
 resource "nsxt_policy_ldap_identity_source" "test" {
-  display_name = "Airius LDAP"
-  description  = "Airius LDAP Identity Source"
-  type         = "ActiveDirectory"
-  domain_name  = "airius.com"
-  base_dn      = "DC=airius, DC=com"
+  nsx_id      = "Airius_LDAP"
+  description = "Airius LDAP Identity Source"
+  type        = "ActiveDirectory"
+  domain_name = "airius.com"
+  base_dn     = "DC=airius, DC=com"
 
   ldap_server {
     bind_identity = "nsxint@airius.com"
@@ -35,13 +35,10 @@ resource "nsxt_policy_ldap_identity_source" "test" {
 
 The following arguments are supported:
 
-* `display_name` - (Optional) Display name of the resource.
+* `nsx_id` - (Required) The NSX ID of this resource.
 * `description` - (Optional) Description of the resource.
 * `tag` - (Optional) A list of scope + tag pairs to associate with this resource.
-* `nsx_id` - (Optional) The NSX ID of this resource. If set, this ID will be used to create the resource.
-* `type` - (Required) Indicates the type of the LDAP identity source. Valid options:
-  * `ActiveDirectory` - This is an Active Directory identity source.
-  * `OpenLdap` - This is an OpenLDAP identity source.
+* `type` - (Required) Indicates the type of the LDAP identity source. Valid values are `ActiveDirectory`, `OpenLdap`.
 * `domain_name` - (Required) Authentication domain name. This is the name of the authentication domain. When users log into NSX using an identity of the form "user@domain", NSX uses the domain portion to determine which LDAP identity source to use.
 * `base_dn` - (Required) DN of subtree for user and group searches.
 * `alternative_domain_names` - (Optional) Additional domains to be directed to this identity source. After parsing the "user@domain", the domain portion is used to select the LDAP identity source to use. Additional domains listed here will also be directed to this LDAP identity source. In Active Directory these are sometimes referred to as Alternative UPN Suffixes.


### PR DESCRIPTION
Since starting from NSX 4.2, display_name has to be identical to id, display_name attribute is redundant