### PR TITLE
Add `vc_folder` flag to project definition.

### DIFF
--- a/nsxt/resource_nsxt_policy_project.go
+++ b/nsxt/resource_nsxt_policy_project.go
@@ -62,6 +62,12 @@ func resourceNsxtPolicyProject() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+			"vc_folder": {
+				Type:        schema.TypeBool,
+				Description: "Flag to specify whether the DVPGs created for project segments are grouped under a folder on the VC",
+				Optional:    true,
+				Default:     true,
+			},
 			"external_ipv4_blocks": {
 				Type:     schema.TypeList,
 				Elem:     getElemPolicyPathSchema(),
@@ -77,6 +83,7 @@ func resourceNsxtPolicyProject() *schema.Resource {
 				Optional: true,
 				MinItems: 1,
 				MaxItems: 1,
+				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"north_south_firewall": {
@@ -139,6 +146,7 @@ func resourceNsxtPolicyProjectPatch(connector client.Connector, d *schema.Resour
 	}
 	tier0s := getStringListFromSchemaList(d, "tier0_gateway_paths")
 	activateDefaultDFWRules := d.Get("activate_default_dfw_rules").(bool)
+	vcFolder := d.Get("vc_folder").(bool)
 	extIpv4BlocksList := getStringListFromSchemaList(d, "external_ipv4_blocks")
 	tgwConnectionsList := getStringListFromSchemaList(d, "tgw_external_connections")
 
@@ -160,6 +168,7 @@ func resourceNsxtPolicyProjectPatch(connector client.Connector, d *schema.Resour
 
 	if util.NsxVersionHigherOrEqual("9.0.0") {
 		obj.TgwExternalConnections = tgwConnectionsList
+		obj.VcFolder = &vcFolder
 	}
 
 	if shortID != "" {
@@ -292,6 +301,7 @@ func resourceNsxtPolicyProjectRead(d *schema.ResourceData, m interface{}) error 
 	}
 	if util.NsxVersionHigherOrEqual("9.0.0") {
 		d.Set("tgw_external_connections", obj.TgwExternalConnections)
+		d.Set("vc_folder", obj.VcFolder)
 	}
 	return nil
 }

--- a/website/docs/r/policy_project.html.markdown
+++ b/website/docs/r/policy_project.html.markdown
@@ -42,6 +42,7 @@ The following arguments are supported:
 * `default_security_profile`- (Optional) Default security profile properties for project.
   * `north_south_firewall` - (Required) North South firewall configuration.
     * `enabled` - (Required) This flag indicates whether north-south firewall (Gateway Firewall) is enabled. If set to false, then gateway firewall policies will not be enforced on the VPCs associated with this configuration.
+* `vc_folder` - (Optional) Flag to specify whether the DVPGs created for project segments are grouped under a folder on the VC. Defaults to `true`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
This is relevant for NSX 9.0.0 onwards.
In addition, mark `default_security_profile` as Computed to avoid non-empty diff.