### PR TITLE
Replace host switch profiles attr with typed ones

### DIFF
--- a/website/docs/r/edge_transport_node.html.markdown
+++ b/website/docs/r/edge_transport_node.html.markdown
@@ -78,7 +78,7 @@ resource "nsxt_edge_transport_node" "test_node" {
     transport_zone_endpoint {
       transport_zone = data.nsxt_policy_transport_zone.vlan_tz.id
     }
-    host_switch_profile = [data.nsxt_policy_uplink_host_switch_profile.edge_uplink_profile.id]
+    uplink_profile = data.nsxt_policy_uplink_host_switch_profile.edge_uplink_profile.id
     pnic {
       device_name = "fp-eth0"
       uplink_name = "uplink1"
@@ -102,7 +102,9 @@ The following arguments are supported:
 * `standard_host_switch` - (Required) Standard host switch specification.
   * `host_switch_id` - (Optional) The host switch id. This ID will be used to reference a host switch.
   * `host_switch_name` - (Optional) Host switch name. This name will be used to reference a host switch.
-  * `host_switch_profile` - (Optional) Identifiers of host switch profiles to be associated with this host switch.
+  * `host_switch_profile` - (Deprecated) Identifiers of host switch profiles to be associated with this host switch. This attribute is deprecated, please use type-specific attribute instead (such as `uplink_profile`)
+  * `uplink_profile` - (Optional) Uplink host switch profile id.
+  * `vtep_ha_profile` - (Optional) VTEP high availablility host switch profile id. Only applicable with VDS switch.
   * `ip_assignment` - (Required) - Specification for IPs to be used with host switch virtual tunnel endpoints. Should contain exatly one of the below:
     * `assigned_by_dhcp` - (Optional) Enables DHCP assignment.
     * `no_ipv4` - (Optional) No IPv4 for this host switch.

--- a/website/docs/r/policy_host_transport_node.html.markdown
+++ b/website/docs/r/policy_host_transport_node.html.markdown
@@ -19,8 +19,8 @@ resource "nsxt_policy_host_transport_node" "test" {
   discovered_node_id = data.nsxt_discovered_node.dn.id
 
   standard_host_switch {
-    host_switch_id      = "50 0b 31 a4 b8 af 35 df-40 56 b6 f9 aa d3 ee 12"
-    host_switch_profile = [data.nsxt_policy_uplink_host_switch_profile.uplink_host_switch_profile.path]
+    host_switch_id = "50 0b 31 a4 b8 af 35 df-40 56 b6 f9 aa d3 ee 12"
+    uplink_profile = data.nsxt_policy_uplink_host_switch_profile.uplink_host_switch_profile.path
 
     ip_assignment {
       assigned_by_dhcp = true
@@ -65,7 +65,9 @@ The following arguments are supported:
   * `host_switch_id` - (Optional) The host switch id. This ID will be used to reference a host switch.
   * `host_switch_name` - (Optional) Host switch name. This name will be used to reference a host switch.
   * `host_switch_mode` - (Optional) Operational mode of a HostSwitch. Accepted values - 'STANDARD', 'ENS', 'ENS_INTERRUPT' or 'LEGACY'.
-  * `host_switch_profile` - (Optional) Policy path of host switch profiles to be associated with this host switch.
+  * `host_switch_profile` - (Deprecated) Policy paths of host switch profiles to be associated with this host switch. This attribute is deprecated, please use type-specific attribute instead (such as `uplink_profile`)
+  * `uplink_profile` - (Optional) Uplink host switch profile path.
+  * `vtep_ha_profile` - (Optional) VTEP high availablility host switch profile path. Only applicable with VDS switch.
   * `ip_assignment` - (Optional) - Specification for IPs to be used with host switch virtual tunnel endpoints. Should contain exatly one of the below:
     * `assigned_by_dhcp` - (Optional) Enables DHCP assignment.
     * `no_ipv4` - (Optional) No IPv4 for this host switch.

--- a/website/docs/r/policy_host_transport_node_profile.html.markdown
+++ b/website/docs/r/policy_host_transport_node_profile.html.markdown
@@ -24,8 +24,8 @@ resource "nsxt_policy_host_transport_node_profile" "test" {
     transport_zone_endpoint {
       transport_zone = data.nsxt_policy_transport_zone.tz1.path
     }
-    host_switch_profile = [nsxt_policy_uplink_host_switch_profile.hsw_profile1.path]
-    is_migrate_pnics    = false
+    uplink_profile   = nsxt_policy_uplink_host_switch_profile.hsw_profile1.path
+    is_migrate_pnics = false
     pnic {
       device_name = "fp-eth0"
       uplink_name = "uplink1"
@@ -46,7 +46,9 @@ The following arguments are supported:
     * `host_switch_id` - (Optional) The host switch id. This ID will be used to reference a host switch.
     * `host_switch_name` - (Optional) Host switch name. This name will be used to reference a host switch.
     * `host_switch_mode` - (Optional) Operational mode of a HostSwitch. Accepted values - 'STANDARD', 'ENS', 'ENS_INTERRUPT' or 'LEGACY'.
-    * `host_switch_profile` - (Optional) Policy paths of host switch profiles to be associated with this host switch.
+    * `host_switch_profile` - (Deprecated) Policy paths of host switch profiles to be associated with this host switch. This attribute is deprecated, please use type-specific attribute instead (such as `uplink_profile`)
+    * `uplink_profile` - (Optional) Uplink host switch profile path.
+    * `vtep_ha_profile` - (Optional) VTEP high availablility host switch profile path. Only applicable with VDS switch.
     * `ip_assignment` - (Required) - Specification for IPs to be used with host switch virtual tunnel endpoints. Should contain exactly one of the below:
         * `assigned_by_dhcp` - (Optional) Enables DHCP assignment.
         * `static_ip` - (Optional) IP assignment specification for Static IP List.


### PR DESCRIPTION
Deprecate list of host switch profiles, and introduce typed profile attributes instead - `uplink_profile` and `vtep_ha_profile`. This is because certain profile types are autoassigned by NSX, in which case permadiff is introduced, unless the user fixes it by adding the auto-assigned profile into resource intent.
Having type-specific computed attributes solves this problem.