### PR TITLE
Improve validation for project importers

### DIFF
--- a/nsxt/policy_utils.go
+++ b/nsxt/policy_utils.go
@@ -407,6 +407,7 @@ func validateImportPolicyPath(policyPath string) error {
 	return nil
 }
 
+// This importer function accepts policy path and resource ID
 func nsxtPolicyPathResourceImporter(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
 	rd, err := nsxtPolicyPathResourceImporterHelper(d, m)
 	if errors.Is(err, ErrNotAPolicyPath) {
@@ -415,6 +416,11 @@ func nsxtPolicyPathResourceImporter(d *schema.ResourceData, m interface{}) ([]*s
 		return rd, err
 	}
 	return rd, nil
+}
+
+// This importer function accepts policy path only as import ID
+func nsxtPolicyPathOnlyResourceImporter(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	return nsxtPolicyPathResourceImporterHelper(d, m)
 }
 
 func nsxtVPCPathResourceImporter(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {

--- a/nsxt/resource_nsxt_policy_distributed_vlan_connection.go
+++ b/nsxt/resource_nsxt_policy_distributed_vlan_connection.go
@@ -61,7 +61,7 @@ func resourceNsxtPolicyDistributedVlanConnection() *schema.Resource {
 		Update: resourceNsxtPolicyDistributedVlanConnectionUpdate,
 		Delete: resourceNsxtPolicyDistributedVlanConnectionDelete,
 		Importer: &schema.ResourceImporter{
-			State: nsxtPolicyPathResourceImporter,
+			State: nsxtPolicyPathOnlyResourceImporter,
 		},
 		Schema: metadata.GetSchemaFromExtendedSchema(distributedVlanConnectionSchema),
 	}

--- a/nsxt/resource_nsxt_policy_gateway_connection.go
+++ b/nsxt/resource_nsxt_policy_gateway_connection.go
@@ -80,7 +80,7 @@ func resourceNsxtPolicyGatewayConnection() *schema.Resource {
 		Update: resourceNsxtPolicyGatewayConnectionUpdate,
 		Delete: resourceNsxtPolicyGatewayConnectionDelete,
 		Importer: &schema.ResourceImporter{
-			State: nsxtPolicyPathResourceImporter,
+			State: nsxtPolicyPathOnlyResourceImporter,
 		},
 		Schema: metadata.GetSchemaFromExtendedSchema(gatewayConnectionSchema),
 	}

--- a/nsxt/resource_nsxt_policy_project_ip_address_allocation.go
+++ b/nsxt/resource_nsxt_policy_project_ip_address_allocation.go
@@ -73,7 +73,7 @@ func resourceNsxtPolicyProjectIpAddressAllocation() *schema.Resource {
 		Update: resourceNsxtPolicyProjectIpAddressAllocationUpdate,
 		Delete: resourceNsxtPolicyProjectIpAddressAllocationDelete,
 		Importer: &schema.ResourceImporter{
-			State: nsxtPolicyPathResourceImporter,
+			State: nsxtPolicyPathOnlyResourceImporter,
 		},
 		Schema: metadata.GetSchemaFromExtendedSchema(projectIpAddressAllocationSchema),
 	}

--- a/nsxt/resource_nsxt_policy_share.go
+++ b/nsxt/resource_nsxt_policy_share.go
@@ -26,7 +26,7 @@ func resourceNsxtPolicyShare() *schema.Resource {
 		Update: resourceNsxtPolicyShareUpdate,
 		Delete: resourceNsxtPolicyShareDelete,
 		Importer: &schema.ResourceImporter{
-			State: nsxtPolicyPathResourceImporter,
+			State: nsxtPolicyPathOnlyResourceImporter,
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_policy_transit_gateway.go
+++ b/nsxt/resource_nsxt_policy_transit_gateway.go
@@ -54,7 +54,7 @@ func resourceNsxtPolicyTransitGateway() *schema.Resource {
 		Update: resourceNsxtPolicyTransitGatewayUpdate,
 		Delete: resourceNsxtPolicyTransitGatewayDelete,
 		Importer: &schema.ResourceImporter{
-			State: nsxtPolicyPathResourceImporter,
+			State: nsxtPolicyPathOnlyResourceImporter,
 		},
 		Schema: metadata.GetSchemaFromExtendedSchema(transitGatewaySchema),
 	}

--- a/nsxt/resource_nsxt_vpc_connectivity_profile.go
+++ b/nsxt/resource_nsxt_vpc_connectivity_profile.go
@@ -211,7 +211,7 @@ func resourceNsxtVpcConnectivityProfile() *schema.Resource {
 		Update: resourceNsxtVpcConnectivityProfileUpdate,
 		Delete: resourceNsxtVpcConnectivityProfileDelete,
 		Importer: &schema.ResourceImporter{
-			State: nsxtPolicyPathResourceImporter,
+			State: nsxtPolicyPathOnlyResourceImporter,
 		},
 		Schema: metadata.GetSchemaFromExtendedSchema(vpcConnectivityProfileSchema),
 	}

--- a/nsxt/resource_nsxt_vpc_service_profile.go
+++ b/nsxt/resource_nsxt_vpc_service_profile.go
@@ -258,7 +258,7 @@ func resourceNsxtVpcServiceProfile() *schema.Resource {
 		Update: resourceNsxtVpcServiceProfileUpdate,
 		Delete: resourceNsxtVpcServiceProfileDelete,
 		Importer: &schema.ResourceImporter{
-			State: nsxtPolicyPathResourceImporter,
+			State: nsxtPolicyPathOnlyResourceImporter,
 		},
 		Schema: metadata.GetSchemaFromExtendedSchema(vpcServiceProfileSchema),
 	}


### PR DESCRIPTION
For resources residing under a project, we only support policy path as import ID. This change introduces PolicyPathOnly importer that only allows policy paths, as opposed to old validator that allows both policy path and ID
Signed-off-by: Anna Khmelnitsky <akhmelnitsky@vmware.com>