### PR TITLE
Allow updating IP allocation under project or VPC

### DIFF
--- a/nsxt/resource_nsxt_policy_project_ip_address_allocation.go
+++ b/nsxt/resource_nsxt_policy_project_ip_address_allocation.go
@@ -181,6 +181,11 @@ func resourceNsxtPolicyProjectIpAddressAllocationUpdate(d *schema.ResourceData, 
 		Revision:    &revision,
 	}
 
+	elem := reflect.ValueOf(&obj).Elem()
+	if err := metadata.SchemaToStruct(elem, d, projectIpAddressAllocationSchema, "", nil); err != nil {
+		return err
+	}
+
 	// Only the above attributes can be updated, others force recreation
 	client := clientLayer.NewIpAddressAllocationsClient(connector)
 	_, err := client.Update(parents[0], parents[1], id, obj)

--- a/nsxt/resource_nsxt_policy_project_ip_address_allocation_test.go
+++ b/nsxt/resource_nsxt_policy_project_ip_address_allocation_test.go
@@ -48,7 +48,6 @@ func TestAccResourceNsxtPolicyProjectIpAddressAllocation_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
 				),
 			},
-			/* TODO - enable when/if IP allocation update is supported on NSX
 			{
 				Config: testAccNsxtPolicyProjectIpAddressAllocationTemplate(false),
 				Check: resource.ComposeTestCheckFunc(
@@ -73,7 +72,7 @@ func TestAccResourceNsxtPolicyProjectIpAddressAllocation_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
 					resource.TestCheckResourceAttr(testResourceName, "tag.#", "0"),
 				),
-			},*/
+			},
 		},
 	})
 }
@@ -176,7 +175,7 @@ resource "nsxt_policy_project_ip_address_allocation" "test" {
 
 data "nsxt_policy_project_ip_address_allocation" "test" {
   %s
-  ip_allocations = nsxt_policy_project_ip_address_allocation.ip_allocations
+  allocation_ips = nsxt_policy_project_ip_address_allocation.test.allocation_ips
 }`, os.Getenv("NSXT_VPC_PROJECT_ID"), testAccNsxtProjectContext(), attrMap["display_name"], attrMap["description"], attrMap["allocation_size"], testAccNsxtProjectContext())
 }
 
@@ -195,6 +194,6 @@ resource "nsxt_policy_project_ip_address_allocation" "test" {
 
 data "nsxt_policy_project_ip_address_allocation" "test" {
   %s
-  ip_allocations = nsxt_policy_project_ip_address_allocation.ip_allocations
+  allocation_ips = nsxt_policy_project_ip_address_allocation.test.allocation_ips
 }`, os.Getenv("NSXT_VPC_PROJECT_ID"), testAccNsxtProjectContext(), accTestProjectIpAddressAllocationUpdateAttributes["display_name"], accTestProjectIpAddressAllocationUpdateAttributes["allocation_size"], testAccNsxtProjectContext())
 }

--- a/nsxt/resource_nsxt_vpc_ip_address_allocation_test.go
+++ b/nsxt/resource_nsxt_vpc_ip_address_allocation_test.go
@@ -20,7 +20,7 @@ var accTestVpcIpAddressAllocationCreateAttributes = map[string]string{
 var accTestVpcIpAddressAllocationUpdateAttributes = map[string]string{
 	"display_name":    getAccTestResourceName(),
 	"description":     "terraform updated",
-	"allocation_size": "1",
+	"allocation_size": "2",
 }
 
 func TestAccResourceNsxtVpcIpAddressAllocation_basic(t *testing.T) {
@@ -48,7 +48,6 @@ func TestAccResourceNsxtVpcIpAddressAllocation_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
 				),
 			},
-			/* For now, UPDATE is not supported for this resource
 			{
 				Config: testAccNsxtVpcIpAddressAllocationTemplate(false),
 				Check: resource.ComposeTestCheckFunc(
@@ -75,7 +74,6 @@ func TestAccResourceNsxtVpcIpAddressAllocation_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(testResourceName, "tag.#", "0"),
 				),
 			},
-			*/
 		},
 	})
 }


### PR DESCRIPTION
This follows fix on NSX, that supports update of generic fields, which was blocked earlier