### PR TITLE
Run multitenancy tests in LM setups

### DIFF
--- a/nsxt/utils_test.go
+++ b/nsxt/utils_test.go
@@ -282,7 +282,7 @@ func testAccOnlyGlobalManager(t *testing.T) {
 }
 
 func testAccOnlyLocalManager(t *testing.T) {
-	if testAccIsGlobalManager() || testAccIsMultitenancy() {
+	if testAccIsGlobalManager() {
 		t.Skipf("This test requires a local manager environment")
 	}
 }


### PR DESCRIPTION
DO not skip multitenancy tests in LM environments, given that project id is set