### PR TITLE
Rename nsxt_policy_ip_address_allocation funcs

### DIFF
--- a/nsxt/provider.go
+++ b/nsxt/provider.go
@@ -523,7 +523,7 @@ func Provider() *schema.Provider {
 			"nsxt_vpc_subnet":                           resourceNsxtVpcSubnet(),
 			"nsxt_policy_transit_gateway_nat_rule":      resourceNsxtPolicyTransitGatewayNatRule(),
 			"nsxt_vpc_static_route":                     resourceNsxtVpcStaticRoutes(),
-			"nsxt_policy_project_ip_address_allocation": resourceNsxtProjectIpAddressAllocation(),
+			"nsxt_policy_project_ip_address_allocation": resourceNsxtPolicyProjectIpAddressAllocation(),
 			"nsxt_vpc_dhcp_v4_static_binding":           resourceNsxtVpcSubnetDhcpV4StaticBindingConfig(),
 		},
 

--- a/nsxt/resource_nsxt_policy_project_ip_address_allocation.go
+++ b/nsxt/resource_nsxt_policy_project_ip_address_allocation.go
@@ -66,12 +66,12 @@ var projectIpAddressAllocationSchema = map[string]*metadata.ExtendedSchema{
 	},
 }
 
-func resourceNsxtProjectIpAddressAllocation() *schema.Resource {
+func resourceNsxtPolicyProjectIpAddressAllocation() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceNsxtProjectIpAddressAllocationCreate,
-		Read:   resourceNsxtProjectIpAddressAllocationRead,
-		Update: resourceNsxtProjectIpAddressAllocationUpdate,
-		Delete: resourceNsxtProjectIpAddressAllocationDelete,
+		Create: resourceNsxtPolicyProjectIpAddressAllocationCreate,
+		Read:   resourceNsxtPolicyProjectIpAddressAllocationRead,
+		Update: resourceNsxtPolicyProjectIpAddressAllocationUpdate,
+		Delete: resourceNsxtPolicyProjectIpAddressAllocationDelete,
 		Importer: &schema.ResourceImporter{
 			State: nsxtPolicyPathResourceImporter,
 		},
@@ -79,7 +79,7 @@ func resourceNsxtProjectIpAddressAllocation() *schema.Resource {
 	}
 }
 
