### PR TITLE
Remove context block from shared resource

### DIFF
--- a/nsxt/resource_nsxt_policy_share_test.go
+++ b/nsxt/resource_nsxt_policy_share_test.go
@@ -5,6 +5,7 @@ package nsxt
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -91,6 +92,48 @@ func TestAccResourceNsxtPolicyShare_importBasic(t *testing.T) {
 	})
 }
 
+func TestAccResourceNsxtPolicyShare_multitenancy(t *testing.T) {
+	testResourceName := "nsxt_policy_share.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccOnlyMultitenancy(t)
+			testAccNSXVersion(t, "4.1.1")
+		},
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyShareCheckDestroy(state, accTestPolicyShareUpdateAttributes["display_name"])
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyShareWithMyselfTemplate(true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicyShareExists(accTestPolicyShareCreateAttributes["display_name"], testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestPolicyShareCreateAttributes["display_name"]),
+					resource.TestCheckResourceAttr(testResourceName, "description", accTestPolicyShareCreateAttributes["description"]),
+					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+					resource.TestCheckResourceAttr(testResourceName, "tag.#", "0"),
+				),
+			},
+			{
+				Config: testAccNsxtPolicyShareWithMyselfTemplate(false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicyShareExists(accTestPolicyShareUpdateAttributes["display_name"], testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestPolicyShareUpdateAttributes["display_name"]),
+					resource.TestCheckResourceAttr(testResourceName, "description", accTestPolicyShareUpdateAttributes["description"]),
+					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+					resource.TestCheckResourceAttr(testResourceName, "tag.#", "0"),
+				),
+			},
+		},
+	})
+}
+
 func testAccNsxtPolicyShareExists(displayName string, resourceName string) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
 
