### PR TITLE
Address GM failures

### DIFF
--- a/nsxt/data_source_nsxt_policy_transport_zone_test.go
+++ b/nsxt/data_source_nsxt_policy_transport_zone_test.go
@@ -18,7 +18,7 @@ func TestAccDataSourceNsxtPolicyTransportZone_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccNSXGlobalManagerSitePrecheck(t)
+			testAccOnlyLocalManager(t)
 		},
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
@@ -30,6 +30,32 @@ func TestAccDataSourceNsxtPolicyTransportZone_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(testResourceName, "path"),
 					resource.TestCheckResourceAttrSet(testResourceName, "is_default"),
 					resource.TestCheckResourceAttrSet(testResourceName, "realized_id"),
+					resource.TestCheckResourceAttr(testResourceName, "transport_type", "VLAN_BACKED"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceNsxtPolicyTransportZone_globalManager(t *testing.T) {
+	transportZoneName := getVlanTransportZoneName()
+	testResourceName := "data.nsxt_policy_transport_zone.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccOnlyGlobalManager(t)
+			testAccNSXGlobalManagerSitePrecheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNSXPolicyTransportZoneReadTemplate(transportZoneName, true, true),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(testResourceName, "display_name"),
+					resource.TestCheckResourceAttrSet(testResourceName, "id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "is_default"),
 					resource.TestCheckResourceAttr(testResourceName, "transport_type", "VLAN_BACKED"),
 				),
 			},

--- a/nsxt/resource_nsxt_policy_edge_high_availability_profile_test.go
+++ b/nsxt/resource_nsxt_policy_edge_high_availability_profile_test.go
@@ -35,6 +35,7 @@ func TestAccResourceNsxtPolicyEdgeHighAvailabilityProfile_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
+			testAccOnlyLocalManager(t)
 			testAccNSXVersion(t, "9.0.0")
 		},
 		Providers: testAccProviders,
@@ -100,6 +101,7 @@ func TestAccResourceNsxtPolicyEdgeHighAvailabilityProfile_importBasic(t *testing
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
+			testAccOnlyLocalManager(t)
 			testAccNSXVersion(t, "9.0.0")
 		},
 		Providers: testAccProviders,

--- a/nsxt/resource_nsxt_policy_ip_block_quota.go
+++ b/nsxt/resource_nsxt_policy_ip_block_quota.go
@@ -206,6 +206,9 @@ func resourceNsxtPolicyIpBlockQuotaCreate(d *schema.ResourceData, m interface{})
 	log.Printf("[INFO] Creating IpBlockQuota with ID %s", id)
 
 	client := clientLayer.NewLimitsClient(getSessionContext(d, m), connector)
+	if client == nil {
+		return fmt.Errorf("error creating IpBlockQuota with ID %s - operation is not supported with this backend", id)
+	}
 	err = client.Patch(id, obj)
 	if err != nil {
 		return handleCreateError("IpBlockQuota", id, err)

--- a/nsxt/resource_nsxt_policy_ip_block_quota_test.go
+++ b/nsxt/resource_nsxt_policy_ip_block_quota_test.go
@@ -119,7 +119,11 @@ func TestAccResourceNsxtPolicyIpBlockQuota_importBasic(t *testing.T) {
 	testResourceName := "nsxt_policy_ip_block_quota.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t); testAccNSXVersion(t, "9.0.0") },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccOnlyLocalManager(t)
+			testAccNSXVersion(t, "9.0.0")
+		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNsxtPolicyIpBlockQuotaCheckDestroy(state, name)

--- a/nsxt/resource_nsxt_policy_transit_gateway_attachment_test.go
+++ b/nsxt/resource_nsxt_policy_transit_gateway_attachment_test.go
@@ -30,6 +30,7 @@ func TestAccResourceNsxtPolicyTransitGatewayAttachment_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
+			testAccOnlyLocalManager(t)
 			testAccNSXVersion(t, "9.0.0")
 		},
 		Providers: testAccProviders,
@@ -74,6 +75,7 @@ func TestAccResourceNsxtPolicyTransitGatewayAttachment_importBasic(t *testing.T)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
+			testAccOnlyLocalManager(t)
 			testAccNSXVersion(t, "9.0.0")
 		},
 		Providers: testAccProviders,


### PR DESCRIPTION
The IpBlockQuota import test should not run on GM, and the create should not end with null ptr exception.
The PolicyEdgeHighAvailabilityProfile, PolicyTransitGatewayAttachment tests shouldn't run on GM as well.
TestAccDataSourceNsxtPolicyTransportZone_basic tests for realized_id - this has been introduced in 3.8.0 which wasn't tested against GM. As this attribute isn't set by GM, test has been split into a GM test an a LM test.