### PR TITLE
docs: correct example in upgrade group

### DIFF
--- a/website/docs/guides/upgrade.html.markdown
+++ b/website/docs/guides/upgrade.html.markdown
@@ -109,6 +109,33 @@ consumed using the data sources `nsxt_edge_upgrade_group` and `nsxt_host_upgrade
 **NOTE:** Only one `nsxt_upgrade_run` resource should be used in the upgrade plan.
 
 ```hcl
+data "nsxt_policy_host_transport_node" "host_transport_node1" {
+  display_name = "HostTransportNode1"
+}
+
+data "nsxt_policy_host_transport_node" "host_transport_node2" {
+  display_name = "HostTransportNode2"
+}
+
+data "nsxt_policy_host_transport_node" "host_transport_node3" {
+  display_name = "HostTransportNode3"
+}
+
+data "nsxt_host_upgrade_group" "hg1" {
+  upgrade_prepare_id = nsxt_upgrade_prepare.test.id
+  display_name       = "Group for Compute-Cluster1"
+}
+
+data "nsxt_edge_upgrade_group" "eg1" {
+  upgrade_prepare_id = nsxt_upgrade_prepare.test.id
+  display_name       = "edgegroup-EDGECLUSTER1"
+}
+
+data "nsxt_edge_upgrade_group" "eg2" {
+  upgrade_prepare_id = nsxt_upgrade_prepare.test.id
+  display_name       = "edgegroup-EDGECLUSTER2"
+}
+
 resource "nsxt_upgrade_run" "run" {
   upgrade_prepare_ready_id = data.nsxt_upgrade_prepare_ready.ready.id
 
@@ -127,22 +154,10 @@ resource "nsxt_upgrade_run" "run" {
     parallel = true
   }
 
-  data "nsxt_policy_host_transport_node" "host_transport_node1" {
-    display_name = "host_transport_node1"
-  }
-
   host_group {
     display_name = "HostWithDifferentSettings"
     parallel     = false
     hosts        = [data.nsxt_policy_host_transport_node.host_transport_node1.id]
-  }
-
-  data "nsxt_policy_host_transport_node" "host_transport_node2" {
-    display_name = "host_transport_node2"
-  }
-
-  data "nsxt_policy_host_transport_node" "host_transport_node3" {
-    display_name = "host_transport_node3"
   }
 
   host_group {


### PR DESCRIPTION
Updates the syntax of the `nsxt_upgrade_run` resource where the data sources were placed within the run resource instead of above it.

Renames some of the display names within the example:  predefined groups have a naming scheme which is set by NSX, and enhanced readability of hosts' data source display names.