### PR TITLE
Fix tier1 for v4.2.0

### DIFF
--- a/nsxt/resource_nsxt_policy_tier1_gateway.go
+++ b/nsxt/resource_nsxt_policy_tier1_gateway.go
@@ -407,11 +407,14 @@ func policyTier1GatewayResourceToInfraStruct(context utl.SessionContext, d *sche
 		DisableFirewall:         &disableFirewall,
 		EnableStandbyRelocation: &enableStandbyRelocation,
 		ForceWhitelisting:       &forceWhitelisting,
-		Tier0Path:               &tier0Path,
 		RouteAdvertisementTypes: routeAdvertisementTypes,
 		RouteAdvertisementRules: routeAdvertisementRules,
 		Ipv6ProfilePaths:        ipv6ProfilePaths,
 		ResourceType:            &t1Type,
+	}
+
+	if tier0Path != "" {
+		obj.Tier0Path = &tier0Path
 	}
 
 	if util.NsxVersionHigherOrEqual("3.2.0") {


### PR DESCRIPTION
Setting empty string to tier0path attribute of tier1 causes failures later on in NAT creation.