### PR TITLE
VPC conn profile: do not enable service gateway by default

### DIFF
--- a/nsxt/resource_nsxt_vpc_connectivity_profile.go
+++ b/nsxt/resource_nsxt_vpc_connectivity_profile.go
@@ -167,7 +167,6 @@ var vpcConnectivityProfileSchema = map[string]*metadata.ExtendedSchema{
 						Schema: schema.Schema{
 							Type:     schema.TypeBool,
 							Optional: true,
-							Default:  true,
 						},
 						Metadata: metadata.Metadata{
 							SchemaType:   "bool",


### PR DESCRIPTION
Enabling the service gateway requires specification of an edge cluster, and therefore the default value cannot be "true"