### PR TITLE
Expose advanced_config in Tier0 Gateway

### DIFF
--- a/nsxt/resource_nsxt_policy_tier0_gateway_gm_test.go
+++ b/nsxt/resource_nsxt_policy_tier0_gateway_gm_test.go
@@ -208,6 +208,10 @@ resource "nsxt_policy_tier0_gateway" "test" {
     primary_site_path = data.nsxt_policy_site.site2.path
     transit_subnet    = "%s"
   }
+
+  advanced_config {
+    forwarding_up_timer = 10
+  }
 }`, defaultTestResourceName, testAccGmGatewayIntersiteSubnet)
 }
 

--- a/website/docs/r/policy_tier0_gateway.html.markdown
+++ b/website/docs/r/policy_tier0_gateway.html.markdown
@@ -173,6 +173,8 @@ The following arguments are supported:
       * `name` - (Optional) Rule name.
       * `route_map_path` - (Optional) Route map to be associated with the redistribution rule.
       * `types` - (Optional) List of redistribution types, possible values are: `TIER0_STATIC`, `TIER0_CONNECTED`, `TIER0_EXTERNAL_INTERFACE`, `TIER0_SEGMENT`, `TIER0_ROUTER_LINK`, `TIER0_SERVICE_INTERFACE`, `TIER0_LOOPBACK_INTERFACE`, `TIER0_DNS_FORWARDER_IP`, `TIER0_IPSEC_LOCAL_IP`, `TIER0_NAT`, `TIER0_EVPN_TEP_IP`, `TIER1_NAT`, `TIER1_STATIC`, `TIER1_LB_VIP`, `TIER1_LB_SNAT`, `TIER1_DNS_FORWARDER_IP`, `TIER1_CONNECTED`, `TIER1_SERVICE_INTERFACE`, `TIER1_SEGMENT`, `TIER1_IPSEC_LOCAL_ENDPOINT`.
+* `advanced_config` - (Optional) Advanced gateway configuration
+  * `forwarding_up_timer` - (Optional) Extra time in seconds the router must wait before sending the UP notification after the peer routing session is established. VRF setting for this attribute must be the same as parent gateway.
 
 ## Attributes Reference
 


### PR DESCRIPTION
I'm omitting `connectivity` attribute from the docs since NSX ignores it. The fix in NSX will be available in next version, hence leaving support in the code.