### PR TITLE
Remove depreceted attribute from tier0_gateway example

### DIFF
--- a/website/docs/r/policy_tier0_gateway.html.markdown
+++ b/website/docs/r/policy_tier0_gateway.html.markdown
@@ -20,7 +20,6 @@ resource "nsxt_policy_tier0_gateway" "tier0_gw" {
   failover_mode            = "PREEMPTIVE"
   default_rule_logging     = false
   enable_firewall          = true
-  force_whitelisting       = false
   ha_mode                  = "ACTIVE_STANDBY"
   internal_transit_subnets = ["102.64.0.0/16"]
   transit_subnets          = ["101.64.0.0/16"]


### PR DESCRIPTION
nsxt_policy_tier0_gateway example contained force_whitelisting attribute which had been deprecated.