### PR TITLE
chore: upgrade to golangci-lint v2

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,12 +1,13 @@
+---
 name: golangci-lint
 
 on:
   pull_request:
     paths-ignore:
-      - 'README.md'
+      - README.md
   push:
     paths-ignore:
-      - 'README.md'
+      - README.md
 
 permissions:
   contents: read
@@ -15,20 +16,19 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    timeout-minutes: 5
     steps:
       - name: Checkout
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       - name: Setup Go
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
-          go-version-file: 'go.mod'
+          go-version-file: go.mod
           cache: false
       - run: go mod download
       - run: go build -v .
       - name: Run Linters
-        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6.5.2
+        uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0
         with:
-          version: v1.64.8
+          version: latest
           args: --issues-exit-code=1 --timeout 10m
           only-new-issues: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,53 +1,84 @@
-# © Broadcom. All Rights Reserved.
-# The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: MPL-2.0
+---
+version: "2"
 
-# For more information about the golangci-lint configuration file, refer to:
-# https://golangci-lint.run/usage/configuration/
-
-issues:
-  exclude-rules:
-    # Exclude specific staticcheck rules to suppress false positives or acceptable issues.
-    - linters: [staticcheck]
-      text: "SA4004|SA1019|GetOkExists"
-    # Exclude specific gosec rules to suppress warnings about issues deemed acceptable.
-    - linters: [gosec]
-      text: "G402|G404|G115"
+output:
+  formats:
+    text:
+      path: stdout
 
 linters:
-  disable-all: true # Disable all linters by default and enable only the ones required.
+  default: none
   enable:
-    - gofmt             # Checks Go code formatting.
-    - goimports         # Ensures proper import formatting.
-    - gosimple          # Reports simplifications in code.
-    - govet             # Examines code for possible mistakes.
     - gosec             # Checks for security issues in code.
+    - govet             # Examines code for possible mistakes.
     - ineffassign       # Detects inefficient assignments.
     - misspell          # Finds and fixes typos.
     - staticcheck       # Reports bugs, code smells, and deprecated practices.
     - unused            # Detects unused variables, constants, etc.
+  settings:
+    errcheck:
+      exclude-functions:
+        - github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema:ForceNew|Set
+        - fmt:.*
+        - io:Close
+    revive:
+      rules:
+        - name: unreachable-code      # Detect code that will never be executed.
+        - name: errorf                # Avoid string formatting in error messages.
+        - name: range                 # Improve range loop usage.
+        - name: superfluous-else       # Eliminate unnecessary else statements.
+        - name: var-declaration       # Simplify variable declaration.
+        - name: duplicated-imports    # Detect and remove duplicate imports.-imports
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      # Exclude specific staticcheck rules to suppress false positives or acceptable issues.
+      - linters:
+          - staticcheck
+        text: SA4004|SA1019|GetOkExists
+      # Exclude specific gosec rules to suppress warnings about issues deemed acceptable.
+      - linters:
+          - gosec
+        text: G402|G404|G115
+      # TODO: Setting temporary exclusions.
+      - linters:
+          - staticcheck
+        text: QF1001
+      - linters:
+          - staticcheck
+        text: QF1003
+      - linters:
+          - staticcheck
+        text: QF1004
+      - linters:
+          - staticcheck
+        text: QF1007
+      - linters:
+          - staticcheck
+        text: QF1011
+      - linters:
+          - staticcheck
+        text: ST1005
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 
 run:
   timeout: 30m # Sets the maximum time limit for the linter run.
 
-output:
-  formats:
-    - format: colored-line-number # Allows colored output with line numbers when errors are reported.
-
-linters-settings:
-  errcheck:
-    # Exclude specific functions from errcheck warnings, as errors are intentionally ignored in these cases.
-    exclude-functions:
-      - "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema:ForceNew|Set"
-      - "fmt:.*"
-      - "io:Close"
-
-  revive:
-    # Enable specific rules for the revive linter for improved code quality and readability.
-    rules:
-      - name: unreachable-code      # Detect code that will never be executed.
-      - name: errorf                # Avoid string formatting in error messages.
-      - name: range                 # Improve range loop usage.
-      - name: superfluous-else      # Eliminate unnecessary else statements.
-      - name: var-declaration       # Simplify variable declaration.
-      - name: duplicated-imports    # Detect and remove duplicate imports.-imports
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$


### PR DESCRIPTION
- Upgrades to golangci-lint configuration to support v2.
- Updates workflow to v7 that supports v2.