-func resourceNsxtProjectIpAddressAllocationExists(sessionContext utl.SessionContext, id string, connector client.Connector) (bool, error) {
+func resourceNsxtPolicyProjectIpAddressAllocationExists(sessionContext utl.SessionContext, id string, connector client.Connector) (bool, error) {
 	var err error
 	parents := getVpcParentsFromContext(sessionContext)
 	client := clientLayer.NewIpAddressAllocationsClient(connector)
@@ -95,10 +95,10 @@ func resourceNsxtProjectIpAddressAllocationExists(sessionContext utl.SessionCont
 	return false, logAPIError("Error retrieving resource", err)
 }
 
-func resourceNsxtProjectIpAddressAllocationCreate(d *schema.ResourceData, m interface{}) error {
+func resourceNsxtPolicyProjectIpAddressAllocationCreate(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
 
-	id, err := getOrGenerateID2(d, m, resourceNsxtProjectIpAddressAllocationExists)
+	id, err := getOrGenerateID2(d, m, resourceNsxtPolicyProjectIpAddressAllocationExists)
 	if err != nil {
 		return err
 	}
@@ -129,10 +129,10 @@ func resourceNsxtProjectIpAddressAllocationCreate(d *schema.ResourceData, m inte
 	d.SetId(id)
 	d.Set("nsx_id", id)
 
-	return resourceNsxtProjectIpAddressAllocationRead(d, m)
+	return resourceNsxtPolicyProjectIpAddressAllocationRead(d, m)
 }
 
-func resourceNsxtProjectIpAddressAllocationRead(d *schema.ResourceData, m interface{}) error {
+func resourceNsxtPolicyProjectIpAddressAllocationRead(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
 
 	id := d.Id()
@@ -158,7 +158,7 @@ func resourceNsxtProjectIpAddressAllocationRead(d *schema.ResourceData, m interf
 	return metadata.StructToSchema(elem, d, projectIpAddressAllocationSchema, "", nil)
 }
 
-func resourceNsxtProjectIpAddressAllocationUpdate(d *schema.ResourceData, m interface{}) error {
+func resourceNsxtPolicyProjectIpAddressAllocationUpdate(d *schema.ResourceData, m interface{}) error {
 
 	connector := getPolicyConnector(m)
 
@@ -188,10 +188,10 @@ func resourceNsxtProjectIpAddressAllocationUpdate(d *schema.ResourceData, m inte
 		return handleUpdateError("ProjectIpAddressAllocation", id, err)
 	}
 
-	return resourceNsxtProjectIpAddressAllocationRead(d, m)
+	return resourceNsxtPolicyProjectIpAddressAllocationRead(d, m)
 }
 
-func resourceNsxtProjectIpAddressAllocationDelete(d *schema.ResourceData, m interface{}) error {
+func resourceNsxtPolicyProjectIpAddressAllocationDelete(d *schema.ResourceData, m interface{}) error {
 	id := d.Id()
 	if id == "" {
 		return fmt.Errorf("Error obtaining ProjectIpAddressAllocation ID")

--- a/nsxt/resource_nsxt_policy_project_ip_address_allocation_test.go
+++ b/nsxt/resource_nsxt_policy_project_ip_address_allocation_test.go
@@ -24,20 +24,20 @@ var accTestProjectIpAddressAllocationUpdateAttributes = map[string]string{
 	"allocation_size": "1",
 }
 
-func TestAccResourceNsxtProjectIpAddressAllocation_basic(t *testing.T) {
+func TestAccResourceNsxtPolicyProjectIpAddressAllocation_basic(t *testing.T) {
 	testResourceName := "nsxt_policy_project_ip_address_allocation.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t); testAccOnlyVPC(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNsxtProjectIpAddressAllocationCheckDestroy(state, accTestProjectIpAddressAllocationUpdateAttributes["display_name"])
+			return testAccNsxtPolicyProjectIpAddressAllocationCheckDestroy(state, accTestProjectIpAddressAllocationUpdateAttributes["display_name"])
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNsxtProjectIpAddressAllocationTemplate(true),
+				Config: testAccNsxtPolicyProjectIpAddressAllocationTemplate(true),
 				Check: resource.ComposeTestCheckFunc(
-					testAccNsxtProjectIpAddressAllocationExists(accTestProjectIpAddressAllocationCreateAttributes["display_name"], testResourceName),
+					testAccNsxtPolicyProjectIpAddressAllocationExists(accTestProjectIpAddressAllocationCreateAttributes["display_name"], testResourceName),
 					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestProjectIpAddressAllocationCreateAttributes["display_name"]),
 					resource.TestCheckResourceAttr(testResourceName, "description", accTestProjectIpAddressAllocationCreateAttributes["description"]),
 					resource.TestCheckResourceAttrSet(testResourceName, "allocation_ips"),
@@ -50,9 +50,9 @@ func TestAccResourceNsxtProjectIpAddressAllocation_basic(t *testing.T) {
 			},
 			/* TODO - enable when/if IP allocation update is supported on NSX
 			{
-				Config: testAccNsxtProjectIpAddressAllocationTemplate(false),
+				Config: testAccNsxtPolicyProjectIpAddressAllocationTemplate(false),
 				Check: resource.ComposeTestCheckFunc(
-					testAccNsxtProjectIpAddressAllocationExists(accTestProjectIpAddressAllocationUpdateAttributes["display_name"], testResourceName),
+					testAccNsxtPolicyProjectIpAddressAllocationExists(accTestProjectIpAddressAllocationUpdateAttributes["display_name"], testResourceName),
 					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestProjectIpAddressAllocationUpdateAttributes["display_name"]),
 					resource.TestCheckResourceAttr(testResourceName, "description", accTestProjectIpAddressAllocationUpdateAttributes["description"]),
 					resource.TestCheckResourceAttrSet(testResourceName, "allocation_ips"),
@@ -64,9 +64,9 @@ func TestAccResourceNsxtProjectIpAddressAllocation_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNsxtProjectIpAddressAllocationMinimalistic(),
+				Config: testAccNsxtPolicyProjectIpAddressAllocationMinimalistic(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccNsxtProjectIpAddressAllocationExists(accTestProjectIpAddressAllocationCreateAttributes["display_name"], testResourceName),
+					testAccNsxtPolicyProjectIpAddressAllocationExists(accTestProjectIpAddressAllocationCreateAttributes["display_name"], testResourceName),
 					resource.TestCheckResourceAttr(testResourceName, "description", ""),
 					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
 					resource.TestCheckResourceAttrSet(testResourceName, "path"),
@@ -78,7 +78,7 @@ func TestAccResourceNsxtProjectIpAddressAllocation_basic(t *testing.T) {
 	})
 }
 
-func TestAccResourceNsxtProjectIpAddressAllocation_importBasic(t *testing.T) {
+func TestAccResourceNsxtPolicyProjectIpAddressAllocation_importBasic(t *testing.T) {
 	name := getAccTestResourceName()
 	testResourceName := "nsxt_policy_project_ip_address_allocation.test"
 
@@ -86,11 +86,11 @@ func TestAccResourceNsxtProjectIpAddressAllocation_importBasic(t *testing.T) {
 		PreCheck:  func() { testAccPreCheck(t); testAccOnlyVPC(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNsxtProjectIpAddressAllocationCheckDestroy(state, name)
+			return testAccNsxtPolicyProjectIpAddressAllocationCheckDestroy(state, name)
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNsxtProjectIpAddressAllocationMinimalistic(),
+				Config: testAccNsxtPolicyProjectIpAddressAllocationMinimalistic(),
 			},
 			{
 				ResourceName:      testResourceName,
@@ -102,7 +102,7 @@ func TestAccResourceNsxtProjectIpAddressAllocation_importBasic(t *testing.T) {
 	})
 }
 
-func testAccNsxtProjectIpAddressAllocationExists(displayName string, resourceName string) resource.TestCheckFunc {
+func testAccNsxtPolicyProjectIpAddressAllocationExists(displayName string, resourceName string) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
 
 		connector := getPolicyConnector(testAccProvider.Meta().(nsxtClients))
@@ -117,7 +117,7 @@ func testAccNsxtProjectIpAddressAllocationExists(displayName string, resourceNam
 			return fmt.Errorf("Policy ProjectIpAddressAllocation resource ID not set in resources")
 		}
 
-		exists, err := resourceNsxtProjectIpAddressAllocationExists(testAccGetSessionContext(), resourceID, connector)
+		exists, err := resourceNsxtPolicyProjectIpAddressAllocationExists(testAccGetSessionContext(), resourceID, connector)
 		if err != nil {
 			return err
 		}
@@ -129,7 +129,7 @@ func testAccNsxtProjectIpAddressAllocationExists(displayName string, resourceNam
 	}
 }
 
-func testAccNsxtProjectIpAddressAllocationCheckDestroy(state *terraform.State, displayName string) error {
+func testAccNsxtPolicyProjectIpAddressAllocationCheckDestroy(state *terraform.State, displayName string) error {
 	connector := getPolicyConnector(testAccProvider.Meta().(nsxtClients))
 	for _, rs := range state.RootModule().Resources {
 
@@ -138,7 +138,7 @@ func testAccNsxtProjectIpAddressAllocationCheckDestroy(state *terraform.State, d
 		}
 
 		resourceID := rs.Primary.Attributes["id"]
-		exists, err := resourceNsxtProjectIpAddressAllocationExists(testAccGetSessionContext(), resourceID, connector)
+		exists, err := resourceNsxtPolicyProjectIpAddressAllocationExists(testAccGetSessionContext(), resourceID, connector)
 		if err == nil {
 			return err
 		}
@@ -150,7 +150,7 @@ func testAccNsxtProjectIpAddressAllocationCheckDestroy(state *terraform.State, d
 	return nil
 }
 
-func testAccNsxtProjectIpAddressAllocationTemplate(createFlow bool) string {
+func testAccNsxtPolicyProjectIpAddressAllocationTemplate(createFlow bool) string {
 	var attrMap map[string]string
 	if createFlow {
 		attrMap = accTestProjectIpAddressAllocationCreateAttributes
@@ -175,7 +175,7 @@ resource "nsxt_policy_project_ip_address_allocation" "test" {
 }`, os.Getenv("NSXT_VPC_PROJECT_ID"), testAccNsxtProjectContext(), attrMap["display_name"], attrMap["description"], attrMap["allocation_size"])
 }
 
-func testAccNsxtProjectIpAddressAllocationMinimalistic() string {
+func testAccNsxtPolicyProjectIpAddressAllocationMinimalistic() string {
 	return fmt.Sprintf(`
 data "nsxt_policy_project" "test" {
   id = "%s"


### PR DESCRIPTION
Functions for the resource above were using a non-policy prefixed names which is inconsistent.