### PR TITLE
Avoid recreating gateway when locale service added

### DIFF
--- a/nsxt/resource_nsxt_policy_tier0_gateway.go
+++ b/nsxt/resource_nsxt_policy_tier0_gateway.go
@@ -785,7 +785,8 @@ func policyTier0GatewayResourceToInfraStruct(context utl.SessionContext, d *sche
 	}
 
 	bgpConfig := d.Get("bgp_config").([]interface{})
-	if len(bgpConfig) > 0 && !isGlobalManager {
+	// no need to include BGP child block if it didn't change
+	if d.HasChange("bgp_config") && len(bgpConfig) > 0 && !isGlobalManager {
 		// For Global Manager BGP is defined as separate resource
 		routingConfigStruct := resourceNsxtPolicyTier0GatewayBGPConfigSchemaToStruct(bgpConfig[0], vrfConfig != nil, id)
 		structValue, err := initPolicyTier0ChildBgpConfig(&routingConfigStruct)
@@ -798,7 +799,7 @@ func policyTier0GatewayResourceToInfraStruct(context utl.SessionContext, d *sche
 	edgeClusterPath := d.Get("edge_cluster_path").(string)
 	_, redistributionSet := d.GetOk("redistribution_config")
 	// The user can either define locale_service (GL or LM) or edge_cluster_path (LM only)
-	if d.HasChange("locale_service") {
+	if d.HasChange("locale_service") && edgeClusterPath == "" {
 		// Update locale services only if configuration changed
 		localeServices, err := initGatewayLocaleServices(context, d, connector, listPolicyTier0GatewayLocaleServices)
 		if err != nil {

--- a/nsxt/resource_nsxt_policy_tier0_gateway_interface_test.go
+++ b/nsxt/resource_nsxt_policy_tier0_gateway_interface_test.go
@@ -467,6 +467,66 @@ func TestAccResourceNsxtPolicyTier0GatewayInterface_withV6(t *testing.T) {
 	})
 }
 
+// Make sure locale-service dependant interface is not deleted when edge cluster
+// config is updated on the gateway
+func TestAccResourceNsxtPolicyTier0GatewayInterface_updateGateway(t *testing.T) {
+	name := getAccTestResourceName()
+	testResourceName := "nsxt_policy_tier0_gateway_interface.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyTier0InterfaceCheckDestroy(state, name)
+		},
+		Steps: []resource.TestStep{
+			{
+				// Create gateway without using locale service
+				Config: testAccNsxtPolicyTier0InterfaceUpdateGatewayTemplate(name, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicyTier0InterfaceExists(testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", name),
+					resource.TestCheckResourceAttr(testResourceName, "subnets.#", "2"),
+					resource.TestCheckResourceAttrSet(testResourceName, "segment_path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "gateway_path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+				),
+			},
+			{
+				// Update gateway to use locale services
+				Config: testAccNsxtPolicyTier0InterfaceUpdateGatewayTemplate(name, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicyTier0InterfaceExists(testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", name),
+					resource.TestCheckResourceAttr(testResourceName, "subnets.#", "2"),
+					resource.TestCheckResourceAttrSet(testResourceName, "segment_path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "gateway_path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "locale_service_id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+				),
+			},
+			{
+				// Update gateway back to original config using edge cluster path
+				Config: testAccNsxtPolicyTier0InterfaceUpdateGatewayTemplate(name, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicyTier0InterfaceExists(testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", name),
+					resource.TestCheckResourceAttr(testResourceName, "subnets.#", "2"),
+					resource.TestCheckResourceAttrSet(testResourceName, "segment_path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "gateway_path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+				),
+			},
+		},
+	})
+}
+
 func testAccNSXPolicyTier0InterfaceImporterGetID(s *terraform.State) (string, error) {
 	testResourceName := "nsxt_policy_tier0_gateway_interface.test"
 	rs, ok := s.RootModule().Resources[testResourceName]
@@ -837,4 +897,24 @@ resource "nsxt_policy_tier0_gateway_interface" "test" {
   }
 }`, nsxtPolicyTier0GatewayName, testAccNsxtPolicyTier0EdgeClusterTemplate(), name, mtu, subnet, enablePim, extraConfig) +
 		testAccNsxtPolicyTier0InterfaceRealizationTemplate()
+}
+
+func testAccNsxtPolicyTier0InterfaceUpdateGatewayTemplate(name string, useLocaleService bool) string {
+	edgeCluster := "edge_cluster_path = data.nsxt_policy_edge_cluster.EC.path"
+	if useLocaleService {
+		edgeCluster = testAccNsxtPolicyLocaleServiceECTemplate()
+	}
+	return testAccNsxtPolicyGatewayInterfaceDeps("11", false) + fmt.Sprintf(`
+resource "nsxt_policy_tier0_gateway" "test" {
+  display_name = "%s"
+  %s
+}
+
+resource "nsxt_policy_tier0_gateway_interface" "test" {
+  display_name   = "%s"
+  gateway_path   = nsxt_policy_tier0_gateway.test.path
+  segment_path   = nsxt_policy_vlan_segment.test.path
+  subnets        = ["10.192.12.2/24", "1002::3:3/64"]
+  type           = "EXTERNAL"
+}`, nsxtPolicyTier1GatewayName, edgeCluster, name)
 }


### PR DESCRIPTION
This change removes ForceNew from nsx_id attribute in locale service schema, in order to avoid recreating the gateway when locale service is added.
Without this fix, adding locale_service within the gateway would trigger recreation even when nsx_id is not specified, since nsx_is is defined as Computed.