### PR TITLE
Change default for create_service_account in CM

### DIFF
--- a/nsxt/resource_nsxt_compute_manager.go
+++ b/nsxt/resource_nsxt_compute_manager.go
@@ -46,7 +46,7 @@ func resourceNsxtComputeManager() *schema.Resource {
 				Type:        schema.TypeBool,
 				Description: "Specifies whether service account is created or not on compute manager",
 				Optional:    true,
-				Default:     false,
+				Default:     true,
 			},
 			"credential": {
 				Type:        schema.TypeList,

--- a/website/docs/r/compute_manager.html.markdown
+++ b/website/docs/r/compute_manager.html.markdown
@@ -41,7 +41,7 @@ The following arguments are supported:
 * `description` - (Optional) Description of the resource.
 * `tag` - (Optional) A list of scope + tag pairs to associate with this resource.
 * `access_level_for_oidc` - (Optional) Specifies access level to NSX from the compute manager. Accepted values - 'FULL' or 'LIMITED'. The default value is 'FULL'.
-* `create_service_account` - (Optional) Specifies whether service account is created or not on compute manager.
+* `create_service_account` - (Optional) Specifies whether service account is created or not on compute manager. The default is `true`. Note that only `true` value will be supported from version 9.0.0 onwards.
 * `credential` - (Required) Login credentials for the compute manager. Should contain exactly one credential enlisted below: 
   * `saml_login` - (Optional) A login credential specifying saml token.
     * `thumbprint` - (Required) Thumbprint of the server.


### PR DESCRIPTION
Although changing the default is not a backward compatible change, we are making an exception for this attribute since compute manager without service account will be forbidden in NSX 9.0.0 onwards.