### PR TITLE
Sync Project resource with latest API

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -142,6 +142,7 @@ github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAh
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
 github.com/vmware/go-vmware-nsxt v0.0.0-20220328155605-f49a14c1ef5f h1:NbC9yOr5At92seXK+kOr2TzU3mIWzcJOVzZasGSuwoU=
 github.com/vmware/go-vmware-nsxt v0.0.0-20220328155605-f49a14c1ef5f/go.mod h1:VEqcmf4Sp7gPB7z05QGyKVmn6xWppr7Nz8cVNvyC80o=
+github.com/vmware/vsphere-automation-sdk-go/services/nsxt v0.12.0/go.mod h1:upLH9b9zpG86P0wwO4+gREf0lBXr8gYcs7P1FRZ9n30=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/zclconf/go-cty v1.14.0 h1:/Xrd39K7DXbHzlisFP9c4pHao4yyf+/Ug9LEz+Y/yhc=

--- a/nsxt/resource_nsxt_policy_project_test.go
+++ b/nsxt/resource_nsxt_policy_project_test.go
@@ -4,8 +4,11 @@
 package nsxt
 
 import (
+	"bytes"
 	"fmt"
+	"strconv"
 	"testing"
+	"text/template"
 
 	"github.com/vmware/terraform-provider-nsxt/nsxt/util"
 
@@ -16,15 +19,15 @@ import (
 var shortID = getAccTestRandomString(6)
 
 var accTestPolicyProjectCreateAttributes = map[string]string{
-	"display_name": getAccTestResourceName(),
-	"description":  "terraform created",
-	"short_id":     shortID,
+	"DisplayName": getAccTestResourceName(),
+	"Description": "terraform created",
+	"ShortId":     shortID,
 }
 
 var accTestPolicyProjectUpdateAttributes = map[string]string{
-	"display_name": getAccTestResourceName(),
-	"description":  "terraform updated",
-	"short_id":     shortID,
+	"DisplayName": getAccTestResourceName(),
+	"Description": "terraform updated",
+	"ShortId":     shortID,
 }
 
 func getExpectedSiteInfoCount(t *testing.T) string {
@@ -47,14 +50,116 @@ func getExpectedSiteInfoCount(t *testing.T) string {
 	return "0"
 }
 
+func runChecksNsx410(testResourceName string, attributes map[string]string, expectedValues map[string]string) resource.TestCheckFunc {
+	return resource.ComposeTestCheckFunc(
+		testAccNsxtPolicyProjectExists(accTestPolicyProjectCreateAttributes["DisplayName"], testResourceName),
+		resource.TestCheckResourceAttr(testResourceName, "display_name", attributes["DisplayName"]),
+		resource.TestCheckResourceAttr(testResourceName, "description", attributes["Description"]),
+		resource.TestCheckResourceAttr(testResourceName, "short_id", attributes["ShortId"]),
+		//TODO: add site info validation
+		resource.TestCheckResourceAttr(testResourceName, "site_info.#", expectedValues["site_count"]),
+		resource.TestCheckResourceAttr(testResourceName, "tier0_gateway_paths.#", expectedValues["t0_count"]),
+
+		resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
+		resource.TestCheckResourceAttrSet(testResourceName, "path"),
+		resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+		resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
+	)
+}
+
+func runChecksNsx411(testResourceName string, expectedValues map[string]string) resource.TestCheckFunc {
+	return resource.ComposeTestCheckFunc(
+		resource.TestCheckResourceAttr(testResourceName, "external_ipv4_blocks.#", expectedValues["ip_block_count"]),
+		resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
+	)
+}
+
+func runChecksNsx420(testResourceName string, expectedValues map[string]string) resource.TestCheckFunc {
+	return resource.ComposeTestCheckFunc(
+		resource.TestCheckResourceAttr(testResourceName, "activate_default_dfw_rules", expectedValues["activate_default_dfw_rules"]),
+		resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
+	)
+}
+
+func runChecksNsx900(testResourceName string, expectedValues map[string]string) resource.TestCheckFunc {
+	return resource.ComposeTestCheckFunc(
+		resource.TestCheckResourceAttr(testResourceName, "tgw_external_connections.#", expectedValues["tgw_ext_conn_count"]),
+		resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
+	)
+}
+
 func TestAccResourceNsxtPolicyProject_basic(t *testing.T) {
 	testResourceName := "nsxt_policy_project.test"
-
+	siteCount := getExpectedSiteInfoCount(t)
+	expectedValuesStep1 := map[string]string{
+		"t0_count":   "1",
+		"site_count": siteCount,
+	}
+	expectedValuesStep2 := expectedValuesStep1
+	expectedValuesStep3 := map[string]string{
+		"t0_count":   "0",
+		"site_count": siteCount,
+	}
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccOnlyLocalManager(t)
 			testAccNSXVersion(t, "4.1.0")
+			testAccNSXVersionLessThan(t, "4.1.1")
+		},
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyProjectCheckDestroy(state, accTestPolicyProjectUpdateAttributes["DisplayName"])
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyProjectTemplate410(true, true),
+				Check:  runChecksNsx410(testResourceName, accTestPolicyProjectCreateAttributes, expectedValuesStep1),
+			},
+			{
+				Config: testAccNsxtPolicyProjectTemplate410(false, true),
+				Check:  runChecksNsx410(testResourceName, accTestPolicyProjectUpdateAttributes, expectedValuesStep2),
+			},
+			{
+				Config: testAccNsxtPolicyProjectTemplate410(false, false),
+				Check:  runChecksNsx410(testResourceName, accTestPolicyProjectUpdateAttributes, expectedValuesStep3),
+			},
+			{
+				Config: testAccNsxtPolicyProjectMinimalistic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicyProjectExists(accTestPolicyProjectCreateAttributes["DisplayName"], testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "description", ""),
+					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+					resource.TestCheckResourceAttr(testResourceName, "tag.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceNsxtPolicyProject_411basic(t *testing.T) {
+	testResourceName := "nsxt_policy_project.test"
+	siteCount := getExpectedSiteInfoCount(t)
+	expectedValuesStep1 := map[string]string{
+		"t0_count":       "1",
+		"ip_block_count": "1",
+		"site_count":     siteCount,
+	}
+	expectedValuesStep2 := expectedValuesStep1
+	expectedValuesStep3 := map[string]string{
+		"t0_count":       "0",
+		"ip_block_count": "0",
+		"site_count":     siteCount,
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccOnlyLocalManager(t)
+			testAccNSXVersion(t, "4.1.1")
+			testAccNSXVersionLessThan(t, "4.2.0")
 		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
@@ -62,63 +167,134 @@ func TestAccResourceNsxtPolicyProject_basic(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNsxtPolicyProjectTemplate(true, true),
+				Config: testAccNsxtPolicyProjectTemplate411(true, true, true),
 				Check: resource.ComposeTestCheckFunc(
-					testAccNsxtPolicyProjectExists(accTestPolicyProjectCreateAttributes["display_name"], testResourceName),
-					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestPolicyProjectCreateAttributes["display_name"]),
-					resource.TestCheckResourceAttr(testResourceName, "description", accTestPolicyProjectCreateAttributes["description"]),
-					resource.TestCheckResourceAttr(testResourceName, "short_id", accTestPolicyProjectCreateAttributes["short_id"]),
-					//TODO: add site info validation
-					resource.TestCheckResourceAttr(testResourceName, "site_info.#", getExpectedSiteInfoCount(t)),
-					resource.TestCheckResourceAttr(testResourceName, "tier0_gateway_paths.#", "1"),
-
-					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
-					resource.TestCheckResourceAttrSet(testResourceName, "path"),
-					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
-					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
+					runChecksNsx410(testResourceName, accTestPolicyProjectCreateAttributes, expectedValuesStep1),
+					runChecksNsx411(testResourceName, expectedValuesStep1),
 				),
 			},
 			{
-				Config: testAccNsxtPolicyProjectTemplate(false, true),
+				Config: testAccNsxtPolicyProjectTemplate411(false, true, true),
 				Check: resource.ComposeTestCheckFunc(
-					testAccNsxtPolicyProjectExists(accTestPolicyProjectUpdateAttributes["display_name"], testResourceName),
-					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestPolicyProjectUpdateAttributes["display_name"]),
-					resource.TestCheckResourceAttr(testResourceName, "description", accTestPolicyProjectUpdateAttributes["description"]),
-					resource.TestCheckResourceAttr(testResourceName, "short_id", accTestPolicyProjectCreateAttributes["short_id"]),
-					resource.TestCheckResourceAttr(testResourceName, "site_info.#", getExpectedSiteInfoCount(t)),
-					resource.TestCheckResourceAttr(testResourceName, "tier0_gateway_paths.#", "1"),
-
-					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
-					resource.TestCheckResourceAttrSet(testResourceName, "path"),
-					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
-					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
+					runChecksNsx410(testResourceName, accTestPolicyProjectUpdateAttributes, expectedValuesStep2),
+					runChecksNsx411(testResourceName, expectedValuesStep2),
 				),
 			},
 			{
-				Config: testAccNsxtPolicyProjectTemplate(false, false),
+				Config: testAccNsxtPolicyProjectTemplate411(false, false, false),
 				Check: resource.ComposeTestCheckFunc(
-					testAccNsxtPolicyProjectExists(accTestPolicyProjectUpdateAttributes["display_name"], testResourceName),
-					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestPolicyProjectUpdateAttributes["display_name"]),
-					resource.TestCheckResourceAttr(testResourceName, "description", accTestPolicyProjectUpdateAttributes["description"]),
-					resource.TestCheckResourceAttr(testResourceName, "short_id", accTestPolicyProjectCreateAttributes["short_id"]),
-					resource.TestCheckResourceAttr(testResourceName, "site_info.#", getExpectedSiteInfoCount(t)),
-					resource.TestCheckResourceAttr(testResourceName, "tier0_gateway_paths.#", "0"),
+					runChecksNsx410(testResourceName, accTestPolicyProjectUpdateAttributes, expectedValuesStep3),
+					runChecksNsx411(testResourceName, expectedValuesStep3),
+				),
+			},
+		},
+	})
+}
 
