### PR TITLE
Disallow empty tag{} clause in VPC resources

### DIFF
--- a/nsxt/policy_utils.go
+++ b/nsxt/policy_utils.go
@@ -143,7 +143,7 @@ func getIgnoredTagsFromSchema(d *schema.ResourceData) []model.Tag {
 	return getPolicyTagsFromSet(discoveredTags)
 }
 
-func getCustomizedPolicyTagsFromSchema(d *schema.ResourceData, schemaName string) []model.Tag {
+func getCustomizedPolicyTagsFromSchema(d *schema.ResourceData, schemaName string) ([]model.Tag, error) {
 	tags := d.Get(schemaName).(*schema.Set).List()
 	ignoredTags := getIgnoredTagsFromSchema(d)
 	tagList := make([]model.Tag, 0)
@@ -151,6 +151,11 @@ func getCustomizedPolicyTagsFromSchema(d *schema.ResourceData, schemaName string
 		data := tag.(map[string]interface{})
 		tagScope := data["scope"].(string)
 		tagTag := data["tag"].(string)
+
+		if len(tagScope)+len(tagTag) == 0 {
+			return tagList, fmt.Errorf("tag value or scope value needs to be specified")
+
+		}
 		elem := model.Tag{
 			Scope: &tagScope,
 			Tag:   &tagTag}
@@ -160,7 +165,7 @@ func getCustomizedPolicyTagsFromSchema(d *schema.ResourceData, schemaName string
 	if len(ignoredTags) > 0 {
 		tagList = append(tagList, ignoredTags...)
 	}
-	return tagList
+	return tagList, nil
 }
 
 func setIgnoredTagsInSchema(d *schema.ResourceData, scopesToIgnore []string, tags []map[string]interface{}) {
@@ -221,6 +226,11 @@ func setCustomizedPolicyTagsInSchema(d *schema.ResourceData, tags []model.Tag, s
 }
 
 func getPolicyTagsFromSchema(d *schema.ResourceData) []model.Tag {
+	tags, _ := getCustomizedPolicyTagsFromSchema(d, "tag")
+	return tags
+}
+
+func getValidatedTagsFromSchema(d *schema.ResourceData) ([]model.Tag, error) {
 	return getCustomizedPolicyTagsFromSchema(d, "tag")
 }
 

--- a/nsxt/resource_nsxt_policy_gateway_policy.go
+++ b/nsxt/resource_nsxt_policy_gateway_policy.go
@@ -132,7 +132,10 @@ func policyGatewayPolicyBuildAndPatch(d *schema.ResourceData, m interface{}, con
 	}
 	displayName := d.Get("display_name").(string)
 	description := d.Get("description").(string)
-	tags := getPolicyTagsFromSchema(d)
+	tags, tagErr := getValidatedTagsFromSchema(d)
+	if tagErr != nil {
+		return tagErr
+	}
 	category := d.Get("category").(string)
 	comments := d.Get("comments").(string)
 	locked := d.Get("locked").(bool)

--- a/nsxt/resource_nsxt_policy_group.go
+++ b/nsxt/resource_nsxt_policy_group.go
@@ -883,7 +883,10 @@ func resourceNsxtPolicyGroupGeneralCreate(d *schema.ResourceData, m interface{},
 	}
 	displayName := d.Get("display_name").(string)
 	description := d.Get("description").(string)
-	tags := getPolicyTagsFromSchema(d)
+	tags, tagErr := getValidatedTagsFromSchema(d)
+	if tagErr != nil {
+		return tagErr
+	}
 
 	var groupTypes []string
 	groupType := d.Get("group_type").(string)

--- a/nsxt/resource_nsxt_policy_parent_security_policy.go
+++ b/nsxt/resource_nsxt_policy_parent_security_policy.go
@@ -25,10 +25,13 @@ func resourceNsxtPolicyParentSecurityPolicy() *schema.Resource {
 	}
 }
 
-func parentSecurityPolicySchemaToModel(d *schema.ResourceData, id string) model.SecurityPolicy {
+func parentSecurityPolicySchemaToModel(d *schema.ResourceData, id string) (model.SecurityPolicy, error) {
 	displayName := d.Get("display_name").(string)
 	description := d.Get("description").(string)
-	tags := getPolicyTagsFromSchema(d)
+	tags, tagErr := getValidatedTagsFromSchema(d)
+	if tagErr != nil {
+		return model.SecurityPolicy{}, tagErr
+	}
 	category := d.Get("category").(string)
 	comments := d.Get("comments").(string)
 	locked := d.Get("locked").(bool)
@@ -52,7 +55,7 @@ func parentSecurityPolicySchemaToModel(d *schema.ResourceData, id string) model.
 		Stateful:       &stateful,
 		TcpStrict:      &tcpStrict,
 		ResourceType:   &objType,
-	}
+	}, nil
 }
 
 func parentSecurityPolicyModelToSchema(d *schema.ResourceData, m interface{}, withDomain bool) (*model.SecurityPolicy, error) {

--- a/nsxt/resource_nsxt_policy_security_policy.go
+++ b/nsxt/resource_nsxt_policy_security_policy.go
@@ -62,7 +62,10 @@ func resourceNsxtPolicySecurityPolicyExistsPartial(domainName string) func(sessi
 }
 
 func policySecurityPolicyBuildAndPatch(d *schema.ResourceData, m interface{}, id string, createFlow, withRule, withDomain bool) error {
-	obj := parentSecurityPolicySchemaToModel(d, id)
+	obj, structErr := parentSecurityPolicySchemaToModel(d, id)
+	if structErr != nil {
+		return structErr
+	}
 	domain := ""
 	if withDomain {
 		domain = d.Get("domain").(string)

--- a/nsxt/resource_nsxt_transit_gateway.go
+++ b/nsxt/resource_nsxt_transit_gateway.go
@@ -86,7 +86,10 @@ func resourceNsxtTransitGatewayCreate(d *schema.ResourceData, m interface{}) err
 	parents := getVpcParentsFromContext(getSessionContext(d, m))
 	displayName := d.Get("display_name").(string)
 	description := d.Get("description").(string)
-	tags := getPolicyTagsFromSchema(d)
+	tags, tagErr := getValidatedTagsFromSchema(d)
+	if tagErr != nil {
+		return tagErr
+	}
 
 	obj := model.TransitGateway{
 		DisplayName: &displayName,
@@ -150,7 +153,10 @@ func resourceNsxtTransitGatewayUpdate(d *schema.ResourceData, m interface{}) err
 	parents := getVpcParentsFromContext(getSessionContext(d, m))
 	description := d.Get("description").(string)
 	displayName := d.Get("display_name").(string)
-	tags := getPolicyTagsFromSchema(d)
+	tags, tagErr := getValidatedTagsFromSchema(d)
+	if tagErr != nil {
+		return tagErr
+	}
 
 	revision := int64(d.Get("revision").(int))
 

--- a/nsxt/resource_nsxt_vpc_connectivity_profile.go
+++ b/nsxt/resource_nsxt_vpc_connectivity_profile.go
@@ -245,7 +245,10 @@ func resourceNsxtVpcConnectivityProfileCreate(d *schema.ResourceData, m interfac
 	parents := getVpcParentsFromContext(getSessionContext(d, m))
 	displayName := d.Get("display_name").(string)
 	description := d.Get("description").(string)
-	tags := getPolicyTagsFromSchema(d)
+	tags, tagErr := getValidatedTagsFromSchema(d)
+	if tagErr != nil {
+		return tagErr
+	}
 
 	obj := model.VpcConnectivityProfile{
 		DisplayName: &displayName,
@@ -309,7 +312,10 @@ func resourceNsxtVpcConnectivityProfileUpdate(d *schema.ResourceData, m interfac
 	parents := getVpcParentsFromContext(getSessionContext(d, m))
 	description := d.Get("description").(string)
 	displayName := d.Get("display_name").(string)
-	tags := getPolicyTagsFromSchema(d)
+	tags, tagErr := getValidatedTagsFromSchema(d)
+	if tagErr != nil {
+		return tagErr
+	}
 
 	revision := int64(d.Get("revision").(int))
 

--- a/nsxt/resource_nsxt_vpc_service_profile.go
+++ b/nsxt/resource_nsxt_vpc_service_profile.go
@@ -342,7 +342,10 @@ func resourceNsxtVpcServiceProfileCreate(d *schema.ResourceData, m interface{}) 
 	parents := getVpcParentsFromContext(getSessionContext(d, m))
 	displayName := d.Get("display_name").(string)
 	description := d.Get("description").(string)
-	tags := getPolicyTagsFromSchema(d)
+	tags, tagErr := getValidatedTagsFromSchema(d)
+	if tagErr != nil {
+		return tagErr
+	}
 
 	obj := model.VpcServiceProfile{
 		DisplayName: &displayName,
@@ -406,7 +409,10 @@ func resourceNsxtVpcServiceProfileUpdate(d *schema.ResourceData, m interface{}) 
 	parents := getVpcParentsFromContext(getSessionContext(d, m))
 	description := d.Get("description").(string)
 	displayName := d.Get("display_name").(string)
-	tags := getPolicyTagsFromSchema(d)
+	tags, tagErr := getValidatedTagsFromSchema(d)
+	if tagErr != nil {
+		return tagErr
+	}
 
 	revision := int64(d.Get("revision").(int))
 


### PR DESCRIPTION
To avoid exessive merges, non-vpc resources will follow later.