### PR TITLE
chore: replace deprecated type `schema.ImportStatePassthrough`

### DIFF
--- a/nsxt/resource_nsxt_algorithm_type_ns_service.go
+++ b/nsxt/resource_nsxt_algorithm_type_ns_service.go
@@ -22,7 +22,7 @@ func resourceNsxtAlgorithmTypeNsService() *schema.Resource {
 		Update: resourceNsxtAlgorithmTypeNsServiceUpdate,
 		Delete: resourceNsxtAlgorithmTypeNsServiceDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		DeprecationMessage: mpObjectResourceDeprecationMessage,
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_cluster_virtual_ip.go
+++ b/nsxt/resource_nsxt_cluster_virtual_ip.go
@@ -31,7 +31,7 @@ func resourceNsxtClusterVirualIP() *schema.Resource {
 		Update: resourceNsxtClusterVirualIPUpdate,
 		Delete: resourceNsxtClusterVirualIPDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_compute_manager.go
+++ b/nsxt/resource_nsxt_compute_manager.go
@@ -28,7 +28,7 @@ func resourceNsxtComputeManager() *schema.Resource {
 		Update: resourceNsxtComputeManagerUpdate,
 		Delete: resourceNsxtComputeManagerDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Schema: map[string]*schema.Schema{
 			"revision":     getRevisionSchema(),

--- a/nsxt/resource_nsxt_dhcp_relay_profile.go
+++ b/nsxt/resource_nsxt_dhcp_relay_profile.go
@@ -19,7 +19,7 @@ func resourceNsxtDhcpRelayProfile() *schema.Resource {
 		Update: resourceNsxtDhcpRelayProfileUpdate,
 		Delete: resourceNsxtDhcpRelayProfileDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		DeprecationMessage: mpObjectResourceDeprecationMessage,
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_dhcp_relay_service.go
+++ b/nsxt/resource_nsxt_dhcp_relay_service.go
@@ -19,7 +19,7 @@ func resourceNsxtDhcpRelayService() *schema.Resource {
 		Update: resourceNsxtDhcpRelayServiceUpdate,
 		Delete: resourceNsxtDhcpRelayServiceDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		DeprecationMessage: mpObjectResourceDeprecationMessage,
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_dhcp_server_profile.go
+++ b/nsxt/resource_nsxt_dhcp_server_profile.go
@@ -19,7 +19,7 @@ func resourceNsxtDhcpServerProfile() *schema.Resource {
 		Update: resourceNsxtDhcpServerProfileUpdate,
 		Delete: resourceNsxtDhcpServerProfileDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		DeprecationMessage: mpObjectResourceDeprecationMessage,
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_edge_cluster.go
+++ b/nsxt/resource_nsxt_edge_cluster.go
@@ -27,7 +27,7 @@ func resourceNsxtEdgeCluster() *schema.Resource {
 		Update: resourceNsxtEdgeClusterUpdate,
 		Delete: resourceNsxtEdgeClusterDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Schema: map[string]*schema.Schema{
 			"revision":     getRevisionSchema(),

--- a/nsxt/resource_nsxt_edge_high_availability_profile.go
+++ b/nsxt/resource_nsxt_edge_high_availability_profile.go
@@ -21,7 +21,7 @@ func resourceNsxtEdgeHighAvailabilityProfile() *schema.Resource {
 		Update: resourceNsxtEdgeHighAvailabilityProfileUpdate,
 		Delete: resourceNsxtEdgeHighAvailabilityProfileDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Schema: map[string]*schema.Schema{
 			"revision":     getRevisionSchema(),

--- a/nsxt/resource_nsxt_edge_transport_node.go
+++ b/nsxt/resource_nsxt_edge_transport_node.go
@@ -79,7 +79,7 @@ func resourceNsxtEdgeTransportNode() *schema.Resource {
 		Update: resourceNsxtEdgeTransportNodeUpdate,
 		Delete: resourceNsxtEdgeTransportNodeDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Schema: map[string]*schema.Schema{
 			"revision":     getRevisionSchema(),

--- a/nsxt/resource_nsxt_edge_transport_node_rtep.go
+++ b/nsxt/resource_nsxt_edge_transport_node_rtep.go
@@ -20,7 +20,7 @@ func resourceNsxtEdgeTransportNodeRTEP() *schema.Resource {
 		Update: resourceNsxtEdgeTransportNodeRTEPUpdate,
 		Delete: resourceNsxtEdgeTransportNodeRTEPDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Schema: map[string]*schema.Schema{
 			"edge_id": {

--- a/nsxt/resource_nsxt_ether_type_ns_service.go
+++ b/nsxt/resource_nsxt_ether_type_ns_service.go
@@ -19,7 +19,7 @@ func resourceNsxtEtherTypeNsService() *schema.Resource {
 		Update: resourceNsxtEtherTypeNsServiceUpdate,
 		Delete: resourceNsxtEtherTypeNsServiceDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		DeprecationMessage: mpObjectResourceDeprecationMessage,
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_failure_domain.go
+++ b/nsxt/resource_nsxt_failure_domain.go
@@ -26,7 +26,7 @@ func resourceNsxtFailureDomain() *schema.Resource {
 		Update: resourceNsxtFailureDomainUpdate,
 		Delete: resourceNsxtFailureDomainDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_firewall_section.go
+++ b/nsxt/resource_nsxt_firewall_section.go
@@ -27,7 +27,7 @@ func resourceNsxtFirewallSection() *schema.Resource {
 		Update: resourceNsxtFirewallSectionUpdate,
 		Delete: resourceNsxtFirewallSectionDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		DeprecationMessage: mpObjectResourceDeprecationMessage,
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_icmp_type_ns_service.go
+++ b/nsxt/resource_nsxt_icmp_type_ns_service.go
@@ -22,7 +22,7 @@ func resourceNsxtIcmpTypeNsService() *schema.Resource {
 		Update: resourceNsxtIcmpTypeNsServiceUpdate,
 		Delete: resourceNsxtIcmpTypeNsServiceDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		DeprecationMessage: mpObjectResourceDeprecationMessage,
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_igmp_type_ns_service.go
+++ b/nsxt/resource_nsxt_igmp_type_ns_service.go
@@ -19,7 +19,7 @@ func resourceNsxtIgmpTypeNsService() *schema.Resource {
 		Update: resourceNsxtIgmpTypeNsServiceUpdate,
 		Delete: resourceNsxtIgmpTypeNsServiceDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		DeprecationMessage: mpObjectResourceDeprecationMessage,
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_ip_block.go
+++ b/nsxt/resource_nsxt_ip_block.go
@@ -19,7 +19,7 @@ func resourceNsxtIPBlock() *schema.Resource {
 		Update: resourceNsxtIPBlockUpdate,
 		Delete: resourceNsxtIPBlockDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		DeprecationMessage: mpObjectResourceDeprecationMessage,
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_ip_block_subnet.go
+++ b/nsxt/resource_nsxt_ip_block_subnet.go
@@ -19,7 +19,7 @@ func resourceNsxtIPBlockSubnet() *schema.Resource {
 		// Update IP block subnet is not supported by the NSX
 		Delete: resourceNsxtIPBlockSubnetDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		DeprecationMessage: mpObjectResourceDeprecationMessage,
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_ip_discovery_switching_profile.go
+++ b/nsxt/resource_nsxt_ip_discovery_switching_profile.go
@@ -20,7 +20,7 @@ func resourceNsxtIPDiscoverySwitchingProfile() *schema.Resource {
 		Update: resourceNsxtIPDiscoverySwitchingProfileUpdate,
 		Delete: resourceNsxtIPDiscoverySwitchingProfileDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		DeprecationMessage: mpObjectResourceDeprecationMessage,
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_ip_pool.go
+++ b/nsxt/resource_nsxt_ip_pool.go
@@ -20,7 +20,7 @@ func resourceNsxtIPPool() *schema.Resource {
 		Update: resourceNsxtIPPoolUpdate,
 		Delete: resourceNsxtIPPoolDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		DeprecationMessage: mpObjectResourceDeprecationMessage,
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_ip_protocol_ns_service.go
+++ b/nsxt/resource_nsxt_ip_protocol_ns_service.go
@@ -20,7 +20,7 @@ func resourceNsxtIPProtocolNsService() *schema.Resource {
 		Update: resourceNsxtIPProtocolNsServiceUpdate,
 		Delete: resourceNsxtIPProtocolNsServiceDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		DeprecationMessage: mpObjectResourceDeprecationMessage,
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_ip_set.go
+++ b/nsxt/resource_nsxt_ip_set.go
@@ -19,7 +19,7 @@ func resourceNsxtIPSet() *schema.Resource {
 		Update: resourceNsxtIPSetUpdate,
 		Delete: resourceNsxtIPSetDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		DeprecationMessage: mpObjectResourceDeprecationMessage,
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_l4_port_set_ns_service.go
+++ b/nsxt/resource_nsxt_l4_port_set_ns_service.go
@@ -22,7 +22,7 @@ func resourceNsxtL4PortSetNsService() *schema.Resource {
 		Update: resourceNsxtL4PortSetNsServiceUpdate,
 		Delete: resourceNsxtL4PortSetNsServiceDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		DeprecationMessage: mpObjectResourceDeprecationMessage,
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_lb_client_ssl_profile.go
+++ b/nsxt/resource_nsxt_lb_client_ssl_profile.go
@@ -19,7 +19,7 @@ func resourceNsxtLbClientSslProfile() *schema.Resource {
 		Update: resourceNsxtLbClientSslProfileUpdate,
 		Delete: resourceNsxtLbClientSslProfileDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		DeprecationMessage: mpObjectResourceDeprecationMessage,
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_lb_cookie_persistence_profile.go
+++ b/nsxt/resource_nsxt_lb_cookie_persistence_profile.go
@@ -23,7 +23,7 @@ func resourceNsxtLbCookiePersistenceProfile() *schema.Resource {
 		Update: resourceNsxtLbCookiePersistenceProfileUpdate,
 		Delete: resourceNsxtLbCookiePersistenceProfileDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		DeprecationMessage: mpObjectResourceDeprecationMessage,
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_lb_fast_tcp_application_profile.go
+++ b/nsxt/resource_nsxt_lb_fast_tcp_application_profile.go
@@ -20,7 +20,7 @@ func resourceNsxtLbFastTCPApplicationProfile() *schema.Resource {
 		Update: resourceNsxtLbFastTCPApplicationProfileUpdate,
 		Delete: resourceNsxtLbFastTCPApplicationProfileDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		DeprecationMessage: mpObjectResourceDeprecationMessage,
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_lb_fast_udp_application_profile.go
+++ b/nsxt/resource_nsxt_lb_fast_udp_application_profile.go
@@ -20,7 +20,7 @@ func resourceNsxtLbFastUDPApplicationProfile() *schema.Resource {
 		Update: resourceNsxtLbFastUDPApplicationProfileUpdate,
 		Delete: resourceNsxtLbFastUDPApplicationProfileDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		DeprecationMessage: mpObjectResourceDeprecationMessage,
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_lb_http_application_profile.go
+++ b/nsxt/resource_nsxt_lb_http_application_profile.go
@@ -22,7 +22,7 @@ func resourceNsxtLbHTTPApplicationProfile() *schema.Resource {
 		Update: resourceNsxtLbHTTPApplicationProfileUpdate,
 		Delete: resourceNsxtLbHTTPApplicationProfileDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		DeprecationMessage: mpObjectResourceDeprecationMessage,
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_lb_http_forwarding_rule.go
+++ b/nsxt/resource_nsxt_lb_http_forwarding_rule.go
@@ -20,7 +20,7 @@ func resourceNsxtLbHTTPForwardingRule() *schema.Resource {
 		Update: resourceNsxtLbHTTPForwardingRuleUpdate,
 		Delete: resourceNsxtLbHTTPRuleDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		DeprecationMessage: mpObjectResourceDeprecationMessage,
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_lb_http_monitor.go
+++ b/nsxt/resource_nsxt_lb_http_monitor.go
@@ -19,7 +19,7 @@ func resourceNsxtLbHTTPMonitor() *schema.Resource {
 		Update: resourceNsxtLbHTTPMonitorUpdate,
 		Delete: resourceNsxtLbMonitorDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		DeprecationMessage: mpObjectResourceDeprecationMessage,
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_lb_http_request_rewrite_rule.go
+++ b/nsxt/resource_nsxt_lb_http_request_rewrite_rule.go
@@ -20,7 +20,7 @@ func resourceNsxtLbHTTPRequestRewriteRule() *schema.Resource {
 		Update: resourceNsxtLbHTTPRequestRewriteRuleUpdate,
 		Delete: resourceNsxtLbHTTPRuleDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		DeprecationMessage: mpObjectResourceDeprecationMessage,
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_lb_http_response_rewrite_rule.go
+++ b/nsxt/resource_nsxt_lb_http_response_rewrite_rule.go
@@ -20,7 +20,7 @@ func resourceNsxtLbHTTPResponseRewriteRule() *schema.Resource {
 		Update: resourceNsxtLbHTTPResponseRewriteRuleUpdate,
 		Delete: resourceNsxtLbHTTPRuleDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		DeprecationMessage: mpObjectResourceDeprecationMessage,
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_lb_http_virtual_server.go
+++ b/nsxt/resource_nsxt_lb_http_virtual_server.go
@@ -19,7 +19,7 @@ func resourceNsxtLbHTTPVirtualServer() *schema.Resource {
 		Update: resourceNsxtLbHTTPVirtualServerUpdate,
 		Delete: resourceNsxtLbHTTPVirtualServerDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		DeprecationMessage: mpObjectResourceDeprecationMessage,
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_lb_https_monitor.go
+++ b/nsxt/resource_nsxt_lb_https_monitor.go
@@ -20,7 +20,7 @@ func resourceNsxtLbHTTPSMonitor() *schema.Resource {
 		Update: resourceNsxtLbHTTPSMonitorUpdate,
 		Delete: resourceNsxtLbMonitorDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		DeprecationMessage: mpObjectResourceDeprecationMessage,
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_lb_icmp_monitor.go
+++ b/nsxt/resource_nsxt_lb_icmp_monitor.go
@@ -20,7 +20,7 @@ func resourceNsxtLbIcmpMonitor() *schema.Resource {
 		Update: resourceNsxtLbIcmpMonitorUpdate,
 		Delete: resourceNsxtLbMonitorDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		DeprecationMessage: mpObjectResourceDeprecationMessage,
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_lb_passive_monitor.go
+++ b/nsxt/resource_nsxt_lb_passive_monitor.go
@@ -19,7 +19,7 @@ func resourceNsxtLbPassiveMonitor() *schema.Resource {
 		Update: resourceNsxtLbPassiveMonitorUpdate,
 		Delete: resourceNsxtLbMonitorDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		DeprecationMessage: mpObjectResourceDeprecationMessage,
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_lb_pool.go
+++ b/nsxt/resource_nsxt_lb_pool.go
@@ -26,7 +26,7 @@ func resourceNsxtLbPool() *schema.Resource {
 		Update: resourceNsxtLbPoolUpdate,
 		Delete: resourceNsxtLbPoolDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		DeprecationMessage: mpObjectResourceDeprecationMessage,
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_lb_server_ssl_profile.go
+++ b/nsxt/resource_nsxt_lb_server_ssl_profile.go
@@ -19,7 +19,7 @@ func resourceNsxtLbServerSslProfile() *schema.Resource {
 		Update: resourceNsxtLbServerSslProfileUpdate,
 		Delete: resourceNsxtLbServerSslProfileDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		DeprecationMessage: mpObjectResourceDeprecationMessage,
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_lb_service.go
+++ b/nsxt/resource_nsxt_lb_service.go
@@ -23,7 +23,7 @@ func resourceNsxtLbService() *schema.Resource {
 		Update: resourceNsxtLbServiceUpdate,
 		Delete: resourceNsxtLbServiceDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		DeprecationMessage: mpObjectResourceDeprecationMessage,
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_lb_source_ip_persistence_profile.go
+++ b/nsxt/resource_nsxt_lb_source_ip_persistence_profile.go
@@ -19,7 +19,7 @@ func resourceNsxtLbSourceIPPersistenceProfile() *schema.Resource {
 		Update: resourceNsxtLbSourceIPPersistenceProfileUpdate,
 		Delete: resourceNsxtLbSourceIPPersistenceProfileDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		DeprecationMessage: mpObjectResourceDeprecationMessage,
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_lb_tcp_monitor.go
+++ b/nsxt/resource_nsxt_lb_tcp_monitor.go
@@ -19,7 +19,7 @@ func resourceNsxtLbTCPMonitor() *schema.Resource {
 		Update: resourceNsxtLbTCPMonitorUpdate,
 		Delete: resourceNsxtLbMonitorDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		DeprecationMessage: mpObjectResourceDeprecationMessage,
 		Schema:             getLbL4MonitorSchema("tcp"),

--- a/nsxt/resource_nsxt_lb_tcp_virtual_server.go
+++ b/nsxt/resource_nsxt_lb_tcp_virtual_server.go
@@ -19,7 +19,7 @@ func resourceNsxtLbTCPVirtualServer() *schema.Resource {
 		Update: resourceNsxtLbTCPVirtualServerUpdate,
 		Delete: resourceNsxtLbTCPVirtualServerDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		DeprecationMessage: mpObjectResourceDeprecationMessage,
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_lb_udp_monitor.go
+++ b/nsxt/resource_nsxt_lb_udp_monitor.go
@@ -19,7 +19,7 @@ func resourceNsxtLbUDPMonitor() *schema.Resource {
 		Update: resourceNsxtLbUDPMonitorUpdate,
 		Delete: resourceNsxtLbMonitorDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		DeprecationMessage: mpObjectResourceDeprecationMessage,
 		Schema:             getLbL4MonitorSchema("udp"),

--- a/nsxt/resource_nsxt_lb_udp_virtual_server.go
+++ b/nsxt/resource_nsxt_lb_udp_virtual_server.go
@@ -19,7 +19,7 @@ func resourceNsxtLbUDPVirtualServer() *schema.Resource {
 		Update: resourceNsxtLbUDPVirtualServerUpdate,
 		Delete: resourceNsxtLbUDPVirtualServerDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		DeprecationMessage: mpObjectResourceDeprecationMessage,
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_logical_dhcp_port.go
+++ b/nsxt/resource_nsxt_logical_dhcp_port.go
@@ -21,7 +21,7 @@ func resourceNsxtLogicalDhcpPort() *schema.Resource {
 		Update: resourceNsxtLogicalDhcpPortUpdate,
 		Delete: resourceNsxtLogicalDhcpPortDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		DeprecationMessage: mpObjectResourceDeprecationMessage,
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_logical_dhcp_server.go
+++ b/nsxt/resource_nsxt_logical_dhcp_server.go
@@ -20,7 +20,7 @@ func resourceNsxtLogicalDhcpServer() *schema.Resource {
 		Update: resourceNsxtLogicalDhcpServerUpdate,
 		Delete: resourceNsxtLogicalDhcpServerDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		DeprecationMessage: mpObjectResourceDeprecationMessage,
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_logical_port.go
+++ b/nsxt/resource_nsxt_logical_port.go
@@ -19,7 +19,7 @@ func resourceNsxtLogicalPort() *schema.Resource {
 		Update: resourceNsxtLogicalPortUpdate,
 		Delete: resourceNsxtLogicalPortDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		DeprecationMessage: mpObjectResourceDeprecationMessage,
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_logical_router_centralized_service_port.go
+++ b/nsxt/resource_nsxt_logical_router_centralized_service_port.go
@@ -20,7 +20,7 @@ func resourceNsxtLogicalRouterCentralizedServicePort() *schema.Resource {
 		Update: resourceNsxtLogicalRouterCentralizedServicePortUpdate,
 		Delete: resourceNsxtLogicalRouterCentralizedServicePortDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		DeprecationMessage: mpObjectResourceDeprecationMessage,
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_logical_router_downlink_port.go
+++ b/nsxt/resource_nsxt_logical_router_downlink_port.go
@@ -24,7 +24,7 @@ func resourceNsxtLogicalRouterDownLinkPort() *schema.Resource {
 		Update: resourceNsxtLogicalRouterDownLinkPortUpdate,
 		Delete: resourceNsxtLogicalRouterDownLinkPortDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		DeprecationMessage: mpObjectResourceDeprecationMessage,
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_logical_router_link_port_on_tier0.go
+++ b/nsxt/resource_nsxt_logical_router_link_port_on_tier0.go
@@ -19,7 +19,7 @@ func resourceNsxtLogicalRouterLinkPortOnTier0() *schema.Resource {
 		Update: resourceNsxtLogicalRouterLinkPortOnTier0Update,
 		Delete: resourceNsxtLogicalRouterLinkPortOnTier0Delete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		DeprecationMessage: mpObjectResourceDeprecationMessage,
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_logical_router_link_port_on_tier1.go
+++ b/nsxt/resource_nsxt_logical_router_link_port_on_tier1.go
@@ -19,7 +19,7 @@ func resourceNsxtLogicalRouterLinkPortOnTier1() *schema.Resource {
 		Update: resourceNsxtLogicalRouterLinkPortOnTier1Update,
 		Delete: resourceNsxtLogicalRouterLinkPortOnTier1Delete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		DeprecationMessage: mpObjectResourceDeprecationMessage,
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_logical_switch.go
+++ b/nsxt/resource_nsxt_logical_switch.go
@@ -39,7 +39,7 @@ func resourceNsxtLogicalSwitch() *schema.Resource {
 		Update: resourceNsxtLogicalSwitchUpdate,
 		Delete: resourceNsxtLogicalSwitchDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		DeprecationMessage: mpObjectResourceDeprecationMessage,
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_logical_tier0_router.go
+++ b/nsxt/resource_nsxt_logical_tier0_router.go
@@ -23,7 +23,7 @@ func resourceNsxtLogicalTier0Router() *schema.Resource {
 		Update: resourceNsxtLogicalTier0RouterUpdate,
 		Delete: resourceNsxtLogicalTier0RouterDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		DeprecationMessage: mpObjectResourceDeprecationMessage,
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_logical_tier1_router.go
+++ b/nsxt/resource_nsxt_logical_tier1_router.go
@@ -37,7 +37,7 @@ func resourceNsxtLogicalTier1Router() *schema.Resource {
 		Update: resourceNsxtLogicalTier1RouterUpdate,
 		Delete: resourceNsxtLogicalTier1RouterDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		DeprecationMessage: mpObjectResourceDeprecationMessage,
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_mac_management_switching_profile.go
+++ b/nsxt/resource_nsxt_mac_management_switching_profile.go
@@ -20,7 +20,7 @@ func resourceNsxtMacManagementSwitchingProfile() *schema.Resource {
 		Update: resourceNsxtMacManagementSwitchingProfileUpdate,
 		Delete: resourceNsxtMacManagementSwitchingProfileDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		DeprecationMessage: mpObjectResourceDeprecationMessage,
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_node_user.go
+++ b/nsxt/resource_nsxt_node_user.go
@@ -22,7 +22,7 @@ func resourceNsxtUsers() *schema.Resource {
 		Update: resourceNsxtNodeUserUpdate,
 		Delete: resourceNsxtNodeUserDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_ns_group.go
+++ b/nsxt/resource_nsxt_ns_group.go
@@ -21,7 +21,7 @@ func resourceNsxtNsGroup() *schema.Resource {
 		Update: resourceNsxtNsGroupUpdate,
 		Delete: resourceNsxtNsGroupDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		DeprecationMessage: mpObjectResourceDeprecationMessage,
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_ns_service_group.go
+++ b/nsxt/resource_nsxt_ns_service_group.go
@@ -20,7 +20,7 @@ func resourceNsxtNsServiceGroup() *schema.Resource {
 		Update: resourceNsxtNsServiceGroupUpdate,
 		Delete: resourceNsxtNsServiceGroupDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		DeprecationMessage: mpObjectResourceDeprecationMessage,
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_policy_context_profile_custom_attribute.go
+++ b/nsxt/resource_nsxt_policy_context_profile_custom_attribute.go
@@ -38,7 +38,7 @@ func resourceNsxtPolicyContextProfileCustomAttribute() *schema.Resource {
 		Read:   resourceNsxtPolicyContextProfileCustomAttributeRead,
 		Delete: resourceNsxtPolicyContextProfileCustomAttributeDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_policy_domain.go
+++ b/nsxt/resource_nsxt_policy_domain.go
@@ -25,7 +25,7 @@ func resourceNsxtPolicyDomain() *schema.Resource {
 		Update: resourceNsxtPolicyDomainUpdate,
 		Delete: resourceNsxtPolicyDomainDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_policy_evpn_tenant.go
+++ b/nsxt/resource_nsxt_policy_evpn_tenant.go
@@ -20,7 +20,7 @@ func resourceNsxtPolicyEvpnTenant() *schema.Resource {
 		Update: resourceNsxtPolicyEvpnTenantUpdate,
 		Delete: resourceNsxtPolicyEvpnTenantDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_policy_firewall_exclude_list_member.go
+++ b/nsxt/resource_nsxt_policy_firewall_exclude_list_member.go
@@ -19,7 +19,7 @@ func resourceNsxtPolicyFirewallExcludeListMember() *schema.Resource {
 		Read:   resourceNsxtPolicyFirewallExcludeListMemberRead,
 		Delete: resourceNsxtPolicyFirewallExcludeListMemberDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Schema: map[string]*schema.Schema{
 			"member": {

--- a/nsxt/resource_nsxt_policy_gateway_qos_profile.go
+++ b/nsxt/resource_nsxt_policy_gateway_qos_profile.go
@@ -27,7 +27,7 @@ func resourceNsxtPolicyGatewayQosProfile() *schema.Resource {
 		Update: resourceNsxtPolicyGatewayQosProfileUpdate,
 		Delete: resourceNsxtPolicyGatewayQosProfileDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_policy_ipsec_vpn_dpd_profile.go
+++ b/nsxt/resource_nsxt_policy_ipsec_vpn_dpd_profile.go
@@ -26,7 +26,7 @@ func resourceNsxtPolicyIPSecVpnDpdProfile() *schema.Resource {
 		Update: resourceNsxtPolicyIPSecVpnDpdProfileUpdate,
 		Delete: resourceNsxtPolicyIPSecVpnDpdProfileDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_policy_ipsec_vpn_ike_profile.go
+++ b/nsxt/resource_nsxt_policy_ipsec_vpn_ike_profile.go
@@ -53,7 +53,7 @@ func resourceNsxtPolicyIPSecVpnIkeProfile() *schema.Resource {
 		Update: resourceNsxtPolicyIPSecVpnIkeProfileUpdate,
 		Delete: resourceNsxtPolicyIPSecVpnIkeProfileDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_policy_ipsec_vpn_tunnel_profile.go
+++ b/nsxt/resource_nsxt_policy_ipsec_vpn_tunnel_profile.go
@@ -56,7 +56,7 @@ func resourceNsxtPolicyIPSecVpnTunnelProfile() *schema.Resource {
 		Update: resourceNsxtPolicyIPSecVpnTunnelProfileUpdate,
 		Delete: resourceNsxtPolicyIPSecVpnTunnelProfileDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_policy_lb_pool.go
+++ b/nsxt/resource_nsxt_policy_lb_pool.go
@@ -37,7 +37,7 @@ func resourceNsxtPolicyLBPool() *schema.Resource {
 		Update: resourceNsxtPolicyLBPoolUpdate,
 		Delete: resourceNsxtPolicyLBPoolDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_policy_lb_service.go
+++ b/nsxt/resource_nsxt_policy_lb_service.go
@@ -41,7 +41,7 @@ func resourceNsxtPolicyLBService() *schema.Resource {
 		Update: resourceNsxtPolicyLBServiceUpdate,
 		Delete: resourceNsxtPolicyLBServiceDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_policy_lb_virtual_server.go
+++ b/nsxt/resource_nsxt_policy_lb_virtual_server.go
@@ -142,7 +142,7 @@ func resourceNsxtPolicyLBVirtualServer() *schema.Resource {
 		Update: resourceNsxtPolicyLBVirtualServerUpdate,
 		Delete: resourceNsxtPolicyLBVirtualServerDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_policy_ldap_identity_source.go
+++ b/nsxt/resource_nsxt_policy_ldap_identity_source.go
@@ -31,7 +31,7 @@ func resourceNsxtPolicyLdapIdentitySource() *schema.Resource {
 		Update: resourceNsxtPolicyLdapIdentitySourceUpdate,
 		Delete: resourceNsxtPolicyLdapIdentitySourceDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_policy_project.go
+++ b/nsxt/resource_nsxt_policy_project.go
@@ -20,7 +20,7 @@ func resourceNsxtPolicyProject() *schema.Resource {
 		Update: resourceNsxtPolicyProjectUpdate,
 		Delete: resourceNsxtPolicyProjectDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_policy_role.go
+++ b/nsxt/resource_nsxt_policy_role.go
@@ -28,7 +28,7 @@ func resourceNsxtPolicyUserManagementRole() *schema.Resource {
 		Update: resourceNsxtPolicyUserManagementRoleUpdate,
 		Delete: resourceNsxtPolicyUserManagementRoleDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_policy_role_binding.go
+++ b/nsxt/resource_nsxt_policy_role_binding.go
@@ -37,7 +37,7 @@ func resourceNsxtPolicyUserManagementRoleBinding() *schema.Resource {
 		Update: resourceNsxtPolicyUserManagementRoleBindingUpdate,
 		Delete: resourceNsxtPolicyUserManagementRoleBindingDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_policy_tier0_gateway.go
+++ b/nsxt/resource_nsxt_policy_tier0_gateway.go
@@ -49,7 +49,7 @@ func resourceNsxtPolicyTier0Gateway() *schema.Resource {
 		Update: resourceNsxtPolicyTier0GatewayUpdate,
 		Delete: resourceNsxtPolicyTier0GatewayDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_principal_identity.go
+++ b/nsxt/resource_nsxt_principal_identity.go
@@ -20,7 +20,7 @@ func resourceNsxtPrincipalIdentity() *schema.Resource {
 		Read:   resourceNsxtPrincipalIdentityRead,
 		Delete: resourceNsxtPrincipalIdentityDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_qos_switching_profile.go
+++ b/nsxt/resource_nsxt_qos_switching_profile.go
@@ -28,7 +28,7 @@ func resourceNsxtQosSwitchingProfile() *schema.Resource {
 		Update: resourceNsxtQosSwitchingProfileUpdate,
 		Delete: resourceNsxtQosSwitchingProfileDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		DeprecationMessage: mpObjectResourceDeprecationMessage,
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_spoofguard_switching_profile.go
+++ b/nsxt/resource_nsxt_spoofguard_switching_profile.go
@@ -19,7 +19,7 @@ func resourceNsxtSpoofGuardSwitchingProfile() *schema.Resource {
 		Update: resourceNsxtSpoofGuardSwitchingProfileUpdate,
 		Delete: resourceNsxtSpoofGuardSwitchingProfileDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		DeprecationMessage: mpObjectResourceDeprecationMessage,
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_switch_security_switching_profile.go
+++ b/nsxt/resource_nsxt_switch_security_switching_profile.go
@@ -33,7 +33,7 @@ func resourceNsxtSwitchSecuritySwitchingProfile() *schema.Resource {
 		Update: resourceNsxtSwitchSecuritySwitchingProfileUpdate,
 		Delete: resourceNsxtSwitchSecuritySwitchingProfileDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		DeprecationMessage: mpObjectResourceDeprecationMessage,
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_vlan_logical_switch.go
+++ b/nsxt/resource_nsxt_vlan_logical_switch.go
@@ -19,7 +19,7 @@ func resourceNsxtVlanLogicalSwitch() *schema.Resource {
 		Update: resourceNsxtVlanLogicalSwitchUpdate,
 		Delete: resourceNsxtVlanLogicalSwitchDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		DeprecationMessage: mpObjectResourceDeprecationMessage,
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_vm_tags.go
+++ b/nsxt/resource_nsxt_vm_tags.go
@@ -22,7 +22,7 @@ func resourceNsxtVMTags() *schema.Resource {
 		Update: resourceNsxtVMTagsUpdate,
 		Delete: resourceNsxtVMTagsDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		DeprecationMessage: mpObjectResourceDeprecationMessage,
 		Schema: map[string]*schema.Schema{

--- a/tools/resource_nsxt_policy_template
+++ b/tools/resource_nsxt_policy_template
@@ -25,7 +25,7 @@ func resourceNsxtPolicy<!RESOURCE!>() *schema.Resource {
 		Update: resourceNsxtPolicy<!RESOURCE!>Update,
 		Delete: resourceNsxtPolicy<!RESOURCE!>Delete,
 		Importer: &schema.ResourceImporter{
-                        State: schema.ImportStatePassthrough,
+                        StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/tools/terragen.py
+++ b/tools/terragen.py
@@ -494,7 +494,7 @@ def main():
         # Add the importer line
         pretty_writeln(f, "Importer: &schema.ResourceImporter{")
         shift()
-        pretty_writeln(f, "State: schema.ImportStatePassthrough,")
+        pretty_writeln(f, "StateContext: schema.ImportStatePassthroughContext,")
         unshift()
         pretty_writeln(f, "},")
 


### PR DESCRIPTION
**Summary of Pull Request**

The type `schema.ImportStatePassthrough` has been deprecated in favour of `schema.ImportStatePassthroughContext` in the SDK `helper/schema`.

References:

- https://www.terraform.io/docs/extend/guides/v2-upgrade-guide.html#more-support-for-context-context
- https://github.com/hashicorp/terraform-plugin-sdk/pull/276


**Type of Pull Request**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style/formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [x] This is a chore update
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

<!--
  Is this related to any GitHub issue(s)?
-->

**Test and Documentation Coverage**

<!--
    Please check the one that applies to this pull request using "x".
-->

For bug fixes or features:

- [ ] Tests have been completed.
- [ ] Documentation has been added/updated.

**Breaking Changes?**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
