### PR TITLE
Remove golangci-lint parameters which are unsupported

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
           go-version-file: 'go.mod'
-          cache: true
+          cache: false
       - run: go mod download
       - run: go build -v .
       - name: Run Linters

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -32,5 +32,3 @@ jobs:
           version: v1.62.0
           args: --issues-exit-code=1 --timeout 10m
           only-new-issues: true
-          skip-pkg-cache: true
-          skip-build-cache: true


### PR DESCRIPTION
skip-pkg-cache and skip-build-cache has been removed in v6.x version of golangci-lint, and therefore removed from config. See here:
https://github.com/golangci/golangci-lint-action/blob/master/README.md#compatibility

This will suppress the warning below from golangci-lint execution:

```
Unexpected input(s) 'skip-pkg-cache', 'skip-build-cache', valid inputs are ['version', 'install-mode', 'working-directory', 'github-token', 'only-new-issues', 'skip-cache', 'skip-save-cache', 'problem-matchers', 'args', 'cache-invalidation-interval']
```