### PR TITLE
VPC and TGW NAT rules: make Action Required

### DIFF
--- a/nsxt/resource_nsxt_vpc_nat_rule.go
+++ b/nsxt/resource_nsxt_vpc_nat_rule.go
@@ -75,7 +75,7 @@ var policyVpcNatRuleSchema = map[string]*metadata.ExtendedSchema{
 		Schema: schema.Schema{
 			Type:         schema.TypeString,
 			ValidateFunc: validation.StringInSlice(policyVpcNatRuleActionValues, false),
-			Optional:     true,
+			Required:     true,
 		},
 		Metadata: metadata.Metadata{
 			SchemaType:   "string",

--- a/website/docs/r/policy_transit_gateway_nat_rule.html.markdown
+++ b/website/docs/r/policy_transit_gateway_nat_rule.html.markdown
@@ -52,7 +52,7 @@ The following arguments are supported:
 * `translated_network` - (Optional) Translated network address.
 * `logging` - (Optional) Boolean flag to indicate whether logging is enabled. The default is `false`.
 * `destination_network` - (Optional) For `DNAT` rules, this is a required field, and represents the destination network for the incoming packets. For other type of rules, it may contain destination network of outgoing packets.
-* `action` - (Optional) NAT action, one of `SNAT` (translates a source IP address into an outbound packet so that
+* `action` - (Required) NAT action, one of `SNAT` (translates a source IP address into an outbound packet so that
 the packet appears to originate from a different network), `DNAT` (translates the destination IP address of inbound packets so that packets are delivered to a target address into another network), and `REFLEXIVE` (one-to-one mapping of source and destination IP addresses).
 * `firewall_match` - (Optional) Indicates how the firewall matches the address after NATing if firewall
 stage is not skipped, one of `MATCH_EXTERNAL_ADDRESS`, `MATCH_INTERNAL_ADDRESS` or `BYPASS`. Default is `MATCH_INTERNAL_ADDRESS`.

--- a/website/docs/r/vpc_nat_rule.html.markdown
+++ b/website/docs/r/vpc_nat_rule.html.markdown
@@ -55,7 +55,7 @@ The following arguments are supported:
 represents the translated network address. In case of `SNAT` and `REFLEXIVE` rule, translated network address should be single IPv4 address allocated from External Block associated with VPC.
 * `logging` - (Optional) Boolean flag to indicate whether logging is enabled. The default is `false`.
 * `destination_network` - (Optional) For `DNAT` rules, this is a required field, and represents the destination network for the incoming packets. For other type of rules, it may contain destination network of outgoing packets. In case of `DNAT` rule, destination network address should be IPv4 address allocated from External Block associated with VPC.
-* `action` - (Optional) NAT action, one of `SNAT` (translates a source IP address into an outbound packet so that
+* `action` - (Required) NAT action, one of `SNAT` (translates a source IP address into an outbound packet so that
 the packet appears to originate from a different network), `DNAT` (translates the destination IP address of inbound packets so that packets are delivered to a target address into another network), and `REFLEXIVE` (one-to-one mapping of source and destination IP addresses).
 * `firewall_match` - (Optional) Indicates how the firewall matches the address after NATing if firewall
 stage is not skipped, one of `MATCH_EXTERNAL_ADDRESS`, `MATCH_INTERNAL_ADDRESS` or `BYPASS`. Default is `MATCH_INTERNAL_ADDRESS`.


### PR DESCRIPTION
NSX mandates rule action to be specified for both TGW and VPC NAT rules, but in the API spec this attribute is not specified as required.

This change addresses this.
Resources' documentaiton has been updated to mark the attribute as required.