### PR TITLE
Set default dns_server attribute to empty list

### DIFF
--- a/nsxt/resource_nsxt_policy_edge_transport_node.go
+++ b/nsxt/resource_nsxt_policy_edge_transport_node.go
@@ -366,6 +366,7 @@ func resourceNsxtPolicyEdgeTransportNode() *schema.Resource {
 								Type:         schema.TypeString,
 								ValidateFunc: validateSingleIP(),
 							},
+							Default: []string{},
 						},
 						"enable_ssh": {
 							Type:        schema.TypeBool,


### PR DESCRIPTION
To address an issue with policy_edge_transport_node import, where this attribute is set to null value.