### PR TITLE
Handle project path parsing properly

### DIFF
--- a/nsxt/policy_utils.go
+++ b/nsxt/policy_utils.go
@@ -311,6 +311,9 @@ func parseStandardPolicyPath(path string) ([]string, error) {
 		// append org and project
 		parents = append(parents, segments[2])
 		parents = append(parents, segments[4])
+		if len(segments) == 5 { // This is a project path, no further parsing is required
+			return parents, nil
+		}
 		idx = 5
 
 		if len(segments) > 6 && segments[5] == "vpcs" {


### PR DESCRIPTION
Path parsing func parseStandardPolicyPath() didn't handle well project paths, seems like it could only handle sub-project objects.