### PR TITLE
Protect casting against nil conversion

### DIFF
--- a/nsxt/resource_nsxt_policy_intrusion_service_profile.go
+++ b/nsxt/resource_nsxt_policy_intrusion_service_profile.go
@@ -185,7 +185,7 @@ func getIdsProfileCriteriaFromSchema(d *schema.ResourceData) ([]*data.StructValu
 	var result []*data.StructValue
 
 	criteria := d.Get("criteria").([]interface{})
-	if len(criteria) == 0 {
+	if len(criteria) == 0 || criteria[0] == nil {
 		return result, nil
 	}
 
@@ -286,7 +286,10 @@ func setIdsProfileCriteriaInSchema(criteriaList []*data.StructValue, d *schema.R
 			criteriaMap["products_affected"] = criteria.FilterValue
 		}
 	}
-	schemaList = append(schemaList, criteriaMap)
+
+	if len(criteriaMap) > 0 {
+		schemaList = append(schemaList, criteriaMap)
+	}
 
 	return d.Set("criteria", schemaList)
 }

--- a/nsxt/resource_nsxt_policy_tier0_gateway.go
+++ b/nsxt/resource_nsxt_policy_tier0_gateway.go
@@ -446,7 +446,7 @@ func getPolicyVRFConfigFromSchema(d *schema.ResourceData) *model.Tier0VrfConfig 
 	}
 
 	vrfConfigs := d.Get("vrf_config").([]interface{})
