### PR TITLE
Remove is_default flag from vpc service profile

### DIFF
--- a/nsxt/resource_nsxt_vpc_service_profile.go
+++ b/nsxt/resource_nsxt_vpc_service_profile.go
@@ -41,16 +41,6 @@ var vpcServiceProfileSchema = map[string]*metadata.ExtendedSchema{
 	"revision":     metadata.GetExtendedSchema(getRevisionSchema()),
 	"tag":          metadata.GetExtendedSchema(getTagsSchema()),
 	"context":      metadata.GetExtendedSchema(getContextSchema(true, false, false)),
-	"is_default": {
-		Schema: schema.Schema{
-			Type:     schema.TypeBool,
-			Optional: true,
-		},
-		Metadata: metadata.Metadata{
-			SchemaType:   "bool",
-			SdkFieldName: "IsDefault",
-		},
-	},
 	"mac_discovery_profile": {
 		Schema: schema.Schema{
 			Type:         schema.TypeString,

--- a/nsxt/resource_nsxt_vpc_service_profile_test.go
+++ b/nsxt/resource_nsxt_vpc_service_profile_test.go
@@ -46,7 +46,7 @@ func TestAccResourceNsxtVpcServiceProfile_basic(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNsxtVpcServiceProfileTemplate(true),
+				Config: testAccNsxtVpcServiceProfileTemplate(true, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNsxtVpcServiceProfileExists(accTestPolicyVpcServiceProfileCreateAttributes["display_name"], testResourceName),
 					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestPolicyVpcServiceProfileCreateAttributes["display_name"]),
@@ -68,7 +68,35 @@ func TestAccResourceNsxtVpcServiceProfile_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNsxtVpcServiceProfileTemplate(false),
+				// add profiles
+				Config: testAccNsxtVpcServiceProfileTemplate(true, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtVpcServiceProfileExists(accTestPolicyVpcServiceProfileCreateAttributes["display_name"], testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestPolicyVpcServiceProfileCreateAttributes["display_name"]),
+					resource.TestCheckResourceAttr(testResourceName, "description", accTestPolicyVpcServiceProfileCreateAttributes["description"]),
+					resource.TestCheckResourceAttr(testResourceName, "dns_forwarder_config.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "dhcp_config.0.ntp_servers.0", accTestPolicyVpcServiceProfileCreateAttributes["ntp_servers"]),
+					resource.TestCheckResourceAttr(testResourceName, "dhcp_config.0.dns_client_config.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "dhcp_config.0.lease_time", accTestPolicyVpcServiceProfileCreateAttributes["lease_time"]),
+					resource.TestCheckResourceAttr(testResourceName, "dhcp_config.0.mode", accTestPolicyVpcServiceProfileCreateAttributes["mode"]),
+					resource.TestCheckResourceAttr(testResourceName, "dhcp_config.0.dhcp_relay_config.#", "0"),
+					resource.TestCheckResourceAttr(testResourceName, "dhcp_config.0.dns_client_config.0.dns_server_ips.0", accTestPolicyVpcServiceProfileCreateAttributes["dns_server_ips"]),
+					resource.TestCheckResourceAttr(testResourceName, "dns_forwarder_config.0.cache_size", accTestPolicyVpcServiceProfileCreateAttributes["cache_size"]),
+					resource.TestCheckResourceAttr(testResourceName, "dns_forwarder_config.0.log_level", accTestPolicyVpcServiceProfileCreateAttributes["log_level"]),
+
+					resource.TestCheckResourceAttrSet(testResourceName, "qos_profile"),
+					resource.TestCheckResourceAttrSet(testResourceName, "spoof_guard_profile"),
+					resource.TestCheckResourceAttrSet(testResourceName, "ip_discovery_profile"),
+					resource.TestCheckResourceAttrSet(testResourceName, "mac_discovery_profile"),
+					resource.TestCheckResourceAttrSet(testResourceName, "security_profile"),
+					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
+				),
+			},
+			{
+				Config: testAccNsxtVpcServiceProfileTemplate(false, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNsxtVpcServiceProfileExists(accTestPolicyVpcServiceProfileUpdateAttributes["display_name"], testResourceName),
 					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestPolicyVpcServiceProfileUpdateAttributes["display_name"]),
@@ -84,6 +112,11 @@ func TestAccResourceNsxtVpcServiceProfile_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(testResourceName, "dns_forwarder_config.0.cache_size", accTestPolicyVpcServiceProfileUpdateAttributes["cache_size"]),
 					resource.TestCheckResourceAttr(testResourceName, "dns_forwarder_config.0.log_level", accTestPolicyVpcServiceProfileUpdateAttributes["log_level"]),
 
+					resource.TestCheckResourceAttr(testResourceName, "qos_profile", ""),
+					resource.TestCheckResourceAttr(testResourceName, "spoof_guard_profile", ""),
+					resource.TestCheckResourceAttr(testResourceName, "ip_discovery_profile", ""),
+					resource.TestCheckResourceAttr(testResourceName, "mac_discovery_profile", ""),
+					resource.TestCheckResourceAttr(testResourceName, "security_profile", ""),
 					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
 					resource.TestCheckResourceAttrSet(testResourceName, "path"),
 					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
@@ -177,15 +210,55 @@ func testAccNsxtVpcServiceProfileCheckDestroy(state *terraform.State, displayNam
 	return nil
 }
 
-func testAccNsxtVpcServiceProfileTemplate(createFlow bool) string {
+var testAccNsxtVpcServiceProfileHelper = getAccTestResourceName()
+
+func testAccNsxtProjectProfiles() string {
+	return fmt.Sprintf(`
+resource "nsxt_policy_mac_discovery_profile" "test" {
+  %s
+  display_name = "%s"
+}
+
+resource "nsxt_policy_ip_discovery_profile" "test" {
+  %s
+  display_name = "%s"
+}
+
+resource "nsxt_policy_spoof_guard_profile" "test" {
+  %s
+  display_name = "%s"
+}
+
+resource "nsxt_policy_segment_security_profile" "test"{
+  %s
+  display_name = "%s"
+}
+
+resource "nsxt_policy_qos_profile" "test" {
+  %s
+  display_name = "%s"
+}`, testAccNsxtProjectContext(), testAccNsxtVpcServiceProfileHelper, testAccNsxtProjectContext(), testAccNsxtVpcServiceProfileHelper, testAccNsxtProjectContext(), testAccNsxtVpcServiceProfileHelper, testAccNsxtProjectContext(), testAccNsxtVpcServiceProfileHelper, testAccNsxtProjectContext(), testAccNsxtVpcServiceProfileHelper)
+}
+
+func testAccNsxtVpcServiceProfileTemplate(createFlow bool, withProfiles bool) string {
 	var attrMap map[string]string
 	if createFlow {
 		attrMap = accTestPolicyVpcServiceProfileCreateAttributes
 	} else {
 		attrMap = accTestPolicyVpcServiceProfileUpdateAttributes
 	}
-	return fmt.Sprintf(`
+	profileAssignment := ""
+	if withProfiles {
+		profileAssignment = `
+  qos_profile           = nsxt_policy_qos_profile.test.path
+  security_profile      = nsxt_policy_segment_security_profile.test.path
+  ip_discovery_profile  = nsxt_policy_ip_discovery_profile.test.path
+  spoof_guard_profile   = nsxt_policy_spoof_guard_profile.test.path
+  mac_discovery_profile = nsxt_policy_mac_discovery_profile.test.path`
+	}
+	return testAccNsxtProjectProfiles() + fmt.Sprintf(`
 resource "nsxt_vpc_service_profile" "test" {
+  %s
   %s
   display_name = "%s"
   description  = "%s"
@@ -210,7 +283,7 @@ resource "nsxt_vpc_service_profile" "test" {
     scope = "scope1"
     tag   = "tag1"
   }
-}`, testAccNsxtProjectContext(), attrMap["display_name"], attrMap["description"], attrMap["ntp_servers"], attrMap["lease_time"], attrMap["mode"], attrMap["dns_server_ips"], attrMap["cache_size"], attrMap["log_level"])
+}`, testAccNsxtProjectContext(), profileAssignment, attrMap["display_name"], attrMap["description"], attrMap["ntp_servers"], attrMap["lease_time"], attrMap["mode"], attrMap["dns_server_ips"], attrMap["cache_size"], attrMap["log_level"])
 }
 
 func testAccNsxtVpcServiceProfileMinimalistic() string {


### PR DESCRIPTION
This flag cannot be set to true via API and thus adds no value. In addition, add qos etc. profile tests to the test suite