### PR TITLE
Remove default for host_switch_mode, set to Computed

### DIFF
--- a/nsxt/resource_nsxt_edge_transport_node.go
+++ b/nsxt/resource_nsxt_edge_transport_node.go
@@ -466,8 +466,7 @@ func getStandardHostSwitchSchema(nodeType string) *schema.Schema {
 			"host_switch_mode": {
 				Type:         schema.TypeString,
 				Description:  "Operational mode of a HostSwitch",
-				Default:      model.StandardHostSwitch_HOST_SWITCH_MODE_STANDARD,
-				Optional:     true,
+				Computed:     true,
 				ValidateFunc: validation.StringInSlice(hostSwitchModeValues, false),
 			},
 			"is_migrate_pnics": {

--- a/website/docs/r/policy_host_transport_node.html.markdown
+++ b/website/docs/r/policy_host_transport_node.html.markdown
@@ -64,7 +64,7 @@ The following arguments are supported:
     * `numa_node_index` - (Required) Unique index of the Non Uniform Memory Access (NUMA) node.
   * `host_switch_id` - (Optional) The host switch id. This ID will be used to reference a host switch.
   * `host_switch_name` - (Optional) Host switch name. This name will be used to reference a host switch.
-  * `host_switch_mode` - (Optional) Operational mode of a HostSwitch. Accepted values - 'STANDARD', 'ENS', 'ENS_INTERRUPT' or 'LEGACY'. The default value is 'STANDARD'.
+  * `host_switch_mode` - (Optional) Operational mode of a HostSwitch. Accepted values - 'STANDARD', 'ENS', 'ENS_INTERRUPT' or 'LEGACY'.
   * `host_switch_profile` - (Optional) Policy path of host switch profiles to be associated with this host switch.
   * `ip_assignment` - (Required) - Specification for IPs to be used with host switch virtual tunnel endpoints. Should contain exatly one of the below:
     * `assigned_by_dhcp` - (Optional) Enables DHCP assignment.

--- a/website/docs/r/policy_host_transport_node_profile.html.markdown
+++ b/website/docs/r/policy_host_transport_node_profile.html.markdown
@@ -43,7 +43,7 @@ The following arguments are supported:
 * `standard_host_switch` - (Required) Standard host switch specification.
     * `host_switch_id` - (Optional) The host switch id. This ID will be used to reference a host switch.
     * `host_switch_name` - (Optional) Host switch name. This name will be used to reference a host switch.
-    * `host_switch_mode` - (Optional) Operational mode of a HostSwitch. Accepted values - 'STANDARD', 'ENS', 'ENS_INTERRUPT' or 'LEGACY'. The default value is 'STANDARD'.
+    * `host_switch_mode` - (Optional) Operational mode of a HostSwitch. Accepted values - 'STANDARD', 'ENS', 'ENS_INTERRUPT' or 'LEGACY'.
     * `host_switch_profile` - (Optional) Policy paths of host switch profiles to be associated with this host switch.
     * `ip_assignment` - (Required) - Specification for IPs to be used with host switch virtual tunnel endpoints. Should contain exactly one of the below:
         * `assigned_by_dhcp` - (Optional) Enables DHCP assignment.


### PR DESCRIPTION
In host_transport_node_profile, host_switch_mode attribute can be set by NSX, and the default behavior is changed.