### PR TITLE
[TGW attachment] Fix documentation for connection_path

### DIFF
--- a/website/docs/r/policy_transit_gateway_attachment.html.markdown
+++ b/website/docs/r/policy_transit_gateway_attachment.html.markdown
@@ -30,7 +30,7 @@ The following arguments are supported:
 * `description` - (Optional) Description of the resource.
 * `tag` - (Optional) A list of scope + tag pairs to associate with this resource.
 * `nsx_id` - (Optional) The NSX ID of this resource. If set, this ID will be used to create the resource.
-* `connection_path` - (Optional) Policy path of connectivity profile.
+* `connection_path` - (Optional) Policy path of the desidered transit gateway external connection.
 
 ## Attributes Reference
 


### PR DESCRIPTION
The connection path property is for specifying a TGW external connection rather than a connectivity profile.