### PR TITLE
Verify that id is actually from the prepare resource

### DIFF
--- a/nsxt/data_source_nsxt_upgrade_prepare_ready.go
+++ b/nsxt/data_source_nsxt_upgrade_prepare_ready.go
@@ -5,6 +5,7 @@ package nsxt
 
 import (
 	"fmt"
+	"github.com/vmware/terraform-provider-nsxt/nsxt/util"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	nsxModel "github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp/nsx/model"
@@ -46,6 +47,11 @@ func getPrechecksText(m interface{}, precheckIDs []string) (string, error) {
 }
 
 func dataSourceNsxtUpgradePrepareReadyRead(d *schema.ResourceData, m interface{}) error {
+	// Validate that upgrade_prepare_id is actually from the nsxt_upgrade_prepare resource
+	upgradePrepareID := d.Get("upgrade_prepare_id").(string)
+	if !util.VerifyVerifiableID(upgradePrepareID, "nsxt_upgrade_prepare") {
+		return fmt.Errorf("value for upgrade_prepare_id is invalid: %s", upgradePrepareID)
+	}
 	precheckErrors, err := getPrecheckErrors(m, nil)
 	if err != nil {
 		return fmt.Errorf("Error while reading precheck failures: %v", err)
@@ -80,10 +86,7 @@ func dataSourceNsxtUpgradePrepareReadyRead(d *schema.ResourceData, m interface{}
 	if len(errMessage) > 0 {
 		return fmt.Errorf(errMessage)
 	}
-	objID := d.Get("id").(string)
-	if objID == "" {
-		objID = newUUID()
-	}
+	objID := util.GetVerifiableID(newUUID(), "nsxt_upgrade_prepare_ready")
 	d.SetId(objID)
 
 	return nil

--- a/nsxt/resource_nsxt_upgrade_prepare.go
+++ b/nsxt/resource_nsxt_upgrade_prepare.go
@@ -131,10 +131,7 @@ func resourceNsxtUpgradePrepare() *schema.Resource {
 }
 
 func resourceNsxtUpgradePrepareCreate(d *schema.ResourceData, m interface{}) error {
-	id := d.Id()
-	if id == "" {
-		id = newUUID()
-	}
+	id := util.GetVerifiableID(newUUID(), "nsxt_upgrade_prepare")
 	err := prepareForUpgrade(d, m)
 	if err != nil {
 		return handleCreateError("NsxtUpgradePrepare", id, err)

--- a/nsxt/resource_nsxt_upgrade_run.go
+++ b/nsxt/resource_nsxt_upgrade_run.go
@@ -16,6 +16,8 @@ import (
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp/nsx/model"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp/nsx/upgrade"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp/nsx/upgrade/plan"
+
+	"github.com/vmware/terraform-provider-nsxt/nsxt/util"
 )
 
 // Order matters
@@ -351,6 +353,13 @@ func upgradeRunCreateOrUpdate(d *schema.ResourceData, m interface{}) error {
 	if id == "" {
 		id = newUUID()
 	}
+
+	// Validate that upgrade_prepare_id is actually from the nsxt_upgrade_prepare_ready data source
+	upgradePrepareReadyID := d.Get("upgrade_prepare_ready_id").(string)
+	if !util.VerifyVerifiableID(upgradePrepareReadyID, "nsxt_upgrade_prepare_ready") {
+		return fmt.Errorf("value for upgrade_prepare_ready_id is invalid: %s", upgradePrepareReadyID)
+	}
+
 	connector := getPolicyConnectorWithHeaders(m, nil, false, false)
 	upgradeClientSet := newUpgradeClientSet(connector, d)
 

--- a/nsxt/util/utils.go
+++ b/nsxt/util/utils.go
@@ -1,7 +1,10 @@
 package util
 
 import (
+	"fmt"
+	"hash/fnv"
 	"log"
+	"strings"
 
 	"github.com/hashicorp/go-version"
 )
@@ -28,4 +31,24 @@ func NsxVersionHigherOrEqual(ver string) bool {
 		return false
 	}
 	return currentVersion.Compare(requestedVersion) >= 0
+}
+
+func hash(s string) uint32 {
+	h := fnv.New32a()
+	h.Write([]byte(s))
+	return h.Sum32()
+}
+
+func GetVerifiableID(id, extra string) string {
+	h := hash(id + extra)
+	return fmt.Sprintf("%s:%x", id, h)
+}
+
+func VerifyVerifiableID(id, extra string) bool {
+	s := strings.Split(id, ":")
+	if len(s) != 2 {
+		return false
+	}
+	h := hash(s[0] + extra)
+	return s[1] == fmt.Sprintf("%x", h)
 }


### PR DESCRIPTION
We added some id attributes in the upgrade resources to enforce dependency, yet we never validate these.