### PR TITLE
Improve validation for LB pool resource

### DIFF
--- a/nsxt/resource_nsxt_policy_lb_pool.go
+++ b/nsxt/resource_nsxt_policy_lb_pool.go
@@ -315,6 +315,9 @@ func getPolicyPoolSnatFromSchema(d *schema.ResourceData) (*data.StructValue, err
 		}
 
 		addresses := snatMap["ip_pool_addresses"].([]interface{})
+		if snatType != "IPPOOL" && len(addresses) > 0 {
+			return nil, fmt.Errorf("ip_pool_addresses should only be specified to snat type IPPOOL")
+		}
 		var addressList []model.LBSnatIpElement
 		for _, address := range addresses {
 			addressStr := address.(string)

--- a/website/docs/r/policy_lb_pool.html.markdown
+++ b/website/docs/r/policy_lb_pool.html.markdown
@@ -66,7 +66,7 @@ The following arguments are supported:
 * `passive_monitor_path` - (Optional) Passive monitor to be associated with this pool.
 * `snat` - (Optional) Source NAT may be required to ensure traffic from the server destined to the client is received by the load balancer.
   * `type` - (Optional) SNAT type, one of `AUTOMAP`, `DISABLED`, `IPPOOL`. Default is `AUTOMAP`.
-  * `ip_pool_addresses` - (Optional) List of IP ranges or IP CIDRs to use for IPPOOL SNAT type.
+  * `ip_pool_addresses` - (Optional) List of IP ranges or IP CIDRs to use for `IPPOOL` SNAT type.
 * `tcp_multiplexing_enabled` - (Optional) Enable TCP multiplexing within the pool.
 * `tcp_multiplexing_number` - (Optional) The maximum number of TCP connections per pool that are idly kept alive for sending future client requests.
 


### PR DESCRIPTION
IP addresses in SNAT can only be specified for certain snat type