### PR TITLE
Add nsxt_policy_edge_transport_node data source

### DIFF
--- a/nsxt/data_source_nsxt_policy_edge_transport_node.go
+++ b/nsxt/data_source_nsxt_policy_edge_transport_node.go
@@ -1,0 +1,45 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package nsxt
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/bindings"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+)
+
+func dataSourceNsxtPolicyEdgeTransportNode() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceNsxtPolicyEdgeTransportNodeRead,
+
+		Schema: map[string]*schema.Schema{
+			"id":           getDataSourceIDSchema(),
+			"display_name": getDataSourceDisplayNameSchema(),
+			"description":  getDataSourceDescriptionSchema(),
+			"path":         getPathSchema(),
+			"unique_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "A unique identifier assigned by the system",
+			},
+		},
+	}
+}
+
+func dataSourceNsxtPolicyEdgeTransportNodeRead(d *schema.ResourceData, m interface{}) error {
+	obj, err := policyDataSourceResourceRead(d, getPolicyConnector(m), getSessionContext(d, m), "PolicyEdgeTransportNode", nil)
+	if err != nil {
+		return err
+	}
+	converter := bindings.NewTypeConverter()
+	dataValue, errors := converter.ConvertToGolang(obj, model.PolicyEdgeTransportNodeBindingType())
+	if len(errors) > 0 {
+		return errors[0]
+	}
+	etn := dataValue.(model.PolicyEdgeTransportNode)
+	d.Set("unique_id", etn.UniqueId)
+
+	return nil
+}

--- a/nsxt/data_source_nsxt_policy_edge_transport_node_test.go
+++ b/nsxt/data_source_nsxt_policy_edge_transport_node_test.go
@@ -1,0 +1,44 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package nsxt
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccDataSourceNsxtPolicyEdgeTransportNode_basic(t *testing.T) {
+	etnName := getEdgeTransportNodeName()
+	testResourceName := "data.nsxt_policy_edge_transport_node.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccOnlyLocalManager(t)
+			testAccPreCheck(t)
+			testAccEnvDefined(t, "NSXT_TEST_EDGE_TRANSPORT_NODE")
+			testAccNSXVersion(t, "9.0.0")
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNSXEdgeTransportNodeReadTemplate(etnName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(testResourceName, "display_name", etnName),
+					resource.TestCheckResourceAttrSet(testResourceName, "id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "unique_id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccNSXEdgeTransportNodeReadTemplate(name string) string {
+	return fmt.Sprintf(`
+data "nsxt_policy_edge_transport_node" "test" {
+  display_name = "%s"
+}`, name)
+}

--- a/nsxt/provider.go
+++ b/nsxt/provider.go
@@ -344,6 +344,7 @@ func Provider() *schema.Provider {
 			"nsxt_policy_distributed_vlan_connection":                dataSourceNsxtPolicyDistributedVlanConnection(),
 			"nsxt_policy_services":                                   dataSourceNsxtPolicyServices(),
 			"nsxt_policy_groups":                                     dataSourceNsxtPolicyGroups(),
+			"nsxt_policy_edge_transport_node":                        dataSourceNsxtPolicyEdgeTransportNode(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{

--- a/website/docs/d/policy_edge_node.html.markdown
+++ b/website/docs/d/policy_edge_node.html.markdown
@@ -7,7 +7,7 @@ description: A policy Edge Node data source.
 
 # nsxt_policy_edge_node
 
-This data source provides information about policy edge nodes configured on NSX.
+This data source provides information about policy edge nodes configured within a cluster, on NSX.
 
 This data source is applicable to NSX Global Manager and NSX Policy Manager.
 

--- a/website/docs/d/policy_edge_transport_node.html.markdown
+++ b/website/docs/d/policy_edge_transport_node.html.markdown
@@ -1,0 +1,32 @@
+---
+subcategory: "Fabric"
+layout: "nsxt"
+page_title: "NSXT: nsxt_policy_edge_transport_node"
+description: An Edge transport node data source.
+---
+
+# nsxt_policy_edge_transport_node
+
+This data source provides information about Edge transport node configured on NSX.
+This data source is applicable to NSX Policy Manager.
+
+## Example Usage
+
+```hcl
+data "nsxt_policy_edge_transport_node" "edge_transport_node" {
+  display_name = "edge_transport_node1"
+}
+```
+
+## Argument Reference
+
+* `id` - (Optional) The ID of Edge transport node to retrieve.
+* `display_name` - (Optional) The Display Name prefix of the Edge transport node to retrieve.
+
+## Attributes Reference
+
+In addition to arguments listed above, the following attributes are exported:
+
+* `description` - The description of the resource.
+* `path` - The NSX path of the policy resource.
+* `unique_id` - A unique identifier assigned by the system.


### PR DESCRIPTION
This data source doesn't require the Edge cluster like nsxt_policy_edge_node, and retrieves the policy path of the edge node itself.