### PR TITLE
data.nsxt_policy_vm: exports tags

### DIFF
--- a/nsxt/data_source_nsxt_policy_vm.go
+++ b/nsxt/data_source_nsxt_policy_vm.go
@@ -26,6 +26,7 @@ func dataSourceNsxtPolicyVM() *schema.Resource {
 			"external_id":  getDataSourceStringSchema("External ID of the Virtual Machine"),
 			"bios_id":      getDataSourceStringSchema("BIOS UUID of the Virtual Machine"),
 			"instance_id":  getDataSourceStringSchema("Instance UUID of the Virtual Machine"),
+			"tag":          getTagsSchema(),
 			"context":      getContextSchema(false, false, false),
 		},
 	}
@@ -47,6 +48,7 @@ func dataSourceNsxtPolicyVMIDRead(d *schema.ResourceData, m interface{}) error {
 
 	objID := getNsxtPolicyVMIDFromSchema(d)
 	context := getSessionContext(d, m)
+
 	if objID != "" {
 		vmObj, err := findNsxtPolicyVMByID(context, connector, objID, m)
 		if err != nil {
@@ -85,5 +87,7 @@ func dataSourceNsxtPolicyVMIDRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("external_id", *vmModel.ExternalId)
 	d.Set("bios_id", computeIDMap[nsxtPolicyBiosUUIDKey])
 	d.Set("instance_id", computeIDMap[nsxtPolicyInstanceUUIDKey])
+	setPolicyTagsInSchema(d, vmModel.Tags)
+
 	return nil
 }

--- a/nsxt/data_source_nsxt_policy_vm_test.go
+++ b/nsxt/data_source_nsxt_policy_vm_test.go
@@ -42,6 +42,7 @@ func testAccDataSourceNsxtPolicyVMBasic(t *testing.T, withContext bool, preCheck
 					resource.TestCheckResourceAttrSet(testResourceName, "bios_id"),
 					resource.TestCheckResourceAttrSet(testResourceName, "external_id"),
 					resource.TestCheckResourceAttrSet(testResourceName, "instance_id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "tag.#"),
 				),
 			},
 			{
@@ -52,6 +53,7 @@ func testAccDataSourceNsxtPolicyVMBasic(t *testing.T, withContext bool, preCheck
 					resource.TestCheckResourceAttrSet(testResourceName, "bios_id"),
 					resource.TestCheckResourceAttrSet(testResourceName, "external_id"),
 					resource.TestCheckResourceAttrSet(testResourceName, "instance_id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "tag.#"),
 				),
 			},
 		},

--- a/website/docs/d/policy_vm.html.markdown
+++ b/website/docs/d/policy_vm.html.markdown
@@ -48,3 +48,4 @@ data "nsxt_policy_vm" "nsxt_vm1" {
 In addition to arguments listed above, the following attributes are exported:
 
 * `description` - The description of the Virtual Machine.
+* `tag` - A list of scope + tag pairs associated with this Virtual Machine.


### PR DESCRIPTION
It's rather convenient to have the tags for a given VM when using the data source, so here is a suggested enhancement. This is my first encounter with this provider, so please let med know if there's any changes the maintainers would like to see implemented.

I've tested this with a debugger towards a local environement.