### PR TITLE
Mark partial update when NSX update fails for vpc

### DIFF
--- a/nsxt/resource_nsxt_policy_project_ip_address_allocation.go
+++ b/nsxt/resource_nsxt_policy_project_ip_address_allocation.go
@@ -185,6 +185,9 @@ func resourceNsxtPolicyProjectIpAddressAllocationUpdate(d *schema.ResourceData, 
 	client := clientLayer.NewIpAddressAllocationsClient(connector)
 	_, err := client.Update(parents[0], parents[1], id, obj)
 	if err != nil {
+		// Trigger partial update to avoid terraform updating state based on failed intent
+		// TODO - move this into handleUpdateError
+		d.Partial(true)
 		return handleUpdateError("ProjectIpAddressAllocation", id, err)
 	}
 

--- a/nsxt/resource_nsxt_vpc.go
+++ b/nsxt/resource_nsxt_vpc.go
@@ -269,6 +269,9 @@ func resourceNsxtVpcUpdate(d *schema.ResourceData, m interface{}) error {
 	client := clientLayer.NewVpcsClient(connector)
 	_, err := client.Update(parents[0], parents[1], id, obj)
 	if err != nil {
+		// Trigger partial update to avoid terraform updating state based on failed intent
+		// TODO - move this into handleUpdateError
+		d.Partial(true)
 		return handleUpdateError("Vpc", id, err)
 	}
 

--- a/nsxt/resource_nsxt_vpc_connectivity_profile.go
+++ b/nsxt/resource_nsxt_vpc_connectivity_profile.go
@@ -332,6 +332,9 @@ func resourceNsxtVpcConnectivityProfileUpdate(d *schema.ResourceData, m interfac
 	client := clientLayer.NewVpcConnectivityProfilesClient(connector)
 	_, err := client.Update(parents[0], parents[1], id, obj)
 	if err != nil {
+		// Trigger partial update to avoid terraform updating state based on failed intent
+		// TODO - move this into handleUpdateError
+		d.Partial(true)
 		return handleUpdateError("VpcConnectivityProfile", id, err)
 	}
 

--- a/nsxt/resource_nsxt_vpc_dhcp_v4_static_binding_config.go
+++ b/nsxt/resource_nsxt_vpc_dhcp_v4_static_binding_config.go
@@ -359,6 +359,9 @@ func resourceNsxtVpcSubnetDhcpV4StaticBindingConfigUpdate(d *schema.ResourceData
 	client := clientLayer.NewDhcpStaticBindingConfigsClient(connector)
 	_, err := client.Update(parents[0], parents[1], parents[2], parents[3], id, convObj.(*data.StructValue))
 	if err != nil {
+		// Trigger partial update to avoid terraform updating state based on failed intent
+		// TODO - move this into handleUpdateError
+		d.Partial(true)
 		return handleUpdateError("DhcpV4StaticBindingConfig", id, err)
 	}
 

--- a/nsxt/resource_nsxt_vpc_external_address.go
+++ b/nsxt/resource_nsxt_vpc_external_address.go
@@ -99,6 +99,9 @@ func resourceNsxtVpcExternalAddressRead(d *schema.ResourceData, m interface{}) e
 func resourceNsxtVpcExternalAddressUpdate(d *schema.ResourceData, m interface{}) error {
 	err := updatePort(d, m, false)
 	if err != nil {
+		// Trigger partial update to avoid terraform updating state based on failed intent
+		// TODO - move this into handleUpdateError
+		d.Partial(true)
 		return handleUpdateError("External Address", "", err)
 	}
 	return resourceNsxtVpcExternalAddressRead(d, m)

--- a/nsxt/resource_nsxt_vpc_ip_address_allocation.go
+++ b/nsxt/resource_nsxt_vpc_ip_address_allocation.go
@@ -221,6 +221,9 @@ func resourceNsxtVpcIpAddressAllocationUpdate(d *schema.ResourceData, m interfac
 	client := clientLayer.NewIpAddressAllocationsClient(connector)
 	_, err := client.Update(parents[0], parents[1], parents[2], id, obj)
 	if err != nil {
+		// Trigger partial update to avoid terraform updating state based on failed intent
+		// TODO - move this into handleUpdateError
+		d.Partial(true)
 		return handleUpdateError("VpcIpAddressAllocation", id, err)
 	}
 

--- a/nsxt/resource_nsxt_vpc_nat_rule.go
+++ b/nsxt/resource_nsxt_vpc_nat_rule.go
@@ -266,6 +266,9 @@ func resourceNsxtPolicyVpcNatRuleUpdate(d *schema.ResourceData, m interface{}) e
 	client := clientLayer.NewNatRulesClient(connector)
 	_, err := client.Update(parents[0], parents[1], parents[2], parents[3], id, obj)
 	if err != nil {
+		// Trigger partial update to avoid terraform updating state based on failed intent
+		// TODO - move this into handleUpdateError
+		d.Partial(true)
 		return handleUpdateError("PolicyVpcNatRule", id, err)
 	}
 

--- a/nsxt/resource_nsxt_vpc_service_profile.go
+++ b/nsxt/resource_nsxt_vpc_service_profile.go
@@ -379,6 +379,9 @@ func resourceNsxtVpcServiceProfileUpdate(d *schema.ResourceData, m interface{}) 
 	client := clientLayer.NewVpcServiceProfilesClient(connector)
 	_, err := client.Update(parents[0], parents[1], id, obj)
 	if err != nil {
+		// Trigger partial update to avoid terraform updating state based on failed intent
+		// TODO - move this into handleUpdateError
+		d.Partial(true)
 		return handleUpdateError("VpcServiceProfile", id, err)
 	}
 

--- a/nsxt/resource_nsxt_vpc_static_routes.go
+++ b/nsxt/resource_nsxt_vpc_static_routes.go
@@ -197,6 +197,9 @@ func resourceNsxtVpcStaticRoutesUpdate(d *schema.ResourceData, m interface{}) er
 	client := clientLayer.NewStaticRoutesClient(connector)
 	_, err := client.Update(parents[0], parents[1], parents[2], id, obj)
 	if err != nil {
+		// Trigger partial update to avoid terraform updating state based on failed intent
+		// TODO - move this into handleUpdateError
+		d.Partial(true)
 		return handleUpdateError("StaticRoutes", id, err)
 	}
 

--- a/nsxt/resource_nsxt_vpc_subnet.go
+++ b/nsxt/resource_nsxt_vpc_subnet.go
@@ -674,6 +674,9 @@ func resourceNsxtVpcSubnetUpdate(d *schema.ResourceData, m interface{}) error {
 	client := clientLayer.NewSubnetsClient(connector)
 	_, err := client.Update(parents[0], parents[1], parents[2], id, obj)
 	if err != nil {
+		// Trigger partial update to avoid terraform updating state based on failed intent
+		// TODO - move this into handleUpdateError
+		d.Partial(true)
 		return handleUpdateError("VpcSubnet", id, err)
 	}
 


### PR DESCRIPTION
After merging VPC branch, this will be refactored to apply to all resources as part of handleUpdateError routine.
Signed-off-by: Anna Khmelnitsky <akhmelnitsky@vmware.com>