### PR TITLE
fix: staticcheck QF1004

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -51,9 +51,6 @@ linters:
         text: QF1003
       - linters:
           - staticcheck
-        text: QF1004
-      - linters:
-          - staticcheck
         text: QF1007
       - linters:
           - staticcheck

--- a/nsxt/policy_common.go
+++ b/nsxt/policy_common.go
@@ -773,7 +773,7 @@ func buildQueryStringFromMap(query map[string]string) string {
 	}
 	keyValues := make([]string, 0, len(query))
 	for key, value := range query {
-		value = strings.Replace(value, "/", "\\/", -1)
+		value = strings.ReplaceAll(value, "/", "\\/")
 		keyValue := strings.Join([]string{key, value}, ":")
 		keyValues = append(keyValues, keyValue)
 	}

--- a/nsxt/policy_search.go
+++ b/nsxt/policy_search.go
@@ -146,7 +146,7 @@ func escapeSpecialCharacters(str string) string {
 	}
 	for _, chr := range specials {
 		strchr := string(chr)
-		str = strings.Replace(str, strchr, "\\"+strchr, -1)
+		str = strings.ReplaceAll(str, strchr, "\\"+strchr)
 	}
 
 	return str

--- a/nsxt/resource_nsxt_policy_tier1_gateway_interface_test.go
+++ b/nsxt/resource_nsxt_policy_tier1_gateway_interface_test.go
@@ -565,7 +565,7 @@ resource "nsxt_policy_tier1_gateway_interface" "test" {
 }
 
 func testAccNextPolicyTier1InterfaceRealizationTemplate() string {
-	return strings.Replace(testAccNsxtPolicyTier0InterfaceRealizationTemplate(), "tier0", "tier1", -1)
+	return strings.ReplaceAll(testAccNsxtPolicyTier0InterfaceRealizationTemplate(), "tier0", "tier1")
 }
 
 func testAccNsxtPolicyTier1InterfaceTemplateWithIPv6(name string, subnet string) string {

--- a/nsxt/utils_test.go
+++ b/nsxt/utils_test.go
@@ -584,7 +584,7 @@ data "nsxt_policy_site" "test" {
 
 func testAccAdjustPolicyInfraConfig(config string) string {
 	if testAccIsGlobalManager() {
-		return strings.Replace(config, "/infra/", "/global-infra/", -1)
+		return strings.ReplaceAll(config, "/infra/", "/global-infra/")
 	}
 
 	return config


### PR DESCRIPTION
Refactors to use `strings.ReplaceAll` instead of `strings.Replace` with `n == -1`.

Ref: `staticcheck` [QF1004](https://staticcheck.dev/docs/checks#QF1004)