### PR TITLE
 Distributed VLAN connection: set vlan_id and gateway_addresses as required

### DIFF
--- a/nsxt/resource_nsxt_policy_distributed_vlan_connection.go
+++ b/nsxt/resource_nsxt_policy_distributed_vlan_connection.go
@@ -26,7 +26,7 @@ var distributedVlanConnectionSchema = map[string]*metadata.ExtendedSchema{
 	"vlan_id": {
 		Schema: schema.Schema{
 			Type:     schema.TypeInt,
-			Optional: true,
+			Required: true,
 		},
 		Metadata: metadata.Metadata{
 			SchemaType:   "int",
@@ -45,7 +45,7 @@ var distributedVlanConnectionSchema = map[string]*metadata.ExtendedSchema{
 					SchemaType: "string",
 				},
 			},
-			Optional: true,
+			Required: true,
 		},
 		Metadata: metadata.Metadata{
 			SchemaType:   "list",

--- a/website/docs/r/policy_distributed_vlan_connection.html.markdown
+++ b/website/docs/r/policy_distributed_vlan_connection.html.markdown
@@ -30,8 +30,8 @@ The following arguments are supported:
 * `description` - (Optional) Description of the resource.
 * `tag` - (Optional) A list of scope + tag pairs to associate with this resource.
 * `nsx_id` - (Optional) The NSX ID of this resource. If set, this ID will be used to create the resource.
-* `vlan_id` - (Optional) Vlan id for external gateway traffic.
-* `gateway_addresses` - (Optional) List of gateway addresses in CIDR format.
+* `vlan_id` - (Required) Vlan id for external gateway traffic.
+* `gateway_addresses` - (Required) List of gateway addresses in CIDR format.
 
 
 ## Attributes Reference


### PR DESCRIPTION
These are not properly set in the API spec but NSX enforces them as required.