### PR TITLE
[VPC 2.0] Make transit_subnets for TGW computed

### DIFF
--- a/nsxt/resource_nsxt_policy_transit_gateway.go
+++ b/nsxt/resource_nsxt_policy_transit_gateway.go
@@ -38,6 +38,7 @@ var transitGatewaySchema = map[string]*metadata.ExtendedSchema{
 				},
 			},
 			Optional: true,
+			Computed: true,
 		},
 		Metadata: metadata.Metadata{
 			SchemaType:   "list",


### PR DESCRIPTION
NSX sets a default transit subnet for a TGW if None is specified. As this default subnet is returned in the API response, the Terraform provider must treat the transit_subnet attribute as computed.