### PR TITLE
Ignore create_service_account with NSX 9.0.0

### DIFF
--- a/nsxt/resource_nsxt_compute_manager.go
+++ b/nsxt/resource_nsxt_compute_manager.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/vmware/terraform-provider-nsxt/nsxt/util"
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/bindings"
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/data"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp/nsx/fabric"
@@ -248,7 +249,6 @@ func resourceNsxtComputeManagerCreate(d *schema.ResourceData, m interface{}) err
 		DisplayName:           &displayName,
 		Tags:                  tags,
 		AccessLevelForOidc:    accessLevelForOidc,
-		CreateServiceAccount:  &createServiceAccount,
 		Credential:            credential,
 		ExtensionCertificate:  getExtensionCertificate(d),
 		MultiNsx:              &multiNSX,
@@ -256,6 +256,12 @@ func resourceNsxtComputeManagerCreate(d *schema.ResourceData, m interface{}) err
 		ReverseProxyHttpsPort: reverseProxyHTTPSsPort,
 		Server:                &server,
 		SetAsOidcProvider:     &setAsOidcProvider,
+	}
+
+	// From 9.0.0 onwards CreateServiceAccount can not be false
+	// so we can effetively ignore this field
+	if util.NsxVersionLower("9.0.0") {
+		obj.CreateServiceAccount = &createServiceAccount
 	}
 
 	log.Printf("[INFO] Creating Compute Manager %s", displayName)
@@ -505,7 +511,6 @@ func resourceNsxtComputeManagerUpdate(d *schema.ResourceData, m interface{}) err
 		DisplayName:           &displayName,
 		Tags:                  tags,
 		AccessLevelForOidc:    accessLevelForOidc,
-		CreateServiceAccount:  &createServiceAccount,
 		Credential:            credential,
 		ExtensionCertificate:  getExtensionCertificate(d),
 		MultiNsx:              &multiNSX,
@@ -514,6 +519,12 @@ func resourceNsxtComputeManagerUpdate(d *schema.ResourceData, m interface{}) err
 		Server:                &server,
 		SetAsOidcProvider:     &setAsOidcProvider,
 		Revision:              &revision,
+	}
+
+	// From 9.0.0 onwards CreateServiceAccount can not be false
+	// so we can effetively ignore this field
+	if util.NsxVersionLower("9.0.0") {
+		obj.CreateServiceAccount = &createServiceAccount
 	}
 
 	_, err = client.Update(id, obj)

--- a/website/docs/r/compute_manager.html.markdown
+++ b/website/docs/r/compute_manager.html.markdown
@@ -41,7 +41,7 @@ The following arguments are supported:
 * `description` - (Optional) Description of the resource.
 * `tag` - (Optional) A list of scope + tag pairs to associate with this resource.
 * `access_level_for_oidc` - (Optional) Specifies access level to NSX from the compute manager. Accepted values - 'FULL' or 'LIMITED'. The default value is 'FULL'.
-* `create_service_account` - (Optional) Specifies whether service account is created or not on compute manager. Note that the default for this setting has changed with NSX 9.0 from `false` to `true`.
+* `create_service_account` - (Optional) Specifies whether service account is created or not on compute manager. Note that `false` value for this attribute is no longer supported with NSX 9.0 and above.
 * `credential` - (Required) Login credentials for the compute manager. Should contain exactly one credential enlisted below: 
   * `saml_login` - (Optional) A login credential specifying saml token.
     * `thumbprint` - (Required) Thumbprint of the server.


### PR DESCRIPTION
In compute manager resource, NSX no longer accepts false value for create_service_account attribute.
Since terraform sdk can't distinguish between unset value and false value for the attribute, we will ignore the attribute entirely for NSX 9.0 and above