### PR TITLE
chore(gh): update release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,4 @@
+---
 name: Release
 
 on:
@@ -9,32 +10,29 @@ permissions:
   contents: write
 
 jobs:
-  goreleaser:
+  release:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
       - name: Setup Go
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
-          go-version-file: 'go.mod'
+          go-version-file: go.mod
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6.5.2
+        uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0
         with:
-          version: v1.61
-          args: --issues-exit-code=1 --timeout=30m
-          skip-pkg-cache: true
-          skip-build-cache: true
+          version: latest
+          args: --issues-exit-code=1 --timeout=10m
       - name: Import GPG Key
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec # v6.3.0
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
-      -
-        name: Run GoReleaser
+      - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@9c156ee8a17a598857849441385a2041ef570552 # v6.3.0
         with:
           version: latest


### PR DESCRIPTION
- Updates `actions/checkout` to v4.2.2.
- Updates `actions/setup-go` to v5.4.0.
- Updates `golangci/golangci-lint-action` to v7.0.0.
- Updates `golangci/golangci-lint-action` to use `latest` of `golangci-lint` to match `golangci-lint.yml`.
- Removes `skip-pkg-cache` and `skip-build-cache` options that were removed April 2024 in `golangci/golangci-lint-action` v5.0.0 asinc ethe cache management is handled in `actions/setup-go`. 

Ref: https://github.com/golangci/golangci-lint-action/releases/tag/v5.0.0
