### PR TITLE
Remove Computed from gateway edge cluster path

### DIFF
--- a/nsxt/gateway_common.go
+++ b/nsxt/gateway_common.go
@@ -82,7 +82,6 @@ func getPolicyEdgeClusterPathSchema() *schema.Schema {
 		Description:  "The path of the edge cluster connected to this gateway",
 		Optional:     true,
 		ValidateFunc: validatePolicyPath(),
-		Computed:     true,
 	}
 }
 

--- a/nsxt/resource_nsxt_policy_tier0_gateway.go
+++ b/nsxt/resource_nsxt_policy_tier0_gateway.go
@@ -649,7 +649,7 @@ func resourceNsxtPolicyTier0GatewayBGPConfigSchemaToStruct(cfg interface{}, isVr
 	return routeStruct
 }
 
-func initSingleTier0GatewayLocaleService(context utl.SessionContext, d *schema.ResourceData, children []*data.StructValue, connector client.Connector) (*data.StructValue, error) {
+func initImplicitTier0GatewayLocaleService(context utl.SessionContext, d *schema.ResourceData, children []*data.StructValue, connector client.Connector) (*data.StructValue, error) {
 
 	edgeClusterPath := d.Get("edge_cluster_path").(string)
 	var serviceStruct *model.LocaleServices
@@ -679,7 +679,7 @@ func initSingleTier0GatewayLocaleService(context utl.SessionContext, d *schema.R
 		serviceStruct.Children = children
 	}
 
-	log.Printf("[DEBUG] Using Locale Service with ID %s and Edge Cluster %v", *serviceStruct.Id, serviceStruct.EdgeClusterPath)
+	log.Printf("[DEBUG] Using Locale Service with ID %s and Edge Cluster %v", *serviceStruct.Id, edgeClusterPath)
 
 	return initChildLocaleService(serviceStruct, false)
 }
@@ -822,7 +822,7 @@ func policyTier0GatewayResourceToInfraStruct(context utl.SessionContext, d *sche
 			}
 
 			var err error
-			dataValue, err := initSingleTier0GatewayLocaleService(context, d, lsChildren, connector)
+			dataValue, err := initImplicitTier0GatewayLocaleService(context, d, lsChildren, connector)
 			if err != nil {
 				return infraStruct, err
 			}

--- a/nsxt/resource_nsxt_policy_tier0_gateway_test.go
+++ b/nsxt/resource_nsxt_policy_tier0_gateway_test.go
@@ -943,10 +943,10 @@ data "nsxt_policy_edge_cluster" "EC" {
 }
 
 resource "nsxt_policy_tier0_gateway" "test" {
-  display_name = "%s"
+  display_name      = "%s"
   edge_cluster_path = data.nsxt_policy_edge_cluster.EC.path
   redistribution_config {
-    enabled  = false
+    enabled      = false
     ospf_enabled = false
     rule {
         name = "test-rule-1"
@@ -967,10 +967,10 @@ data "nsxt_policy_edge_cluster" "EC" {
 }
 
 resource "nsxt_policy_tier0_gateway" "test" {
-  display_name = "%s"
+  display_name      = "%s"
   edge_cluster_path = data.nsxt_policy_edge_cluster.EC.path
   redistribution_config {
-    enabled  = false
+    enabled      = false
     ospf_enabled = false
     rule {
         name = "test-rule-1"
@@ -989,8 +989,13 @@ data "nsxt_policy_realization_info" "realization_info" {
 
 func testAccNsxtPolicyTier0Update2WithRedistribution(name string) string {
 	return fmt.Sprintf(`
-resource "nsxt_policy_tier0_gateway" "test" {
+data "nsxt_policy_edge_cluster" "EC" {
   display_name = "%s"
+}
+resource "nsxt_policy_tier0_gateway" "test" {
+  display_name      = "%s"
+  edge_cluster_path = data.nsxt_policy_edge_cluster.EC.path
+
   redistribution_config {
     enabled  = false
     ospf_enabled = true
@@ -999,5 +1004,5 @@ resource "nsxt_policy_tier0_gateway" "test" {
 
 data "nsxt_policy_realization_info" "realization_info" {
   path = nsxt_policy_tier0_gateway.test.path
-}`, name)
+}`, getEdgeClusterName(), name)
 }

--- a/nsxt/resource_nsxt_policy_tier1_gateway.go
+++ b/nsxt/resource_nsxt_policy_tier1_gateway.go
@@ -343,7 +343,7 @@ func resourceNsxtPolicyTier1GatewaySetVersionDependentAttrs(d *schema.ResourceDa
 
 }
 
-func initSingleTier1GatewayLocaleService(context utl.SessionContext, d *schema.ResourceData, connector client.Connector) (*data.StructValue, error) {
+func initImplicitTier1GatewayLocaleService(context utl.SessionContext, d *schema.ResourceData, connector client.Connector) (*data.StructValue, error) {
 
 	edgeClusterPath := d.Get("edge_cluster_path").(string)
 	var serviceStruct *model.LocaleServices
@@ -363,13 +363,16 @@ func initSingleTier1GatewayLocaleService(context utl.SessionContext, d *schema.R
 			ResourceType: &lsType,
 		}
 	}
+	// clear preferred edge nodes if exist
+	serviceStruct.PreferredEdgePaths = nil
 	if len(edgeClusterPath) > 0 {
 		serviceStruct.EdgeClusterPath = &edgeClusterPath
+		log.Printf("[DEBUG] Using Locale Service with ID %s and Edge Cluster %v", *serviceStruct.Id, edgeClusterPath)
 	} else {
 		serviceStruct.EdgeClusterPath = nil
+		log.Printf("[DEBUG] Using Locale Service with ID %s no Edge Cluster", *serviceStruct.Id)
 	}
 
-	log.Printf("[DEBUG] Using Locale Service with ID %s and Edge Cluster %v", *serviceStruct.Id, serviceStruct.EdgeClusterPath)
 	return initChildLocaleService(serviceStruct, false)
 }
 
@@ -462,7 +465,7 @@ func policyTier1GatewayResourceToInfraStruct(context utl.SessionContext, d *sche
 
 	// edge cluster is specified using edge_cluster_path on local manager
 	if useImplicitLocaleService(d) && context.ClientType != utl.Global {
-		dataValue, err := initSingleTier1GatewayLocaleService(context, d, connector)
+		dataValue, err := initImplicitTier1GatewayLocaleService(context, d, connector)
 		if err != nil {
 			return infraStruct, err
 		}


### PR DESCRIPTION
When attribute is Computed, clearing the attribute is not flagged by terraform SDK as change in intent. This means user can not clear edge cluster path and convert gateway to Distributed Only mode.

In addition, fix log printouts.
Signed-off-by: Anna Khmelnitsky <akhmelnitsky@vmware.com>