### PR TITLE
Edge transport node docfix

### DIFF
--- a/docs/data-sources/policy_edge_transport_node.md
+++ b/docs/data-sources/policy_edge_transport_node.md
@@ -1,6 +1,5 @@
 ---
 subcategory: "Fabric"
-layout: "nsxt"
 page_title: "NSXT: nsxt_policy_edge_transport_node"
 description: An Edge transport node data source.
 ---

--- a/docs/resources/policy_edge_transport_node.md
+++ b/docs/resources/policy_edge_transport_node.md
@@ -187,6 +187,8 @@ The following arguments are supported:
   * `storage_id` - (Required) Storage/datastore identifier in the specified vcenter server.
   * `compute_manager_id` - (Required) Vsphere compute identifier for identifying the vcenter server.
 
+~> **NOTE:** `credentials` block and `allow_ssh_root_login` attribute cannot be modified after the resource is initially applied. To update credentials, use the Edge appliance CLI.
+
 ## Attributes Reference
 
 In addition to arguments listed above, the following attributes are exported:


### PR DESCRIPTION
Data source doc filename is incorrectly suffixed.
Also add a comment for non-updatable attributes.