### PR TITLE
[VPC 2.0] Add Private_TGW subnet access mode

### DIFF
--- a/nsxt/resource_nsxt_vpc_subnet.go
+++ b/nsxt/resource_nsxt_vpc_subnet.go
@@ -22,6 +22,7 @@ var vpcSubnetAccessModeValues = []string{
 	model.VpcSubnet_ACCESS_MODE_PRIVATE,
 	model.VpcSubnet_ACCESS_MODE_PUBLIC,
 	model.VpcSubnet_ACCESS_MODE_ISOLATED,
+	model.VpcSubnet_ACCESS_MODE_PRIVATE_TGW,
 }
 
 var vpcSubnetSchema = map[string]*metadata.ExtendedSchema{


### PR DESCRIPTION
This attribute was added with the latest SDK bump, the vpcSubnetModeAccessValues enum must be updated to include it.

Entry has been manually added to enum.