### PR TITLE
chore(gh): update dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,48 @@
----
 version: 2
 updates:
-  # Maintain dependencies for GitHub Actions.
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
-      # Check for updates to GitHub Actions every week.
-      interval: "weekly"
-
-  # Maintain dependencies for Go modules
-  - package-ecosystem: "gomod"
-    directory: "/"
+      interval: weekly
+    labels:
+      - chore
+      - github-actions
+    commit-message:
+      prefix: "chore(gh)"
+      include: "scope"
+  - package-ecosystem: gomod
+    directory: /
+    groups:
+      terraform:
+        patterns:
+          - github.com/hashicorp/terraform-plugin-*
+      golang-x:
+        patterns:
+          - golang.org/x/*
+      google-golang:
+        patterns:
+          - google.golang.org/*
+    ignore:
+      # go-cty should only be updated via terraform-plugin-sdk
+      - dependency-name: github.com/hashicorp/go-cty
+      # hcl/v2 should only be updated via terraform-plugin-sdk
+      - dependency-name: github.com/hashicorp/hcl/v2
+      # terraform-plugin-go should only be updated via terraform-plugin-framework
+      - dependency-name: github.com/hashicorp/terraform-plugin-go
+      # terraform-plugin-log should only be updated via terraform-plugin-framework
+      - dependency-name: github.com/hashicorp/terraform-plugin-log
+      # go-hclog should only be updated via terraform-plugin-log
+      - dependency-name: github.com/hashicorp/go-hclog
+      # grpc should only be updated via terraform-plugin-go/terraform-plugin-framework
+      - dependency-name: google.golang.org/grpc
+      # protobuf should only be updated via terraform-plugin-go/terraform-plugin-framework
+      - dependency-name: google.golang.org/protobuf
     schedule:
-      # Check for updates to Go modules every week.
-      interval: "weekly"
+      interval: weekly
+    open-pull-requests-limit: 30
+    labels:
+      - chore
+      - dependencies
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"


### PR DESCRIPTION
### Description

Reconfigures Dependabot for the repository with two main update configurations:

**GitHub Actions** (`github-actions`):

- Checks for updates to GitHub Actions used in workflows located in the repository root (`/`).
- Runs weekly.
- Applies labels `chore` and `github-actions` to pull requests.
- Uses commit messages prefixed with `chore(gh):`, including the action name and new version (e.g., `chore(gh): actions/checkout v3`).

**Go Modules** (`gomod`):

- Checks for updates to Go module dependencies defined in the [go.mod](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) file in the repository root (`/`).
- Runs weekly.
- Groups updates for related dependencies into single pull requests:
- `terraform`: Bundles updates for `github.com/hashicorp/terraform-plugin-*.`
- `golang-x`: Bundles updates for `golang.org/x/*`.
- `google-golang`: Bundles updates for `google.golang.org/*`.
- Ignores direct updates for several specific dependencies (`go-cty`, `hcl/v2`, `terraform-plugin-go`, `terraform-plugin-log`, `go-hclog`, `google.golang.org/grpc`, `google.golang.org/protobuf`), because they are managed as transitive dependencies via other primary packages (like `terraform-plugin-sdk` or `terraform-plugin-framework`).
- Limits the number of open Dependabot pull requests for Go modules to 30.
- Applies labels `chore` and `dependencies` to pull requests.
- Uses commit messages prefixed with `chore(deps):`, including the dependency name and new version (e.g., `chore(deps): golang.org/x/net v0.24.0`).