### PR TITLE
Enable VPC policy rule test with context profiles

### DIFF
--- a/nsxt/resource_nsxt_policy_context_profile_test.go
+++ b/nsxt/resource_nsxt_policy_context_profile_test.go
@@ -415,7 +415,7 @@ func testAccNsxtPolicyContextProfileCheckDestroy(state *terraform.State, display
 func testAccNsxtPolicyContextProfileTemplate(name string, attributes string, withContext bool) string {
 	context := ""
 	if withContext {
-		context = testAccNsxtPolicyMultitenancyContext()
+		context = testAccNsxtMultitenancyContext(false)
 	}
 	return fmt.Sprintf(`
 resource "nsxt_policy_context_profile" "test" {

--- a/nsxt/resource_nsxt_vpc_security_policy_test.go
+++ b/nsxt/resource_nsxt_vpc_security_policy_test.go
@@ -110,33 +110,28 @@ func TestAccResourceNsxtVPCSecurityPolicy_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(testResourceName, "rule.0.tag.#", "1"),
 				),
 			},
-			// TODO: For now, creation od the context profile with VPC context crashes the provider. This should be addressed in the
-			//       generated wrappers (check that there is an implementation in VPC (or whatever) context.
-			//       Then, the context profile should be created in the project context, shared to the VPC (no sharing capability yet in TF)
-			//       to enable testing functionality below.
-			//
-			//{
-			//	Config: testAccNsxtPolicySecurityPolicyWithProfiles(resourceName, updatedName, direction2, proto2, tag2, defaultDomain, true),
-			//	Check: resource.ComposeTestCheckFunc(
-			//		testAccNsxtPolicySecurityPolicyExists(testResourceName, defaultDomain),
-			//		resource.TestCheckResourceAttr(testResourceName, "display_name", updatedName),
-			//		resource.TestCheckResourceAttr(testResourceName, "description", "Acceptance Test"),
-			//		resource.TestCheckResourceAttr(testResourceName, "comments", ""),
-			//		resource.TestCheckResourceAttr(testResourceName, "locked", "false"),
-			//		resource.TestCheckResourceAttr(testResourceName, "scope.#", "0"),
-			//		resource.TestCheckResourceAttr(testResourceName, "sequence_number", "3"),
-			//		resource.TestCheckResourceAttr(testResourceName, "stateful", "true"),
-			//		resource.TestCheckResourceAttr(testResourceName, "tcp_strict", "false"),
-			//		resource.TestCheckResourceAttr(testResourceName, "rule.#", "1"),
-			//		resource.TestCheckResourceAttr(testResourceName, "rule.0.display_name", updatedName),
-			//		resource.TestCheckResourceAttr(testResourceName, "rule.0.direction", direction2),
-			//		resource.TestCheckResourceAttr(testResourceName, "rule.0.ip_version", proto2),
-			//		resource.TestCheckResourceAttr(testResourceName, "rule.0.action", defaultAction),
-			//		resource.TestCheckResourceAttr(testResourceName, "rule.0.log_label", tag2),
-			//		resource.TestCheckResourceAttr(testResourceName, "rule.0.tag.#", "1"),
-			//		resource.TestCheckResourceAttr(testResourceName, "rule.0.profiles.#", "1"),
-			//	),
-			//},
+			{
+				Config: testAccNsxtPolicySecurityPolicyWithProfiles(resourceName, updatedName, direction2, proto2, tag2, defaultDomain, true, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicySecurityPolicyExists(testResourceName, defaultDomain),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", updatedName),
+					resource.TestCheckResourceAttr(testResourceName, "description", "Acceptance Test"),
+					resource.TestCheckResourceAttr(testResourceName, "comments", ""),
+					resource.TestCheckResourceAttr(testResourceName, "locked", "false"),
+					resource.TestCheckResourceAttr(testResourceName, "scope.#", "0"),
+					resource.TestCheckResourceAttr(testResourceName, "sequence_number", "3"),
+					resource.TestCheckResourceAttr(testResourceName, "stateful", "true"),
+					resource.TestCheckResourceAttr(testResourceName, "tcp_strict", "false"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.0.display_name", updatedName),
+					resource.TestCheckResourceAttr(testResourceName, "rule.0.direction", direction2),
+					resource.TestCheckResourceAttr(testResourceName, "rule.0.ip_version", proto2),
+					resource.TestCheckResourceAttr(testResourceName, "rule.0.action", defaultAction),
+					resource.TestCheckResourceAttr(testResourceName, "rule.0.log_label", tag2),
+					resource.TestCheckResourceAttr(testResourceName, "rule.0.tag.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "rule.0.profiles.#", "1"),
+				),
+			},
 		},
 	})
 }

--- a/nsxt/utils_test.go
+++ b/nsxt/utils_test.go
@@ -719,6 +719,40 @@ func testAccNsxtPolicyMultitenancyContext() string {
 	return ""
 }
 
+func testAccNsxtMultitenancyContext(includeVpc bool) string {
+	if testAccIsVPC() {
+		// Some tests run in VPC context, however dependency resources are
+		// not under VPC. In this case, we rely on VPC env configuration
+		// but need to only list project in the context
+		projectID := os.Getenv("NSXT_VPC_PROJECT_ID")
+		if !includeVpc {
+			return fmt.Sprintf(`
+  context {
+    project_id = "%s"
+  }
+`, projectID)
+		}
+		// VPC resource
+		vpcID := os.Getenv("NSXT_VPC_ID")
+		return fmt.Sprintf(`
+  context {
+    project_id = "%s"
+    vpc_id     = "%s"
+  }
+`, projectID, vpcID)
+	}
+	// CLassic Multi Tenancy resource
+	projectID := os.Getenv("NSXT_PROJECT_ID")
+	if projectID != "" {
+		return fmt.Sprintf(`
+  context {
+    project_id = "%s"
+  }
+`, projectID)
+	}
+	return ""
+}
+
 func testAccResourceNsxtPolicyImportIDRetriever(resourceID string) func(*terraform.State) (string, error) {
 	return func(s *terraform.State) (string, error) {
 
@@ -778,4 +812,29 @@ func testAccGenerateTLSKeyPair() (string, string, error) {
 	}
 	privatePem = buf.String()
 	return publicPem, privatePem, nil
+}
+
+func testAccNsxtProjectShareAll(sharedResourcePath string) string {
+	name := getAccTestResourceName()
+	projectPath := fmt.Sprintf("/orgs/default/projects/%s", os.Getenv("NSXT_VPC_PROJECT_ID"))
+	context := testAccNsxtMultitenancyContext(false)
+	return fmt.Sprintf(`
+resource "nsxt_policy_share" "test" {
+%s
+  display_name = "%s"
+
+  sharing_strategy = "ALL_DESCENDANTS"
+  shared_with      = ["%s"]
+}
+
+resource "nsxt_policy_shared_resource" "test" {
+%s
+  display_name = "%s"
+
+  share_path   = nsxt_policy_share.test.path
+  resource_object {
+    resource_path    = %s
+    include_children = true
+  }
+}`, context, name, projectPath, context, name, sharedResourcePath)
 }


### PR DESCRIPTION
This test creates context profile and shares it with the VPC
Signed-off-by: Anna Khmelnitsky <akhmelnitsky@vmware.com>