### PR TITLE
Fix documentation issue in nsxt_policy_edge_cluster

### DIFF
--- a/docs/resources/policy_edge_cluster.md
+++ b/docs/resources/policy_edge_cluster.md
@@ -16,7 +16,7 @@ This resource is applicable to NSX Policy Manager.
 resource "nsxt_policy_edge_cluster" "test" {
   display_name              = "test"
   description               = "Terraform provisioned PolicyEdgeCluster"
-  edge_cluster_profile_path = data.nsxt_policy_edge_cluster_profile.path
+  edge_cluster_profile_path = nsxt_policy_edge_high_availability_profile.path
   password_managed_by_vcf   = true
 }
 ```


### PR DESCRIPTION
Documentation included reference to a data source which doesn't exist.