### PR TITLE
Adding SUSPICIOUS severity support to nsxt_policy_intrusion_service_profile resource

### DIFF
--- a/nsxt/resource_nsxt_policy_intrusion_service_profile.go
+++ b/nsxt/resource_nsxt_policy_intrusion_service_profile.go
@@ -24,6 +24,7 @@ var idsProfileSeverityValues = []string{
 	model.IdsProfile_PROFILE_SEVERITY_HIGH,
 	model.IdsProfile_PROFILE_SEVERITY_LOW,
 	model.IdsProfile_PROFILE_SEVERITY_CRITICAL,
+	model.IdsProfile_PROFILE_SEVERITY_SUSPICIOUS,
 }
 
 var idsProfileCvssValues = []string{

--- a/website/docs/r/policy_intrusion_service_profile.html.markdown
+++ b/website/docs/r/policy_intrusion_service_profile.html.markdown
@@ -80,7 +80,7 @@ The following arguments are supported:
 * `nsx_id` - (Optional) The NSX ID of this resource. If set, this ID will be used to create the resource.
 * `context` - (Optional) The context which the object belongs to
   * `project_id` - (Required) The ID of the project which the object belongs to
-* `severities` - (Required) List of profile severities, supported values are `LOW`, `MEDIUM`, `HIGH`, 'CRITICAL`.
+* `severities` - (Required) List of profile severities, supported values are `LOW`, `MEDIUM`, `HIGH`, `CRITICAL`, `SUSPICIOUS`.
 * `criteria` - (Optional) Filtering criteria for the IDS Profile.
   * `attack_types` - (Optional) List of supported attack types.
   * `attack_targets` - (Optional) List of supported attack targets. Please refer to example above to ensure correct formatting - in some versions, UI shows a different format than NSX expects.


### PR DESCRIPTION
The NSXT terraform provider (resource "nsxt_policy_intrusion_service_profile") supports severities "LOW", "MEDIUM", "HIGH" and "CRITICAL". Adding "SUSPICIOUS" to the list.