### PR TITLE
Address issue with nsxt_policy_uplink_host_switch_profile

### DIFF
--- a/website/docs/d/policy_ip_pool.html.markdown
+++ b/website/docs/d/policy_ip_pool.html.markdown
@@ -47,4 +47,4 @@ In addition to arguments listed above, the following attributes are exported:
 
 * `description` - The description of the resource.
 * `path` - The NSX path of the policy resource.
-* `realized_id` - The id of realized pool object. This id should be used in `nsxt_transport_node` resource.
+* `realized_id` - The id of realized pool object. This id should be used in `nsxt_edge_transport_node` resource.

--- a/website/docs/d/policy_uplink_host_switch_profile.html.markdown
+++ b/website/docs/d/policy_uplink_host_switch_profile.html.markdown
@@ -29,3 +29,4 @@ In addition to arguments listed above, the following attributes are exported:
 
 * `description` - The description of the resource.
 * `path` - The NSX path of the policy resource.
+* `realized_id` - The id of realized pool object. This id should be used in `nsxt_edge_transport_node` resource.


### PR DESCRIPTION
Uplink host switch profile data source does not retrieve the realized_id of the object. It is also not retrievable with the nsxt_policy_realization_info data source, as the data returned by NSX doesn't contain this info, e.g

```
{
  "results" : [ {
    "entity_type" : "RZ_BASE_HOST_SWITCH_PROFILE",
    "intent_paths" : [ "/infra/host-switch-profiles/da7ea85b-e286-47bd-950e-bd7a8519c120" ],
    "resource_type" : "GenericPolicyRealizedResource",
    "id" : "da7ea85b-e286-47bd-950e-bd7a8519c120",
    "display_name" : "da7ea85b-e286-47bd-950e-bd7a8519c120",
    "path" : "/infra/realized-state/enforcement-points/default/host-switch-profiles/da7ea85b-e286-47bd-950e-bd7a8519c120",
    "relative_path" : "da7ea85b-e286-47bd-950e-bd7a8519c120",
    "parent_path" : "/infra/realized-state/enforcement-points/default",
    "remote_path" : "",
    "unique_id" : "5af90399-45ec-47f3-b884-e29cb79e06e0",
    "realization_id" : "5af90399-45ec-47f3-b884-e29cb79e06e0",
    "owner_id" : "4d4c5ded-c15f-49de-b7f6-cac9dbb48fbb",
    "intent_reference" : [ "/infra/host-switch-profiles/da7ea85b-e286-47bd-950e-bd7a8519c120" ],
    "state" : "REALIZED",
    "alarms" : [ ],
    "runtime_status" : "UNINITIALIZED",
    "publish_status" : "UNINITIALIZED",
    "_create_time" : 1722436827167,
    "_create_user" : "system",
    "_last_modified_time" : 1722436827167,
    "_last_modified_user" : "system",
    "_system_owned" : false,
    "_protection" : "NOT_PROTECTED",
    "_revision" : 0
  } ],
  "result_count" : 1
}
```

With no `realization_specific_identifier` attribute.