### PR TITLE
Pre-check bundle should be optional also for 4.1.1 and beyond

### DIFF
--- a/nsxt/resource_nsxt_upgrade_prepare.go
+++ b/nsxt/resource_nsxt_upgrade_prepare.go
@@ -273,7 +273,7 @@ func uploadPrecheckAndUpgradeBundle(d *schema.ResourceData, m interface{}) error
 	precheckBundleType := nsxModel.UpgradeBundleFetchRequest_BUNDLE_TYPE_PRE_UPGRADE
 	precheckBundleURL := d.Get("precheck_bundle_url").(string)
 	if !precheckBundleCompatibilityCheck(precheckBundleURL) {
-		return fmt.Errorf("Precheck bundle is only supported and is required for NSXT version >= 4.1.1")
+		return fmt.Errorf("Precheck bundle is only supported for NSXT version >= 4.1.1")
 	}
 	if len(precheckBundleURL) > 0 {
 		err := uploadUpgradeBundle(d, m, precheckBundleType)
@@ -290,9 +290,6 @@ func uploadPrecheckAndUpgradeBundle(d *schema.ResourceData, m interface{}) error
 
 func precheckBundleCompatibilityCheck(precheckBundleURL string) bool {
 	if util.NsxVersionLower("4.1.1") && len(precheckBundleURL) > 0 {
-		return false
-	}
-	if util.NsxVersionHigherOrEqual("4.1.1") && len(precheckBundleURL) == 0 {
 		return false
 	}
 	return true

--- a/website/docs/r/upgrade_prepare.html.markdown
+++ b/website/docs/r/upgrade_prepare.html.markdown
@@ -36,7 +36,7 @@ The following arguments are supported:
 
 * `upgrade_bundle_url` - (Required) The url to download the Manager Upgrade bundle.
 * `version` - (Optional) Target upgrade version for NSX, format is x.x.x..., should include at least 3 digits, example: 4.1.2
-* `precheck_bundle_url` - (Optional) The url to download the Precheck bundle. This field is required if NSX >= 4.1.1
+* `precheck_bundle_url` - (Optional) The url to download the Precheck bundle.
 * `accept_user_agreement` - (Required) This field must be set to true otherwise upgrade will not proceed.
 * `bundle_upload_timeout` - (Optional) Timeout for uploading upgrade bundle in seconds. Default is `3600`.
 * `uc_upgrade_timeout` - (Optional) Timeout for upgrading upgrade coordinator in seconds. Default is `1800`.


### PR DESCRIPTION
Upgrade bundle contains the pre-checks as well. This attribute can be still used when a user would like to run pre-checks from a later build than the upgrade itself.