### PR TITLE
Handle upload failures properly

### DIFF
--- a/nsxt/resource_nsxt_upgrade_prepare.go
+++ b/nsxt/resource_nsxt_upgrade_prepare.go
@@ -417,6 +417,9 @@ func waitForBundleUpload(m interface{}, bundleID string, timeout int) error {
 			}
 
 			log.Printf("[DEBUG] Current status for uploading bundle %s is %s", bundleID, *state.Status)
+			if *state.Status == nsxModel.UpgradeBundleUploadStatus_STATUS_FAILED {
+				return state, nsxModel.UpgradeBundleUploadStatus_STATUS_FAILED, fmt.Errorf(*state.DetailedStatus)
+			}
 
 			return state, *state.Status, nil
 		},


### PR DESCRIPTION
When upload fails, report properly and fail the resource.