### PR TITLE
Handle v9.0 upgrade finalize case correctly

### DIFF
--- a/nsxt/resource_nsxt_upgrade_prepare.go
+++ b/nsxt/resource_nsxt_upgrade_prepare.go
@@ -176,9 +176,14 @@ func isVCF9HostUpgrade(m interface{}, targetVersion string) (bool, error) {
 		return false, nil
 	}
 	// In this case, all components other than host will be NOT_STARTED, but hosts will be with status SUCCESS
+	// Finalize component can be NOT_STARTED or PAUSED
 	for _, c := range statusSummary.ComponentStatus {
 		if *c.ComponentType == hostUpgradeGroup {
 			if *c.Status != nsxModel.ComponentUpgradeStatus_STATUS_SUCCESS {
+				return false, nil
+			}
+		} else if *c.ComponentType == finalizeUpgradeGroup {
+			if *c.Status != nsxModel.ComponentUpgradeStatus_STATUS_PAUSED && *c.Status != nsxModel.ComponentUpgradeStatus_STATUS_NOT_STARTED {
 				return false, nil
 			}
 		} else {


### PR DESCRIPTION
NSX v9.0 upgrade introduces few changes:
* A new upgrade component, 'FINALIZE_UPGRADE'.
* Pre-upgrading the HOST compoenent during the ESXi upgrade.

Upgrading the hosts outside of upgrading coordinator (by upgrading ESXi) affects the FINALIZE_UPGRADE component - it can be either in 'PAUSE' state, or 'NOT_STARTED'.