### PR TITLE
Fix VPC documentation with correct DS name

### DIFF
--- a/website/docs/r/vpc_gateway_policy.html.markdown
+++ b/website/docs/r/vpc_gateway_policy.html.markdown
@@ -20,7 +20,7 @@ data "nsxt_policy_project" "demoproj" {
   display_name = "demoproj"
 }
 
-data "nsxt_policy_vpc" "demovpc" {
+data "nsxt_vpc" "demovpc" {
   context {
     project_id = data.nsxt_policy_project.demoproj.id
   }
@@ -30,7 +30,7 @@ data "nsxt_policy_vpc" "demovpc" {
 resource "nsxt_vpc_gateway_policy" "test" {
   context {
     project_id = data.nsxt_policy_project.demoproj.id
-    vpc_id     = data.nsxt_policy_vpc.demovpc.id
+    vpc_id     = data.nsxt_vpc.demovpc.id
   }
   display_name    = "tf-gw-policy"
   description     = "Terraform provisioned Gateway Policy"

--- a/website/docs/r/vpc_group.html.markdown
+++ b/website/docs/r/vpc_group.html.markdown
@@ -17,7 +17,7 @@ data "nsxt_policy_project" "demoproj" {
   display_name = "demoproj"
 }
 
-data "nsxt_policy_vpc" "demovpc" {
+data "nsxt_vpc" "demovpc" {
   context {
     project_id = data.nsxt_policy_project.demoproj.id
   }
@@ -27,7 +27,7 @@ data "nsxt_policy_vpc" "demovpc" {
 resource "nsxt_vpc_group" "group1" {
   context {
     project_id = data.nsxt_policy_project.demoproj.id
-    vpc_id     = data.nsxt_policy_vpc.demovpc.id
+    vpc_id     = data.nsxt_vpc.demovpc.id
   }
 
   display_name = "tf-group1"

--- a/website/docs/r/vpc_security_policy.html.markdown
+++ b/website/docs/r/vpc_security_policy.html.markdown
@@ -18,7 +18,7 @@ data "nsxt_policy_project" "demoproj" {
   display_name = "demoproj"
 }
 
-data "nsxt_policy_vpc" "demovpc" {
+data "nsxt_vpc" "demovpc" {
   context {
     project_id = data.nsxt_policy_project.demoproj.id
   }
@@ -28,7 +28,7 @@ data "nsxt_policy_vpc" "demovpc" {
 resource "nsxt_vpc_security_policy" "policy1" {
   context {
     project_id = data.nsxt_policy_project.demoproj.id
-    vpc_id     = data.nsxt_policy_vpc.demovpc.id
+    vpc_id     = data.nsxt_vpc.demovpc.id
   }
   display_name = "policy1"
   description  = "Terraform provisioned Security Policy"


### PR DESCRIPTION
nsxt_policy_vpc datasource has been renamed to nsxt_vpc