-	if len(vrfConfigs) == 0 {
+	if len(vrfConfigs) == 0 || vrfConfigs[0] == nil {
 		return nil
 	}
 
@@ -786,7 +786,7 @@ func policyTier0GatewayResourceToInfraStruct(context utl.SessionContext, d *sche
 
 	bgpConfig := d.Get("bgp_config").([]interface{})
 	// no need to include BGP child block if it didn't change
-	if d.HasChange("bgp_config") && len(bgpConfig) > 0 && !isGlobalManager {
+	if d.HasChange("bgp_config") && len(bgpConfig) > 0 && bgpConfig[0] != nil && !isGlobalManager {
 		// For Global Manager BGP is defined as separate resource
 		routingConfigStruct := resourceNsxtPolicyTier0GatewayBGPConfigSchemaToStruct(bgpConfig[0], vrfConfig != nil, id)
 		structValue, err := initPolicyTier0ChildBgpConfig(&routingConfigStruct)

--- a/nsxt/resource_nsxt_policy_tier0_gateway_interface.go
+++ b/nsxt/resource_nsxt_policy_tier0_gateway_interface.go
@@ -174,7 +174,7 @@ func gatewayInterfaceVersionDepenantSet(d *schema.ResourceData, m interface{}, o
 
 func policyTier0GatewayInterfaceOspfSet(d *schema.ResourceData, m interface{}, obj *model.Tier0Interface) error {
 	ospfConfigs := d.Get("ospf").([]interface{})
-	if len(ospfConfigs) == 0 {
+	if len(ospfConfigs) == 0 || ospfConfigs[0] == nil {
 		return nil
 	}
 

--- a/nsxt/resource_nsxt_upgrade_run.go
+++ b/nsxt/resource_nsxt_upgrade_run.go
@@ -781,7 +781,7 @@ func getPostResetGroupIDFromPreResetList(groupID string, preResetGroupList model
 
 func updateComponentUpgradePlanSetting(settingClient plan.SettingsClient, d *schema.ResourceData, component string) error {
 	settingI := d.Get(componentToSettingKey[component]).([]interface{})
-	if len(settingI) == 0 {
+	if len(settingI) == 0 || settingI[0] == nil {
 		return nil
 	}
 

--- a/nsxt/segment_common.go
+++ b/nsxt/segment_common.go
@@ -509,7 +509,7 @@ func getSegmentSubnetDhcpConfigFromSchema(schemaConfig map[string]interface{}) (
 
 	converter := bindings.NewTypeConverter()
 
-	if len(dhcpV4Config) > 0 {
+	if len(dhcpV4Config) > 0 && dhcpV4Config[0] != nil {
 		dhcpConfig := dhcpV4Config[0].(map[string]interface{})
 		serverAddress := dhcpConfig["server_address"].(string)
 		dnsServers := dhcpConfig["dns_servers"].([]interface{})
@@ -538,7 +538,7 @@ func getSegmentSubnetDhcpConfigFromSchema(schemaConfig map[string]interface{}) (
 		return dataValue.(*data.StructValue), nil
 	}
 
-	if len(dhcpV6Config) > 0 {
+	if len(dhcpV6Config) > 0 && dhcpV6Config[0] != nil {
 		dhcpConfig := dhcpV6Config[0].(map[string]interface{})
 		serverAddress := dhcpConfig["server_address"].(string)
 		dnsServers := dhcpConfig["dns_servers"].([]interface{})
@@ -793,7 +793,7 @@ func policySegmentResourceToInfraStruct(context utl.SessionContext, id string, d
 	obj.Subnets = subnetStructs
 
 	advConfig := d.Get("advanced_config").([]interface{})
-	if len(advConfig) > 0 {
+	if len(advConfig) > 0 && advConfig[0] != nil {
 		advConfigMap := advConfig[0].(map[string]interface{})
 		connectivity := advConfigMap["connectivity"].(string)
 		hybrid := advConfigMap["hybrid"].(bool)
@@ -987,8 +987,10 @@ func nsxtPolicySegmentDiscoveryProfileSetInStruct(d *schema.ResourceData) (*data
 	revision := int64(0)
 	shouldDelete := false
 	oldProfiles, newProfiles := d.GetChange("discovery_profile")
-	if len(newProfiles.([]interface{})) > 0 {
-		profileMap := newProfiles.([]interface{})[0].(map[string]interface{})
+	newProfilesList := newProfiles.([]interface{})
+
+	if len(newProfilesList) > 0 && newProfilesList[0] != nil {
+		profileMap := newProfilesList[0].(map[string]interface{})
 
 		ipDiscoveryProfilePath = profileMap["ip_discovery_profile_path"].(string)
 		macDiscoveryProfilePath = profileMap["mac_discovery_profile_path"].(string)
@@ -1046,9 +1048,10 @@ func nsxtPolicySegmentQosProfileSetInStruct(d *schema.ResourceData) (*data.Struc
 	qosProfilePath := ""
 	revision := int64(0)
 	oldProfiles, newProfiles := d.GetChange("qos_profile")
+	newProfilesList := newProfiles.([]interface{})
 	shouldDelete := false
-	if len(newProfiles.([]interface{})) > 0 {
-		profileMap := newProfiles.([]interface{})[0].(map[string]interface{})
+	if len(newProfilesList) > 0 && newProfilesList[0] != nil {
+		profileMap := newProfilesList[0].(map[string]interface{})
 
 		qosProfilePath = profileMap["qos_profile_path"].(string)
 		if len(profileMap["binding_map_path"].(string)) > 0 {
@@ -1103,9 +1106,10 @@ func nsxtPolicySegmentSecurityProfileSetInStruct(d *schema.ResourceData) (*data.
 	securityProfilePath := ""
 	revision := int64(0)
 	oldProfiles, newProfiles := d.GetChange("security_profile")
+	newProfilesList := newProfiles.([]interface{})
 	shouldDelete := false
-	if len(newProfiles.([]interface{})) > 0 {
-		profileMap := newProfiles.([]interface{})[0].(map[string]interface{})
+	if len(newProfilesList) > 0 && newProfilesList[0] != nil {
+		profileMap := newProfilesList[0].(map[string]interface{})
 
 		spoofguardProfilePath = profileMap["spoofguard_profile_path"].(string)
 		securityProfilePath = profileMap["security_profile_path"].(string)

--- a/website/docs/r/policy_intrusion_service_profile.html.markdown
+++ b/website/docs/r/policy_intrusion_service_profile.html.markdown
@@ -81,7 +81,7 @@ The following arguments are supported:
 * `context` - (Optional) The context which the object belongs to
   * `project_id` - (Required) The ID of the project which the object belongs to
 * `severities` - (Required) List of profile severities, supported values are `LOW`, `MEDIUM`, `HIGH`, 'CRITICAL`.
-* `criteria` - (Required) Filtering criteria for the IDS Profile.
+* `criteria` - (Optional) Filtering criteria for the IDS Profile.
   * `attack_types` - (Optional) List of supported attack types.
   * `attack_targets` - (Optional) List of supported attack targets. Please refer to example above to ensure correct formatting - in some versions, UI shows a different format than NSX expects.
   * `cvss` - (Optional) List of CVSS (Common Vulnerability Scoring System) ranges. Supported values are `NONE`, `LOW`, `MEDIUM`, `HIGH`, `CRITICAL`.


### PR DESCRIPTION
Empty block is represeted in schema by slice of size 1 with nil value. Wherever empty block is allowed (no required attributes), we should protect against nil values in slice.