### PR TITLE
TGW attachment connection_path attribute should be required

### DIFF
--- a/nsxt/resource_nsxt_policy_transit_gateway_attachment.go
+++ b/nsxt/resource_nsxt_policy_transit_gateway_attachment.go
@@ -30,7 +30,7 @@ var transitGatewayAttachmentSchema = map[string]*metadata.ExtendedSchema{
 		Schema: schema.Schema{
 			Type:         schema.TypeString,
 			ValidateFunc: validatePolicyPath(),
-			Optional:     true,
+			Required:     true,
 		},
 		Metadata: metadata.Metadata{
 			SchemaType:   "string",

--- a/website/docs/r/policy_transit_gateway_attachment.html.markdown
+++ b/website/docs/r/policy_transit_gateway_attachment.html.markdown
@@ -50,7 +50,7 @@ The following arguments are supported:
 * `description` - (Optional) Description of the resource.
 * `tag` - (Optional) A list of scope + tag pairs to associate with this resource.
 * `nsx_id` - (Optional) The NSX ID of this resource. If set, this ID will be used to create the resource.
-* `connection_path` - (Optional) Policy path of the desidered transit gateway external connection.
+* `connection_path` - (Required) Policy path of the desired transit gateway external connection.
 
 ## Attributes Reference
 


### PR DESCRIPTION
This is not properly set in the API spec but NSX enforces this requirement.