### PR TITLE
Fix nsxt_upgrade_run crash

### DIFF
--- a/nsxt/policy_errors.go
+++ b/nsxt/policy_errors.go
@@ -160,6 +160,13 @@ func isTimeoutError(err error) bool {
 	return false
 }
 
+func isInternalServerError(err error) bool {
+	if _, ok := err.(errors.InternalServerError); ok {
+		return true
+	}
+	return false
+}
+
 func handleCreateError(resourceType string, resource string, err error) error {
 	msg := fmt.Sprintf("Failed to create %s %s", resourceType, resource)
 	return logAPIError(msg, err)

--- a/nsxt/resource_nsxt_upgrade_run.go
+++ b/nsxt/resource_nsxt_upgrade_run.go
@@ -562,10 +562,10 @@ func waitUpgradeForStatus(upgradeClientSet *upgradeClientSet, component *string,
 		Target:  target,
 		Refresh: func() (interface{}, string, error) {
 			status, err := getUpgradeStatus(upgradeClientSet.StatusClient, component)
-			if component != nil && *component == mpUpgradeGroup && (isServiceUnavailableError(err) || isTimeoutError(err)) {
+			if component != nil && *component == mpUpgradeGroup && (isServiceUnavailableError(err) || isTimeoutError(err) || isInternalServerError(err)) {
 				// After MP upgrade is completed, NSXT will restart and service_unavailable error or timeout error will be received depending on the request timing.
 				// Keep polling for this case.
-				return model.ComponentUpgradeStatus_STATUS_IN_PROGRESS, model.ComponentUpgradeStatus_STATUS_IN_PROGRESS, nil
+				return nil, model.ComponentUpgradeStatus_STATUS_IN_PROGRESS, nil
 			}
 			if err != nil {
 				return status, model.ComponentUpgradeStatus_STATUS_FAILED, err


### PR DESCRIPTION
The resource nsxt_upgrade_run crashed while receiving a 500 error while polling for upgrade status. This status should be handled as other statuses which we swallow while waiting for MP to restart.