@@ -156,4 +199,29 @@ resource "nsxt_policy_share" "test" {
     tag   = "tag1"
   }
 }`, attrMap["display_name"], attrMap["description"])
+}
+
+func testAccNsxtPolicyShareWithMyselfTemplate(createFlow bool) string {
+	var attrMap map[string]string
+	if createFlow {
+		attrMap = accTestPolicyShareCreateAttributes
+	} else {
+		attrMap = accTestPolicyShareUpdateAttributes
+	}
+	projectID := os.Getenv("NSXT_PROJECT_ID")
+	return fmt.Sprintf(`
+data "nsxt_policy_project" "test" {
+  id = "%s"
+}
+
+resource "nsxt_policy_share" "test" {
+  context {
+    project_id = data.nsxt_policy_project.test.id
+  }
+  display_name = "%s"
+  description  = "%s"
+
+  sharing_strategy = "ALL_DESCENDANTS"
+  shared_with      = [data.nsxt_policy_project.test.path]
+}`, projectID, attrMap["display_name"], attrMap["description"])
 }

--- a/nsxt/resource_nsxt_policy_shared_resource.go
+++ b/nsxt/resource_nsxt_policy_shared_resource.go
@@ -28,7 +28,6 @@ func resourceNsxtPolicySharedResource() *schema.Resource {
 			"description":  getDescriptionSchema(),
 			"revision":     getRevisionSchema(),
 			"tag":          getTagsSchema(),
-			"context":      getContextSchema(false, false, false),
 			"share_path": {
 				Type:        schema.TypeString,
 				Required:    true,
@@ -64,7 +63,9 @@ func resourceNsxtPolicySharedResourceCreate(d *schema.ResourceData, m interface{
 	id := newUUID()
 
 	connector := getPolicyConnector(m)
-	shareID := getPolicyIDFromPath(d.Get("share_path").(string))
+	sharePath := d.Get("share_path").(string)
+	shareID := getPolicyIDFromPath(sharePath)
+	context := getParentContext(d, m, sharePath)
 	displayName := d.Get("display_name").(string)
 	description := d.Get("description").(string)
 	tags := getPolicyTagsFromSchema(d)
@@ -85,7 +86,6 @@ func resourceNsxtPolicySharedResourceCreate(d *schema.ResourceData, m interface{
 		Tags:            tags,
 		ResourceObjects: resourceObjects,
 	}
-	context := getSessionContext(d, m)
 	client := shares.NewResourcesClient(context, connector)
 	err := client.Patch(shareID, id, obj)
 	if err != nil {
@@ -106,8 +106,9 @@ func resourceNsxtPolicySharedResourceRead(d *schema.ResourceData, m interface{})
 		return fmt.Errorf("error obtaining Shared Resource ID")
 	}
 
-	shareID := getPolicyIDFromPath(d.Get("share_path").(string))
-	context := getSessionContext(d, m)
+	sharePath := d.Get("share_path").(string)
+	shareID := getPolicyIDFromPath(sharePath)
+	context := getParentContext(d, m, sharePath)
 	client := shares.NewResourcesClient(context, connector)
 	obj, err := client.Get(shareID, id)
 	if err != nil {
@@ -137,7 +138,9 @@ func resourceNsxtPolicySharedResourceUpdate(d *schema.ResourceData, m interface{
 	id := d.Id()
 
 	connector := getPolicyConnector(m)
-	shareID := getPolicyIDFromPath(d.Get("share_path").(string))
+	sharePath := d.Get("share_path").(string)
+	shareID := getPolicyIDFromPath(sharePath)
+	context := getParentContext(d, m, sharePath)
 	displayName := d.Get("display_name").(string)
 	description := d.Get("description").(string)
 	tags := getPolicyTagsFromSchema(d)
@@ -158,7 +161,6 @@ func resourceNsxtPolicySharedResourceUpdate(d *schema.ResourceData, m interface{
 		Tags:            tags,
 		ResourceObjects: resourceObjects,
 	}
-	context := getSessionContext(d, m)
 	client := shares.NewResourcesClient(context, connector)
 	err := client.Patch(shareID, id, obj)
 	if err != nil {
@@ -176,10 +178,11 @@ func resourceNsxtPolicySharedResourceDelete(d *schema.ResourceData, m interface{
 	if id == "" {
 		return fmt.Errorf("error obtaining Shared Resource ID")
 	}
-	shareID := getPolicyIDFromPath(d.Get("share_path").(string))
+	sharePath := d.Get("share_path").(string)
+	shareID := getPolicyIDFromPath(sharePath)
 
 	connector := getPolicyConnector(m)
-	context := getSessionContext(d, m)
+	context := getParentContext(d, m, sharePath)
 	client := shares.NewResourcesClient(context, connector)
 	err := client.Delete(shareID, id)
 

--- a/nsxt/utils_test.go
+++ b/nsxt/utils_test.go
@@ -275,6 +275,12 @@ func testAccIsGlobalManager2() tf_api.ClientType {
 	return tf_api.Local
 }
 
+func testAccNotGlobalManager(t *testing.T) {
+	if testAccIsGlobalManager() {
+		t.Skipf("This test requires a global manager environment")
+	}
+}
+
 func testAccOnlyGlobalManager(t *testing.T) {
 	if !testAccIsGlobalManager() {
 		t.Skipf("This test requires a global manager environment")
@@ -828,7 +834,6 @@ resource "nsxt_policy_share" "test" {
 }
 
 resource "nsxt_policy_shared_resource" "test" {
-%s
   display_name = "%s"
 
   share_path   = nsxt_policy_share.test.path
@@ -836,5 +841,5 @@ resource "nsxt_policy_shared_resource" "test" {
     resource_path    = %s
     include_children = true
   }
-}`, context, name, projectPath, context, name, sharedResourcePath)
+}`, context, name, projectPath, name, sharedResourcePath)
 }

--- a/website/docs/r/policy_shared_resource.html.markdown
+++ b/website/docs/r/policy_shared_resource.html.markdown
@@ -33,8 +33,6 @@ The following arguments are supported:
 * `description` - (Optional) Description of the resource.
 * `tag` - (Optional) A list of scope + tag pairs to associate with this resource.
 * `nsx_id` - (Optional) The NSX ID of this resource. If set, this ID will be used to create the resource.
-* `context` - (Optional) The context which the object belongs to
-    * `project_id` - (Required) The ID of the project which the object belongs to
 * `share_path` - (Required) Share policy path to associate the resource to.
 * `resource_object` _ (Required) List of resources to be shared.
   * `include_children` - (Optional) Denotes if the children of the shared path are also shared.


### PR DESCRIPTION
Context is determined fromthe parent share_path
For consistency with other resources, we don't expose the context block (which provides redundant info) when parent path is present and required.