### PR TITLE
fix: staticcheck QF1011

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -57,9 +57,6 @@ linters:
         text: QF1007
       - linters:
           - staticcheck
-        text: QF1011
-      - linters:
-          - staticcheck
         text: ST1005
     paths:
       - third_party$

--- a/nsxt/provider_test.go
+++ b/nsxt/provider_test.go
@@ -42,7 +42,7 @@ func TestProvider(t *testing.T) {
 }
 
 func TestProvider_impl(t *testing.T) {
-	var _ *schema.Provider = Provider()
+	var _ = Provider()
 }
 
 func testAccPreCheck(t *testing.T) {


### PR DESCRIPTION
Omit redundant type from variable declaration

Ref: `staticcheck` [QF1011](https://staticcheck.dev/docs/checks#QF1011)