### PR TITLE
Drop policy prefix for VPC-related objects naming

### DIFF
--- a/nsxt/provider.go
+++ b/nsxt/provider.go
@@ -507,11 +507,11 @@ func Provider() *schema.Provider {
 			"nsxt_transit_gateway":                                     resourceNsxtTransitGateway(),
 			"nsxt_policy_share":                                        resourceNsxtPolicyShare(),
 			"nsxt_policy_shared_resource":                              resourceNsxtPolicySharedResource(),
-			"nsxt_policy_gateway_connection":                           resourceNsxtPolicyGatewayConnection(),
+			"nsxt_gateway_connection":                                  resourceNsxtGatewayConnection(),
 			"nsxt_vpc":                                                 resourceNsxtVpc(),
 			"nsxt_vpc_nat_rule":                                        resourceNsxtPolicyVpcNatRule(),
 			"nsxt_vpc_ip_address_allocation":                           resourceNsxtVpcIpAddressAllocation(),
-			"nsxt_policy_transit_gateway_attachment":                   resourceNsxtPolicyTransitGatewayAttachment(),
+			"nsxt_transit_gateway_attachment":                          resourceNsxtTransitGatewayAttachment(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/nsxt/resource_nsxt_gateway_connection.go
+++ b/nsxt/resource_nsxt_gateway_connection.go
@@ -73,12 +73,12 @@ var gatewayConnectionSchema = map[string]*metadata.ExtendedSchema{
 	},
 }
 
-func resourceNsxtPolicyGatewayConnection() *schema.Resource {
+func resourceNsxtGatewayConnection() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceNsxtPolicyGatewayConnectionCreate,
-		Read:   resourceNsxtPolicyGatewayConnectionRead,
-		Update: resourceNsxtPolicyGatewayConnectionUpdate,
-		Delete: resourceNsxtPolicyGatewayConnectionDelete,
+		Create: resourceNsxtGatewayConnectionCreate,
+		Read:   resourceNsxtGatewayConnectionRead,
+		Update: resourceNsxtGatewayConnectionUpdate,
+		Delete: resourceNsxtGatewayConnectionDelete,
 		Importer: &schema.ResourceImporter{
 			State: nsxtPolicyPathResourceImporter,
 		},
@@ -86,7 +86,7 @@ func resourceNsxtPolicyGatewayConnection() *schema.Resource {
 	}
 }
 
-func resourceNsxtPolicyGatewayConnectionExists(id string, connector client.Connector, isGlobalManager bool) (bool, error) {
+func resourceNsxtGatewayConnectionExists(id string, connector client.Connector, isGlobalManager bool) (bool, error) {
 	var err error
 
 	client := clientLayer.NewGatewayConnectionsClient(connector)
@@ -102,10 +102,10 @@ func resourceNsxtPolicyGatewayConnectionExists(id string, connector client.Conne
 	return false, logAPIError("Error retrieving resource", err)
 }
 
-func resourceNsxtPolicyGatewayConnectionCreate(d *schema.ResourceData, m interface{}) error {
+func resourceNsxtGatewayConnectionCreate(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
 
-	id, err := getOrGenerateID(d, m, resourceNsxtPolicyGatewayConnectionExists)
+	id, err := getOrGenerateID(d, m, resourceNsxtGatewayConnectionExists)
 	if err != nil {
 		return err
 	}
@@ -135,10 +135,10 @@ func resourceNsxtPolicyGatewayConnectionCreate(d *schema.ResourceData, m interfa
 	d.SetId(id)
 	d.Set("nsx_id", id)
 
-	return resourceNsxtPolicyGatewayConnectionRead(d, m)
+	return resourceNsxtGatewayConnectionRead(d, m)
 }
 
-func resourceNsxtPolicyGatewayConnectionRead(d *schema.ResourceData, m interface{}) error {
+func resourceNsxtGatewayConnectionRead(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
 
 	id := d.Id()
@@ -164,7 +164,7 @@ func resourceNsxtPolicyGatewayConnectionRead(d *schema.ResourceData, m interface
 	return metadata.StructToSchema(elem, d, gatewayConnectionSchema, "", nil)
 }
 
-func resourceNsxtPolicyGatewayConnectionUpdate(d *schema.ResourceData, m interface{}) error {
+func resourceNsxtGatewayConnectionUpdate(d *schema.ResourceData, m interface{}) error {
 
 	connector := getPolicyConnector(m)
 
@@ -196,10 +196,10 @@ func resourceNsxtPolicyGatewayConnectionUpdate(d *schema.ResourceData, m interfa
 		return handleUpdateError("GatewayConnection", id, err)
 	}
 
-	return resourceNsxtPolicyGatewayConnectionRead(d, m)
+	return resourceNsxtGatewayConnectionRead(d, m)
 }
 
-func resourceNsxtPolicyGatewayConnectionDelete(d *schema.ResourceData, m interface{}) error {
+func resourceNsxtGatewayConnectionDelete(d *schema.ResourceData, m interface{}) error {
 	id := d.Id()
 	if id == "" {
 		return fmt.Errorf("Error obtaining GatewayConnection ID")

--- a/nsxt/resource_nsxt_gateway_connection_test.go
+++ b/nsxt/resource_nsxt_gateway_connection_test.go
@@ -11,20 +11,20 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-var accTestPolicyGatewayConnectionCreateAttributes = map[string]string{
+var accTestGatewayConnectionCreateAttributes = map[string]string{
 	"display_name":     getAccTestResourceName(),
 	"description":      "terraform created",
 	"aggregate_routes": "192.168.240.0/24",
 }
 
-var accTestPolicyGatewayConnectionUpdateAttributes = map[string]string{
+var accTestGatewayConnectionUpdateAttributes = map[string]string{
 	"display_name":     getAccTestResourceName(),
 	"description":      "terraform updated",
 	"aggregate_routes": "192.168.241.0/24",
 }
 
-func TestAccResourceNsxtPolicyGatewayConnection_basic(t *testing.T) {
-	testResourceName := "nsxt_policy_gateway_connection.test"
+func TestAccResourceNsxtGatewayConnection_basic(t *testing.T) {
+	testResourceName := "nsxt_gateway_connection.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -33,16 +33,16 @@ func TestAccResourceNsxtPolicyGatewayConnection_basic(t *testing.T) {
 		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNsxtPolicyGatewayConnectionCheckDestroy(state, accTestPolicyGatewayConnectionUpdateAttributes["display_name"])
+			return testAccNsxtGatewayConnectionCheckDestroy(state, accTestGatewayConnectionUpdateAttributes["display_name"])
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNsxtPolicyGatewayConnectionTemplate(true),
+				Config: testAccNsxtGatewayConnectionTemplate(true),
 				Check: resource.ComposeTestCheckFunc(
-					testAccNsxtPolicyGatewayConnectionExists(accTestPolicyGatewayConnectionCreateAttributes["display_name"], testResourceName),
-					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestPolicyGatewayConnectionCreateAttributes["display_name"]),
-					resource.TestCheckResourceAttr(testResourceName, "description", accTestPolicyGatewayConnectionCreateAttributes["description"]),
-					resource.TestCheckResourceAttr(testResourceName, "aggregate_routes.0", accTestPolicyGatewayConnectionCreateAttributes["aggregate_routes"]),
+					testAccNsxtGatewayConnectionExists(accTestGatewayConnectionCreateAttributes["display_name"], testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestGatewayConnectionCreateAttributes["display_name"]),
+					resource.TestCheckResourceAttr(testResourceName, "description", accTestGatewayConnectionCreateAttributes["description"]),
+					resource.TestCheckResourceAttr(testResourceName, "aggregate_routes.0", accTestGatewayConnectionCreateAttributes["aggregate_routes"]),
 					resource.TestCheckResourceAttrSet(testResourceName, "tier0_path"),
 
 					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
@@ -52,12 +52,12 @@ func TestAccResourceNsxtPolicyGatewayConnection_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNsxtPolicyGatewayConnectionTemplate(false),
+				Config: testAccNsxtGatewayConnectionTemplate(false),
 				Check: resource.ComposeTestCheckFunc(
-					testAccNsxtPolicyGatewayConnectionExists(accTestPolicyGatewayConnectionUpdateAttributes["display_name"], testResourceName),
-					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestPolicyGatewayConnectionUpdateAttributes["display_name"]),
-					resource.TestCheckResourceAttr(testResourceName, "description", accTestPolicyGatewayConnectionUpdateAttributes["description"]),
-					resource.TestCheckResourceAttr(testResourceName, "aggregate_routes.0", accTestPolicyGatewayConnectionUpdateAttributes["aggregate_routes"]),
+					testAccNsxtGatewayConnectionExists(accTestGatewayConnectionUpdateAttributes["display_name"], testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestGatewayConnectionUpdateAttributes["display_name"]),
+					resource.TestCheckResourceAttr(testResourceName, "description", accTestGatewayConnectionUpdateAttributes["description"]),
+					resource.TestCheckResourceAttr(testResourceName, "aggregate_routes.0", accTestGatewayConnectionUpdateAttributes["aggregate_routes"]),
 					resource.TestCheckResourceAttrSet(testResourceName, "tier0_path"),
 
 					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
@@ -67,9 +67,9 @@ func TestAccResourceNsxtPolicyGatewayConnection_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNsxtPolicyGatewayConnectionMinimalistic(),
+				Config: testAccNsxtGatewayConnectionMinimalistic(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccNsxtPolicyGatewayConnectionExists(accTestPolicyGatewayConnectionCreateAttributes["display_name"], testResourceName),
+					testAccNsxtGatewayConnectionExists(accTestGatewayConnectionCreateAttributes["display_name"], testResourceName),
 					resource.TestCheckResourceAttr(testResourceName, "description", ""),
 					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
 					resource.TestCheckResourceAttrSet(testResourceName, "path"),
@@ -81,9 +81,9 @@ func TestAccResourceNsxtPolicyGatewayConnection_basic(t *testing.T) {
 	})
 }
 
-func TestAccResourceNsxtPolicyGatewayConnection_importBasic(t *testing.T) {
+func TestAccResourceNsxtGatewayConnection_importBasic(t *testing.T) {
 	name := getAccTestResourceName()
-	testResourceName := "nsxt_policy_gateway_connection.test"
+	testResourceName := "nsxt_gateway_connection.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -92,11 +92,11 @@ func TestAccResourceNsxtPolicyGatewayConnection_importBasic(t *testing.T) {
 		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNsxtPolicyGatewayConnectionCheckDestroy(state, name)
+			return testAccNsxtGatewayConnectionCheckDestroy(state, name)
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNsxtPolicyGatewayConnectionMinimalistic(),
+				Config: testAccNsxtGatewayConnectionMinimalistic(),
 			},
 			{
 				ResourceName:      testResourceName,
@@ -107,7 +107,7 @@ func TestAccResourceNsxtPolicyGatewayConnection_importBasic(t *testing.T) {
 	})
 }
 
-func testAccNsxtPolicyGatewayConnectionExists(displayName string, resourceName string) resource.TestCheckFunc {
+func testAccNsxtGatewayConnectionExists(displayName string, resourceName string) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
 
 		connector := getPolicyConnector(testAccProvider.Meta().(nsxtClients))
@@ -122,7 +122,7 @@ func testAccNsxtPolicyGatewayConnectionExists(displayName string, resourceName s
 			return fmt.Errorf("Policy GatewayConnection resource ID not set in resources")
 		}
 
-		exists, err := resourceNsxtPolicyGatewayConnectionExists(resourceID, connector, testAccIsGlobalManager())
+		exists, err := resourceNsxtGatewayConnectionExists(resourceID, connector, testAccIsGlobalManager())
 		if err != nil {
 			return err
 		}
@@ -134,16 +134,16 @@ func testAccNsxtPolicyGatewayConnectionExists(displayName string, resourceName s
 	}
 }
 
-func testAccNsxtPolicyGatewayConnectionCheckDestroy(state *terraform.State, displayName string) error {
+func testAccNsxtGatewayConnectionCheckDestroy(state *terraform.State, displayName string) error {
 	connector := getPolicyConnector(testAccProvider.Meta().(nsxtClients))
 	for _, rs := range state.RootModule().Resources {
 
-		if rs.Type != "nsxt_policy_gateway_connection" {
+		if rs.Type != "nsxt_gateway_connection" {
 			continue
 		}
 
 		resourceID := rs.Primary.Attributes["id"]
-		exists, err := resourceNsxtPolicyGatewayConnectionExists(resourceID, connector, testAccIsGlobalManager())
+		exists, err := resourceNsxtGatewayConnectionExists(resourceID, connector, testAccIsGlobalManager())
 		if err == nil {
 			return err
 		}
@@ -155,12 +155,12 @@ func testAccNsxtPolicyGatewayConnectionCheckDestroy(state *terraform.State, disp
 	return nil
 }
 
-func testAccNsxtPolicyGatewayConnectionTemplate(createFlow bool) string {
+func testAccNsxtGatewayConnectionTemplate(createFlow bool) string {
 	var attrMap map[string]string
 	if createFlow {
-		attrMap = accTestPolicyGatewayConnectionCreateAttributes
+		attrMap = accTestGatewayConnectionCreateAttributes
 	} else {
-		attrMap = accTestPolicyGatewayConnectionUpdateAttributes
+		attrMap = accTestGatewayConnectionUpdateAttributes
 	}
 	return fmt.Sprintf(`
 data "nsxt_policy_edge_cluster" "EC" {
@@ -172,7 +172,7 @@ resource "nsxt_policy_tier0_gateway" "test" {
   edge_cluster_path = data.nsxt_policy_edge_cluster.EC.path
 }
 
-resource "nsxt_policy_gateway_connection" "test" {
+resource "nsxt_gateway_connection" "test" {
   display_name = "%s"
   description  = "%s"
   tier0_path = nsxt_policy_tier0_gateway.test.path
@@ -185,10 +185,10 @@ resource "nsxt_policy_gateway_connection" "test" {
 }`, getEdgeClusterName(), attrMap["display_name"], attrMap["description"], attrMap["aggregate_routes"])
 }
 
-func testAccNsxtPolicyGatewayConnectionMinimalistic() string {
+func testAccNsxtGatewayConnectionMinimalistic() string {
 	return fmt.Sprintf(`
-resource "nsxt_policy_gateway_connection" "test" {
+resource "nsxt_gateway_connection" "test" {
   display_name = "%s"
 
-}`, accTestPolicyGatewayConnectionUpdateAttributes["display_name"])
+}`, accTestGatewayConnectionUpdateAttributes["display_name"])
 }

--- a/nsxt/resource_nsxt_transit_gateway_attachment.go
+++ b/nsxt/resource_nsxt_transit_gateway_attachment.go
@@ -40,12 +40,12 @@ var transitGatewayAttachmentSchema = map[string]*metadata.ExtendedSchema{
 	},
 }
 
-func resourceNsxtPolicyTransitGatewayAttachment() *schema.Resource {
+func resourceNsxtTransitGatewayAttachment() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceNsxtPolicyTransitGatewayAttachmentCreate,
-		Read:   resourceNsxtPolicyTransitGatewayAttachmentRead,
-		Update: resourceNsxtPolicyTransitGatewayAttachmentUpdate,
-		Delete: resourceNsxtPolicyTransitGatewayAttachmentDelete,
+		Create: resourceNsxtTransitGatewayAttachmentCreate,
+		Read:   resourceNsxtTransitGatewayAttachmentRead,
+		Update: resourceNsxtTransitGatewayAttachmentUpdate,
+		Delete: resourceNsxtTransitGatewayAttachmentDelete,
 		Importer: &schema.ResourceImporter{
 			State: nsxtParentPathResourceImporter,
 		},
@@ -53,7 +53,7 @@ func resourceNsxtPolicyTransitGatewayAttachment() *schema.Resource {
 	}
 }
 
-func resourceNsxtPolicyTransitGatewayAttachmentExists(sessionContext utl.SessionContext, parentPath string, id string, connector client.Connector) (bool, error) {
+func resourceNsxtTransitGatewayAttachmentExists(sessionContext utl.SessionContext, parentPath string, id string, connector client.Connector) (bool, error) {
 	var err error
 	parents, pathErr := parseStandardPolicyPathVerifySize(parentPath, 3)
 	if pathErr != nil {
@@ -72,10 +72,10 @@ func resourceNsxtPolicyTransitGatewayAttachmentExists(sessionContext utl.Session
 	return false, logAPIError("Error retrieving resource", err)
 }
 
-func resourceNsxtPolicyTransitGatewayAttachmentCreate(d *schema.ResourceData, m interface{}) error {
+func resourceNsxtTransitGatewayAttachmentCreate(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
 
-	id, err := getOrGenerateIDWithParent(d, m, resourceNsxtPolicyTransitGatewayAttachmentExists)
+	id, err := getOrGenerateIDWithParent(d, m, resourceNsxtTransitGatewayAttachmentExists)
 	if err != nil {
 		return err
 	}
@@ -110,10 +110,10 @@ func resourceNsxtPolicyTransitGatewayAttachmentCreate(d *schema.ResourceData, m 
 	d.SetId(id)
 	d.Set("nsx_id", id)
 
-	return resourceNsxtPolicyTransitGatewayAttachmentRead(d, m)
+	return resourceNsxtTransitGatewayAttachmentRead(d, m)
 }
 
-func resourceNsxtPolicyTransitGatewayAttachmentRead(d *schema.ResourceData, m interface{}) error {
+func resourceNsxtTransitGatewayAttachmentRead(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
 
 	id := d.Id()
@@ -143,7 +143,7 @@ func resourceNsxtPolicyTransitGatewayAttachmentRead(d *schema.ResourceData, m in
 	return metadata.StructToSchema(elem, d, transitGatewayAttachmentSchema, "", nil)
 }
 
-func resourceNsxtPolicyTransitGatewayAttachmentUpdate(d *schema.ResourceData, m interface{}) error {
+func resourceNsxtTransitGatewayAttachmentUpdate(d *schema.ResourceData, m interface{}) error {
 
 	connector := getPolicyConnector(m)
 
@@ -180,10 +180,10 @@ func resourceNsxtPolicyTransitGatewayAttachmentUpdate(d *schema.ResourceData, m 
 		return handleUpdateError("TransitGatewayAttachment", id, err)
 	}
 
-	return resourceNsxtPolicyTransitGatewayAttachmentRead(d, m)
+	return resourceNsxtTransitGatewayAttachmentRead(d, m)
 }
 
-func resourceNsxtPolicyTransitGatewayAttachmentDelete(d *schema.ResourceData, m interface{}) error {
+func resourceNsxtTransitGatewayAttachmentDelete(d *schema.ResourceData, m interface{}) error {
 	id := d.Id()
 	if id == "" {
 		return fmt.Errorf("Error obtaining TransitGatewayAttachment ID")

--- a/nsxt/resource_nsxt_transit_gateway_attachment_test.go
+++ b/nsxt/resource_nsxt_transit_gateway_attachment_test.go
@@ -13,32 +13,32 @@ import (
 
 var dependantEntityName = getAccTestResourceName()
 
-var accTestPolicyTransitGatewayAttachmentCreateAttributes = map[string]string{
+var accTestTransitGatewayAttachmentCreateAttributes = map[string]string{
 	"display_name": getAccTestResourceName(),
 	"description":  "terraform created",
 }
 
-var accTestPolicyTransitGatewayAttachmentUpdateAttributes = map[string]string{
+var accTestTransitGatewayAttachmentUpdateAttributes = map[string]string{
 	"display_name": getAccTestResourceName(),
 	"description":  "terraform updated",
 }
 
-func TestAccResourceNsxtPolicyTransitGatewayAttachment_basic(t *testing.T) {
-	testResourceName := "nsxt_policy_transit_gateway_attachment.test"
+func TestAccResourceNsxtTransitGatewayAttachment_basic(t *testing.T) {
+	testResourceName := "nsxt_transit_gateway_attachment.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNsxtPolicyTransitGatewayAttachmentCheckDestroy(state, accTestPolicyTransitGatewayAttachmentUpdateAttributes["display_name"])
+			return testAccNsxtTransitGatewayAttachmentCheckDestroy(state, accTestTransitGatewayAttachmentUpdateAttributes["display_name"])
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNsxtPolicyTransitGatewayAttachmentTemplate(true),
+				Config: testAccNsxtTransitGatewayAttachmentTemplate(true),
 				Check: resource.ComposeTestCheckFunc(
-					testAccNsxtPolicyTransitGatewayAttachmentExists(accTestPolicyTransitGatewayAttachmentCreateAttributes["display_name"], testResourceName),
-					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestPolicyTransitGatewayAttachmentCreateAttributes["display_name"]),
-					resource.TestCheckResourceAttr(testResourceName, "description", accTestPolicyTransitGatewayAttachmentCreateAttributes["description"]),
+					testAccNsxtTransitGatewayAttachmentExists(accTestTransitGatewayAttachmentCreateAttributes["display_name"], testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestTransitGatewayAttachmentCreateAttributes["display_name"]),
+					resource.TestCheckResourceAttr(testResourceName, "description", accTestTransitGatewayAttachmentCreateAttributes["description"]),
 
 					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
 					resource.TestCheckResourceAttrSet(testResourceName, "path"),
@@ -47,11 +47,11 @@ func TestAccResourceNsxtPolicyTransitGatewayAttachment_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNsxtPolicyTransitGatewayAttachmentTemplate(false),
+				Config: testAccNsxtTransitGatewayAttachmentTemplate(false),
 				Check: resource.ComposeTestCheckFunc(
-					testAccNsxtPolicyTransitGatewayAttachmentExists(accTestPolicyTransitGatewayAttachmentUpdateAttributes["display_name"], testResourceName),
-					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestPolicyTransitGatewayAttachmentUpdateAttributes["display_name"]),
-					resource.TestCheckResourceAttr(testResourceName, "description", accTestPolicyTransitGatewayAttachmentUpdateAttributes["description"]),
+					testAccNsxtTransitGatewayAttachmentExists(accTestTransitGatewayAttachmentUpdateAttributes["display_name"], testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestTransitGatewayAttachmentUpdateAttributes["display_name"]),
+					resource.TestCheckResourceAttr(testResourceName, "description", accTestTransitGatewayAttachmentUpdateAttributes["description"]),
 
 					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
 					resource.TestCheckResourceAttrSet(testResourceName, "path"),
@@ -63,19 +63,19 @@ func TestAccResourceNsxtPolicyTransitGatewayAttachment_basic(t *testing.T) {
 	})
 }
 
-func TestAccResourceNsxtPolicyTransitGatewayAttachment_importBasic(t *testing.T) {
+func TestAccResourceNsxtTransitGatewayAttachment_importBasic(t *testing.T) {
 	name := getAccTestResourceName()
-	testResourceName := "nsxt_policy_transit_gateway_attachment.test"
+	testResourceName := "nsxt_transit_gateway_attachment.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNsxtPolicyTransitGatewayAttachmentCheckDestroy(state, name)
+			return testAccNsxtTransitGatewayAttachmentCheckDestroy(state, name)
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNsxtPolicyTransitGatewayAttachmentTemplate(true),
+				Config: testAccNsxtTransitGatewayAttachmentTemplate(true),
 			},
 			{
 				ResourceName:      testResourceName,
@@ -87,7 +87,7 @@ func TestAccResourceNsxtPolicyTransitGatewayAttachment_importBasic(t *testing.T)
 	})
 }
 
-func testAccNsxtPolicyTransitGatewayAttachmentExists(displayName string, resourceName string) resource.TestCheckFunc {
+func testAccNsxtTransitGatewayAttachmentExists(displayName string, resourceName string) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
 
 		connector := getPolicyConnector(testAccProvider.Meta().(nsxtClients))
@@ -103,7 +103,7 @@ func testAccNsxtPolicyTransitGatewayAttachmentExists(displayName string, resourc
 		}
 
 		parentPath := rs.Primary.Attributes["parent_path"]
-		exists, err := resourceNsxtPolicyTransitGatewayAttachmentExists(testAccGetSessionContext(), parentPath, resourceID, connector)
+		exists, err := resourceNsxtTransitGatewayAttachmentExists(testAccGetSessionContext(), parentPath, resourceID, connector)
 		if err != nil {
 			return err
 		}
@@ -115,17 +115,17 @@ func testAccNsxtPolicyTransitGatewayAttachmentExists(displayName string, resourc
 	}
 }
 
-func testAccNsxtPolicyTransitGatewayAttachmentCheckDestroy(state *terraform.State, displayName string) error {
+func testAccNsxtTransitGatewayAttachmentCheckDestroy(state *terraform.State, displayName string) error {
 	connector := getPolicyConnector(testAccProvider.Meta().(nsxtClients))
 	for _, rs := range state.RootModule().Resources {
 
-		if rs.Type != "nsxt_policy_transit_gateway_attachment" {
+		if rs.Type != "nsxt_transit_gateway_attachment" {
 			continue
 		}
 
 		resourceID := rs.Primary.Attributes["id"]
 		parentPath := rs.Primary.Attributes["parent_path"]
-		exists, err := resourceNsxtPolicyTransitGatewayAttachmentExists(testAccGetSessionContext(), parentPath, resourceID, connector)
+		exists, err := resourceNsxtTransitGatewayAttachmentExists(testAccGetSessionContext(), parentPath, resourceID, connector)
 		if err == nil {
 			return err
 		}
@@ -137,12 +137,12 @@ func testAccNsxtPolicyTransitGatewayAttachmentCheckDestroy(state *terraform.Stat
 	return nil
 }
 
-func testAccNsxtPolicyTransitGatewayAttachmentTemplate(createFlow bool) string {
+func testAccNsxtTransitGatewayAttachmentTemplate(createFlow bool) string {
 	var attrMap map[string]string
 	if createFlow {
-		attrMap = accTestPolicyTransitGatewayAttachmentCreateAttributes
+		attrMap = accTestTransitGatewayAttachmentCreateAttributes
 	} else {
-		attrMap = accTestPolicyTransitGatewayAttachmentUpdateAttributes
+		attrMap = accTestTransitGatewayAttachmentUpdateAttributes
 	}
 	return fmt.Sprintf(`
 data "nsxt_policy_edge_cluster" "test" {
@@ -163,7 +163,7 @@ resource "nsxt_policy_gateway_connection" "test" {
 resource "nsxt_policy_project" "test" {
   display_name      = "%s"
   tier0_gateway_paths = [nsxt_policy_tier0_gateway.test.path]
-  tgw_external_connections = [nsxt_policy_gateway_connection.test.path]
+  tgw_external_connections = [nsxt_gateway_connection.test.path]
 }
 
 resource "nsxt_transit_gateway" "test" {
@@ -174,9 +174,9 @@ resource "nsxt_transit_gateway" "test" {
   transit_subnets = ["192.168.7.0/24"]
 }
 
-resource "nsxt_policy_transit_gateway_attachment" "test" {
+resource "nsxt_transit_gateway_attachment" "test" {
   parent_path  = nsxt_transit_gateway.test.path
-  connection_path = nsxt_policy_gateway_connection.test.path
+  connection_path = nsxt_gateway_connection.test.path
   display_name = "%s"
   description  = "%s"
 

--- a/website/docs/r/gateway_connection.html.markdown
+++ b/website/docs/r/gateway_connection.html.markdown
@@ -1,13 +1,13 @@
 ---
 subcategory: "Beta"
 layout: "nsxt"
-page_title: "NSXT: nsxt_policy_gateway_connection"
-description: A resource to configure a GatewayConnection.
+page_title: "NSXT: nsxt_gateway_connection"
+description: A resource to configure a Gateway Connection.
 ---
 
-# nsxt_policy_gateway_connection
+# nsxt_gateway_connection
 
-This resource provides a method for the management of a GatewayConnection.
+This resource provides a method for the management of a Gateway Connection.
 
 This resource is applicable to NSX Policy Manager.
 
@@ -18,12 +18,11 @@ data "nsxt_policy_tier0_gateway" "test" {
   display_name = "test-t0gw"
 }
 
-resource "nsxt_policy_gateway_connection" "test" {
+resource "nsxt_gateway_connection" "test" {
   display_name     = "test"
-  description      = "Terraform provisioned GatewayConnection"
+  description      = "Terraform provisioned Gateway Connection"
   tier0_path       = data.nsxt_policy_tier0_gateway.test.path
   aggregate_routes = ["192.168.240.0/24"]
-
 }
 ```
 
@@ -57,7 +56,7 @@ An existing object can be [imported][docs-import] into this resource, via the fo
 [docs-import]: https://www.terraform.io/cli/import
 
 ```
-terraform import nsxt_policy_gateway_connection.test PATH
+terraform import nsxt_gateway_connection.test PATH
 ```
 
 The above command imports GatewayConnection named `test` with the policy path `PATH`.

--- a/website/docs/r/transit_gateway_attachment.html.markdown
+++ b/website/docs/r/transit_gateway_attachment.html.markdown
@@ -1,23 +1,24 @@
 ---
 subcategory: "Beta"
 layout: "nsxt"
-page_title: "NSXT: nsxt_policy_transit_gateway_attachment"
-description: A resource to configure a TransitGatewayAttachment.
+page_title: "NSXT: nsxt_transit_gateway_attachment"
+description: A resource to configure a Transit Gateway Attachment.
 ---
 
-# nsxt_policy_transit_gateway_attachment
+# nsxt_transit_gateway_attachment
 
-This resource provides a method for the management of a TransitGatewayAttachment.
+This resource provides a method for the management of a Transit Gateway Attachment.
 
-This resource is applicable to NSX Global Manager, NSX Policy Manager and VMC.
+This resource is applicable to NSX Policy Manager.
 
 ## Example Usage
 
 ```hcl
-resource "nsxt_policy_transit_gateway_attachment" "test" {
+resource "nsxt_transit_gateway_attachment" "test" {
+  parent_path     = nsxt_transit_gateway.test.path
   display_name    = "test"
-  description     = "Terraform provisioned TransitGatewayAttachment"
-  connection_path = nsxt_policy_vpc_connectivity_profile.test.path
+  description     = "Terraform provisioned Transit Gateway Attachment"
+  connection_path = nsxt_gateway_connection.test.path
 }
 ```
 
@@ -47,7 +48,7 @@ An existing object can be [imported][docs-import] into this resource, via the fo
 [docs-import]: https://www.terraform.io/cli/import
 
 ```
-terraform import nsxt_policy_transit_gateway_attachment.test PATH
+terraform import nsxt_transit_gateway_attachment.test PATH
 ```
 
 The above command imports TransitGatewayAttachment named `test` with the policy path `PATH`.


### PR DESCRIPTION
Since MP resources are deprecated, it makes sense to drop policy prefix for new objects, especially those that are VPC related.