### PR TITLE
Fix crash in metadata code with empty clause

### DIFF
--- a/nsxt/metadata/metadata.go
+++ b/nsxt/metadata/metadata.go
@@ -365,6 +365,12 @@ func SchemaToStruct(elem reflect.Value, d *schema.ResourceData, metadata map[str
 			nestedObj := reflect.New(item.Metadata.ReflectType)
 			itemList := getItemListForSchemaToStruct(d, item.Metadata.SchemaType, key, parent, parentMap)
 			if len(itemList) == 0 {
+				logger.Printf("[TRACE] Item list empty")
+				continue
+			}
+			if itemList[0] == nil {
+				// empty clause is specified
+				logger.Printf("[TRACE] Item list contains empty value")
 				continue
 			}
 			nestedSchema := itemList[0].(map[string]interface{})
@@ -394,6 +400,9 @@ func SchemaToStruct(elem reflect.Value, d *schema.ResourceData, metadata map[str
 				}
 
 				for i, v := range itemList {
+					if v == nil {
+						continue
+					}
 					if childElem.Metadata.SchemaType == "int" {
 						sliceElem.Index(i).Set(reflect.ValueOf(v).Convert(reflect.TypeOf(int64(0))))
 					} else {
@@ -409,6 +418,9 @@ func SchemaToStruct(elem reflect.Value, d *schema.ResourceData, metadata map[str
 				sliceElem.Set(
 					reflect.MakeSlice(reflect.SliceOf(item.Metadata.ReflectType), len(itemList), len(itemList)))
 				for i, childItem := range itemList {
+					if childItem == nil {
+						continue
+					}
 					nestedObj := reflect.New(item.Metadata.ReflectType)
 					nestedSchema := childItem.(map[string]interface{})
 					if err = SchemaToStruct(nestedObj.Elem(), d, childElem.Schema, key, nestedSchema); err != nil {

--- a/nsxt/metadata/metadata_test.go
+++ b/nsxt/metadata/metadata_test.go
@@ -751,3 +751,19 @@ func TestSchemaToStructEmptySlice(t *testing.T) {
 		assert.Equal(t, 0, len(obj.StructList))
 	})
 }
+
+func TestSchemaToStructNilStruct(t *testing.T) {
+	d := schema.TestResourceDataRaw(
+		t, testSchema, map[string]interface{}{
+			"struct_field": []interface{}{nil},
+		})
+
+	obj := testStruct{}
+	elem := reflect.ValueOf(&obj).Elem()
+	err := SchemaToStruct(elem, d, testExtendedSchema, "", nil)
+	assert.NoError(t, err, "unexpected error calling SchemaToStruct")
+
+	t.Run("Struct field with Nil", func(t *testing.T) {
+		assert.Nil(t, obj.StructField)
+	})
+}


### PR DESCRIPTION
When empty clause is specified in resource, the code needs to guard against nil value before casting the value to map. This PR ensures this protection.
Signed-off-by: Anna Khmelnitsky <akhmelnitsky@vmware.com>