### PR TITLE
Update vpc_ip_address_allocation

### DIFF
--- a/nsxt/resource_nsxt_vpc_ip_address_allocation.go
+++ b/nsxt/resource_nsxt_vpc_ip_address_allocation.go
@@ -26,6 +26,7 @@ var vpcIpAddressAllocationIpAddressTypeValues = []string{
 var vpcIpAddressAllocationIpAddressBlockVisibilityValues = []string{
 	model.VpcIpAddressAllocation_IP_ADDRESS_BLOCK_VISIBILITY_EXTERNAL,
 	model.VpcIpAddressAllocation_IP_ADDRESS_BLOCK_VISIBILITY_PRIVATE,
+	model.VpcIpAddressAllocation_IP_ADDRESS_BLOCK_VISIBILITY_PRIVATE_TGW,
 }
 
 var vpcIpAddressAllocationSchema = map[string]*metadata.ExtendedSchema{
@@ -58,6 +59,7 @@ var vpcIpAddressAllocationSchema = map[string]*metadata.ExtendedSchema{
 		Metadata: metadata.Metadata{
 			SchemaType:   "int",
 			SdkFieldName: "AllocationSize",
+			OmitIfEmpty:  true,
 		},
 	},
 	"ip_address_type": {


### PR DESCRIPTION
1) Add support for PRIVATE_TGW IP visibility
2) Set OmitIfEmpty=True for allocation_size, to avoid 0 being sent  to NSX when allocating a single address