### PR TITLE
Define set_as_oidc_provider flag as computed

### DIFF
--- a/nsxt/resource_nsxt_compute_manager.go
+++ b/nsxt/resource_nsxt_compute_manager.go
@@ -209,7 +209,7 @@ func resourceNsxtComputeManager() *schema.Resource {
 				Type:        schema.TypeBool,
 				Description: "Specifies whether compute manager has been set as OIDC provider",
 				Optional:    true,
-				Default:     false,
+				Computed:    true, // default varies based on NSX version
 			},
 		},
 	}


### PR DESCRIPTION
Default for this flag in compute_manager depends on NSX version. Hence enforcing the default in provider is not applicable. This PR set this attribute as Computed instead.