### PR TITLE
Add support for Edge transport nodes which were created externally

### DIFF
--- a/website/docs/d/transport_node_realization.html.markdown
+++ b/website/docs/d/transport_node_realization.html.markdown
@@ -45,7 +45,7 @@ resource "nsxt_transport_node" "test" {
     }
   }
   node_settings {
-    hostname             = "tf_edge_node"
+    hostname             = "tf-edge-node"
     allow_ssh_root_login = true
     enable_ssh           = true
   }


### PR DESCRIPTION
Normally users create Edge Transport Nodes within NSX, which deploys them into the regsitered compute manager. However, users have the option to do the same by deploying the Edge appliance anywhere, outside NSX, and registering it with NSX using the Edge CLI or OVA parameters. Later, this Edge appliance can be converted into a transport node using NSX API - this change attempts to utilize this capability.

Fixes: #1459