### PR TITLE
Document undocumented attributes of nsxt_upgrade_run

### DIFF
--- a/nsxt/resource_nsxt_upgrade_run.go
+++ b/nsxt/resource_nsxt_upgrade_run.go
@@ -57,7 +57,7 @@ var (
 	// Default waiting setup in seconds
 	defaultUpgradeStatusCheckInterval = 30
 	defaultUpgradeStatusCheckTimeout  = 3600
-	defaultUpgradeStatusCheckDelay    = 30
+	defaultUpgradeStatusCheckDelay    = 300
 )
 
 var staticComponentUpgradeStatus = []string{

--- a/website/docs/r/upgrade_run.html.markdown
+++ b/website/docs/r/upgrade_run.html.markdown
@@ -89,7 +89,10 @@ The following arguments are supported:
     * `post_upgrade_check` - (Optional) Flag to indicate whether run post upgrade check after upgrade. Default: True.
     * `stop_on_error` - (Optional) Flag to indicate whether to pause the upgrade plan execution when an error occurs. Default: False.
 * `finalize_upgrade_setting` - (Optional) FINALIZE_UPGRADE component upgrade plan setting.
-    * `enabled` - (Optional) Finalize upgrade after completion of all the components' upgrade is complete. Default: True.   
+    * `enabled` - (Optional) Finalize upgrade after completion of all the components' upgrade is complete. Default: True.
+* `timeout` - (Optional) Upgrade status check timeout in seconds. Default: 3600 seconds.
+* `interval` - (Optional) Interval to check upgrade status in seconds. Default: 30 seconds.
+* `delay` - (Optional) Initial delay to start upgrade status checks in seconds. Default: 300 seconds. 
 
 ## Argument Reference
 


### PR DESCRIPTION
The upgrade run resource has some attributes which control the wait for the upgrade execution. However these aren't documented, and could be handy.

Also, change default initial delay to 5 minutes.