### PR TITLE
fix: staticcheck QF1001

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -48,9 +48,6 @@ linters:
       # TODO: Setting temporary exclusions.
       - linters:
           - staticcheck
-        text: QF1001
-      - linters:
-          - staticcheck
         text: QF1003
       - linters:
           - staticcheck

--- a/nsxt/data_source_nsxt_policy_transport_zone.go
+++ b/nsxt/data_source_nsxt_policy_transport_zone.go
@@ -114,7 +114,7 @@ func dataSourceNsxtPolicyTransportZoneRead(d *schema.ResourceData, m interface{}
 			return handleDataSourceReadError(d, "TransportZone", objID, err)
 		}
 		obj = objGet
-	} else if objName == "" && !(isDefault && transportType != "") {
+	} else if objName == "" && (!isDefault || transportType == "") {
 		return fmt.Errorf("please specify id, display_name or is_default and transport_type in order to identify Transport Zone")
 	} else {
 		// Get by full name/prefix


### PR DESCRIPTION
Modifies the conditional expression in `data_source_nsxt_policy_transport_zone.go` to address the QF1001 staticcheck warning.

```diff
- else if objName == "" && !(isDefault && transportType != "") {
+ else if objName == "" && (!isDefault || transportType == "") {
```

The diff of the expressions are logically equivalent according to De Morgan's law, which states that `!(A && B)` is equivalent to `(!A || !B)`. This change maintains identical behavior while expressing the condition in a more direct and easier-to-understand form that aligns with staticcheck.