-					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
-					resource.TestCheckResourceAttrSet(testResourceName, "path"),
-					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
-					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
+func TestAccResourceNsxtPolicyProject_420basic(t *testing.T) {
+	testResourceName := "nsxt_policy_project.test"
+	siteCount := getExpectedSiteInfoCount(t)
+	expectedValuesStep1 := map[string]string{
+		"t0_count":                   "1",
+		"ip_block_count":             "1",
+		"site_count":                 siteCount,
+		"activate_default_dfw_rules": "false",
+	}
+	expectedValuesStep2 := expectedValuesStep1
+	expectedValuesStep3 := map[string]string{
+		"t0_count":                   "0",
+		"ip_block_count":             "0",
+		"site_count":                 siteCount,
+		"activate_default_dfw_rules": "true",
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccOnlyLocalManager(t)
+			testAccNSXVersion(t, "4.2.0")
+			testAccNSXVersionLessThan(t, "9.0.0")
+		},
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyProjectCheckDestroy(state, accTestPolicyProjectUpdateAttributes["display_name"])
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyProjectTemplate420(true, true, true, false),
+				Check: resource.ComposeTestCheckFunc(
+					runChecksNsx410(testResourceName, accTestPolicyProjectCreateAttributes, expectedValuesStep1),
+					runChecksNsx411(testResourceName, expectedValuesStep1),
+					runChecksNsx420(testResourceName, expectedValuesStep1),
 				),
 			},
 			{
-				Config: testAccNsxtPolicyProjectMinimalistic(),
+				Config: testAccNsxtPolicyProjectTemplate420(false, true, true, false),
 				Check: resource.ComposeTestCheckFunc(
-					testAccNsxtPolicyProjectExists(accTestPolicyProjectCreateAttributes["display_name"], testResourceName),
-					resource.TestCheckResourceAttr(testResourceName, "description", ""),
-					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
-					resource.TestCheckResourceAttrSet(testResourceName, "path"),
-					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
-					resource.TestCheckResourceAttr(testResourceName, "tag.#", "0"),
+					runChecksNsx410(testResourceName, accTestPolicyProjectUpdateAttributes, expectedValuesStep2),
+					runChecksNsx411(testResourceName, expectedValuesStep2),
+					runChecksNsx420(testResourceName, expectedValuesStep2),
+				),
+			},
+			{
+				Config: testAccNsxtPolicyProjectTemplate420(false, false, false, true),
+				Check: resource.ComposeTestCheckFunc(
+					runChecksNsx410(testResourceName, accTestPolicyProjectUpdateAttributes, expectedValuesStep3),
+					runChecksNsx411(testResourceName, expectedValuesStep3),
+					runChecksNsx420(testResourceName, expectedValuesStep3),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceNsxtPolicyProject_900basic(t *testing.T) {
+	testResourceName := "nsxt_policy_project.test"
+	siteCount := getExpectedSiteInfoCount(t)
+	expectedValuesStep1 := map[string]string{
+		"t0_count":                   "1",
+		"ip_block_count":             "1",
+		"tgw_ext_conn_count":         "1",
+		"activate_default_dfw_rules": "true",
+		"site_count":                 siteCount,
+	}
+	expectedValuesStep2 := map[string]string{
+		"t0_count":                   "1",
+		"ip_block_count":             "0",
+		"tgw_ext_conn_count":         "1",
+		"activate_default_dfw_rules": "false",
+		"site_count":                 siteCount,
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccOnlyLocalManager(t)
+			testAccNSXVersion(t, "9.0.0")
+		},
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyProjectCheckDestroy(state, accTestPolicyProjectUpdateAttributes["display_name"])
+		},
+		Steps: []resource.TestStep{
+			{
+				// Create: Set T0, Ext GW connection, Ext IPv4 Block, activate default DFW
+				Config: testAccNsxtPolicyProjectTemplate900(true, true, true, true),
+				Check: resource.ComposeTestCheckFunc(
+					runChecksNsx410(testResourceName, accTestPolicyProjectCreateAttributes, expectedValuesStep1),
+					runChecksNsx411(testResourceName, expectedValuesStep1),
+					runChecksNsx420(testResourceName, expectedValuesStep1),
+					runChecksNsx900(testResourceName, expectedValuesStep1),
+				),
+			},
+			{
+				// Update: Set T0, Ext GW connection, No Ext IPv4 Block, disable default DFW
+				Config: testAccNsxtPolicyProjectTemplate900(false, true, false, false),
+				Check: resource.ComposeTestCheckFunc(
+					runChecksNsx410(testResourceName, accTestPolicyProjectUpdateAttributes, expectedValuesStep2),
+					runChecksNsx411(testResourceName, expectedValuesStep2),
+					runChecksNsx420(testResourceName, expectedValuesStep2),
+					runChecksNsx900(testResourceName, expectedValuesStep2),
 				),
 			},
 		},
@@ -200,34 +376,125 @@ func testAccNsxtPolicyProjectCheckDestroy(state *terraform.State, displayName st
 	return nil
 }
 
-func testAccNsxtPolicyProjectTemplate(createFlow, includeT0GW bool) string {
-	var attrMap map[string]string
-	shortIDSpec := ""
-	t0GW := ""
-	if createFlow {
-		attrMap = accTestPolicyProjectCreateAttributes
-		shortIDSpec = fmt.Sprintf("short_id     = \"%s\"", attrMap["short_id"])
-	} else {
-		attrMap = accTestPolicyProjectUpdateAttributes
-	}
-	if includeT0GW {
-		t0GW = "tier0_gateway_paths = [data.nsxt_policy_tier0_gateway.test.path]"
-	}
-	return fmt.Sprintf(`
+// TODO: Visibility should not be set for 410 tests (attribute exists, different enum values since 411)
+var templateData = `
 data "nsxt_policy_tier0_gateway" "test" {
-  display_name = "%s"
+  display_name = "{{.T0Name}}"
 }
-resource "nsxt_policy_project" "test" {
-  display_name = "%s"
-  description  = "%s"
-  %s
-  %s
 
+resource "nsxt_policy_ip_block" "test_ip_block" {
+  display_name = "test_ip_block"
+  cidr         = "10.20.0.0/16"
+  {{if .SetIpBlockVisibility}}visibility   = "EXTERNAL"{{end}}
+}
+
+{{if .ExternalTGWConnectionPath}}resource "nsxt_policy_gateway_connection" "test_gw_conn" {
+  display_name     = "test_gw_conn"
+  tier0_path       = {{.T0GwPath}}
+  aggregate_routes = ["192.168.240.0/24"]
+}{{end}}
+
+resource "nsxt_policy_project" "test" {
+  display_name               = "{{.DisplayName}}"
+  description                = "{{.Description}}"
+  {{if .ShortId}}short_id                   = "{{.ShortId}}"{{end}}
+  {{if .T0GwPath}}tier0_gateway_paths        = [{{.T0GwPath}}]{{end}}
+  {{if .ExternalIPv4BlockPath}}external_ipv4_blocks       = [{{.ExternalIPv4BlockPath}}]{{end}}
+  {{if .ExternalTGWConnectionPath}}tgw_external_connections   = [{{.ExternalTGWConnectionPath}}]{{end}}
+  {{if .ActivateDefaultDfwRules}}activate_default_dfw_rules = {{.ActivateDefaultDfwRules}}{{end}}
   tag {
     scope = "scope1"
     tag   = "tag1"
   }
-}`, getTier0RouterName(), attrMap["display_name"], attrMap["description"], shortIDSpec, t0GW)
+}
+`
+
+func getBasicAttrMap(createFlow, includeT0GW bool) map[string]string {
+	var attrMap map[string]string
+	if createFlow {
+		attrMap = accTestPolicyProjectCreateAttributes
+	} else {
+		// do not pass short_id on update
+		attrMap = make(map[string]string)
+		attrMap["DisplayName"] = accTestPolicyProjectUpdateAttributes["DisplayName"]
+		attrMap["Description"] = accTestPolicyProjectUpdateAttributes["Description"]
+	}
+	if includeT0GW {
+		attrMap["T0GwPath"] = "data.nsxt_policy_tier0_gateway.test.path"
+	}
+	attrMap["T0Name"] = getTier0RouterName()
+	return attrMap
+}
+
+func testAccNsxtPolicyProjectTemplate410(createFlow, includeT0GW bool) string {
+	attrMap := getBasicAttrMap(createFlow, includeT0GW)
+	buffer := new(bytes.Buffer)
+	tmpl, err := template.New("testAaccNsxtPolicyProject").Parse(templateData)
+	if err != nil {
+		panic(err)
+	}
+	err = tmpl.Execute(buffer, attrMap)
+	if err != nil {
+		panic(err)
+	}
+	return buffer.String()
+}
+
+func testAccNsxtPolicyProjectTemplate411(createFlow, includeT0GW, includeExternalIPv4Block bool) string {
+	attrMap := getBasicAttrMap(createFlow, includeT0GW)
+	if includeExternalIPv4Block {
+		attrMap["ExternalIPv4BlockPath"] = "nsxt_policy_ip_block.test_ip_block.path"
+	}
+	attrMap["SetIpBlockVisibility"] = "true"
+	buffer := new(bytes.Buffer)
+	tmpl, err := template.New("testAaccNsxtPolicyProject").Parse(templateData)
+	if err != nil {
+		panic(err)
+	}
+	err = tmpl.Execute(buffer, attrMap)
+	if err != nil {
+		panic(err)
+	}
+	return buffer.String()
+}
+
+func testAccNsxtPolicyProjectTemplate420(createFlow, includeT0GW, includeExternalIPv4Block, activateDefaultDfwRules bool) string {
+	attrMap := getBasicAttrMap(createFlow, includeT0GW)
+	if includeExternalIPv4Block {
+		attrMap["ExternalIPv4BlockPath"] = "nsxt_policy_ip_block.test_ip_block.path"
+	}
+	attrMap["SetIpBlockVisibility"] = "true"
+	attrMap["ActivateDefaultDfwRules"] = strconv.FormatBool(activateDefaultDfwRules)
+	buffer := new(bytes.Buffer)
+	tmpl, err := template.New("testAaccNsxtPolicyProject").Parse(templateData)
+	if err != nil {
+		panic(err)
+	}
+	err = tmpl.Execute(buffer, attrMap)
+	if err != nil {
+		panic(err)
+	}
+	return buffer.String()
+}
+
+func testAccNsxtPolicyProjectTemplate900(createFlow, includeT0GW, includeExternalIPv4Block, activateDefaultDfwRules bool) string {
+	attrMap := getBasicAttrMap(createFlow, includeT0GW)
+	if includeExternalIPv4Block {
+		attrMap["ExternalIPv4BlockPath"] = "nsxt_policy_ip_block.test_ip_block.path"
+	}
+	attrMap["SetIpBlockVisibility"] = "true"
+	attrMap["ActivateDefaultDfwRules"] = strconv.FormatBool(activateDefaultDfwRules)
+	attrMap["ExternalTGWConnectionPath"] = "nsxt_policy_gateway_connection.test_gw_conn.path"
+	buffer := new(bytes.Buffer)
+	tmpl, err := template.New("testAaccNsxtPolicyProject").Parse(templateData)
+	if err != nil {
+		panic(err)
+	}
+	err = tmpl.Execute(buffer, attrMap)
+	if err != nil {
+		panic(err)
+	}
+	return buffer.String()
 }
 
 func testAccNsxtPolicyProjectMinimalistic() string {
@@ -235,5 +502,5 @@ func testAccNsxtPolicyProjectMinimalistic() string {
 resource "nsxt_policy_project" "test" {
   display_name = "%s"
 
-}`, accTestPolicyProjectUpdateAttributes["display_name"])
+}`, accTestPolicyProjectUpdateAttributes["DisplayName"])
 }


### PR DESCRIPTION
This commit adds attributes introduced in recent NSX versions to the Project resource.
This commit also refactors the test module for reourceNSXTPolicyProject adding multiple CRUD tests, each one tailored for a different NSX versions. These tests are meant to be backward compatible, ie: the test for NSX 4.1.0 also works, on 4.1.x, 4.2.x, and subsequent releases.