### PR TITLE
Check that target version is set

### DIFF
--- a/nsxt/resource_nsxt_upgrade_run.go
+++ b/nsxt/resource_nsxt_upgrade_run.go
@@ -90,6 +90,9 @@ func getTargetVersion(m interface{}) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	if obj.TargetVersion == nil {
+		return "", fmt.Errorf("failed to fetch upgrade target version. Upgrade process should be restarted with a clean state")
+	}
 	return *obj.TargetVersion, nil
 }
 


### PR DESCRIPTION
Upgrade state can be erased in NSX due to various reasons, e.g restoration from backup. In this case the TF state could allow execution of the nsxt_upgrade_run resource even though there is no ongoing backup.
This case should be properly handled instead of failing with a SIGSEGV.