### PR TITLE
Standard Host switch: set host switch mode as Optional

### DIFF
--- a/nsxt/resource_nsxt_edge_transport_node.go
+++ b/nsxt/resource_nsxt_edge_transport_node.go
@@ -467,6 +467,7 @@ func getStandardHostSwitchSchema(nodeType string) *schema.Schema {
 				Type:         schema.TypeString,
 				Description:  "Operational mode of a HostSwitch",
 				Computed:     true,
+				Optional:     true,
 				ValidateFunc: validation.StringInSlice(hostSwitchModeValues, false),
 			},
 			"is_migrate_pnics": {


### PR DESCRIPTION
If this attribute is set only as Computed, the SDK plugin won't accept any ValidateFunc for it.