### PR TITLE
Handle VLCM upgrade as potentially partial

### DIFF
--- a/nsxt/resource_nsxt_upgrade_run.go
+++ b/nsxt/resource_nsxt_upgrade_run.go
@@ -506,8 +506,9 @@ func getPartialUpgradeMap(d *schema.ResourceData, targetVersion string) map[stri
 		for _, groupI := range d.Get(componentToGroupKey[component]).([]interface{}) {
 			group := groupI.(map[string]interface{})
 			enabled := group["enabled"].(bool)
+			upgradeMode := group["upgrade_mode"].(string)
 			pauseAfterEach := group["pause_after_each_upgrade_unit"].(bool)
-			if !enabled || pauseAfterEach {
+			if !enabled || pauseAfterEach || upgradeMode == "stage_in_vlcm" {
 				isPartialUpgradeMap[component] = true
 				break
 			}


### PR DESCRIPTION
When host upgrade is done with VLCM, there is the possibility that host upgrade will not be concluded and then, result will be a paused state. This case should be handled as partial upgrade.