### PR TITLE
Remove IP blocks from connectivity profiles NAT

### DIFF
--- a/nsxt/resource_nsxt_vpc_connectivity_profile.go
+++ b/nsxt/resource_nsxt_vpc_connectivity_profile.go
@@ -96,25 +96,6 @@ var vpcConnectivityProfileSchema = map[string]*metadata.ExtendedSchema{
 											SdkFieldName: "EnableDefaultSnat",
 										},
 									},
-									"ip_blocks": {
-										Schema: schema.Schema{
-											Type: schema.TypeList,
-											Elem: &metadata.ExtendedSchema{
-												Schema: schema.Schema{
-													Type:         schema.TypeString,
-													ValidateFunc: validatePolicyPath(),
-												},
-												Metadata: metadata.Metadata{
-													SchemaType: "string",
-												},
-											},
-											Optional: true,
-										},
-										Metadata: metadata.Metadata{
-											SchemaType:   "list",
-											SdkFieldName: "IpBlocks",
-										},
-									},
 								},
 							},
 							Optional: true,

--- a/website/docs/r/vpc_connectivity_profile.html.markdown
+++ b/website/docs/r/vpc_connectivity_profile.html.markdown
@@ -46,7 +46,6 @@ The following arguments are supported:
 * `service_gateway` - (Optional) Service Gateway configuration
   * `nat_config` - (Optional) NAT configuration
     * `enable_default_snat` - (Optional) Auto configured SNAT for private subnet.
-    * `ip_blocks` - (Optional) IP blocks for NAT external IPs. If not configured external IP block will be used. These blocks must be subset of external IP blocks.
   * `qos_config` - (Optional) None
     * `ingress_qos_profile_path` - (Optional) Policy path to gateway QoS profile in ingress direction.
     * `egress_qos_profile_path` - (Optional) Policy path to gateway QoS profile in egress direction.


### PR DESCRIPTION
This attribute is removed from first VPC2.0 release on platform