### PR TITLE
Validate that default project isn't specified in context block

### DIFF
--- a/nsxt/data_source_nsxt_vpc.go
+++ b/nsxt/data_source_nsxt_vpc.go
@@ -18,7 +18,7 @@ func dataSourceNsxtVPC() *schema.Resource {
 			"display_name": getDataSourceDisplayNameSchema(),
 			"description":  getDataSourceDescriptionSchema(),
 			"path":         getPathSchema(),
-			"context":      getContextSchema(true, false, false),
+			"context":      getContextSchemaExtended(true, false, false, true),
 			"short_id": {
 				Type:     schema.TypeString,
 				Optional: true,

--- a/nsxt/resource_nsxt_vpc.go
+++ b/nsxt/resource_nsxt_vpc.go
@@ -31,7 +31,7 @@ var vpcSchema = map[string]*metadata.ExtendedSchema{
 	"description":  metadata.GetExtendedSchema(getDescriptionSchema()),
 	"revision":     metadata.GetExtendedSchema(getRevisionSchema()),
 	"tag":          metadata.GetExtendedSchema(getTagsSchema()),
-	"context":      metadata.GetExtendedSchema(getContextSchema(true, false, false)),
+	"context":      metadata.GetExtendedSchema(getContextSchemaExtended(true, false, false, true)),
 	"private_ips": {
 		Schema: schema.Schema{
 			Type: schema.TypeList,

--- a/nsxt/utils.go
+++ b/nsxt/utils.go
@@ -690,13 +690,17 @@ func handlePagination(lister func(*paginationInfo) error) (int64, error) {
 }
 
 func getContextSchema(isRequired, isComputed, isVPC bool) *schema.Schema {
+	return getContextSchemaExtended(isRequired, isComputed, isVPC, false)
+}
+
+func getContextSchemaExtended(isRequired, isComputed, isVPC, allowDefaultProject bool) *schema.Schema {
 	elemSchema := map[string]*schema.Schema{
 		"project_id": {
 			Type:         schema.TypeString,
 			Description:  "Id of the project which the resource belongs to.",
 			Required:     true,
 			ForceNew:     true,
-			ValidateFunc: validateID(),
+			ValidateFunc: validateProjectID(allowDefaultProject),
 		},
 	}
 	if isVPC {

--- a/nsxt/validators.go
+++ b/nsxt/validators.go
@@ -422,6 +422,25 @@ func validateID() schema.SchemaValidateFunc {
 	}
 }
 
+func validateProjectID(allowDefault bool) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (s []string, es []error) {
+		v, ok := i.(string)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be string", k))
+			return
+		}
+
+		if !allowDefault && v == "default" {
+			es = append(es, fmt.Errorf("for creation in default project context, do not use a context block"))
+		}
+		if !isValidID(v) {
+			es = append(es, fmt.Errorf("invalid ID atrribute: %s", v))
+		}
+
+		return
+	}
+}
+
 func validateVLANId(i interface{}, k string) (s []string, es []error) {
 	var vlan int
 	vlan, ok := i.(int)


### PR DESCRIPTION
This should be only supported for VPC resource and data source.