### PR TITLE
Fix upgrade pause issue

### DIFF
--- a/nsxt/resource_nsxt_upgrade_precheck_acknowledge.go
+++ b/nsxt/resource_nsxt_upgrade_precheck_acknowledge.go
@@ -137,8 +137,7 @@ func getAcknowledgedPrecheckIDs(m interface{}) ([]string, error) {
 		return result, err
 	}
 	for _, warning := range precheckWarnings {
-		acked := *warning.Acked
-		if acked {
+		if warning.Acked != nil && *warning.Acked {
 			result = append(result, *warning.Id)
 		}
 	}


### PR DESCRIPTION
Upgrade run resource can activate pause_after_each_upgrade_unit attribute which pauses after each unit within the upgrade group.

The upgrade should also pause after before moving on to the next component type since a user might need to do some manual operation.

The UI has this capability.

Also, set the delay parameter in waitUpgradeForStatus only when needed:
During upgrade execution, There are long stretches of time where polling NSX has no value as Edges are restarted/hosts are being configured/Manager is being restarted. However in different cases polling can start immediately.
