### PR TITLE
chore: apply hcl formatting to tests

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -54,8 +54,16 @@ test-compile:
 	fi
 	go test -c $(TEST) $(TESTARGS)
 
-website-lint:
-	@echo "==> Checking HCL formatting for docs..."
+test-hcl:
+	@echo "==> Checking HCL formatting in tests..."
+	@terrafmt diff ./nsxt --check --pattern '*_test.go' --quiet || (echo; \
+	    echo "Unexpected differences in HCL formatting for tests."; \
+	    echo "To see the full differences, run: terrafmt diff ./nsxt --pattern '*_test.go'"; \
+	    echo "To automatically fix the formatting, run 'make test-hcl-fix' and commit the changes."; \
+	    exit 1)
+
+docs-lint:
+	@echo "==> Applying HCL formatting for docs..."
 	@terrafmt diff ./docs --check --pattern '*.md' --quiet || (echo; \
 	    echo "Unexpected differences in HCL formatting for docs."; \
 	    echo "To see the full differences, run: terrafmt diff ./docs --pattern '*.md'"; \
@@ -63,7 +71,7 @@ website-lint:
 	    exit 1)
 
 docs-lint-fix:
-	@echo "==> Applying HCL formatting for docs..."
+	@echo "==> Applying HCL formatting to docs..."
 	@terrafmt fmt ./docs --pattern '*.md'
 
 docs-list-category:

--- a/nsxt/data_source_nsxt_manager_cluster_node_test.go
+++ b/nsxt/data_source_nsxt_manager_cluster_node_test.go
@@ -37,6 +37,6 @@ func TestAccDataSourceNsxtManagerClusterNode_basic(t *testing.T) {
 func testAccNsxtPolicyManagerClusterNodeReadTemplate() string {
 	return fmt.Sprintf(`
 data "nsxt_manager_cluster_node" "test" {
-	display_name = "%s"
+  display_name = "%s"
 }`, getTestManagerClusterNode())
 }

--- a/nsxt/data_source_nsxt_policy_edge_high_availability_profile_test.go
+++ b/nsxt/data_source_nsxt_policy_edge_high_availability_profile_test.go
@@ -36,7 +36,7 @@ func TestAccDataSourceNsxtPolicyEdgeHighAvailabilityProfile_basic(t *testing.T) 
 func testAccNSXEdgeHighAvailabilityProfileReadTemplate() string {
 	return testAccNsxtPolicyEdgeHighAvailabilityProfileMinimalistic() + `
 data "nsxt_policy_edge_high_availability_profile" "test" {
-  display_name = nsxt_policy_edge_high_availability_profile.test.display_name 
+  display_name = nsxt_policy_edge_high_availability_profile.test.display_name
 
   depends_on = [nsxt_policy_edge_high_availability_profile.test]
 }`

--- a/nsxt/data_source_nsxt_policy_groups_test.go
+++ b/nsxt/data_source_nsxt_policy_groups_test.go
@@ -65,9 +65,9 @@ data "nsxt_policy_groups" "test" {
 }
 
 locals {
-// Get id from path
+  // Get id from path
   path_split = split("/", data.nsxt_policy_groups.test.items["%s"])
-  group_id = element(local.path_split, length(local.path_split) - 1)
+  group_id   = element(local.path_split, length(local.path_split) - 1)
 }
 
 data "nsxt_policy_group" "test" {

--- a/nsxt/data_source_nsxt_policy_ipsec_vpn_local_endpoint_test.go
+++ b/nsxt/data_source_nsxt_policy_ipsec_vpn_local_endpoint_test.go
@@ -78,7 +78,7 @@ func testAccNsxtPolicyDataSourceIPSecVpnLocalEndpointPreconfig(name string) stri
 	return testAccNsxtPolicyTier0WithEdgeClusterForVPN() + fmt.Sprintf(`
 resource "nsxt_policy_ipsec_vpn_service" "test" {
   display_name        = "%s"
-  locale_service_path =  one(nsxt_policy_tier0_gateway.test.locale_service).path
+  locale_service_path = one(nsxt_policy_tier0_gateway.test.locale_service).path
 }
 
 resource "nsxt_policy_ipsec_vpn_local_endpoint" "test" {

--- a/nsxt/data_source_nsxt_policy_ipsec_vpn_service_test.go
+++ b/nsxt/data_source_nsxt_policy_ipsec_vpn_service_test.go
@@ -59,8 +59,8 @@ func TestAccDataSourceNsxtPolicyIPSecVpnService_withGateway(t *testing.T) {
 func testAccNsxtPolicyIPSecVpnServiceReadTemplate(name string) string {
 	return testAccNsxtPolicyTier0WithEdgeClusterForVPN() + fmt.Sprintf(`
 resource "nsxt_policy_ipsec_vpn_service" "test" {
- display_name        = "%s"
- locale_service_path = one(nsxt_policy_tier0_gateway.test.locale_service).path
+  display_name        = "%s"
+  locale_service_path = one(nsxt_policy_tier0_gateway.test.locale_service).path
 }`, name) + `
 data "nsxt_policy_ipsec_vpn_service" "test" {
   display_name = nsxt_policy_ipsec_vpn_service.test.display_name
@@ -70,8 +70,8 @@ data "nsxt_policy_ipsec_vpn_service" "test" {
 func testAccNsxtPolicyIPSecVpnServiceReadTemplateWithGateway(name string) string {
 	return testAccNsxtPolicyTier0WithEdgeClusterForVPN() + fmt.Sprintf(`
 resource "nsxt_policy_ipsec_vpn_service" "test" {
- display_name          = "%s"
- locale_service_path   = one(nsxt_policy_tier0_gateway.test.locale_service).path
+  display_name        = "%s"
+  locale_service_path = one(nsxt_policy_tier0_gateway.test.locale_service).path
 }`, name) + `
 data "nsxt_policy_ipsec_vpn_service" "test" {
   display_name = nsxt_policy_ipsec_vpn_service.test.display_name

--- a/nsxt/data_source_nsxt_policy_l2_vpn_service_test.go
+++ b/nsxt/data_source_nsxt_policy_l2_vpn_service_test.go
@@ -58,23 +58,23 @@ func TestAccDataSourceNsxtPolicyL2VpnService_withGateway(t *testing.T) {
 
 func testAccNsxtPolicyL2VpnServiceReadTemplate(name string) string {
 	return testAccNsxtPolicyTier0WithEdgeClusterForVPN() + fmt.Sprintf(`
-   resource "nsxt_policy_l2_vpn_service" "test" {
-	display_name          = "%s"
-	locale_service_path   = one(nsxt_policy_tier0_gateway.test.locale_service).path
-   }`, name) + `
-   data "nsxt_policy_l2_vpn_service" "test" {
-	 display_name = nsxt_policy_l2_vpn_service.test.display_name
-   }`
+resource "nsxt_policy_l2_vpn_service" "test" {
+  display_name        = "%s"
+  locale_service_path = one(nsxt_policy_tier0_gateway.test.locale_service).path
+}`, name) + `
+data "nsxt_policy_l2_vpn_service" "test" {
+  display_name = nsxt_policy_l2_vpn_service.test.display_name
+}`
 }
 
 func testAccNsxtPolicyL2VpnServiceReadTemplateWithGateway(name string) string {
 	return testAccNsxtPolicyTier0WithEdgeClusterForVPN() + fmt.Sprintf(`
-   resource "nsxt_policy_l2_vpn_service" "test" {
-	display_name          = "%s"
-	locale_service_path   = one(nsxt_policy_tier0_gateway.test.locale_service).path
-   }`, name) + `
-   data "nsxt_policy_l2_vpn_service" "test" {
-	 display_name = nsxt_policy_l2_vpn_service.test.display_name
-	 gateway_path = nsxt_policy_tier0_gateway.test.path
-   }`
+resource "nsxt_policy_l2_vpn_service" "test" {
+  display_name        = "%s"
+  locale_service_path = one(nsxt_policy_tier0_gateway.test.locale_service).path
+}`, name) + `
+data "nsxt_policy_l2_vpn_service" "test" {
+  display_name = nsxt_policy_l2_vpn_service.test.display_name
+  gateway_path = nsxt_policy_tier0_gateway.test.path
+}`
 }

--- a/nsxt/data_source_nsxt_policy_lb_app_profile_test.go
+++ b/nsxt/data_source_nsxt_policy_lb_app_profile_test.go
@@ -128,7 +128,7 @@ func testAccDataSourceNsxtPolicyLBAppProfileDeleteByName(name string) error {
 func testAccNsxtPolicyLBAppProfileReadTemplate(name string) string {
 	return fmt.Sprintf(`
 data "nsxt_policy_lb_app_profile" "test" {
-  type = "TCP"
+  type         = "TCP"
   display_name = "%s"
 }`, name)
 }

--- a/nsxt/data_source_nsxt_policy_lb_monitor_test.go
+++ b/nsxt/data_source_nsxt_policy_lb_monitor_test.go
@@ -128,7 +128,7 @@ func testAccDataSourceNsxtPolicyLBMonitorDeleteByName(name string) error {
 func testAccNsxtPolicyLBMonitorReadTemplate(name string) string {
 	return fmt.Sprintf(`
 data "nsxt_policy_lb_monitor" "test" {
-  type = "TCP"
+  type         = "TCP"
   display_name = "%s"
 }`, name)
 }

--- a/nsxt/data_source_nsxt_policy_realization_info_test.go
+++ b/nsxt/data_source_nsxt_policy_realization_info_test.go
@@ -215,9 +215,9 @@ data "nsxt_policy_site" "test" {
 }
 
 data "nsxt_policy_realization_info" "realization_info" {
-  path = data.%s.policy_resource.path
+  path        = data.%s.policy_resource.path
   entity_type = "%s"
-  site_path = data.nsxt_policy_site.test.path
+  site_path   = data.nsxt_policy_site.test.path
 }`, resourceDataType, resourceName, site, resourceDataType, entityType)
 }
 
@@ -271,7 +271,7 @@ data "%s" "policy_resource" {
 
 data "nsxt_policy_realization_info" "realization_info" {
 %s
-  path = data.%s.policy_resource.path
+  path        = data.%s.policy_resource.path
   entity_type = "%s"
 }`, resourceDataType, context, resourceName, context, resourceDataType, entityType)
 }
@@ -289,7 +289,7 @@ resource "%s" "policy_resource" {
 
 data "nsxt_policy_realization_info" "realization_info" {
 %s
-  path = %s.policy_resource.path
+  path        = %s.policy_resource.path
   entity_type = "%s"
 }`, resourceType, context, resourceName, context, resourceType, entityType)
 }

--- a/nsxt/data_source_nsxt_policy_segment_realization_test.go
+++ b/nsxt/data_source_nsxt_policy_segment_realization_test.go
@@ -80,7 +80,7 @@ data "nsxt_policy_transport_zone" "test" {
 %s
 resource "%s" "test" {
 %s
-  display_name        = "terra-test"
+  display_name = "terra-test"
   %s
   %s
 }

--- a/nsxt/data_source_nsxt_policy_service_test.go
+++ b/nsxt/data_source_nsxt_policy_service_test.go
@@ -167,11 +167,11 @@ resource "nsxt_policy_service" "test" {
   description  = "Acceptance Test"
 
   icmp_entry {
-	display_name = "%s"
-	description  = "Entry"
-	icmp_type    = "3"
-	icmp_code    = "1"
-	protocol     = "ICMPv4"
+    display_name = "%s"
+    description  = "Entry"
+    icmp_type    = "3"
+    icmp_code    = "1"
+    protocol     = "ICMPv4"
   }
 
   tag {

--- a/nsxt/data_source_nsxt_policy_services_test.go
+++ b/nsxt/data_source_nsxt_policy_services_test.go
@@ -56,7 +56,7 @@ data "nsxt_policy_services" "test" {
 }
 
 locals {
-// Get id from path
+  // Get id from path
   path_split = split("/", data.nsxt_policy_services.test.items["%s"])
   service_id = element(local.path_split, length(local.path_split) - 1)
 }

--- a/nsxt/data_source_nsxt_policy_tags_test.go
+++ b/nsxt/data_source_nsxt_policy_tags_test.go
@@ -48,7 +48,7 @@ resource "nsxt_policy_segment" "segment1" {
     tag   = "%s"
   }
   tag {
-    tag   = "%s"
+    tag = "%s"
   }
 
 }
@@ -58,7 +58,7 @@ data "nsxt_policy_transport_zone" "overlay_transport_zone" {
 }
 
 data "nsxt_policy_tags" "tags" {
-  scope = "scope-test"
+  scope      = "scope-test"
   depends_on = [nsxt_policy_segment.segment1]
 }
 
@@ -67,22 +67,23 @@ output "nsxt_tags" {
 }
 
 data "nsxt_policy_tags" "emptytags" {
-  scope = ""
+  scope      = ""
   depends_on = [nsxt_policy_segment.segment1]
 }
 
 output "empty_nsxt_tags" {
-  value = join("--",data.nsxt_policy_tags.emptytags.items)
+  value = join("--", data.nsxt_policy_tags.emptytags.items)
 }
 
 data "nsxt_policy_tags" "wildcardscope" {
-  scope = "*test"
+  scope      = "*test"
   depends_on = [nsxt_policy_segment.segment1]
 }
 
 output "wildcard_nsxt_tags" {
   value = data.nsxt_policy_tags.wildcardscope.items[0]
 }
+
 
 `, tagName, emptyScopeTag, transportZone)
 }

--- a/nsxt/data_source_nsxt_policy_transport_zone_test.go
+++ b/nsxt/data_source_nsxt_policy_transport_zone_test.go
@@ -136,8 +136,8 @@ data "nsxt_policy_site" "test" {
 }
 
 data "nsxt_policy_transport_zone" "test" {
-  display_name = "%s"
-  site_path = data.nsxt_policy_site.test.path
+  display_name   = "%s"
+  site_path      = data.nsxt_policy_site.test.path
   transport_type = "VLAN_BACKED"
 }`, getTestSiteName(), transportZoneName)
 }

--- a/nsxt/resource_nsxt_algorithm_type_ns_service_test.go
+++ b/nsxt/resource_nsxt_algorithm_type_ns_service_test.go
@@ -136,11 +136,11 @@ func testAccNSXAlgServiceCheckDestroy(state *terraform.State, displayName string
 func testAccNSXAlgServiceCreateTemplate(serviceName string, protocol string, sourcePorts string, destPort string) string {
 	return fmt.Sprintf(`
 resource "nsxt_algorithm_type_ns_service" "test" {
-  description       = "alg service"
-  display_name      = "%s"
-  algorithm         = "%s"
-  source_ports      = ["%s"]
-  destination_port  = "%s"
+  description      = "alg service"
+  display_name     = "%s"
+  algorithm        = "%s"
+  source_ports     = ["%s"]
+  destination_port = "%s"
   tag {
     scope = "scope1"
     tag   = "tag1"

--- a/nsxt/resource_nsxt_compute_manager_test.go
+++ b/nsxt/resource_nsxt_compute_manager_test.go
@@ -150,8 +150,8 @@ resource "nsxt_compute_manager" "test" {
 
   credential {
     username_password_login {
-      username = "%s"
-      password = "%s"
+      username   = "%s"
+      password   = "%s"
       thumbprint = "%s"
     }
   }

--- a/nsxt/resource_nsxt_dhcp_server_ip_pool_test.go
+++ b/nsxt/resource_nsxt_dhcp_server_ip_pool_test.go
@@ -273,11 +273,11 @@ resource "nsxt_dhcp_server_profile" "PRF" {
 }
 
 resource "nsxt_logical_dhcp_server" "DS" {
-    display_name     = "Acceptance Test"
-    description      = "Acceptance Test"
-    dhcp_profile_id  = "${nsxt_dhcp_server_profile.PRF.id}"
-    dhcp_server_ip   = "1.1.1.10/24"
-    gateway_ip       = "1.1.1.1"
+  display_name    = "Acceptance Test"
+  description     = "Acceptance Test"
+  dhcp_profile_id = "${nsxt_dhcp_server_profile.PRF.id}"
+  dhcp_server_ip  = "1.1.1.10/24"
+  gateway_ip      = "1.1.1.1"
 }`, edgeClusterName)
 }
 
@@ -298,13 +298,13 @@ resource "nsxt_dhcp_server_ip_pool" "test" {
   }
 
   dhcp_generic_option {
-    code = "119"
+    code   = "119"
     values = ["abc"]
   }
 
   ip_range {
-      start = "1.1.1.20"
-      end   = "1.1.1.40"
+    start = "1.1.1.20"
+    end   = "1.1.1.40"
   }
 
   tag {
@@ -321,13 +321,13 @@ resource "nsxt_dhcp_server_ip_pool" "test" {
   logical_dhcp_server_id = "${nsxt_logical_dhcp_server.DS.id}"
 
   ip_range {
-      start = "%s"
-      end   = "%s"
+    start = "%s"
+    end   = "%s"
   }
 
   ip_range {
-      start = "%s"
-      end   = "%s"
+    start = "%s"
+    end   = "%s"
   }
 
 }`, name, start1, end1, start2, end2)

--- a/nsxt/resource_nsxt_edge_cluster_test.go
+++ b/nsxt/resource_nsxt_edge_cluster_test.go
@@ -133,12 +133,12 @@ func testAccNSXEdgeClusterCheckDestroy(state *terraform.State, displayName strin
 func testAccNSXEdgeClusterCreateTemplate(displayName string) string {
 	return fmt.Sprintf(`
 resource "nsxt_edge_cluster" "test" {
-    description  = "Terraform test edge cluster"
-    display_name = "%s"
-    tag {
-    	scope = "scope1"
-        tag   = "tag1"
-    }
+  description  = "Terraform test edge cluster"
+  display_name = "%s"
+  tag {
+    scope = "scope1"
+    tag   = "tag1"
+  }
 }
 `, displayName)
 }

--- a/nsxt/resource_nsxt_edge_high_availability_profile_test.go
+++ b/nsxt/resource_nsxt_edge_high_availability_profile_test.go
@@ -148,12 +148,12 @@ func testAccNSXEdgeHighAvailabilityProfileCheckDestroy(state *terraform.State, d
 func testAccNSXEdgeHighAvailabilityProfileCreateTemplate(displayName string) string {
 	return fmt.Sprintf(`
 resource "nsxt_edge_high_availability_profile" "test" {
-    description  = "Terraform test edge high availability profile"
-    display_name = "%s"
-    tag {
-    	scope = "scope1"
-        tag   = "tag1"
-    }
+  description  = "Terraform test edge high availability profile"
+  display_name = "%s"
+  tag {
+    scope = "scope1"
+    tag   = "tag1"
+  }
 }
 `, displayName)
 }

--- a/nsxt/resource_nsxt_ether_type_ns_service_test.go
+++ b/nsxt/resource_nsxt_ether_type_ns_service_test.go
@@ -131,12 +131,12 @@ func testAccNSXEtherServiceCheckDestroy(state *terraform.State, displayName stri
 func testAccNSXEtherServiceCreateTemplate(serviceName string, etherType int) string {
 	return fmt.Sprintf(`
 resource "nsxt_ether_type_ns_service" "test" {
-    description = "ether service"
-    display_name = "%s"
-    ether_type = "%d"
-    tag {
-    	scope = "scope1"
-        tag = "tag1"
-    }
+  description  = "ether service"
+  display_name = "%s"
+  ether_type   = "%d"
+  tag {
+    scope = "scope1"
+    tag   = "tag1"
+  }
 }`, serviceName, etherType)
 }

--- a/nsxt/resource_nsxt_failure_domain_test.go
+++ b/nsxt/resource_nsxt_failure_domain_test.go
@@ -163,8 +163,8 @@ func testAccNsxtFailureDomainTemplate(createFlow bool) string {
 	}
 	return fmt.Sprintf(`
 resource "nsxt_failure_domain" "test" {
-  display_name = "%s"
-  description  = "%s"
+  display_name            = "%s"
+  description             = "%s"
   preferred_edge_services = "%s"
   tag {
     scope = "scope1"
@@ -174,7 +174,7 @@ resource "nsxt_failure_domain" "test" {
 
 data "nsxt_failure_domain" "test" {
   display_name = "%s"
-  depends_on = [nsxt_failure_domain.test]
+  depends_on   = [nsxt_failure_domain.test]
 }`, attrMap["display_name"], attrMap["description"], attrMap["preferred_edge_services"], attrMap["display_name"])
 }
 

--- a/nsxt/resource_nsxt_icmp_type_ns_service_test.go
+++ b/nsxt/resource_nsxt_icmp_type_ns_service_test.go
@@ -135,7 +135,7 @@ func testAccNSXIcmpServiceCheckDestroy(state *terraform.State, displayName strin
 func testAccNSXIcmpServiceCreateTemplate(serviceName string, protocol string, icmpType int, icmpCode int) string {
 	return fmt.Sprintf(`
 resource "nsxt_icmp_type_ns_service" "test" {
-  description = "icmp service"
+  description  = "icmp service"
   display_name = "%s"
   protocol     = "%s"
   icmp_type    = "%d"

--- a/nsxt/resource_nsxt_ip_discovery_switching_profile_test.go
+++ b/nsxt/resource_nsxt_ip_discovery_switching_profile_test.go
@@ -158,7 +158,7 @@ resource "nsxt_ip_discovery_switching_profile" "test" {
 func testAccNSXIpDiscoverySwitchingProfileEmptyTemplate(name string) string {
 	return fmt.Sprintf(`
 resource "nsxt_ip_discovery_switching_profile" "test" {
-  display_name          = "%s"
+  display_name = "%s"
 }
 `, name)
 }
@@ -166,7 +166,7 @@ resource "nsxt_ip_discovery_switching_profile" "test" {
 func testAccNSXIpDiscoverySwitchingProfileCreateTemplateTrivial(name string) string {
 	return fmt.Sprintf(`
 resource "nsxt_ip_discovery_switching_profile" "test" {
-  display_name          = "%s"
+  display_name = "%s"
 }
 `, name)
 }

--- a/nsxt/resource_nsxt_l4_port_set_ns_service_test.go
+++ b/nsxt/resource_nsxt_l4_port_set_ns_service_test.go
@@ -133,7 +133,7 @@ resource "nsxt_l4_port_set_ns_service" "test" {
   description       = "l4 service"
   display_name      = "%s"
   protocol          = "%s"
-  destination_ports = [ "%s" ]
+  destination_ports = ["%s"]
 
   tag {
     scope = "scope1"

--- a/nsxt/resource_nsxt_lb_cookie_persistence_profile_test.go
+++ b/nsxt/resource_nsxt_lb_cookie_persistence_profile_test.go
@@ -243,11 +243,11 @@ resource "nsxt_lb_cookie_persistence_profile" "test" {
   cookie_mode        = "INSERT"
 
   insert_mode_params {
-  	cookie_domain      = "%s"
-  	cookie_path        = "%s"
-  	cookie_expiry_type = "SESSION_COOKIE_TIME"
-  	max_idle_time      = "1000"
-  	max_life_time      = "2000"
+    cookie_domain      = "%s"
+    cookie_path        = "%s"
+    cookie_expiry_type = "SESSION_COOKIE_TIME"
+    max_idle_time      = "1000"
+    max_life_time      = "2000"
   }
 
   tag {

--- a/nsxt/resource_nsxt_lb_http_forwarding_rule_test.go
+++ b/nsxt/resource_nsxt_lb_http_forwarding_rule_test.go
@@ -292,7 +292,7 @@ resource "nsxt_lb_http_forwarding_rule" "test" {
   }
 
   http_reject_action {
-    reply_status = "500"
+    reply_status  = "500"
     reply_message = "rejected"
   }
 }

--- a/nsxt/resource_nsxt_lb_http_response_rewrite_rule_test.go
+++ b/nsxt/resource_nsxt_lb_http_response_rewrite_rule_test.go
@@ -258,8 +258,8 @@ resource "nsxt_lb_http_response_rewrite_rule" "test" {
   match_strategy = "ANY"
 
   response_header_condition {
-    name = "NAME1"
-    value = "VALUE1"
+    name       = "NAME1"
+    value      = "VALUE1"
     match_type = "EQUALS"
   }
 

--- a/nsxt/resource_nsxt_lb_http_virtual_server_test.go
+++ b/nsxt/resource_nsxt_lb_http_virtual_server_test.go
@@ -362,7 +362,7 @@ resource "nsxt_lb_http_request_rewrite_rule" "rule2" {
 resource "nsxt_lb_http_request_rewrite_rule" "rule3" {
   display_name = "%s"
   uri_condition {
-    uri = "html"
+    uri        = "html"
     match_type = "ENDS_WITH"
   }
 

--- a/nsxt/resource_nsxt_lb_pool_test.go
+++ b/nsxt/resource_nsxt_lb_pool_test.go
@@ -372,7 +372,7 @@ resource "nsxt_lb_pool" "test" {
   min_active_members = "%s"
 
   snat_translation {
-  	type = "%s"
+    type = "%s"
   }
 
   tag {
@@ -386,13 +386,13 @@ resource "nsxt_lb_pool" "test" {
 func testAccNSXLbPoolUpdateTemplate(name string, algorithm string, minActiveMembers string, snatTranslationType string) string {
 	return fmt.Sprintf(`
 resource "nsxt_lb_pool" "test" {
-  display_name          = "%s"
-  algorithm             = "%s"
-  description           = "Updated Acceptance Test"
-  min_active_members    = "%s"
+  display_name       = "%s"
+  algorithm          = "%s"
+  description        = "Updated Acceptance Test"
+  min_active_members = "%s"
 
   snat_translation {
-  	type = "%s"
+    type = "%s"
   }
 
   tag {
@@ -437,8 +437,8 @@ resource "nsxt_lb_pool" "test" {
 func testAccNSXLbPoolUpdateWithMonitorsTemplate(name string) string {
 	return testAccNSXLbPoolMonitorsTemplate() + fmt.Sprintf(`
 resource "nsxt_lb_pool" "test" {
-  display_name       = "%s"
-  description        = "Updated Acceptance Test"
+  display_name = "%s"
+  description  = "Updated Acceptance Test"
 }
 `, name)
 }
@@ -452,8 +452,8 @@ resource "nsxt_lb_pool" "test" {
   min_active_members = "%s"
 
   snat_translation {
-  	type          = "%s"
-  	ip            = "%s"
+    type = "%s"
+    ip   = "%s"
   }
 
   tag {
@@ -473,8 +473,8 @@ resource "nsxt_lb_pool" "test" {
   min_active_members = "%s"
 
   snat_translation {
-  	type          = "%s"
-  	ip            = "%s"
+    type = "%s"
+    ip   = "%s"
   }
 
   tag {
@@ -506,7 +506,7 @@ resource "nsxt_lb_pool" "test" {
   min_active_members = "%s"
 
   snat_translation {
-  	type = "%s"
+    type = "%s"
   }
 
   tag {
@@ -530,13 +530,13 @@ resource "nsxt_lb_pool" "test" {
 func testAccNSXLbPoolUpdateWithMemberTemplate(name string, algorithm string, minActiveMembers string, snatTranslationType string, memberIP string) string {
 	return fmt.Sprintf(`
 resource "nsxt_lb_pool" "test" {
-  display_name          = "%s"
-  algorithm             = "%s"
-  description           = "Updated Acceptance Test"
-  min_active_members    = "%s"
+  display_name       = "%s"
+  algorithm          = "%s"
+  description        = "Updated Acceptance Test"
+  min_active_members = "%s"
 
   snat_translation {
-  	type = "%s"
+    type = "%s"
   }
 
   tag {
@@ -577,9 +577,9 @@ resource "nsxt_ns_group" "grp1" {
 }
 
 resource "nsxt_lb_pool" "test" {
-  display_name          = "%s"
-  algorithm             = "%s"
-  description           = "Acceptance Test"
+  display_name = "%s"
+  algorithm    = "%s"
+  description  = "Acceptance Test"
 
   member_group {
     ip_version_filter  = "IPV4"
@@ -603,9 +603,9 @@ resource "nsxt_ns_group" "grp1" {
 }
 
 resource "nsxt_lb_pool" "test" {
-  display_name          = "%s"
-  algorithm             = "%s"
-  description           = "Updated Acceptance Test"
+  display_name = "%s"
+  algorithm    = "%s"
+  description  = "Updated Acceptance Test"
 
   member_group {
     ip_version_filter  = "IPV6"

--- a/nsxt/resource_nsxt_lb_service_test.go
+++ b/nsxt/resource_nsxt_lb_service_test.go
@@ -247,6 +247,7 @@ resource "nsxt_lb_service" "test" {
 func testAccNSXLbServiceCreateTemplateWithServers(name string, logLevel string) string {
 	return testAccNSXLbCreateTopology() + fmt.Sprintf(`
 
+
 resource "nsxt_lb_fast_tcp_application_profile" "test" {
   display_name = "lb service test"
 }
@@ -255,13 +256,13 @@ resource "nsxt_lb_fast_udp_application_profile" "test" {
   display_name = "lb service test"
 }
 
-resource "nsxt_lb_tcp_virtual_server" "test"{
+resource "nsxt_lb_tcp_virtual_server" "test" {
   application_profile_id = "${nsxt_lb_fast_tcp_application_profile.test.id}"
   ip_address             = "1.1.1.2"
   ports                  = ["7887"]
 }
 
-resource "nsxt_lb_udp_virtual_server" "test"{
+resource "nsxt_lb_udp_virtual_server" "test" {
   application_profile_id = "${nsxt_lb_fast_udp_application_profile.test.id}"
   ip_address             = "1.1.1.2"
   ports                  = ["7888"]

--- a/nsxt/resource_nsxt_lb_source_ip_persistence_profile_test.go
+++ b/nsxt/resource_nsxt_lb_source_ip_persistence_profile_test.go
@@ -136,7 +136,7 @@ func testAccNSXLbSourceIPPersistenceProfileBasicTemplate(name string, timeout st
 	return fmt.Sprintf(`
 resource "nsxt_lb_source_ip_persistence_profile" "test" {
   display_name             = "%s"
-  description             = "test description"
+  description              = "test description"
   persistence_shared       = "true"
   ha_persistence_mirroring = "true"
   purge_when_full          = "false"

--- a/nsxt/resource_nsxt_logical_dhcp_port_test.go
+++ b/nsxt/resource_nsxt_logical_dhcp_port_test.go
@@ -90,10 +90,10 @@ resource "nsxt_dhcp_server_profile" "test" {
   edge_cluster_id = "${data.nsxt_edge_cluster.EC.id}"
 }
 resource "nsxt_logical_dhcp_server" "test" {
-  display_name     = "server1"
-  dhcp_profile_id  = "${nsxt_dhcp_server_profile.test.id}"
-  dhcp_server_ip   = "1.1.1.1/24"
-  gateway_ip       = "1.1.1.2"
+  display_name    = "server1"
+  dhcp_profile_id = "${nsxt_dhcp_server_profile.test.id}"
+  dhcp_server_ip  = "1.1.1.1/24"
+  gateway_ip      = "1.1.1.2"
 }`, edgeClusterName)
 }
 
@@ -107,7 +107,7 @@ resource "nsxt_logical_dhcp_port" "test" {
   dhcp_server_id    = "${nsxt_logical_dhcp_server.test.id}"
 
   tag {
-  	scope = "scope1"
+    scope = "scope1"
     tag   = "tag1"
   }
 }`, portName)

--- a/nsxt/resource_nsxt_logical_dhcp_server_test.go
+++ b/nsxt/resource_nsxt_logical_dhcp_server_test.go
@@ -233,7 +233,7 @@ resource "nsxt_logical_dhcp_server" "test" {
   }
 
   dhcp_generic_option {
-    code = "119"
+    code   = "119"
     values = ["abc"]
   }
 
@@ -247,8 +247,8 @@ resource "nsxt_logical_dhcp_server" "test" {
 func testAccNSXLogicalDhcpServerUpdateTemplate(edgeClusterName string, updatedName string, ip1 string, ip2 string, ip3 string, ip4 string, ip5 string) string {
 	return testAccNSXDhcpServerProfileCreateForServerTemplate(edgeClusterName) + fmt.Sprintf(`
 resource "nsxt_logical_dhcp_server" "test" {
-  display_name                = "%s"
-  description                 = "Acceptance Test Update"
+  display_name     = "%s"
+  description      = "Acceptance Test Update"
   dhcp_profile_id  = "${nsxt_dhcp_server_profile.PRF.id}"
   dhcp_server_ip   = "%s"
   gateway_ip       = "%s"
@@ -266,7 +266,7 @@ resource "nsxt_logical_dhcp_server" "test" {
   }
 
   dhcp_generic_option {
-    code = "119"
+    code   = "119"
     values = ["abc", "def"]
   }
 

--- a/nsxt/resource_nsxt_logical_port_test.go
+++ b/nsxt/resource_nsxt_logical_port_test.go
@@ -232,7 +232,7 @@ resource "nsxt_logical_port" "test" {
   logical_switch_id = "${nsxt_logical_switch.test.id}"
 
   tag {
-  	scope = "scope1"
+    scope = "scope1"
     tag   = "tag1"
   }
 }`, portName)
@@ -290,9 +290,9 @@ func testAccNSXLogicalPortCreateNSGroup() string {
 	return `
 resource "nsxt_ns_group" "test" {
   membership_criteria {
-      target_type = "LogicalPort"
-      scope       = "scope1"
-      tag         = "tag1"
+    target_type = "LogicalPort"
+    scope       = "scope1"
+    tag         = "tag1"
   }
 }`
 }

--- a/nsxt/resource_nsxt_logical_router_downlink_port_test.go
+++ b/nsxt/resource_nsxt_logical_router_downlink_port_test.go
@@ -202,10 +202,10 @@ data "nsxt_transport_zone" "tz1" {
 }
 
 resource "nsxt_logical_switch" "ls1" {
-  display_name     = "downlink_test_switch"
-  admin_state      = "UP"
-  replication_mode = "MTEP"
-  vlan             = "0"
+  display_name      = "downlink_test_switch"
+  admin_state       = "UP"
+  replication_mode  = "MTEP"
+  vlan              = "0"
   transport_zone_id = "${data.nsxt_transport_zone.tz1.id}"
 }
 
@@ -234,9 +234,9 @@ resource "nsxt_dhcp_relay_profile" "drp1" {
 }
 
 resource "nsxt_dhcp_relay_service" "drs1" {
-	display_name = "srv"
-	description = "Acceptance Test"
-	dhcp_relay_profile_id = "${nsxt_dhcp_relay_profile.drp1.id}"
+  display_name          = "srv"
+  description           = "Acceptance Test"
+  dhcp_relay_profile_id = "${nsxt_dhcp_relay_profile.drp1.id}"
 }`
 }
 
@@ -292,7 +292,7 @@ resource "nsxt_logical_router_downlink_port" "test" {
 
   service_binding {
     target_id   = "${nsxt_dhcp_relay_service.drs1.id}"
-	target_type = "%s"
+    target_type = "%s"
   }
 
   tag {

--- a/nsxt/resource_nsxt_logical_router_link_port_on_tier1_test.go
+++ b/nsxt/resource_nsxt_logical_router_link_port_on_tier1_test.go
@@ -172,9 +172,9 @@ resource "nsxt_logical_router_link_port_on_tier1" "test" {
 func testAccNSXLogicalRouterLinkPortOnTier1UpdateTemplate(name string, tier0RouterName string, edgeClusterName string) string {
 	return testAccNSXLogicalRouterLinkPortOnTier1PreconditionsTemplate(tier0RouterName, edgeClusterName) + fmt.Sprintf(`
 resource "nsxt_logical_router_link_port_on_tier1" "test" {
-  display_name                 = "%s"
-  description                  = "Acceptance Test Update"
-  logical_router_id            = "${nsxt_logical_tier1_router.test.id}"
+  display_name                  = "%s"
+  description                   = "Acceptance Test Update"
+  logical_router_id             = "${nsxt_logical_tier1_router.test.id}"
   linked_logical_router_port_id = "${nsxt_logical_router_link_port_on_tier0.test.id}"
 
   tag {

--- a/nsxt/resource_nsxt_logical_switch_test.go
+++ b/nsxt/resource_nsxt_logical_switch_test.go
@@ -304,7 +304,7 @@ resource "nsxt_logical_switch" "%s" {
   vlan              = "%s"
 
   address_binding {
-    ip_address = "1.1.1.1"
+    ip_address  = "1.1.1.1"
     mac_address = "00:11:22:33:44:55"
   }
 

--- a/nsxt/resource_nsxt_logical_tier0_router_test.go
+++ b/nsxt/resource_nsxt_logical_tier0_router_test.go
@@ -195,7 +195,7 @@ resource "nsxt_logical_tier0_router" "test" {
 func testAccNSXLogicalTier0RouterUpdateTemplate(name string, haMode string, edgeClusterName string) string {
 	return fmt.Sprintf(`
 data "nsxt_edge_cluster" "EC" {
-     display_name = "%s"
+  display_name = "%s"
 }
 
 resource "nsxt_logical_tier0_router" "test" {

--- a/nsxt/resource_nsxt_logical_tier1_router_test.go
+++ b/nsxt/resource_nsxt_logical_tier1_router_test.go
@@ -176,7 +176,7 @@ resource "nsxt_logical_tier1_router" "test" {
 func testAccNSXLogicalTier1RouterUpdateTemplate(name string, failoverMode string, edgeClusterName string) string {
 	return fmt.Sprintf(`
 data "nsxt_edge_cluster" "EC" {
-     display_name = "%s"
+  display_name = "%s"
 }
 
 resource "nsxt_logical_tier1_router" "test" {

--- a/nsxt/resource_nsxt_mac_management_switching_profile_test.go
+++ b/nsxt/resource_nsxt_mac_management_switching_profile_test.go
@@ -150,10 +150,10 @@ resource "nsxt_mac_management_switching_profile" "test" {
   mac_change_allowed = "%s"
 
   mac_learning {
-  	enabled                  = "%s"
-  	limit                    = "%s"
-  	limit_policy             = "%s"
-  	unicast_flooding_allowed = "%s"
+    enabled                  = "%s"
+    limit                    = "%s"
+    limit_policy             = "%s"
+    unicast_flooding_allowed = "%s"
   }
 
   tag {
@@ -167,7 +167,7 @@ resource "nsxt_mac_management_switching_profile" "test" {
 func testAccNSXMacManagementSwitchingProfileBasicTemplate(name string) string {
 	return fmt.Sprintf(`
 resource "nsxt_mac_management_switching_profile" "test" {
-  display_name       = "%s"
+  display_name = "%s"
 }
 `, name)
 }

--- a/nsxt/resource_nsxt_node_user_test.go
+++ b/nsxt/resource_nsxt_node_user_test.go
@@ -189,12 +189,12 @@ func testAccNodeUserCreate(username string) string {
 	attrMap := accTestNodeUserCreateAttributes
 	return fmt.Sprintf(`
 resource "nsxt_node_user" "test" {
-  active = %s
-  full_name = "%s"
-  password = "%s"
-  username = "%s"
+  active                    = %s
+  full_name                 = "%s"
+  password                  = "%s"
+  username                  = "%s"
   password_change_frequency = %s
-  password_change_warning = %s
+  password_change_warning   = %s
 }`, attrMap["active"], attrMap["full_name"], attrMap["password"], username, attrMap["password_change_frequency"], attrMap["password_change_warning"])
 }
 
@@ -202,11 +202,11 @@ func testAccNodeUserUpdate(username, password string) string {
 	attrMap := accTestNodeUserUpdateAttributes
 	return fmt.Sprintf(`
 resource "nsxt_node_user" "test" {
-  active = %s
-  full_name = "%s"
-  password = "%s"
-  username = "%s"
+  active                    = %s
+  full_name                 = "%s"
+  password                  = "%s"
+  username                  = "%s"
   password_change_frequency = %s
-  password_change_warning = %s
+  password_change_warning   = %s
 }`, attrMap["active"], attrMap["full_name"], password, username, attrMap["password_change_frequency"], attrMap["password_change_warning"])
 }

--- a/nsxt/resource_nsxt_ns_group_test.go
+++ b/nsxt/resource_nsxt_ns_group_test.go
@@ -332,16 +332,16 @@ resource "nsxt_logical_switch" "test" {
 
 resource "nsxt_ns_group" "test" {
   display_name = "%s"
-  description = "Acceptance Test Update"
+  description  = "Acceptance Test Update"
 
   membership_criteria {
-	target_type = "LogicalSwitch"
+    target_type = "LogicalSwitch"
     scope       = "XXX"
   }
 
   member {
     target_type = "LogicalSwitch"
-    value = "${nsxt_logical_switch.test.id}"
+    value       = "${nsxt_logical_switch.test.id}"
   }
 }`, tzName, testAccNsxtNSGroupHelperName, name)
 }

--- a/nsxt/resource_nsxt_ns_service_group_test.go
+++ b/nsxt/resource_nsxt_ns_service_group_test.go
@@ -138,7 +138,7 @@ resource "nsxt_ip_protocol_ns_service" "srv1" {
 resource "nsxt_l4_port_set_ns_service" "srv2" {
   display_name      = "test_l4_service"
   protocol          = "TCP"
-  destination_ports = [ "8080" ]
+  destination_ports = ["8080"]
 }`
 }
 

--- a/nsxt/resource_nsxt_policy_bgp_config_test.go
+++ b/nsxt/resource_nsxt_policy_bgp_config_test.go
@@ -138,7 +138,7 @@ resource "nsxt_policy_bgp_config" "test" {
 
 
 data "nsxt_policy_realization_info" "bgp_realization_info" {
-  path      = nsxt_policy_bgp_config.test.path
+  path = nsxt_policy_bgp_config.test.path
   %s
 }`, attrMap["enabled"], attrMap["inter_sr_ibgp"], attrMap["local_as_num"], attrMap["multipath_relax"], attrMap["prefix"], attrMap["summary_only"], attrMap["graceful_restart_mode"], attrMap["graceful_restart_timer"], attrMap["graceful_restart_stale_route_timer"], extraConfig, extraConfig)
 }
@@ -156,7 +156,7 @@ resource "nsxt_policy_bgp_config" "test" {
 }
 
 data "nsxt_policy_realization_info" "realization_info" {
-  path      = nsxt_policy_bgp_config.test.path
+  path = nsxt_policy_bgp_config.test.path
   %s
 }`, extraConfig, extraConfig)
 }

--- a/nsxt/resource_nsxt_policy_bgp_neighbor_test.go
+++ b/nsxt/resource_nsxt_policy_bgp_neighbor_test.go
@@ -438,7 +438,7 @@ resource "nsxt_policy_vlan_segment" "test" {
   display_name        = "Acceptance Test"
   vlan_ids            = [11]
   subnet {
-      cidr = "10.2.2.2/24"
+    cidr = "10.2.2.2/24"
   }
 }
 
@@ -457,12 +457,12 @@ resource "nsxt_policy_tier0_gateway" "test" {
 }
 
 resource "nsxt_policy_tier0_gateway_interface" "test" {
-  display_name   = "terraformt0gwintf"
-  type           = "EXTERNAL"
-  description    = "Acceptance Test"
-  gateway_path   = nsxt_policy_tier0_gateway.test.path
-  segment_path   = nsxt_policy_vlan_segment.test.path
-  subnets        = ["%s"]
+  display_name = "terraformt0gwintf"
+  type         = "EXTERNAL"
+  description  = "Acceptance Test"
+  gateway_path = nsxt_policy_tier0_gateway.test.path
+  segment_path = nsxt_policy_vlan_segment.test.path
+  subnets      = ["%s"]
 }
 
 resource "nsxt_policy_bgp_neighbor" "test" {
@@ -664,10 +664,10 @@ resource "nsxt_policy_gateway_prefix_list" "test" {
   gateway_path = nsxt_policy_tier0_gateway.test.path
 
   prefix {
-  	action  = "DENY"
-  	ge      = "20"
-  	le      = "23"
-  	network = "4.4.0.0/20"
+    action  = "DENY"
+    ge      = "20"
+    le      = "23"
+    network = "4.4.0.0/20"
   }
 }
 
@@ -684,8 +684,8 @@ resource "nsxt_policy_bgp_neighbor" "test" {
   }
 
   route_filtering {
-    address_family  = "IPV4"
-    in_route_filter = nsxt_policy_gateway_prefix_list.test.path
+    address_family   = "IPV4"
+    in_route_filter  = nsxt_policy_gateway_prefix_list.test.path
     out_route_filter = nsxt_policy_gateway_prefix_list.test.path
   }
 }`, getEdgeClusterName())
@@ -700,18 +700,19 @@ func testAccNsxtPolicyBgpNeighborGMTemplate(createFlow bool, subnet string) stri
 	}
 	return testAccNsxtGlobalPolicyEdgeClusterReadTemplate() + testAccNSXGlobalPolicyTransportZoneReadTemplate(true, false) + fmt.Sprintf(`
 
+
 resource "nsxt_policy_vlan_segment" "test" {
   transport_zone_path = data.nsxt_policy_transport_zone.test.path
   display_name        = "Acceptance Test"
   vlan_ids            = [11]
   subnet {
-      cidr = "10.2.2.2/24"
+    cidr = "10.2.2.2/24"
   }
 }
 
 resource "nsxt_policy_tier0_gateway" "test" {
-  display_name      = "terraformt0gw"
-  description       = "Acceptance Test"
+  display_name = "terraformt0gw"
+  description  = "Acceptance Test"
   locale_service {
     edge_cluster_path = data.nsxt_policy_edge_cluster.test.path
   }
@@ -728,13 +729,13 @@ resource "nsxt_policy_bgp_config" "test" {
 }
 
 resource "nsxt_policy_tier0_gateway_interface" "test" {
-  display_name   = "terraformt0gwintf"
-  type           = "EXTERNAL"
-  description    = "Acceptance Test"
-  gateway_path   = nsxt_policy_tier0_gateway.test.path
-  segment_path   = nsxt_policy_vlan_segment.test.path
-  subnets        = ["%s"]
-  site_path      = data.nsxt_policy_site.test.path
+  display_name = "terraformt0gwintf"
+  type         = "EXTERNAL"
+  description  = "Acceptance Test"
+  gateway_path = nsxt_policy_tier0_gateway.test.path
+  segment_path = nsxt_policy_vlan_segment.test.path
+  subnets      = ["%s"]
+  site_path    = data.nsxt_policy_site.test.path
 }
 
 resource "nsxt_policy_bgp_neighbor" "test" {
@@ -766,13 +767,13 @@ resource "nsxt_policy_vlan_segment" "test" {
   display_name        = "Acceptance Test"
   vlan_ids            = [11]
   subnet {
-      cidr = "10.2.2.2/24"
+    cidr = "10.2.2.2/24"
   }
 }
 
 resource "nsxt_policy_tier0_gateway" "test" {
-  display_name      = "terraformt0gw"
-  description       = "Acceptance Test"
+  display_name = "terraformt0gw"
+  description  = "Acceptance Test"
   locale_service {
     edge_cluster_path = data.nsxt_policy_edge_cluster.test.path
   }
@@ -789,13 +790,13 @@ resource "nsxt_policy_bgp_config" "test" {
 }
 
 resource "nsxt_policy_tier0_gateway_interface" "test" {
-  display_name   = "terraformt0gwintf"
-  type           = "EXTERNAL"
-  description    = "Acceptance Test"
-  gateway_path   = nsxt_policy_tier0_gateway.test.path
-  segment_path   = nsxt_policy_vlan_segment.test.path
-  subnets        = ["12.12.12.1/24"]
-  site_path      = data.nsxt_policy_site.test.path
+  display_name = "terraformt0gwintf"
+  type         = "EXTERNAL"
+  description  = "Acceptance Test"
+  gateway_path = nsxt_policy_tier0_gateway.test.path
+  segment_path = nsxt_policy_vlan_segment.test.path
+  subnets      = ["12.12.12.1/24"]
+  site_path    = data.nsxt_policy_site.test.path
 }
 
 resource "nsxt_policy_bgp_neighbor" "test" {

--- a/nsxt/resource_nsxt_policy_constraint_test.go
+++ b/nsxt/resource_nsxt_policy_constraint_test.go
@@ -215,7 +215,7 @@ func testAccNsxtPolicyConstraintTemplate(createFlow bool) string {
 resource "nsxt_policy_constraint" "test" {
   display_name = "%s"
   description  = "%s"
-  message = "%s"
+  message      = "%s"
 
   target {
     path_prefix = nsxt_policy_project.test.path
@@ -245,7 +245,7 @@ resource "nsxt_policy_constraint" "test" {
   %s
   display_name = "%s"
   description  = "%s"
-  message = "%s"
+  message      = "%s"
 
   target {
     path_prefix = "${data.nsxt_vpc.test.path}/"

--- a/nsxt/resource_nsxt_policy_context_profile_custom_attribute_test.go
+++ b/nsxt/resource_nsxt_policy_context_profile_custom_attribute_test.go
@@ -140,7 +140,7 @@ func testAccNsxtPolicyContextProfileCustomAttributeArgTemplate(key string, attri
 	return fmt.Sprintf(`
 resource "nsxt_policy_context_profile_custom_attribute" "test" {
 %s
-  key = "%s"
+  key       = "%s"
   attribute = "%s"
 }`, context, key, attribute)
 }

--- a/nsxt/resource_nsxt_policy_dhcp_relay_test.go
+++ b/nsxt/resource_nsxt_policy_dhcp_relay_test.go
@@ -200,7 +200,7 @@ func testAccNsxtPolicyDhcpRelayConfigTemplate(createFlow bool, withContext bool)
 	return fmt.Sprintf(`
 resource "nsxt_policy_dhcp_relay" "test" {
 %s
-  display_name      = "%s"
+  display_name     = "%s"
   description      = "%s"
   server_addresses = %s
 

--- a/nsxt/resource_nsxt_policy_dhcp_server_test.go
+++ b/nsxt/resource_nsxt_policy_dhcp_server_test.go
@@ -207,13 +207,14 @@ func testAccNsxtPolicyDhcpServerCreateTemplate(withContext bool) string {
 
 	return defsSpec + fmt.Sprintf(`
 
+
 resource "nsxt_policy_dhcp_server" "test" {
 %s
-  display_name = "%s"
-  description  = "%s"
+  display_name      = "%s"
+  description       = "%s"
   edge_cluster_path = %s
-  lease_time = %s
-  server_addresses = ["110.64.0.1/16"]
+  lease_time        = %s
+  server_addresses  = ["110.64.0.1/16"]
 
   tag {
     scope = "scope1"
@@ -244,11 +245,11 @@ func testAccNsxtPolicyDhcpServerUpdateTemplate(withContext bool) string {
 	return defsSpec + fmt.Sprintf(`
 resource "nsxt_policy_dhcp_server" "test" {
 %s
-  display_name = "%s"
-  description  = "%s"
+  display_name      = "%s"
+  description       = "%s"
   edge_cluster_path = %s
-  lease_time = %s
-  server_addresses = ["2001::1234:abcd:ffff:c0a8:101/64", "110.64.0.1/16"]
+  lease_time        = %s
+  server_addresses  = ["2001::1234:abcd:ffff:c0a8:101/64", "110.64.0.1/16"]
 
   tag {
     scope = "scope1"
@@ -266,7 +267,7 @@ func testAccNsxtPolicyDhcpServerMinimalistic(withContext bool) string {
 	return fmt.Sprintf(`
 resource "nsxt_policy_dhcp_server" "test" {
 %s
-  display_name = "%s"
+  display_name     = "%s"
   server_addresses = ["110.64.0.1/16"]
 }
 `, context, accTestPolicyDhcpServerUpdateAttributes["display_name"])

--- a/nsxt/resource_nsxt_policy_dhcp_v6_static_binding_test.go
+++ b/nsxt/resource_nsxt_policy_dhcp_v6_static_binding_test.go
@@ -300,7 +300,7 @@ func testAccNsxtPolicyDhcpV6StaticBindingMinimalistic(isFixed, withContext bool)
 	return testAccNsxtPolicyDhcpStaticBindingPrerequisites(isFixed, true, withContext) + fmt.Sprintf(`
 resource "nsxt_policy_dhcp_v6_static_binding" "test" {
 %s
-  segment_path    = %s.test.path
+  segment_path = %s.test.path
   display_name = "%s"
   mac_address  = "%s"
 }`, context, testAccNsxtPolicyGetSegmentResourceName(isFixed), attrMap["display_name"], attrMap["mac_address"])

--- a/nsxt/resource_nsxt_policy_distributed_flood_protection_profile_binding_test.go
+++ b/nsxt/resource_nsxt_policy_distributed_flood_protection_profile_binding_test.go
@@ -196,16 +196,16 @@ func testAccNsxtPolicyDistributedFloodProtectionProfileBindingTemplate(createFlo
 	return testAccNsxtPolicyDistributedFloodProtectionProfileBindingDeps(withContext) + fmt.Sprintf(`
 resource "nsxt_policy_distributed_flood_protection_profile_binding" "%s" {
 %s
- display_name = "%s"
- description  = "%s"
- profile_path    = nsxt_policy_distributed_flood_protection_profile.%s.path
- group_path      = nsxt_policy_group.test.path
- sequence_number = %s
+  display_name    = "%s"
+  description     = "%s"
+  profile_path    = nsxt_policy_distributed_flood_protection_profile.%s.path
+  group_path      = nsxt_policy_group.test.path
+  sequence_number = %s
 
- tag {
-   scope = "scope1"
-   tag   = "tag1"
- }
+  tag {
+    scope = "scope1"
+    tag   = "tag1"
+  }
 }
 `, resourceName, context, name, attrMap["description"], attrMap["profile_res_name"], attrMap["seq_num"])
 }
@@ -233,26 +233,26 @@ resource "nsxt_policy_group" "test" {
 
 resource "nsxt_policy_distributed_flood_protection_profile" "test1" {
 %s
-  display_name = "dfpp1"
-  description  = "Acceptance Test"
-  icmp_active_flow_limit = 3
-  other_active_conn_limit = 3
+  display_name             = "dfpp1"
+  description              = "Acceptance Test"
+  icmp_active_flow_limit   = 3
+  other_active_conn_limit  = 3
   tcp_half_open_conn_limit = 3
-  udp_active_flow_limit = 3
-  enable_rst_spoofing = false
-  enable_syncache = false
+  udp_active_flow_limit    = 3
+  enable_rst_spoofing      = false
+  enable_syncache          = false
 }
 
 resource "nsxt_policy_distributed_flood_protection_profile" "test2" {
 %s
-  display_name = "dfpp2"
-  description  = "Acceptance Test"
-  icmp_active_flow_limit = 4
-  other_active_conn_limit = 4
+  display_name             = "dfpp2"
+  description              = "Acceptance Test"
+  icmp_active_flow_limit   = 4
+  other_active_conn_limit  = 4
   tcp_half_open_conn_limit = 4
-  udp_active_flow_limit = 4
-  enable_rst_spoofing = false
-  enable_syncache = false
+  udp_active_flow_limit    = 4
+  enable_rst_spoofing      = false
+  enable_syncache          = false
 }
 `, context, context, context)
 }

--- a/nsxt/resource_nsxt_policy_distributed_flood_protection_profile_test.go
+++ b/nsxt/resource_nsxt_policy_distributed_flood_protection_profile_test.go
@@ -229,14 +229,14 @@ func testAccNsxtPolicyDistributedFloodProtectionProfileTemplate(createFlow, with
 	return fmt.Sprintf(`
 resource "nsxt_policy_distributed_flood_protection_profile" "%s" {
 %s
-  display_name = "%s"
-  description  = "%s"
-  icmp_active_flow_limit = %s
-  other_active_conn_limit = %s
+  display_name             = "%s"
+  description              = "%s"
+  icmp_active_flow_limit   = %s
+  other_active_conn_limit  = %s
   tcp_half_open_conn_limit = %s
-  udp_active_flow_limit = %s
-  enable_rst_spoofing = %s
-  enable_syncache = %s
+  udp_active_flow_limit    = %s
+  enable_rst_spoofing      = %s
+  enable_syncache          = %s
 
   tag {
     scope = "scope1"
@@ -247,7 +247,7 @@ resource "nsxt_policy_distributed_flood_protection_profile" "%s" {
 data "nsxt_policy_distributed_flood_protection_profile" "%s" {
 %s
   display_name = "%s"
-  depends_on = [nsxt_policy_distributed_flood_protection_profile.%s]
+  depends_on   = [nsxt_policy_distributed_flood_protection_profile.%s]
 }`, resourceName, context, name, attrMap["description"], attrMap["icmp_active_flow_limit"], attrMap["other_active_conn_limit"], attrMap["tcp_half_open_conn_limit"], attrMap["udp_active_flow_limit"], attrMap["enable_rst_spoofing"], attrMap["enable_syncache"], resourceName, context, name, resourceName)
 }
 

--- a/nsxt/resource_nsxt_policy_edge_high_availability_profile_test.go
+++ b/nsxt/resource_nsxt_policy_edge_high_availability_profile_test.go
@@ -200,10 +200,10 @@ func testAccNsxtPolicyEdgeHighAvailabilityProfileTemplate(createFlow bool) strin
 	}
 	return fmt.Sprintf(`
 resource "nsxt_policy_edge_high_availability_profile" "test" {
-  display_name = "%s"
-  description  = "%s"
-  bfd_probe_interval = %s
-  bfd_allowed_hops = %s
+  display_name              = "%s"
+  description               = "%s"
+  bfd_probe_interval        = %s
+  bfd_allowed_hops          = %s
   bfd_declare_dead_multiple = %s
   standby_relocation_config {
     standby_relocation_threshold = %s

--- a/nsxt/resource_nsxt_policy_evpn_tenant_test.go
+++ b/nsxt/resource_nsxt_policy_evpn_tenant_test.go
@@ -156,9 +156,9 @@ func testAccNsxtPolicyEvpnTenantCheckDestroy(state *terraform.State, displayName
 
 func testAccNsxtPolicyEvpnTenantPrerequisites() string {
 	return testAccNsxtPolicyVniPoolConfigReadTemplate() + fmt.Sprintf(`
-    data "nsxt_policy_transport_zone" "test" {
-      display_name = "%s"
-    }
+data "nsxt_policy_transport_zone" "test" {
+  display_name = "%s"
+}
     `, getOverlayTransportZoneName())
 }
 

--- a/nsxt/resource_nsxt_policy_evpn_tunnel_endpoint_test.go
+++ b/nsxt/resource_nsxt_policy_evpn_tunnel_endpoint_test.go
@@ -215,6 +215,7 @@ func testAccNsxtPolicyEvpnTunnelEndpointBasic(createFlow bool) string {
 
 	return testAccEvpnTunnelEndpointPrerequisites() + fmt.Sprintf(`
 
+
 resource "nsxt_policy_evpn_tunnel_endpoint" "test" {
   display_name = "%s"
   description  = "%s"
@@ -222,8 +223,8 @@ resource "nsxt_policy_evpn_tunnel_endpoint" "test" {
   external_interface_path = nsxt_policy_tier0_gateway_interface.test.path
   edge_node_path          = data.nsxt_policy_edge_node.test.path
 
-  local_address  = "%s"
-  mtu            = %s
+  local_address = "%s"
+  mtu           = %s
 
   tag {
     scope = "scope1"

--- a/nsxt/resource_nsxt_policy_firewall_exclude_list_member_test.go
+++ b/nsxt/resource_nsxt_policy_firewall_exclude_list_member_test.go
@@ -145,12 +145,12 @@ func testAccNsxtPolicyFirewallExcludeListMemberCheckDestroy(state *terraform.Sta
 func testAccNsxtPolicyFirewallExcludeListMemberTemplate(name string) string {
 	return fmt.Sprintf(`
 resource "nsxt_policy_group" "%s" {
-  nsx_id = "%s"
+  nsx_id       = "%s"
   display_name = "%s"
   description  = "Acceptance Test"
 }
 resource "nsxt_policy_firewall_exclude_list_member" "%s" {
-	member = nsxt_policy_group.%s.path
+  member = nsxt_policy_group.%s.path
 }
 `, name, name, name, name, name)
 }

--- a/nsxt/resource_nsxt_policy_fixed_segment_test.go
+++ b/nsxt/resource_nsxt_policy_fixed_segment_test.go
@@ -369,12 +369,12 @@ func testAccNsxtPolicyFixedSegmentImportTemplate(tzName string, name string, wit
 	return testAccNsxtPolicySegmentDeps(tzName, withContext) + fmt.Sprintf(`
 resource "nsxt_policy_fixed_segment" "test" {
 %s
-  display_name        = "%s"
-  description         = "Acceptance Test"
-  connectivity_path   = nsxt_policy_tier1_gateway.tier1ForSegments.path
+  display_name      = "%s"
+  description       = "Acceptance Test"
+  connectivity_path = nsxt_policy_tier1_gateway.tier1ForSegments.path
 
   subnet {
-     cidr = "12.12.2.1/24"
+    cidr = "12.12.2.1/24"
   }
 }
 `, context, name)
@@ -387,16 +387,17 @@ func testAccNsxtPolicyFixedSegmentBasicTemplate(tzName string, name string, with
 	}
 	return testAccNsxtPolicySegmentDeps(tzName, withContext) + fmt.Sprintf(`
 
+
 resource "nsxt_policy_fixed_segment" "test" {
 %s
-  display_name        = "%s"
-  description         = "Acceptance Test"
-  domain_name         = "tftest.org"
-  overlay_id          = 1011
-  connectivity_path   = nsxt_policy_tier1_gateway.tier1ForSegments.path
+  display_name      = "%s"
+  description       = "Acceptance Test"
+  domain_name       = "tftest.org"
+  overlay_id        = 1011
+  connectivity_path = nsxt_policy_tier1_gateway.tier1ForSegments.path
 
   subnet {
-     cidr = "12.12.2.1/24"
+    cidr = "12.12.2.1/24"
   }
 
   tag {
@@ -415,14 +416,14 @@ func testAccNsxtPolicyFixedSegmentBasicUpdateTemplate(tzName string, name string
 	return testAccNsxtPolicySegmentDeps(tzName, withContext) + fmt.Sprintf(`
 resource "nsxt_policy_fixed_segment" "test" {
 %s
-  display_name        = "%s"
-  description         = "Acceptance Test2"
-  domain_name         = "tftest2.org"
-  overlay_id          = 1011
-  connectivity_path   = nsxt_policy_tier1_gateway.tier1ForSegments.path
+  display_name      = "%s"
+  description       = "Acceptance Test2"
+  domain_name       = "tftest2.org"
+  overlay_id        = 1011
+  connectivity_path = nsxt_policy_tier1_gateway.tier1ForSegments.path
 
   subnet {
-     cidr = "22.22.22.1/24"
+    cidr = "22.22.22.1/24"
   }
 
   tag {
@@ -440,15 +441,16 @@ resource "nsxt_policy_fixed_segment" "test" {
 func testAccNsxtPolicyFixedSegmentUpdateConnectivityTemplate(tzName string, name string) string {
 	return testAccNsxtPolicySegmentDeps(tzName, false) + fmt.Sprintf(`
 
+
 resource "nsxt_policy_fixed_segment" "test" {
-  display_name        = "%s"
-  description         = "Acceptance Test2"
-  domain_name         = "tftest2.org"
-  overlay_id          = 1011
-  connectivity_path   = nsxt_policy_tier1_gateway.anotherTier1ForSegments.path
+  display_name      = "%s"
+  description       = "Acceptance Test2"
+  domain_name       = "tftest2.org"
+  overlay_id        = 1011
+  connectivity_path = nsxt_policy_tier1_gateway.anotherTier1ForSegments.path
 
   subnet {
-     cidr = "22.22.22.1/24"
+    cidr = "22.22.22.1/24"
   }
 
   tag {
@@ -466,6 +468,7 @@ resource "nsxt_policy_fixed_segment" "test" {
 func testAccNsxtPolicyFixedSegmentBasicAdvConfigTemplate(tzName string, name string) string {
 	return testAccNsxtPolicySegmentDeps(tzName, false) + fmt.Sprintf(`
 
+
 resource "nsxt_policy_fixed_segment" "test" {
   display_name     = "%s"
   description      = "Acceptance Test"
@@ -474,10 +477,10 @@ resource "nsxt_policy_fixed_segment" "test" {
   overlay_id       = 1011
   vlan_ids         = ["101", "102"]
 
-  connectivity_path   = nsxt_policy_tier1_gateway.anotherTier1ForSegments.path
+  connectivity_path = nsxt_policy_tier1_gateway.anotherTier1ForSegments.path
 
   subnet {
-     cidr = "12.12.2.1/24"
+    cidr = "12.12.2.1/24"
   }
 
   tag {
@@ -496,6 +499,7 @@ resource "nsxt_policy_fixed_segment" "test" {
 func testAccNsxtPolicyFixedSegmentBasicAdvConfigUpdateTemplate(tzName string, name string) string {
 	return testAccNsxtPolicySegmentDeps(tzName, false) + fmt.Sprintf(`
 
+
 resource "nsxt_policy_fixed_segment" "test" {
   display_name     = "%s"
   description      = "Acceptance Test"
@@ -504,10 +508,10 @@ resource "nsxt_policy_fixed_segment" "test" {
   overlay_id       = 1011
   vlan_ids         = ["101-104"]
 
-  connectivity_path   = nsxt_policy_tier1_gateway.anotherTier1ForSegments.path
+  connectivity_path = nsxt_policy_tier1_gateway.anotherTier1ForSegments.path
 
   subnet {
-     cidr = "12.12.2.1/24"
+    cidr = "12.12.2.1/24"
   }
 
   tag {
@@ -527,6 +531,7 @@ func testAccNsxtPolicyFixedSegmentWithDhcpTemplate(tzName string, name string, d
 	return testAccNsxtPolicySegmentDeps(tzName, false) +
 		testAccNsxtPolicyEdgeCluster(getEdgeClusterName()) + fmt.Sprintf(`
 
+
 resource "nsxt_policy_dhcp_server" "test" {
   edge_cluster_path = data.nsxt_policy_edge_cluster.EC.path
   display_name      = "segment-test"
@@ -540,40 +545,40 @@ resource "nsxt_policy_fixed_segment" "test" {
   subnet {
     cidr = "12.12.2.1/24"
     dhcp_v4_config {
-        lease_time     = %s
-        server_address = "12.12.2.2/24"
-        dns_servers    = ["%s"]
-        dhcp_option_121 {
-          network  = "2.1.1.0/24"
-          next_hop = "2.3.1.3"
-        }
-        dhcp_option_121 {
-          network  = "3.1.1.0/24"
-          next_hop = "3.3.1.3"
-        }
-        dhcp_generic_option {
-          code   = "119"
-          values = ["abc", "def"]
-        }
+      lease_time     = %s
+      server_address = "12.12.2.2/24"
+      dns_servers    = ["%s"]
+      dhcp_option_121 {
+        network  = "2.1.1.0/24"
+        next_hop = "2.3.1.3"
+      }
+      dhcp_option_121 {
+        network  = "3.1.1.0/24"
+        next_hop = "3.3.1.3"
+      }
+      dhcp_generic_option {
+        code   = "119"
+        values = ["abc", "def"]
+      }
     }
   }
 
   subnet {
     cidr = "4012::1/64"
     dhcp_v6_config {
-        server_address = "4012::2/64"
-        lease_time     = %s
-        preferred_time = %s
-        dns_servers    = ["%s"]
-        sntp_servers   = ["3001::1", "3001::2"]
-        excluded_range {
-            start = "4012::400"
-            end   = "4012::500"
-        }
-        excluded_range {
-            start = "4012::a00"
-            end   = "4012::b00"
-        }
+      server_address = "4012::2/64"
+      lease_time     = %s
+      preferred_time = %s
+      dns_servers    = ["%s"]
+      sntp_servers   = ["3001::1", "3001::2"]
+      excluded_range {
+        start = "4012::400"
+        end   = "4012::500"
+      }
+      excluded_range {
+        start = "4012::a00"
+        end   = "4012::b00"
+      }
     }
   }
 

--- a/nsxt/resource_nsxt_policy_gateway_connection_test.go
+++ b/nsxt/resource_nsxt_policy_gateway_connection_test.go
@@ -181,9 +181,9 @@ func testAccNsxtPolicyGatewayConnectionTemplate(createFlow bool) string {
 	}
 	return testAccNsxtPolicyGatewayConnectionPrerequisites() + fmt.Sprintf(`
 resource "nsxt_policy_gateway_connection" "test" {
-  display_name = "%s"
-  description  = "%s"
-  tier0_path = nsxt_policy_tier0_gateway.test.path
+  display_name     = "%s"
+  description      = "%s"
+  tier0_path       = nsxt_policy_tier0_gateway.test.path
   aggregate_routes = ["%s"]
 
   tag {
@@ -193,9 +193,9 @@ resource "nsxt_policy_gateway_connection" "test" {
 }
 
 data "nsxt_policy_gateway_connection" "test" {
-  tier0_path = nsxt_policy_tier0_gateway.test.path
+  tier0_path   = nsxt_policy_tier0_gateway.test.path
   display_name = "%s"
-  depends_on = [nsxt_policy_gateway_connection.test]
+  depends_on   = [nsxt_policy_gateway_connection.test]
 }`, attrMap["display_name"], attrMap["description"], attrMap["aggregate_routes"], attrMap["display_name"])
 }
 
@@ -208,6 +208,6 @@ resource "nsxt_policy_gateway_connection" "test" {
 
 data "nsxt_policy_gateway_connection" "test" {
   display_name = "%s"
-  depends_on = [nsxt_policy_gateway_connection.test]
+  depends_on   = [nsxt_policy_gateway_connection.test]
 }`, accTestPolicyGatewayConnectionUpdateAttributes["display_name"], accTestPolicyGatewayConnectionUpdateAttributes["display_name"])
 }

--- a/nsxt/resource_nsxt_policy_gateway_dns_forwarder_test.go
+++ b/nsxt/resource_nsxt_policy_gateway_dns_forwarder_test.go
@@ -268,7 +268,7 @@ data "nsxt_policy_gateway_dns_forwarder" "test" {
   display_name = "%s"
 
   gateway_path = nsxt_policy_tier%d_gateway.test.path
-  depends_on = [nsxt_policy_gateway_dns_forwarder.test]
+  depends_on   = [nsxt_policy_gateway_dns_forwarder.test]
 }
 `, context, attrMap["display_name"], attrMap["description"], whyDoesGoNeedToBeSoComplicated[isT0], attrMap["listener_ip"], attrMap["enabled"], attrMap["log_level"], attrMap["cache_size"], context, attrMap["display_name"], whyDoesGoNeedToBeSoComplicated[isT0])
 }
@@ -286,7 +286,7 @@ resource "nsxt_policy_gateway_dns_forwarder" "test" {
   gateway_path = nsxt_policy_tier%d_gateway.test.path
   listener_ip  = "78.2.1.12"
 
-  default_forwarder_zone_path      = nsxt_policy_dns_forwarder_zone.default.path
+  default_forwarder_zone_path = nsxt_policy_dns_forwarder_zone.default.path
 }
 `, context, accTestPolicyGatewayDNSForwarderCreateAttributes["display_name"], whyDoesGoNeedToBeSoComplicated[isT0])
 }

--- a/nsxt/resource_nsxt_policy_gateway_flood_protection_profile_binding_test.go
+++ b/nsxt/resource_nsxt_policy_gateway_flood_protection_profile_binding_test.go
@@ -241,15 +241,15 @@ func testAccNsxtPolicyGatewayFloodProtectionProfileBindingTemplate(createFlow, w
 	return testAccNsxtPolicyGatewayFloodProtectionProfileBindingDeps(withContext) + fmt.Sprintf(`
 resource "nsxt_policy_gateway_flood_protection_profile_binding" "%s" {
 %s
- display_name = "%s"
- description  = "%s"
- profile_path = nsxt_policy_gateway_flood_protection_profile.%s.path
- parent_path = %s
+  display_name = "%s"
+  description  = "%s"
+  profile_path = nsxt_policy_gateway_flood_protection_profile.%s.path
+  parent_path  = %s
 
- tag {
-   scope = "scope1"
-   tag   = "tag1"
- }
+  tag {
+    scope = "scope1"
+    tag   = "tag1"
+  }
 }
 `, resourceName, context, name, attrMap["description"], attrMap["profile_res_name"], attrMap["parent_path"])
 }
@@ -262,7 +262,7 @@ func testAccNsxtPolicyGatewayFloodProtectionProfileBindingDeps(withContext bool)
 		parentDeps = fmt.Sprintf(`
 resource "nsxt_policy_tier1_gateway" "test" {
 %s
-  display_name             = "test"
+  display_name = "test"
 }
 `, context)
 	} else if testAccIsGlobalManager() {
@@ -281,7 +281,7 @@ data "nsxt_policy_edge_node" "en_site1" {
 }
 
 resource "nsxt_policy_tier0_gateway" "test" {
-  display_name      = "test"
+  display_name = "test"
   locale_service {
     edge_cluster_path    = data.nsxt_policy_edge_cluster.ec_site1.path
     preferred_edge_paths = [data.nsxt_policy_edge_node.en_site1.path]
@@ -309,24 +309,24 @@ resource "nsxt_policy_tier1_gateway" "test" {
 	return parentDeps + fmt.Sprintf(`
 resource "nsxt_policy_gateway_flood_protection_profile" "test1" {
 %s
-  display_name = "gfpp1"
-  description  = "Acceptance Test"
-  icmp_active_flow_limit = 3
-  other_active_conn_limit = 3
+  display_name             = "gfpp1"
+  description              = "Acceptance Test"
+  icmp_active_flow_limit   = 3
+  other_active_conn_limit  = 3
   tcp_half_open_conn_limit = 3
-  udp_active_flow_limit = 3
-  nat_active_conn_limit = 3
+  udp_active_flow_limit    = 3
+  nat_active_conn_limit    = 3
 }
 
 resource "nsxt_policy_gateway_flood_protection_profile" "test2" {
 %s
-  display_name = "gfpp2"
-  description  = "Acceptance Test"
-  icmp_active_flow_limit = 4
-  other_active_conn_limit = 4
+  display_name             = "gfpp2"
+  description              = "Acceptance Test"
+  icmp_active_flow_limit   = 4
+  other_active_conn_limit  = 4
   tcp_half_open_conn_limit = 4
-  udp_active_flow_limit = 4
-  nat_active_conn_limit = 4
+  udp_active_flow_limit    = 4
+  nat_active_conn_limit    = 4
 }
 `, context, context)
 }

--- a/nsxt/resource_nsxt_policy_gateway_flood_protection_profile_test.go
+++ b/nsxt/resource_nsxt_policy_gateway_flood_protection_profile_test.go
@@ -225,13 +225,13 @@ func testAccNsxtPolicyGatewayFloodProtectionProfileTemplate(createFlow, withCont
 	return fmt.Sprintf(`
 resource "nsxt_policy_gateway_flood_protection_profile" "%s" {
 %s
-  display_name = "%s"
-  description  = "%s"
-  icmp_active_flow_limit = %s
-  other_active_conn_limit = %s
+  display_name             = "%s"
+  description              = "%s"
+  icmp_active_flow_limit   = %s
+  other_active_conn_limit  = %s
   tcp_half_open_conn_limit = %s
-  udp_active_flow_limit = %s
-  nat_active_conn_limit = %s
+  udp_active_flow_limit    = %s
+  nat_active_conn_limit    = %s
 
   tag {
     scope = "scope1"
@@ -242,7 +242,7 @@ resource "nsxt_policy_gateway_flood_protection_profile" "%s" {
 data "nsxt_policy_gateway_flood_protection_profile" "%s" {
 %s
   display_name = "%s"
-  depends_on = [nsxt_policy_gateway_flood_protection_profile.%s]
+  depends_on   = [nsxt_policy_gateway_flood_protection_profile.%s]
 }`, resourceName, context, name, attrMap["description"], attrMap["icmp_active_flow_limit"], attrMap["other_active_conn_limit"], attrMap["tcp_half_open_conn_limit"], attrMap["udp_active_flow_limit"], attrMap["nat_active_conn_limit"], resourceName, context, name, resourceName)
 }
 

--- a/nsxt/resource_nsxt_policy_gateway_policy_test.go
+++ b/nsxt/resource_nsxt_policy_gateway_policy_test.go
@@ -668,8 +668,8 @@ func testAccNsxtPolicyGatewayPolicyWithRule(resourceName, name, direction, proto
 	return fmt.Sprintf(`
 resource "nsxt_policy_tier1_gateway" "gwt1test" {
 %s
-  display_name      = "tf-t1-gw"
-  description       = "Acceptance Test"
+  display_name = "tf-t1-gw"
+  description  = "Acceptance Test"
 }
 
 resource "%s" "test" {
@@ -706,8 +706,8 @@ resource "%s" "test" {
 func testAccNsxtPolicyGatewayPolicyWithMultipleRulesCreate(name string) string {
 	return fmt.Sprintf(`
 resource "nsxt_policy_tier1_gateway" "gwt1test" {
-  display_name      = "tf-t1-gw"
-  description       = "Acceptance Test"
+  display_name = "tf-t1-gw"
+  description  = "Acceptance Test"
 }
 
 resource "nsxt_policy_group" "group1" {
@@ -719,18 +719,18 @@ resource "nsxt_policy_group" "group2" {
 }
 
 resource "nsxt_policy_service" "icmp" {
-    display_name = "gateway-policy-test-icmp"
-    icmp_entry {
-        protocol = "ICMPv4"
-    }
+  display_name = "gateway-policy-test-icmp"
+  icmp_entry {
+    protocol = "ICMPv4"
+  }
 }
 
 resource "nsxt_policy_service" "tcp778" {
-    display_name = "gateway-policy-test-tcp"
-    l4_port_set_entry {
-        protocol          = "TCP"
-        destination_ports = [ "778" ]
-    }
+  display_name = "gateway-policy-test-tcp"
+  l4_port_set_entry {
+    protocol          = "TCP"
+    destination_ports = ["778"]
+  }
 }
 
 resource "nsxt_policy_gateway_policy" "test" {
@@ -748,17 +748,17 @@ resource "nsxt_policy_gateway_policy" "test" {
   }
 
   rule {
-    display_name          = "rule1"
-    source_groups         = [nsxt_policy_group.group1.path]
-    destination_groups    = [nsxt_policy_group.group2.path]
-    scope                 = [nsxt_policy_tier1_gateway.gwt1test.path]
-    services              = [nsxt_policy_service.icmp.path]
+    display_name       = "rule1"
+    source_groups      = [nsxt_policy_group.group1.path]
+    destination_groups = [nsxt_policy_group.group2.path]
+    scope              = [nsxt_policy_tier1_gateway.gwt1test.path]
+    services           = [nsxt_policy_service.icmp.path]
   }
 
   rule {
-    display_name          = "rule2"
-    source_groups         = [nsxt_policy_group.group1.path, nsxt_policy_group.group2.path]
-    scope                 = [nsxt_policy_tier1_gateway.gwt1test.path]
+    display_name  = "rule2"
+    source_groups = [nsxt_policy_group.group1.path, nsxt_policy_group.group2.path]
+    scope         = [nsxt_policy_tier1_gateway.gwt1test.path]
   }
 }`, name)
 }
@@ -766,8 +766,8 @@ resource "nsxt_policy_gateway_policy" "test" {
 func testAccNsxtPolicyGatewayPolicyWithMultipleRulesUpdate(name string) string {
 	return fmt.Sprintf(`
 resource "nsxt_policy_tier1_gateway" "gwt1test" {
-  display_name      = "tf-t1-gw"
-  description       = "Acceptance Test"
+  display_name = "tf-t1-gw"
+  description  = "Acceptance Test"
 }
 
 resource "nsxt_policy_group" "group1" {
@@ -779,18 +779,18 @@ resource "nsxt_policy_group" "group2" {
 }
 
 resource "nsxt_policy_service" "icmp" {
-    display_name = "gateway-policy-test-icmp"
-    icmp_entry {
-        protocol = "ICMPv4"
-    }
+  display_name = "gateway-policy-test-icmp"
+  icmp_entry {
+    protocol = "ICMPv4"
+  }
 }
 
 resource "nsxt_policy_service" "tcp778" {
-    display_name = "gateway-policy-test-tcp"
-    l4_port_set_entry {
-        protocol          = "TCP"
-        destination_ports = [ "778" ]
-    }
+  display_name = "gateway-policy-test-tcp"
+  l4_port_set_entry {
+    protocol          = "TCP"
+    destination_ports = ["778"]
+  }
 }
 
 resource "nsxt_policy_gateway_policy" "test" {
@@ -808,13 +808,13 @@ resource "nsxt_policy_gateway_policy" "test" {
   }
 
   rule {
-    display_name          = "rule1"
-    destination_groups    = [nsxt_policy_group.group1.path, nsxt_policy_group.group2.path]
-    disabled              = true
-    action                = "DROP"
-    logged                = true
-    scope                 = [nsxt_policy_tier1_gateway.gwt1test.path]
-    services              = [nsxt_policy_service.tcp778.path]
+    display_name       = "rule1"
+    destination_groups = [nsxt_policy_group.group1.path, nsxt_policy_group.group2.path]
+    disabled           = true
+    action             = "DROP"
+    logged             = true
+    scope              = [nsxt_policy_tier1_gateway.gwt1test.path]
+    services           = [nsxt_policy_service.tcp778.path]
   }
 
 }`, name)
@@ -871,8 +871,8 @@ resource "nsxt_policy_gateway_policy" "test" {
 func testAccNsxtGlobalPolicyGatewayPolicyWithRule(name string, direction string, protocol string, ruleTag string, domainName string) string {
 	return testAccNsxtGlobalPolicySite(domainName) + fmt.Sprintf(`
 resource "nsxt_policy_tier1_gateway" "gwt1test" {
-  display_name      = "tf-t1-gw"
-  description       = "Acceptance Test"
+  display_name = "tf-t1-gw"
+  description  = "Acceptance Test"
 }
 
 resource "nsxt_policy_gateway_policy" "test" {
@@ -909,8 +909,8 @@ resource "nsxt_policy_gateway_policy" "test" {
 func testAccNsxtPolicyGatewayPolicyDeps() string {
 	return `
 resource "nsxt_policy_tier1_gateway" "gwt1test" {
-	display_name      = "tf-t1-gw"
-	description       = "Acceptance Test"
+  display_name = "tf-t1-gw"
+  description  = "Acceptance Test"
 }
 
 resource "nsxt_policy_group" "group1" {
@@ -922,91 +922,91 @@ resource "nsxt_policy_group" "group2" {
 }
 
 resource "nsxt_policy_service" "icmp" {
-    display_name = "security-policy-test-icmp"
-    icmp_entry {
-        protocol = "ICMPv4"
-    }
+  display_name = "security-policy-test-icmp"
+  icmp_entry {
+    protocol = "ICMPv4"
+  }
 }`
 }
 
 func testAccNsxtPolicyGatewayPolicyWithIPCidrRange(name string, destIP string, destCidr string, destIPRange string, sourceIP string, sourceCidr string, sourceIPRange string) string {
 	return testAccNsxtPolicyGatewayPolicyDeps() + fmt.Sprintf(`
-	resource "nsxt_policy_gateway_policy" "test" {
-		display_name    = "%s"
-		description     = "Acceptance Test"
-		category        = "LocalGatewayRules"
-		sequence_number = 3
-		locked          = false
-		stateful        = true
-		tcp_strict      = false
+resource "nsxt_policy_gateway_policy" "test" {
+  display_name    = "%s"
+  description     = "Acceptance Test"
+  category        = "LocalGatewayRules"
+  sequence_number = 3
+  locked          = false
+  stateful        = true
+  tcp_strict      = false
 
-		tag {
-		  scope = "color"
-		  tag   = "orange"
-		}
+  tag {
+    scope = "color"
+    tag   = "orange"
+  }
 
-		rule {
-		  display_name          = "rule1"
-		  source_groups         = [nsxt_policy_group.group1.path]
-		  destination_groups    = ["%s"]
-		  services              = [nsxt_policy_service.icmp.path]
-		  scope                 = [nsxt_policy_tier1_gateway.gwt1test.path]
-		  action                = "ALLOW"
-		}
+  rule {
+    display_name       = "rule1"
+    source_groups      = [nsxt_policy_group.group1.path]
+    destination_groups = ["%s"]
+    services           = [nsxt_policy_service.icmp.path]
+    scope              = [nsxt_policy_tier1_gateway.gwt1test.path]
+    action             = "ALLOW"
+  }
 
-		rule {
-		  display_name          = "rule2"
-		  source_groups         = [nsxt_policy_group.group1.path]			
-		  destination_groups    = ["%s"]
-		  services              = [nsxt_policy_service.icmp.path]
-		  scope                 = [nsxt_policy_tier1_gateway.gwt1test.path]			
-		  action                = "ALLOW"
-	        }
+  rule {
+    display_name       = "rule2"
+    source_groups      = [nsxt_policy_group.group1.path]
+    destination_groups = ["%s"]
+    services           = [nsxt_policy_service.icmp.path]
+    scope              = [nsxt_policy_tier1_gateway.gwt1test.path]
+    action             = "ALLOW"
+  }
 
-		rule {
-		  display_name          = "rule3"
-		  source_groups         = [nsxt_policy_group.group1.path]
-		  destination_groups    = ["%s"]
-		  services              = [nsxt_policy_service.icmp.path]
-		  scope                 = [nsxt_policy_tier1_gateway.gwt1test.path]			
-		  action                = "ALLOW"
-		}
+  rule {
+    display_name       = "rule3"
+    source_groups      = [nsxt_policy_group.group1.path]
+    destination_groups = ["%s"]
+    services           = [nsxt_policy_service.icmp.path]
+    scope              = [nsxt_policy_tier1_gateway.gwt1test.path]
+    action             = "ALLOW"
+  }
 
-		rule {
-		  display_name          = "rule4"
-		  source_groups         = ["%s"]
-		  destination_groups    = [nsxt_policy_group.group2.path]
-		  services              = [nsxt_policy_service.icmp.path]
-		  scope                 = [nsxt_policy_tier1_gateway.gwt1test.path]		  
-		  action                = "ALLOW"
-		}
-  
-		rule {
-		  display_name          = "rule5"
-		  source_groups         = ["%s"]			
-		  destination_groups    = [nsxt_policy_group.group2.path]
-		  services              = [nsxt_policy_service.icmp.path]
-		  scope                 = [nsxt_policy_tier1_gateway.gwt1test.path]			
-		  action                = "ALLOW"
-		}
-  
-		rule {
-		  display_name          = "rule6"
-		  source_groups         = ["%s"]
-		  destination_groups    = [nsxt_policy_group.group2.path]
-		  services              = [nsxt_policy_service.icmp.path]
-		  scope                 = [nsxt_policy_tier1_gateway.gwt1test.path]			
-	          action                = "ALLOW"
-		  service_entries {
-		    algorithm_entry {
-		      algorithm         = "TFTP"
-		      destination_port  = "9000"
-	            }
+  rule {
+    display_name       = "rule4"
+    source_groups      = ["%s"]
+    destination_groups = [nsxt_policy_group.group2.path]
+    services           = [nsxt_policy_service.icmp.path]
+    scope              = [nsxt_policy_tier1_gateway.gwt1test.path]
+    action             = "ALLOW"
+  }
 
-		    ether_type_entry {
-		      ether_type = "1536"
-		    }
-		  }
-		}
+  rule {
+    display_name       = "rule5"
+    source_groups      = ["%s"]
+    destination_groups = [nsxt_policy_group.group2.path]
+    services           = [nsxt_policy_service.icmp.path]
+    scope              = [nsxt_policy_tier1_gateway.gwt1test.path]
+    action             = "ALLOW"
+  }
+
+  rule {
+    display_name       = "rule6"
+    source_groups      = ["%s"]
+    destination_groups = [nsxt_policy_group.group2.path]
+    services           = [nsxt_policy_service.icmp.path]
+    scope              = [nsxt_policy_tier1_gateway.gwt1test.path]
+    action             = "ALLOW"
+    service_entries {
+      algorithm_entry {
+        algorithm        = "TFTP"
+        destination_port = "9000"
+      }
+
+      ether_type_entry {
+        ether_type = "1536"
+      }
+    }
+  }
 }`, name, destIP, destCidr, destIPRange, sourceIP, sourceCidr, sourceIPRange)
 }

--- a/nsxt/resource_nsxt_policy_gateway_prefix_list_test.go
+++ b/nsxt/resource_nsxt_policy_gateway_prefix_list_test.go
@@ -197,10 +197,10 @@ resource "nsxt_policy_gateway_prefix_list" "test" {
   gateway_path = nsxt_policy_tier0_gateway.test.path
 
   prefix {
-  	action  = "%s"
-  	ge      = "%s"
-  	le      = "%s"
-  	network = "%s"
+    action  = "%s"
+    ge      = "%s"
+    le      = "%s"
+    network = "%s"
   }
 
   tag {
@@ -213,7 +213,7 @@ data "nsxt_policy_gateway_prefix_list" "test" {
   display_name = "%s"
 
   gateway_path = nsxt_policy_tier0_gateway.test.path
-  depends_on = [nsxt_policy_gateway_prefix_list.test]
+  depends_on   = [nsxt_policy_gateway_prefix_list.test]
 }
 `, name, action, ge, le, network, name)
 }
@@ -227,14 +227,14 @@ resource "nsxt_policy_gateway_prefix_list" "test" {
   gateway_path = nsxt_policy_tier0_gateway.test.path
 
   prefix {
-  	action  = "%s"
-  	ge      = "%s"
-  	le      = "%s"
-  	network = "%s"
+    action  = "%s"
+    ge      = "%s"
+    le      = "%s"
+    network = "%s"
   }
 
   prefix {
-  	action  = "%s"
+    action = "%s"
   }
 
   tag {

--- a/nsxt/resource_nsxt_policy_gateway_qos_profile_test.go
+++ b/nsxt/resource_nsxt_policy_gateway_qos_profile_test.go
@@ -165,11 +165,11 @@ func testAccNsxtPolicyGatewayQosProfileTemplate(createFlow bool) string {
 	}
 	return fmt.Sprintf(`
 resource "nsxt_policy_gateway_qos_profile" "test" {
-  display_name = "%s"
-  description  = "%s"
-  burst_size = %s
+  display_name        = "%s"
+  description         = "%s"
+  burst_size          = %s
   committed_bandwidth = %s
-  excess_action = "%s"
+  excess_action       = "%s"
 
   tag {
     scope = "scope1"

--- a/nsxt/resource_nsxt_policy_gateway_redistribution_config_test.go
+++ b/nsxt/resource_nsxt_policy_gateway_redistribution_config_test.go
@@ -209,7 +209,7 @@ func testAccNSXPolicyRedistributionConfigImporterGetID(s *terraform.State) (stri
 func testAccNsxtPolicyGatewayRedistributionPrerequisites() string {
 	return testAccNsxtPolicyGatewayFabricDeps(false) + fmt.Sprintf(`
 resource "nsxt_policy_tier0_gateway" "test" {
-  display_name      = "%s"
+  display_name = "%s"
   %s
 }`, testAccNsxtPolicyGatewayRedistributionHelperName, testAccNsxtPolicyTier0EdgeClusterTemplate())
 }
@@ -231,9 +231,9 @@ resource "nsxt_policy_gateway_redistribution_config" "test" {
   bgp_enabled  = false
   ospf_enabled = true
   rule {
-      name  = "test-rule-1"
-      types = ["TIER0_SEGMENT", "TIER0_EVPN_TEP_IP", "TIER1_CONNECTED"]
-      ospf  = true
+    name  = "test-rule-1"
+    types = ["TIER0_SEGMENT", "TIER0_EVPN_TEP_IP", "TIER1_CONNECTED"]
+    ospf  = true
   }
 }`, getAccTestSitePathConfig())
 }
@@ -247,14 +247,14 @@ resource "nsxt_policy_gateway_redistribution_config" "test" {
   bgp_enabled  = true
   ospf_enabled = false
   rule {
-      name  = "test-rule-1"
-      types = ["TIER1_CONNECTED"]
-      bgp   = false
-      ospf  = true
+    name  = "test-rule-1"
+    types = ["TIER1_CONNECTED"]
+    bgp   = false
+    ospf  = true
   }
   rule {
-      name  = "test-rule-2"
-      types = ["TIER1_LB_VIP"]
+    name  = "test-rule-2"
+    types = ["TIER1_LB_VIP"]
   }
 }`, getAccTestSitePathConfig())
 }
@@ -279,9 +279,9 @@ resource "nsxt_policy_gateway_redistribution_config" "prod" {
   bgp_enabled  = false
   ospf_enabled = true
   rule {
-      name  = "test-rule-1"
-      types = ["TIER0_SEGMENT", "TIER0_EVPN_TEP_IP", "TIER1_CONNECTED"]
-      ospf  = true
+    name  = "test-rule-1"
+    types = ["TIER0_SEGMENT", "TIER0_EVPN_TEP_IP", "TIER1_CONNECTED"]
+    ospf  = true
   }
 }`, getAccTestSitePathConfig())
 }

--- a/nsxt/resource_nsxt_policy_group_test.go
+++ b/nsxt/resource_nsxt_policy_group_test.go
@@ -895,8 +895,8 @@ resource "nsxt_policy_group" "test" {
 
   criteria {
     ipaddress_expression {
-	  ip_addresses = ["111.1.1.1", "222.2.2.2"]
-	}
+      ip_addresses = ["111.1.1.1", "222.2.2.2"]
+    }
   }
 
   tag {
@@ -924,18 +924,18 @@ resource "nsxt_policy_group" "test" {
 
   criteria {
     ipaddress_expression {
-	  ip_addresses = ["111.2.1.1", "232.2.2.2"]
-	}
+      ip_addresses = ["111.2.1.1", "232.2.2.2"]
+    }
   }
 
   conjunction {
-	operator = "OR"
+    operator = "OR"
   }
 
   criteria {
     ipaddress_expression {
-	  ip_addresses = ["111.1.1.3", "222.2.2.4"]
-	}
+      ip_addresses = ["111.1.1.3", "222.2.2.4"]
+    }
   }
 }
 `, siteName, name)
@@ -956,8 +956,8 @@ resource "nsxt_policy_group" "test" {
 
   criteria {
     ipaddress_expression {
-	  ip_addresses = ["111.1.1.1", "222.2.2.2"]
-	}
+      ip_addresses = ["111.1.1.1", "222.2.2.2"]
+    }
   }
 
   tag {
@@ -981,18 +981,18 @@ resource "nsxt_policy_group" "test" {
 
   criteria {
     ipaddress_expression {
-	  ip_addresses = ["111.1.1.1", "222.2.2.2"]
-	}
+      ip_addresses = ["111.1.1.1", "222.2.2.2"]
+    }
   }
 
   conjunction {
-	operator = "OR"
+    operator = "OR"
   }
 
   criteria {
     ipaddress_expression {
-	  ip_addresses = ["111.1.1.3", "222.2.2.3"]
-	}
+      ip_addresses = ["111.1.1.3", "222.2.2.3"]
+    }
   }
 
   tag {
@@ -1016,7 +1016,7 @@ resource "nsxt_policy_group" "test" {
 
   criteria {
     external_id_expression {
-      member_type = "VirtualMachine"
+      member_type  = "VirtualMachine"
       external_ids = ["520ba7b0-d9f8-87b1-6f44-15bbeb7935c7", "52748a9e-d61d-e29b-d54b-07f169ff0ee8-4000"]
     }
   }
@@ -1042,18 +1042,18 @@ resource "nsxt_policy_group" "test" {
 
   criteria {
     external_id_expression {
-      member_type = "VirtualMachine"
+      member_type  = "VirtualMachine"
       external_ids = ["520ba7b0-d9f8-87b1-6f44-15bbeb7935c7", "52748a9e-d61d-e29b-d54b-07f169ff0ee8-4000"]
     }
   }
 
   conjunction {
-	operator = "OR"
+    operator = "OR"
   }
 
   criteria {
     external_id_expression {
-      member_type = "VirtualNetworkInterface"
+      member_type  = "VirtualNetworkInterface"
       external_ids = ["520ba7b0-d9f8-87b1-6f44-15bbeb7935c7", "52748a9e-d61d-e29b-d54b-07f169ff0ee8-4000"]
     }
   }
@@ -1086,7 +1086,7 @@ func testNsxtGlobalPolicyGroupPathsTransportZone() string {
 data "nsxt_policy_site" "test" {
   display_name = "%s"
 }
-data "nsxt_policy_transport_zone" "test"{
+data "nsxt_policy_transport_zone" "test" {
   site_path      = data.nsxt_policy_site.test.path
   transport_type = "OVERLAY_STANDARD"
   is_default     = true
@@ -1140,18 +1140,18 @@ resource "nsxt_policy_group" "test" {
 
   criteria {
     ipaddress_expression {
-	  ip_addresses = ["111.1.1.1-111.1.1.10", "222.2.2.0/24"]
-	}
+      ip_addresses = ["111.1.1.1-111.1.1.10", "222.2.2.0/24"]
+    }
   }
 
   conjunction {
-	operator = "OR"
+    operator = "OR"
   }
 
   criteria {
     ipaddress_expression {
-	  ip_addresses = ["111.1.2.4", "222.2.3.4"]
-	}
+      ip_addresses = ["111.1.2.4", "222.2.3.4"]
+    }
   }
 
   tag {
@@ -1325,7 +1325,7 @@ resource "nsxt_policy_group" "test" {
   }
 
   conjunction {
-	operator = "OR"
+    operator = "OR"
   }
 
   criteria {
@@ -1344,13 +1344,13 @@ resource "nsxt_policy_group" "test" {
   }
 
   conjunction {
-	operator = "OR"
+    operator = "OR"
   }
 
   criteria {
     ipaddress_expression {
-	  ip_addresses = ["111.1.1.4", "222.2.2.4"]
-	}
+      ip_addresses = ["111.1.1.4", "222.2.2.4"]
+    }
   }
 
   tag {
@@ -1383,7 +1383,7 @@ resource "nsxt_policy_group" "test" {
   }
 
   conjunction {
-	operator = "OR"
+    operator = "OR"
   }
 
   criteria {
@@ -1425,7 +1425,7 @@ resource "nsxt_policy_group" "test" {
   }
 
   conjunction {
-	operator = "OR"
+    operator = "OR"
   }
 
   criteria {
@@ -1492,9 +1492,9 @@ resource "nsxt_policy_group" "test" {
 
   extended_criteria {
     identity_group {
-          distinguished_name             = "test-dn-update"
-          domain_base_distinguished_name = "test-dbdn-update"
-          sid                            = "test-sid"
+      distinguished_name             = "test-dn-update"
+      domain_base_distinguished_name = "test-dbdn-update"
+      sid                            = "test-sid"
     }
   }
 }
@@ -1509,15 +1509,15 @@ resource "nsxt_policy_group" "test" {
 
   extended_criteria {
     identity_group {
-          distinguished_name             = "test-dn-1"
-          domain_base_distinguished_name = "test-dbdn-1"
-          sid                            = "test-sid-1"
+      distinguished_name             = "test-dn-1"
+      domain_base_distinguished_name = "test-dbdn-1"
+      sid                            = "test-sid-1"
     }
 
     identity_group {
-          distinguished_name             = "test-dn-2"
-          domain_base_distinguished_name = "test-dbdn-2"
-          sid                            = "test-sid-2"
+      distinguished_name             = "test-dn-2"
+      domain_base_distinguished_name = "test-dbdn-2"
+      sid                            = "test-sid-2"
     }
   }
 }
@@ -1542,8 +1542,8 @@ resource "nsxt_policy_group" "test" {
 
   criteria {
     ipaddress_expression {
-	  ip_addresses = ["111.1.1.1", "222.2.2.2"]
-	}
+      ip_addresses = ["111.1.1.1", "222.2.2.2"]
+    }
   }
 
   tag {
@@ -1586,18 +1586,18 @@ resource "nsxt_policy_group" "test" {
 
   criteria {
     ipaddress_expression {
-	  ip_addresses = ["111.2.1.1", "232.2.2.2"]
-	}
+      ip_addresses = ["111.2.1.1", "232.2.2.2"]
+    }
   }
 
   conjunction {
-	operator = "OR"
+    operator = "OR"
   }
 
   criteria {
     ipaddress_expression {
-	  ip_addresses = ["111.1.1.3", "222.2.2.4"]
-	}
+      ip_addresses = ["111.1.1.3", "222.2.2.4"]
+    }
   }
 }
 `, name)

--- a/nsxt/resource_nsxt_policy_intrusion_service_policy_test.go
+++ b/nsxt/resource_nsxt_policy_intrusion_service_policy_test.go
@@ -388,12 +388,12 @@ resource "nsxt_policy_intrusion_service_policy" "test" {
   }
 
   rule {
-    display_name = "%s"
-    direction    = "%s"
-    ip_version   = "%s"
-    log_label    = "%s"
+    display_name  = "%s"
+    direction     = "%s"
+    ip_version    = "%s"
+    log_label     = "%s"
     source_groups = [nsxt_policy_group.test.path]
-    ids_profiles = ["%s"]
+    ids_profiles  = ["%s"]
 
     tag {
       scope = "color"
@@ -414,18 +414,18 @@ resource "nsxt_policy_group" "group2" {
 }
 
 resource "nsxt_policy_service" "icmp" {
-    display_name = "security-policy-test-icmp"
-    icmp_entry {
-        protocol = "ICMPv4"
-    }
+  display_name = "security-policy-test-icmp"
+  icmp_entry {
+    protocol = "ICMPv4"
+  }
 }
 
 resource "nsxt_policy_service" "tcp778" {
-    display_name = "security-policy-test-tcp"
-    l4_port_set_entry {
-        protocol          = "TCP"
-        destination_ports = [ "778" ]
-    }
+  display_name = "security-policy-test-tcp"
+  l4_port_set_entry {
+    protocol          = "TCP"
+    destination_ports = ["778"]
+  }
 }`
 }
 

--- a/nsxt/resource_nsxt_policy_ip_block_quota_test.go
+++ b/nsxt/resource_nsxt_policy_ip_block_quota_test.go
@@ -227,7 +227,7 @@ resource "nsxt_policy_ip_block_quota" "test" {
     ip_block_paths        = [nsxt_policy_ip_block.%s.path]
     ip_block_visibility   = "%s"
     ip_block_address_type = "%s"
-    
+
     single_ip_cidrs = %s
     other_cidrs {
       mask        = "%s"

--- a/nsxt/resource_nsxt_policy_ip_discovery_profile_test.go
+++ b/nsxt/resource_nsxt_policy_ip_discovery_profile_test.go
@@ -250,19 +250,19 @@ func testAccNsxtPolicyIPDiscoveryProfileTemplate(createFlow, withContext bool) s
 	return fmt.Sprintf(`
 resource "nsxt_policy_ip_discovery_profile" "test" {
 %s
-  display_name = "%s"
-  description  = "%s"
-  arp_nd_binding_timeout = %s
+  display_name                   = "%s"
+  description                    = "%s"
+  arp_nd_binding_timeout         = %s
   duplicate_ip_detection_enabled = %s
-  arp_binding_limit = %s
-  arp_snooping_enabled = %s
-  dhcp_snooping_enabled = %s
-  vmtools_enabled = %s
-  dhcp_snooping_v6_enabled = %s
-  nd_snooping_enabled = %s
-  nd_snooping_limit = %s
-  vmtools_v6_enabled = %s
-  tofu_enabled = %s
+  arp_binding_limit              = %s
+  arp_snooping_enabled           = %s
+  dhcp_snooping_enabled          = %s
+  vmtools_enabled                = %s
+  dhcp_snooping_v6_enabled       = %s
+  nd_snooping_enabled            = %s
+  nd_snooping_limit              = %s
+  vmtools_v6_enabled             = %s
+  tofu_enabled                   = %s
   tag {
     scope = "scope1"
     tag   = "tag1"

--- a/nsxt/resource_nsxt_policy_ipsec_vpn_local_endpoint_test.go
+++ b/nsxt/resource_nsxt_policy_ipsec_vpn_local_endpoint_test.go
@@ -174,22 +174,22 @@ var accTestPolicyIPSecVpnServiceTestName = getAccTestResourceName()
 
 func testAccNsxtPolicyIPSecVpnLocalEndpointPrerequisite() string {
 	return fmt.Sprintf(`
-   data "nsxt_policy_edge_cluster" "test" {
-	 display_name = "%s"
-   }
-   resource "nsxt_policy_tier0_gateway" "test" {
-	 display_name      = "%s"
-	 ha_mode           = "ACTIVE_STANDBY"
-	 edge_cluster_path = data.nsxt_policy_edge_cluster.test.path
-   }
-   data "nsxt_policy_gateway_locale_service" "test" {
-	 gateway_path = nsxt_policy_tier0_gateway.test.path
-	 display_name = "default"
-   }
-   resource "nsxt_policy_ipsec_vpn_service" "test" {
-	 display_name        = "%s"
-	 locale_service_path = data.nsxt_policy_gateway_locale_service.test.path
-   }`, getEdgeClusterName(), accTestPolicyIPSecVpnGatewayTestName, accTestPolicyIPSecVpnServiceTestName)
+data "nsxt_policy_edge_cluster" "test" {
+  display_name = "%s"
+}
+resource "nsxt_policy_tier0_gateway" "test" {
+  display_name      = "%s"
+  ha_mode           = "ACTIVE_STANDBY"
+  edge_cluster_path = data.nsxt_policy_edge_cluster.test.path
+}
+data "nsxt_policy_gateway_locale_service" "test" {
+  gateway_path = nsxt_policy_tier0_gateway.test.path
+  display_name = "default"
+}
+resource "nsxt_policy_ipsec_vpn_service" "test" {
+  display_name        = "%s"
+  locale_service_path = data.nsxt_policy_gateway_locale_service.test.path
+}`, getEdgeClusterName(), accTestPolicyIPSecVpnGatewayTestName, accTestPolicyIPSecVpnServiceTestName)
 }
 
 func testAccNsxtPolicyIPSecVpnLocalEndpointTemplate(createFlow bool) string {
@@ -200,24 +200,24 @@ func testAccNsxtPolicyIPSecVpnLocalEndpointTemplate(createFlow bool) string {
 		attrMap = accTestPolicyIPSecVpnLocalEndpointUpdateAttributes
 	}
 	return testAccNsxtPolicyIPSecVpnLocalEndpointPrerequisite() + fmt.Sprintf(`
-   resource "nsxt_policy_ipsec_vpn_local_endpoint" "test" {
-	 service_path = nsxt_policy_ipsec_vpn_service.test.path
-	 display_name = "%s"
-	 description  = "%s"
-	 local_address = "%s"
-	 local_id = "%s"
-	 tag {
-	   scope = "scope1"
-	   tag   = "tag1"
-	 }
-   }`, attrMap["display_name"], attrMap["description"], attrMap["local_address"], attrMap["local_id"])
+resource "nsxt_policy_ipsec_vpn_local_endpoint" "test" {
+  service_path  = nsxt_policy_ipsec_vpn_service.test.path
+  display_name  = "%s"
+  description   = "%s"
+  local_address = "%s"
+  local_id      = "%s"
+  tag {
+    scope = "scope1"
+    tag   = "tag1"
+  }
+}`, attrMap["display_name"], attrMap["description"], attrMap["local_address"], attrMap["local_id"])
 }
 
 func testAccNsxtPolicyIPSecVpnLocalEndpointMinimalistic() string {
 	return testAccNsxtPolicyIPSecVpnLocalEndpointPrerequisite() + fmt.Sprintf(`
-   resource "nsxt_policy_ipsec_vpn_local_endpoint" "test" {
-	 service_path  = nsxt_policy_ipsec_vpn_service.test.path
-	 display_name  = "%s"
-	 local_address = "%s"
-   }`, accTestPolicyIPSecVpnLocalEndpointUpdateAttributes["display_name"], accTestPolicyIPSecVpnLocalEndpointUpdateAttributes["local_address"])
+resource "nsxt_policy_ipsec_vpn_local_endpoint" "test" {
+  service_path  = nsxt_policy_ipsec_vpn_service.test.path
+  display_name  = "%s"
+  local_address = "%s"
+}`, accTestPolicyIPSecVpnLocalEndpointUpdateAttributes["display_name"], accTestPolicyIPSecVpnLocalEndpointUpdateAttributes["local_address"])
 }

--- a/nsxt/resource_nsxt_policy_ipsec_vpn_service_test.go
+++ b/nsxt/resource_nsxt_policy_ipsec_vpn_service_test.go
@@ -342,23 +342,23 @@ func testAccNsxtPolicyIPSecVpnServiceTemplate(createFlow bool, useGatewayPath bo
 	gatewayOrLocaleServicePath := getGatewayOrLocaleServicePath(useGatewayPath, true)
 	return testAccNsxtPolicyTier0WithEdgeClusterForVPN() + fmt.Sprintf(`
 resource "nsxt_policy_ipsec_vpn_service" "test" {
-	display_name                   = "%s"
-	description                    = "%s"
+  display_name = "%s"
+  description  = "%s"
 	%s
-	enabled                        = "%s"
-	ha_sync                        = "%s"
-	ike_log_level                  = "%s"
-	bypass_rule {
-		sources                    = ["%s"]
-		destinations               = ["%s"]
-		action                     = "%s"
-	}
+  enabled       = "%s"
+  ha_sync       = "%s"
+  ike_log_level = "%s"
+  bypass_rule {
+    sources      = ["%s"]
+    destinations = ["%s"]
+    action       = "%s"
+  }
 
-	tag {
-	scope = "scope1"
-	tag   = "tag1"
-	}
-   }`, attrMap["display_name"], attrMap["description"], gatewayOrLocaleServicePath, attrMap["enabled"], attrMap["ha_sync"], attrMap["ike_log_level"], attrMap["sources"], attrMap["destinations"], attrMap["action"])
+  tag {
+    scope = "scope1"
+    tag   = "tag1"
+  }
+}`, attrMap["display_name"], attrMap["description"], gatewayOrLocaleServicePath, attrMap["enabled"], attrMap["ha_sync"], attrMap["ike_log_level"], attrMap["sources"], attrMap["destinations"], attrMap["action"])
 }
 
 func getGatewayOrLocaleServicePath(useGatewayPath bool, isT0 bool) string {
@@ -378,8 +378,8 @@ func getGatewayOrLocaleServicePath(useGatewayPath bool, isT0 bool) string {
 func testAccNsxtPolicyIPSecVpnServiceMinimalistic(useGatewayPath bool) string {
 	gatewayOrLocaleServicePath := getGatewayOrLocaleServicePath(useGatewayPath, true)
 	return testAccNsxtPolicyTier0WithEdgeClusterForVPN() + fmt.Sprintf(`
-   resource "nsxt_policy_ipsec_vpn_service" "test" {
-	 display_name          = "%s"
+resource "nsxt_policy_ipsec_vpn_service" "test" {
+  display_name = "%s"
 	 %s
-   }`, accTestPolicyIPSecVpnServiceUpdateAttributes["display_name"], gatewayOrLocaleServicePath)
+}`, accTestPolicyIPSecVpnServiceUpdateAttributes["display_name"], gatewayOrLocaleServicePath)
 }

--- a/nsxt/resource_nsxt_policy_ipsec_vpn_session_test.go
+++ b/nsxt/resource_nsxt_policy_ipsec_vpn_session_test.go
@@ -612,70 +612,70 @@ func testAccNsxtPolicyIPSecVpnSessionPreConditionTemplate(isT0 bool, useCert boo
 	if useCert {
 		localEndpointTemplate = fmt.Sprintf(`
 data "nsxt_policy_certificate" "test" {
-	display_name = "%s"
-	}
+  display_name = "%s"
+}
 
 resource "nsxt_policy_ipsec_vpn_local_endpoint" "test" {
-	service_path  = nsxt_policy_ipsec_vpn_service.test_ipsec_svc.path
-	display_name  = "%s"
-	local_address = "20.20.0.25"
-	certificate_path = data.nsxt_policy_certificate.test.path
-	trust_ca_paths = [data.nsxt_policy_certificate.test.path]
-	}
+  service_path     = nsxt_policy_ipsec_vpn_service.test_ipsec_svc.path
+  display_name     = "%s"
+  local_address    = "20.20.0.25"
+  certificate_path = data.nsxt_policy_certificate.test.path
+  trust_ca_paths   = [data.nsxt_policy_certificate.test.path]
+}
 		`, certName, ipsecVpnResourceName)
 	} else {
 		localEndpointTemplate = fmt.Sprintf(`
 resource "nsxt_policy_ipsec_vpn_local_endpoint" "test" {
-	service_path  = nsxt_policy_ipsec_vpn_service.test_ipsec_svc.path
-	display_name  = "%s"
-	local_address = "20.20.0.25"
-	}
+  service_path  = nsxt_policy_ipsec_vpn_service.test_ipsec_svc.path
+  display_name  = "%s"
+  local_address = "20.20.0.25"
+}
 	`, ipsecVpnResourceName)
 	}
 	var vpnServiceTemplate string
 	if isT0 {
 		vpnServiceTemplate = fmt.Sprintf(`
 resource "nsxt_policy_ipsec_vpn_service" "test_ipsec_svc" {
-	display_name          = "%s"
-	locale_service_path   = one(nsxt_policy_tier0_gateway.test.locale_service).path
-	}
+  display_name        = "%s"
+  locale_service_path = one(nsxt_policy_tier0_gateway.test.locale_service).path
+}
 `, ipsecVpnResourceName)
 	} else {
 		vpnServiceTemplate = fmt.Sprintf(`
 resource "nsxt_policy_ipsec_vpn_service" "test_ipsec_svc" {
-	display_name          = "%s"
-	locale_service_path   = one(nsxt_policy_tier1_gateway.test.locale_service).path
-	}
+  display_name        = "%s"
+  locale_service_path = one(nsxt_policy_tier1_gateway.test.locale_service).path
+}
 `, ipsecVpnResourceName)
 	}
 	return vpnServiceTemplate + localEndpointTemplate + fmt.Sprintf(`
 resource "nsxt_policy_ipsec_vpn_ike_profile" "test" {
-	display_name          = "%s"
-	description           = "Ike profile for ipsec vpn session"
-	encryption_algorithms = ["AES_128"]
-	digest_algorithms     = ["SHA2_256"]
-	dh_groups             = ["GROUP14"]
-	ike_version           = "IKE_V2"
+  display_name          = "%s"
+  description           = "Ike profile for ipsec vpn session"
+  encryption_algorithms = ["AES_128"]
+  digest_algorithms     = ["SHA2_256"]
+  dh_groups             = ["GROUP14"]
+  ike_version           = "IKE_V2"
 }
 
 resource "nsxt_policy_ipsec_vpn_tunnel_profile" "test" {
-	display_name          = "%s"
-	description           = "Terraform provisioned IPSec VPN Ike Profile"
-	df_policy             = "COPY"
-	encryption_algorithms = ["AES_128"]
-	digest_algorithms     = ["SHA2_256"]
-	dh_groups             = ["GROUP14"]
-	sa_life_time          = 7200
+  display_name          = "%s"
+  description           = "Terraform provisioned IPSec VPN Ike Profile"
+  df_policy             = "COPY"
+  encryption_algorithms = ["AES_128"]
+  digest_algorithms     = ["SHA2_256"]
+  dh_groups             = ["GROUP14"]
+  sa_life_time          = 7200
 }
 
 resource "nsxt_policy_ipsec_vpn_dpd_profile" "test" {
-	display_name       = "%s"
-	description        = "Terraform provisioned IPSec VPN DPD Profile"
-	dpd_probe_mode     = "ON_DEMAND"
-	dpd_probe_interval = 1
-	enabled            = true
-	retry_count        = 8
-  }
+  display_name       = "%s"
+  description        = "Terraform provisioned IPSec VPN DPD Profile"
+  dpd_probe_mode     = "ON_DEMAND"
+  dpd_probe_interval = 1
+  enabled            = true
+  retry_count        = 8
+}
 `, ipsecVpnResourceName, ipsecVpnResourceName, ipsecVpnResourceName)
 }
 
@@ -685,16 +685,16 @@ func testAccNsxtPolicyIPSecVpnSessionRouteBasedMinimalistic() string {
 		testAccNsxtPolicyIPSecVpnSessionPreConditionTemplate(true, false) +
 		fmt.Sprintf(`
 resource "nsxt_policy_ipsec_vpn_session" "test" {
-	display_name        = "%s"
-	tunnel_profile_path = nsxt_policy_ipsec_vpn_tunnel_profile.test.path
-	local_endpoint_path = nsxt_policy_ipsec_vpn_local_endpoint.test.path
-	service_path        = nsxt_policy_ipsec_vpn_service.test_ipsec_svc.path
-	vpn_type            = "%s"
-	peer_address        = "%s"
-	peer_id             = "%s"
-	ip_addresses        = ["%s"]
-	prefix_length       = %s
-	psk                 = "%s"
+  display_name        = "%s"
+  tunnel_profile_path = nsxt_policy_ipsec_vpn_tunnel_profile.test.path
+  local_endpoint_path = nsxt_policy_ipsec_vpn_local_endpoint.test.path
+  service_path        = nsxt_policy_ipsec_vpn_service.test_ipsec_svc.path
+  vpn_type            = "%s"
+  peer_address        = "%s"
+  peer_id             = "%s"
+  ip_addresses        = ["%s"]
+  prefix_length       = %s
+  psk                 = "%s"
 }`, attrMap["display_name"], attrMap["vpn_type"], attrMap["peer_address"], attrMap["peer_id"], attrMap["ip_addresses"], attrMap["prefix_length"], attrMap["psk"])
 }
 
@@ -708,28 +708,28 @@ func testAccNsxtPolicyIPSecVpnSessionRouteBasedTemplate(createFlow bool, isT0 bo
 	return testAccNsxtPolicyGatewayTemplate(isT0) + testAccNsxtPolicyIPSecVpnSessionPreConditionTemplate(isT0, false) +
 		fmt.Sprintf(`
 resource "nsxt_policy_ipsec_vpn_session" "test" {
-	display_name               = "%s"
-	description                = "%s"
-	ike_profile_path           = nsxt_policy_ipsec_vpn_ike_profile.test.path
-	tunnel_profile_path        = nsxt_policy_ipsec_vpn_tunnel_profile.test.path
-	dpd_profile_path           = nsxt_policy_ipsec_vpn_dpd_profile.test.path
-	local_endpoint_path        = nsxt_policy_ipsec_vpn_local_endpoint.test.path
-	enabled                    = "%s"
-	service_path               = nsxt_policy_ipsec_vpn_service.test_ipsec_svc.path
-	vpn_type                   = "%s"
-	authentication_mode        = "%s"
-	compliance_suite           = "%s"
-	ip_addresses               = ["%s"]
-	prefix_length              = "%s"
-	peer_address               = "%s"
-	peer_id                    = "%s"
-	psk                        = "%s"
-	connection_initiation_mode = "%s"
+  display_name               = "%s"
+  description                = "%s"
+  ike_profile_path           = nsxt_policy_ipsec_vpn_ike_profile.test.path
+  tunnel_profile_path        = nsxt_policy_ipsec_vpn_tunnel_profile.test.path
+  dpd_profile_path           = nsxt_policy_ipsec_vpn_dpd_profile.test.path
+  local_endpoint_path        = nsxt_policy_ipsec_vpn_local_endpoint.test.path
+  enabled                    = "%s"
+  service_path               = nsxt_policy_ipsec_vpn_service.test_ipsec_svc.path
+  vpn_type                   = "%s"
+  authentication_mode        = "%s"
+  compliance_suite           = "%s"
+  ip_addresses               = ["%s"]
+  prefix_length              = "%s"
+  peer_address               = "%s"
+  peer_id                    = "%s"
+  psk                        = "%s"
+  connection_initiation_mode = "%s"
 
-	tag {
-	  scope = "scope1"
-	  tag   = "tag1"
-	}
+  tag {
+    scope = "scope1"
+    tag   = "tag1"
+  }
 }`, attrMap["display_name"], attrMap["description"], attrMap["enabled"], attrMap["vpn_type"],
 			attrMap["authentication_mode"], attrMap["compliance_suite"], attrMap["ip_addresses"], attrMap["prefix_length"], attrMap["peer_address"], attrMap["peer_id"], attrMap["psk"], attrMap["connection_initiation_mode"])
 }
@@ -744,32 +744,32 @@ func testAccNsxtPolicyIPSecVpnSessionPolicyBasedTemplate(createFlow bool, isT0 b
 	return testAccNsxtPolicyGatewayTemplate(isT0) + testAccNsxtPolicyIPSecVpnSessionPreConditionTemplate(isT0, false) +
 		fmt.Sprintf(`
 resource "nsxt_policy_ipsec_vpn_session" "test" {
-	display_name               = "%s"
-	description                = "%s"
-	ike_profile_path           = nsxt_policy_ipsec_vpn_ike_profile.test.path
-	tunnel_profile_path        = nsxt_policy_ipsec_vpn_tunnel_profile.test.path
-	dpd_profile_path		   = nsxt_policy_ipsec_vpn_dpd_profile.test.path
-	local_endpoint_path		   = nsxt_policy_ipsec_vpn_local_endpoint.test.path
-	enabled                    = "%s"
-	service_path               = nsxt_policy_ipsec_vpn_service.test_ipsec_svc.path
-	vpn_type                   = "%s"
-	authentication_mode        = "%s"
-	compliance_suite           = "%s"
-	peer_address               = "%s"
-	peer_id                    = "%s"
-	psk                        = "%s"
-	connection_initiation_mode = "%s"
+  display_name               = "%s"
+  description                = "%s"
+  ike_profile_path           = nsxt_policy_ipsec_vpn_ike_profile.test.path
+  tunnel_profile_path        = nsxt_policy_ipsec_vpn_tunnel_profile.test.path
+  dpd_profile_path           = nsxt_policy_ipsec_vpn_dpd_profile.test.path
+  local_endpoint_path        = nsxt_policy_ipsec_vpn_local_endpoint.test.path
+  enabled                    = "%s"
+  service_path               = nsxt_policy_ipsec_vpn_service.test_ipsec_svc.path
+  vpn_type                   = "%s"
+  authentication_mode        = "%s"
+  compliance_suite           = "%s"
+  peer_address               = "%s"
+  peer_id                    = "%s"
+  psk                        = "%s"
+  connection_initiation_mode = "%s"
 
-	rule {
-		sources             = ["%s"]
-		destinations        = ["%s"]
-		action              = "%s"
-	  }
+  rule {
+    sources      = ["%s"]
+    destinations = ["%s"]
+    action       = "%s"
+  }
 
-	tag {
-	scope = "scope1"
-	tag   = "tag1"
-	  }
+  tag {
+    scope = "scope1"
+    tag   = "tag1"
+  }
 }`, attrMap["display_name"], attrMap["description"], attrMap["enabled"], attrMap["vpn_type"],
 			attrMap["authentication_mode"], attrMap["compliance_suite"], attrMap["peer_address"], attrMap["peer_id"],
 			attrMap["psk"], attrMap["connection_initiation_mode"], attrMap["sources"], attrMap["destinations"], attrMap["action"])
@@ -780,25 +780,25 @@ func testAccNsxtPolicyIPSecVpnSessionRouteBasedTemplateWithComplianceSuite(isT0 
 	return testAccNsxtPolicyGatewayTemplate(isT0) + testAccNsxtPolicyIPSecVpnSessionPreConditionTemplate(isT0, true) +
 		fmt.Sprintf(`
 resource "nsxt_policy_ipsec_vpn_session" "test" {
-	display_name               = "%s"
-	description                = "%s"
-	dpd_profile_path		   = nsxt_policy_ipsec_vpn_dpd_profile.test.path
-	local_endpoint_path		   = nsxt_policy_ipsec_vpn_local_endpoint.test.path
-	enabled                    = "%s"
-	service_path               = nsxt_policy_ipsec_vpn_service.test_ipsec_svc.path
-	vpn_type                   = "%s"
-	authentication_mode        = "%s"
-	compliance_suite           = "%s"
-	peer_address               = "%s"
-	peer_id                    = "%s"
-	connection_initiation_mode = "%s"
-	ip_addresses               = ["%s"]
-	prefix_length              = "%s"
+  display_name               = "%s"
+  description                = "%s"
+  dpd_profile_path           = nsxt_policy_ipsec_vpn_dpd_profile.test.path
+  local_endpoint_path        = nsxt_policy_ipsec_vpn_local_endpoint.test.path
+  enabled                    = "%s"
+  service_path               = nsxt_policy_ipsec_vpn_service.test_ipsec_svc.path
+  vpn_type                   = "%s"
+  authentication_mode        = "%s"
+  compliance_suite           = "%s"
+  peer_address               = "%s"
+  peer_id                    = "%s"
+  connection_initiation_mode = "%s"
+  ip_addresses               = ["%s"]
+  prefix_length              = "%s"
 
-	tag {
-	scope = "scope1"
-	tag   = "tag1"
-	  }
+  tag {
+    scope = "scope1"
+    tag   = "tag1"
+  }
 }`, attrMap["display_name"], attrMap["description"], attrMap["enabled"], attrMap["vpn_type"],
 			attrMap["authentication_mode"], attrMap["compliance_suite"], attrMap["peer_address"], attrMap["peer_id"],
 			attrMap["connection_initiation_mode"], attrMap["ip_addresses"], attrMap["prefix_length"])
@@ -809,29 +809,29 @@ func testAccNsxtPolicyIPSecVpnSessionPolicyBasedTemplateWithComplianceSuite(isT0
 	return testAccNsxtPolicyGatewayTemplate(isT0) + testAccNsxtPolicyIPSecVpnSessionPreConditionTemplate(isT0, true) +
 		fmt.Sprintf(`
 resource "nsxt_policy_ipsec_vpn_session" "test" {
-	display_name               = "%s"
-	description                = "%s"
-	dpd_profile_path		   = nsxt_policy_ipsec_vpn_dpd_profile.test.path
-	local_endpoint_path		   = nsxt_policy_ipsec_vpn_local_endpoint.test.path
-	enabled                    = "%s"
-	service_path               = nsxt_policy_ipsec_vpn_service.test_ipsec_svc.path
-	vpn_type                   = "%s"
-	authentication_mode        = "%s"
-	compliance_suite           = "%s"
-	peer_address               = "%s"
-	peer_id                    = "%s"
-	connection_initiation_mode = "%s"
+  display_name               = "%s"
+  description                = "%s"
+  dpd_profile_path           = nsxt_policy_ipsec_vpn_dpd_profile.test.path
+  local_endpoint_path        = nsxt_policy_ipsec_vpn_local_endpoint.test.path
+  enabled                    = "%s"
+  service_path               = nsxt_policy_ipsec_vpn_service.test_ipsec_svc.path
+  vpn_type                   = "%s"
+  authentication_mode        = "%s"
+  compliance_suite           = "%s"
+  peer_address               = "%s"
+  peer_id                    = "%s"
+  connection_initiation_mode = "%s"
 
-	rule {
-		sources             = ["%s"]
-		destinations        = ["%s"]
-		action              = "%s"
-	  }
+  rule {
+    sources      = ["%s"]
+    destinations = ["%s"]
+    action       = "%s"
+  }
 
-	tag {
-	scope = "scope1"
-	tag   = "tag1"
-	  }
+  tag {
+    scope = "scope1"
+    tag   = "tag1"
+  }
 }`, attrMap["display_name"], attrMap["description"], attrMap["enabled"], attrMap["vpn_type"],
 			attrMap["authentication_mode"], attrMap["compliance_suite"], attrMap["peer_address"], attrMap["peer_id"],
 			attrMap["connection_initiation_mode"], attrMap["sources"], attrMap["destinations"], attrMap["action"])

--- a/nsxt/resource_nsxt_policy_l2_vpn_service_test.go
+++ b/nsxt/resource_nsxt_policy_l2_vpn_service_test.go
@@ -392,25 +392,25 @@ func testAccNsxtPolicyL2VpnServiceTemplate(createFlow bool, clientMode bool, use
 	}
 	gatewayOrLocaleServicePath := getGatewayOrLocaleServicePath(useGatewayPath, true)
 	return testAccNsxtPolicyTier0WithEdgeClusterForVPN() + fmt.Sprintf(`
-	  resource "nsxt_policy_l2_vpn_service" "test" {
-		display_name                   = "%s"
-		description                    = "%s"
+resource "nsxt_policy_l2_vpn_service" "test" {
+  display_name = "%s"
+  description  = "%s"
 		%s
-		enable_hub                     = "%s"
-		mode               			   = "%s"
-		encap_ip_pool 				   = ["%s"]
-		tag {
-		  scope = "scope1"
-		  tag   = "tag1"
-		}
-	  }`, attrMap["display_name"], attrMap["description"], gatewayOrLocaleServicePath, attrMap["enable_hub"], attrMap["mode"], attrMap["encap_ip_pool"])
+  enable_hub    = "%s"
+  mode          = "%s"
+  encap_ip_pool = ["%s"]
+  tag {
+    scope = "scope1"
+    tag   = "tag1"
+  }
+}`, attrMap["display_name"], attrMap["description"], gatewayOrLocaleServicePath, attrMap["enable_hub"], attrMap["mode"], attrMap["encap_ip_pool"])
 }
 
 func testAccNsxtPolicyL2VpnServiceMinimalistic(useGatewayPath bool) string {
 	gatewayOrLocaleServicePath := getGatewayOrLocaleServicePath(useGatewayPath, true)
 	return testAccNsxtPolicyTier0WithEdgeClusterForVPN() + fmt.Sprintf(`
-	  resource "nsxt_policy_l2_vpn_service" "test" {
-		display_name          = "%s"
+resource "nsxt_policy_l2_vpn_service" "test" {
+  display_name = "%s"
 		%s
-	  }`, accTestPolicyL2VpnServiceUpdateAttributes["display_name"], gatewayOrLocaleServicePath)
+}`, accTestPolicyL2VpnServiceUpdateAttributes["display_name"], gatewayOrLocaleServicePath)
 }

--- a/nsxt/resource_nsxt_policy_l2_vpn_session_test.go
+++ b/nsxt/resource_nsxt_policy_l2_vpn_session_test.go
@@ -270,80 +270,80 @@ func testAccNsxtPolicyL2VpnSessionPreConditionTemplate(isT0 bool, useGatewayPath
 	if isT0 {
 		vpnServiceTemplate = fmt.Sprintf(`
 resource "nsxt_policy_l2_vpn_service" "test_l2_svc" {
-	display_name          = "%s"
+  display_name = "%s"
 	%s
-	enable_hub            = true
-	mode                  = "SERVER"
-	encap_ip_pool         = ["192.168.10.0/24"]
+  enable_hub    = true
+  mode          = "SERVER"
+  encap_ip_pool = ["192.168.10.0/24"]
 }
 
 resource "nsxt_policy_ipsec_vpn_service" "test_ipsec_svc" {
-	display_name          = "%s"
+  display_name = "%s"
 	%s
 }
 `, l2VpnResourceName, gatewayOrLocaleServicePath, l2VpnResourceName, gatewayOrLocaleServicePath)
 	} else {
 		vpnServiceTemplate = fmt.Sprintf(`
 resource "nsxt_policy_l2_vpn_service" "test_l2_svc" {
-	display_name          = "%s"
+  display_name = "%s"
 	%s
-	enable_hub            = true
-	mode                  = "SERVER"
-	encap_ip_pool         = ["192.168.10.0/24"]
+  enable_hub    = true
+  mode          = "SERVER"
+  encap_ip_pool = ["192.168.10.0/24"]
 }
 resource "nsxt_policy_ipsec_vpn_service" "test_ipsec_svc" {
-	display_name          = "%s"
+  display_name = "%s"
 	%s
 }
 `, l2VpnResourceName, gatewayOrLocaleServicePath, l2VpnResourceName, gatewayOrLocaleServicePath)
 	}
 	return vpnServiceTemplate + fmt.Sprintf(`
 resource "nsxt_policy_ipsec_vpn_ike_profile" "test" {
-	display_name          = "%s"
-	description           = "Ike profile for ipsec vpn session"
-	encryption_algorithms = ["AES_128"]
-	digest_algorithms     = ["SHA2_256"]
-	dh_groups             = ["GROUP14"]
-	ike_version           = "IKE_V2"
+  display_name          = "%s"
+  description           = "Ike profile for ipsec vpn session"
+  encryption_algorithms = ["AES_128"]
+  digest_algorithms     = ["SHA2_256"]
+  dh_groups             = ["GROUP14"]
+  ike_version           = "IKE_V2"
 }
 resource "nsxt_policy_ipsec_vpn_dpd_profile" "test" {
-	display_name       = "%s"
-	description        = "Terraform provisioned IPSec VPN DPD Profile"
-	dpd_probe_mode     = "ON_DEMAND"
-	dpd_probe_interval = 1
-	enabled            = true
-	retry_count        = 8
+  display_name       = "%s"
+  description        = "Terraform provisioned IPSec VPN DPD Profile"
+  dpd_probe_mode     = "ON_DEMAND"
+  dpd_probe_interval = 1
+  enabled            = true
+  retry_count        = 8
 }
 
 resource "nsxt_policy_ipsec_vpn_local_endpoint" "test" {
-	service_path  = nsxt_policy_ipsec_vpn_service.test_ipsec_svc.path
-	display_name  = "%s"
-	local_address = "20.20.0.20"
+  service_path  = nsxt_policy_ipsec_vpn_service.test_ipsec_svc.path
+  display_name  = "%s"
+  local_address = "20.20.0.20"
 }
 
 resource "nsxt_policy_ipsec_vpn_tunnel_profile" "test" {
-	display_name          = "%s"
-	description           = "Terraform provisioned IPSec VPN Ike Profile"
-	df_policy             = "COPY"
-	encryption_algorithms = ["AES_GCM_128"]
-	dh_groups             = ["GROUP14"]
-	sa_life_time          = 7200
+  display_name          = "%s"
+  description           = "Terraform provisioned IPSec VPN Ike Profile"
+  df_policy             = "COPY"
+  encryption_algorithms = ["AES_GCM_128"]
+  dh_groups             = ["GROUP14"]
+  sa_life_time          = 7200
 }
 
 resource "nsxt_policy_ipsec_vpn_session" "test" {
-	display_name               = "%s"
-	tunnel_profile_path        = nsxt_policy_ipsec_vpn_tunnel_profile.test.path
-	local_endpoint_path        = nsxt_policy_ipsec_vpn_local_endpoint.test.path
-	dpd_profile_path           = nsxt_policy_ipsec_vpn_dpd_profile.test.path
-	ike_profile_path           = nsxt_policy_ipsec_vpn_ike_profile.test.path
-	service_path               = nsxt_policy_ipsec_vpn_service.test_ipsec_svc.path
-	vpn_type                   = "RouteBased"
-	authentication_mode        = "PSK"
-	peer_address               = "18.18.18.19"
-	peer_id                    = "18.18.18.19"
-	psk                        = "secret1"
-	ip_addresses               = ["169.254.152.2"]
-	prefix_length              = 24
+  display_name        = "%s"
+  tunnel_profile_path = nsxt_policy_ipsec_vpn_tunnel_profile.test.path
+  local_endpoint_path = nsxt_policy_ipsec_vpn_local_endpoint.test.path
+  dpd_profile_path    = nsxt_policy_ipsec_vpn_dpd_profile.test.path
+  ike_profile_path    = nsxt_policy_ipsec_vpn_ike_profile.test.path
+  service_path        = nsxt_policy_ipsec_vpn_service.test_ipsec_svc.path
+  vpn_type            = "RouteBased"
+  authentication_mode = "PSK"
+  peer_address        = "18.18.18.19"
+  peer_id             = "18.18.18.19"
+  psk                 = "secret1"
+  ip_addresses        = ["169.254.152.2"]
+  prefix_length       = 24
 }
 `, l2VpnResourceName, l2VpnResourceName, l2VpnResourceName, l2VpnResourceName, l2VpnResourceName)
 }
@@ -363,21 +363,22 @@ func testAccNsxtPolicyL2VpnSessionTemplate(createFlow bool) string {
 	}
 	return fmt.Sprintf(`
 resource "nsxt_policy_l2_vpn_session" "test" {
-	display_name      = "%s"
-	description       = "%s"
-	service_path      = nsxt_policy_l2_vpn_service.test_l2_svc.path
-	transport_tunnels = [nsxt_policy_ipsec_vpn_session.test.path]
-	direction         = "%s"
-  	max_segment_size  = "%s"
-	local_address     = "%s"
-	peer_address      = "%s"
-	protocol          = "%s"
+  display_name      = "%s"
+  description       = "%s"
+  service_path      = nsxt_policy_l2_vpn_service.test_l2_svc.path
+  transport_tunnels = [nsxt_policy_ipsec_vpn_session.test.path]
+  direction         = "%s"
+  max_segment_size  = "%s"
+  local_address     = "%s"
+  peer_address      = "%s"
+  protocol          = "%s"
 
-	tag {
-	  scope = "scope1"
-	  tag   = "tag1"
-	}
+  tag {
+    scope = "scope1"
+    tag   = "tag1"
+  }
 }
+
 
 `, attrMap["display_name"], attrMap["description"], attrMap["direction"], attrMap["max_segment_size"], attrMap["local_address"], attrMap["peer_address"], attrMap["protocol"])
 }
@@ -387,10 +388,11 @@ func testAccNsxtPolicyL2VpnSessionMinimalistic(useGatewayPath bool) string {
 	return testAccNsxtPolicyTier0WithEdgeClusterForVPN() +
 		testAccNsxtPolicyL2VpnSessionPreConditionTemplate(true, useGatewayPath) + fmt.Sprintf(`
 resource "nsxt_policy_l2_vpn_session" "test" {
-	display_name      = "%s"
-	service_path      = nsxt_policy_l2_vpn_service.test_l2_svc.path
-	transport_tunnels = [nsxt_policy_ipsec_vpn_session.test.path]
+  display_name      = "%s"
+  service_path      = nsxt_policy_l2_vpn_service.test_l2_svc.path
+  transport_tunnels = [nsxt_policy_ipsec_vpn_session.test.path]
 }
+
 
 `, attrMap["display_name"])
 }

--- a/nsxt/resource_nsxt_policy_l7_access_profile_test.go
+++ b/nsxt/resource_nsxt_policy_l7_access_profile_test.go
@@ -287,38 +287,38 @@ func testAccNsxtPolicyL7AccessProfileTemplate(createFlow bool, withContext bool)
 	return fmt.Sprintf(`
 resource "nsxt_policy_l7_access_profile" "test" {
 %s
-  display_name = "%s"
-  description  = "%s"
+  display_name          = "%s"
+  description           = "%s"
   default_action_logged = %s
-  default_action = "%s"
+  default_action        = "%s"
 
   l7_access_entry {
     nsx_id = "%s"
     action = "%s"
 
     attribute {
-      key = "%s"
-      values = ["%s"]
+      key              = "%s"
+      values           = ["%s"]
       attribute_source = "%s"
 
       sub_attribute {
-        key = "%s"
+        key    = "%s"
         values = ["%s"]
       }
     }
 
-    disabled = %s
-    logged = "%s"
+    disabled        = %s
+    logged          = "%s"
     sequence_number = "%s"
   }
 
   l7_access_entry {
-     display_name = "%s"
-     action = "%s"
+    display_name = "%s"
+    action       = "%s"
 
     attribute {
-      key = "%s"
-      values = ["%s"]
+      key              = "%s"
+      values           = ["%s"]
       attribute_source = "%s"
     }
     sequence_number = "%s"
@@ -344,16 +344,16 @@ func testAccNsxtPolicyL7AccessProfileMinimalistic(withContext bool) string {
 	return fmt.Sprintf(`
 resource "nsxt_policy_l7_access_profile" "test" {
 %s
-  display_name = "%s"
+  display_name   = "%s"
   default_action = "ALLOW"
 
   l7_access_entry {
-     display_name = "%s"
-     action = "%s"
+    display_name = "%s"
+    action       = "%s"
 
     attribute {
-      key = "%s"
-      values = ["%s"]
+      key              = "%s"
+      values           = ["%s"]
       attribute_source = "%s"
     }
     sequence_number = "%s"

--- a/nsxt/resource_nsxt_policy_lb_client_ssl_profile_test.go
+++ b/nsxt/resource_nsxt_policy_lb_client_ssl_profile_test.go
@@ -180,25 +180,25 @@ func testAccNsxtPolicyLBClientSslProfileTemplate(createFlow bool) string {
 		attrMap = accTestPolicyLBClientSslProfileUpdateAttributes
 	}
 	return fmt.Sprintf(`
-   resource "nsxt_policy_lb_client_ssl_profile" "test" {
-	 display_name = "%s"
-	 description  = "%s"
-	 cipher_group_label = "%s"
-	 ciphers = ["%s"]
-	 prefer_server_ciphers = %s
-	 protocols = ["%s"]
-	 session_cache_enabled = %s
-	 session_cache_timeout = %s
-	 tag {
-	   scope = "scope1"
-	   tag   = "tag1"
-	 }
-   }`, attrMap["display_name"], attrMap["description"], attrMap["cipher_group_label"], attrMap["ciphers"], attrMap["prefer_server_ciphers"], attrMap["protocols"], attrMap["session_cache_enabled"], attrMap["session_cache_timeout"])
+resource "nsxt_policy_lb_client_ssl_profile" "test" {
+  display_name          = "%s"
+  description           = "%s"
+  cipher_group_label    = "%s"
+  ciphers               = ["%s"]
+  prefer_server_ciphers = %s
+  protocols             = ["%s"]
+  session_cache_enabled = %s
+  session_cache_timeout = %s
+  tag {
+    scope = "scope1"
+    tag   = "tag1"
+  }
+}`, attrMap["display_name"], attrMap["description"], attrMap["cipher_group_label"], attrMap["ciphers"], attrMap["prefer_server_ciphers"], attrMap["protocols"], attrMap["session_cache_enabled"], attrMap["session_cache_timeout"])
 }
 
 func testAccNsxtPolicyLBClientSslProfileMinimalistic() string {
 	return fmt.Sprintf(`
-   resource "nsxt_policy_lb_client_ssl_profile" "test" {
-	 display_name = "%s"
-   }`, accTestPolicyLBClientSslProfileUpdateAttributes["display_name"])
+resource "nsxt_policy_lb_client_ssl_profile" "test" {
+  display_name = "%s"
+}`, accTestPolicyLBClientSslProfileUpdateAttributes["display_name"])
 }

--- a/nsxt/resource_nsxt_policy_lb_fast_udp_application_profile_test.go
+++ b/nsxt/resource_nsxt_policy_lb_fast_udp_application_profile_test.go
@@ -132,9 +132,9 @@ func testAccNsxtPolicyLBFastUdpApplicationProfileTemplate(createFlow bool) strin
 	}
 	return fmt.Sprintf(`
 resource "nsxt_policy_lb_fast_udp_application_profile" "test" {
-  display_name  = "%s"
-  description   = "%s"
-  idle_timeout  = %s
+  display_name = "%s"
+  description  = "%s"
+  idle_timeout = %s
 
   flow_mirroring_enabled = %s
 

--- a/nsxt/resource_nsxt_policy_lb_generic_persistence_profile_test.go
+++ b/nsxt/resource_nsxt_policy_lb_generic_persistence_profile_test.go
@@ -143,7 +143,7 @@ resource "nsxt_policy_lb_generic_persistence_profile" "test" {
 
   persistence_shared = %s
   timeout            = %s
-  
+
   ha_persistence_mirroring_enabled = %s
 
   tag {

--- a/nsxt/resource_nsxt_policy_lb_http_application_profile_test.go
+++ b/nsxt/resource_nsxt_policy_lb_http_application_profile_test.go
@@ -193,18 +193,18 @@ func testAccNsxtPolicyLBHttpApplicationProfileTemplate(createFlow bool) string {
 	}
 	return fmt.Sprintf(`
 resource "nsxt_policy_lb_http_application_profile" "test" {
-  display_name = "%s"
-  description  = "%s"
-  http_redirect_to = "%s"
+  display_name           = "%s"
+  description            = "%s"
+  http_redirect_to       = "%s"
   http_redirect_to_https = %s
-  idle_timeout = %s
-  request_body_size = %s
-  request_header_size = %s
-  response_buffering = %s
-  response_header_size = %s
-  response_timeout = %s
-  server_keep_alive = %s
-  x_forwarded_for = "%s"
+  idle_timeout           = %s
+  request_body_size      = %s
+  request_header_size    = %s
+  response_buffering     = %s
+  response_header_size   = %s
+  response_timeout       = %s
+  server_keep_alive      = %s
+  x_forwarded_for        = "%s"
 
   tag {
     scope = "scope1"

--- a/nsxt/resource_nsxt_policy_lb_http_monitor_profile_test.go
+++ b/nsxt/resource_nsxt_policy_lb_http_monitor_profile_test.go
@@ -211,19 +211,19 @@ resource "nsxt_policy_lb_http_monitor_profile" "test" {
   description  = "%s"
   request_body = "%s"
 
-  request_method = "%s"
-  request_url = "%s"
-  request_version = "%s"
-  response_body = "%s"
+  request_method        = "%s"
+  request_url           = "%s"
+  request_version       = "%s"
+  response_body         = "%s"
   response_status_codes = [%s]
-  fall_count = %s
-  interval = %s
-  monitor_port = %s
-  rise_count = %s
-  timeout = %s
+  fall_count            = %s
+  interval              = %s
+  monitor_port          = %s
+  rise_count            = %s
+  timeout               = %s
 
   request_header {
-    name = "%s"
+    name  = "%s"
     value = "%s"
   }
 

--- a/nsxt/resource_nsxt_policy_lb_https_monitor_profile_test.go
+++ b/nsxt/resource_nsxt_policy_lb_https_monitor_profile_test.go
@@ -222,26 +222,26 @@ resource "nsxt_policy_lb_https_monitor_profile" "test" {
   request_body = "%s"
 
 
-  request_method = "%s"
-  request_url = "%s"
-  request_version = "%s"
-  response_body = "%s"
+  request_method        = "%s"
+  request_url           = "%s"
+  request_version       = "%s"
+  response_body         = "%s"
   response_status_codes = [%s]
 
   request_header {
-    name = "%s"
+    name  = "%s"
     value = "%s"
   }
 
-  fall_count = %s
-  interval = %s
+  fall_count   = %s
+  interval     = %s
   monitor_port = %s
-  rise_count = %s
-  timeout = %s
+  rise_count   = %s
+  timeout      = %s
 
   server_ssl {
     certificate_chain_depth = %s
-    server_auth = "%s"
+    server_auth             = "%s"
   }
 
   tag {

--- a/nsxt/resource_nsxt_policy_lb_icmp_monitor_profile_test.go
+++ b/nsxt/resource_nsxt_policy_lb_icmp_monitor_profile_test.go
@@ -175,11 +175,11 @@ func testAccNsxtPolicyLBIcmpMonitorProfileTemplate(createFlow bool) string {
 resource "nsxt_policy_lb_icmp_monitor_profile" "test" {
   display_name = "%s"
   description  = "%s"
-  data_length = %s
-  fall_count = %s
-  interval = %s
-  rise_count = %s
-  timeout = %s
+  data_length  = %s
+  fall_count   = %s
+  interval     = %s
+  rise_count   = %s
+  timeout      = %s
 
   tag {
     scope = "scope1"

--- a/nsxt/resource_nsxt_policy_lb_passive_monitor_profile_test.go
+++ b/nsxt/resource_nsxt_policy_lb_passive_monitor_profile_test.go
@@ -163,8 +163,8 @@ func testAccNsxtPolicyLBPassiveMonitorProfileTemplate(createFlow bool) string {
 resource "nsxt_policy_lb_passive_monitor_profile" "test" {
   display_name = "%s"
   description  = "%s"
-  max_fails = %s
-  timeout = %s
+  max_fails    = %s
+  timeout      = %s
 
   tag {
     scope = "scope1"

--- a/nsxt/resource_nsxt_policy_lb_pool_test.go
+++ b/nsxt/resource_nsxt_policy_lb_pool_test.go
@@ -320,9 +320,9 @@ func testAccNsxtPolicyLBPoolMemberTemplate(createFlow bool) string {
 resource "nsxt_policy_lb_pool" "test" {
   display_name = "%s"
   description  = "%s"
-  algorithm = "%s"
+  algorithm    = "%s"
   %s
-  min_active_members = %s
+  min_active_members      = %s
   tcp_multiplexing_number = %s
   %s
 
@@ -341,22 +341,22 @@ func testAccNsxtPolicyLBPoolGroupTemplate() string {
 	attrMap := accTestPolicyLBPoolUpdateAttributes
 	return fmt.Sprintf(`
 resource "nsxt_policy_group" "test" {
-    display_name = "lb-test"
+  display_name = "lb-test"
 }
 
 resource "nsxt_policy_lb_pool" "test" {
-  display_name = "%s"
-  description  = "%s"
-  algorithm = "%s"
-  min_active_members = %s
+  display_name            = "%s"
+  description             = "%s"
+  algorithm               = "%s"
+  min_active_members      = %s
   tcp_multiplexing_number = %s
 
   member_group {
-      group_path       = nsxt_policy_group.test.path
-      allow_ipv4       = false
-      allow_ipv6       = true
-      max_ip_list_size = 10
-      port             = 888
+    group_path       = nsxt_policy_group.test.path
+    allow_ipv4       = false
+    allow_ipv6       = true
+    max_ip_list_size = 10
+    port             = 888
   }
 
   tag {
@@ -380,7 +380,7 @@ ip_pool_addresses = ["1.1.1.60-1.1.1.82", "1.1.2.0/24", "3.3.3.3"]
 	}
 	return fmt.Sprintf(`
 resource "nsxt_policy_group" "test" {
-    display_name = "lb-test"
+  display_name = "lb-test"
 }
 
 resource "nsxt_policy_lb_pool" "test" {
@@ -388,13 +388,13 @@ resource "nsxt_policy_lb_pool" "test" {
   description  = "%s"
 
   member_group {
-      allow_ipv4 = true
-      allow_ipv6 = false
-      group_path = nsxt_policy_group.test.path
+    allow_ipv4 = true
+    allow_ipv6 = false
+    group_path = nsxt_policy_group.test.path
   }
 
   snat {
-      type = "%s"
+    type = "%s"
       %s
   }
 }
@@ -407,7 +407,7 @@ data "nsxt_policy_realization_info" "realization_info" {
 func testAccNsxtPolicyLBPoolMinimalistic() string {
 	return fmt.Sprintf(`
 resource "nsxt_policy_group" "test" {
-    display_name = "lb-test"
+  display_name = "lb-test"
 }
 
 resource "nsxt_policy_lb_pool" "test" {

--- a/nsxt/resource_nsxt_policy_lb_source_ip_persistence_profile_test.go
+++ b/nsxt/resource_nsxt_policy_lb_source_ip_persistence_profile_test.go
@@ -148,7 +148,7 @@ resource "nsxt_policy_lb_source_ip_persistence_profile" "test" {
   persistence_shared = %s
   purge              = "%s"
   timeout            = %s
-  
+
   ha_persistence_mirroring_enabled = %s
 
   tag {

--- a/nsxt/resource_nsxt_policy_lb_tcp_monitor_profile_test.go
+++ b/nsxt/resource_nsxt_policy_lb_tcp_monitor_profile_test.go
@@ -183,13 +183,13 @@ func testAccNsxtPolicyLBTcpMonitorProfileTemplate(createFlow bool) string {
 resource "nsxt_policy_lb_tcp_monitor_profile" "test" {
   display_name = "%s"
   description  = "%s"
-  receive = "%s"
-  send = "%s"
-  fall_count = %s
-  interval = %s
+  receive      = "%s"
+  send         = "%s"
+  fall_count   = %s
+  interval     = %s
   monitor_port = %s
-  rise_count = %s
-  timeout = %s
+  rise_count   = %s
+  timeout      = %s
 
   tag {
     scope = "scope1"

--- a/nsxt/resource_nsxt_policy_lb_udp_monitor_profile_test.go
+++ b/nsxt/resource_nsxt_policy_lb_udp_monitor_profile_test.go
@@ -183,13 +183,13 @@ func testAccNsxtPolicyLBUdpMonitorProfileTemplate(createFlow bool) string {
 resource "nsxt_policy_lb_udp_monitor_profile" "test" {
   display_name = "%s"
   description  = "%s"
-  receive = "%s"
-  send = "%s"
-  fall_count = %s
-  interval = %s
+  receive      = "%s"
+  send         = "%s"
+  fall_count   = %s
+  interval     = %s
   monitor_port = %s
-  rise_count = %s
-  timeout = %s
+  rise_count   = %s
+  timeout      = %s
 
   tag {
     scope = "scope1"

--- a/nsxt/resource_nsxt_policy_lb_virtual_server_test.go
+++ b/nsxt/resource_nsxt_policy_lb_virtual_server_test.go
@@ -763,8 +763,8 @@ func testAccNsxtPolicyLBVirtualServerTemplate(createFlow bool) string {
 		attrMap = accTestPolicyLBVirtualServerUpdateAttributes
 	}
 	return fmt.Sprintf(`
-data "nsxt_policy_lb_app_profile" "default_tcp"{
-  type = "TCP"
+data "nsxt_policy_lb_app_profile" "default_tcp" {
+  type         = "TCP"
   display_name = "default-tcp-lb-app-profile"
 }
 
@@ -809,17 +809,17 @@ data "nsxt_policy_realization_info" "realization_info" {
 func testAccNsxtPolicyLBVirtualServerMinimalistic() string {
 	attrMap := accTestPolicyLBVirtualServerCreateAttributes
 	return fmt.Sprintf(`
-data "nsxt_policy_lb_app_profile" "default_http"{
-    type = "HTTP"
-	display_name = "default-http-lb-app-profile"
+data "nsxt_policy_lb_app_profile" "default_http" {
+  type         = "HTTP"
+  display_name = "default-http-lb-app-profile"
 }
 
 resource "nsxt_policy_lb_pool" "pool" {
-    display_name = "terraform-vs-test-pool"
+  display_name = "terraform-vs-test-pool"
 }
 
 resource "nsxt_policy_lb_pool" "sorry_pool" {
-    display_name = "terraform-vs-test-sorry-pool"
+  display_name = "terraform-vs-test-sorry-pool"
 }
 
 resource "nsxt_policy_lb_virtual_server" "test" {
@@ -847,19 +847,19 @@ func testAccNsxtPolicyLBVirtualServerSSLTemplate(createFlow bool) string {
 	}
 	return fmt.Sprintf(`
 data "nsxt_policy_certificate" "test" {
-    display_name = "%s"
+  display_name = "%s"
 }
-data "nsxt_policy_lb_app_profile" "default_tcp"{
-    type = "TCP"
-	display_name = "default-tcp-lb-app-profile"
+data "nsxt_policy_lb_app_profile" "default_tcp" {
+  type         = "TCP"
+  display_name = "default-tcp-lb-app-profile"
 }
 
 data "nsxt_policy_lb_client_ssl_profile" "default" {
-     display_name = "default-balanced-client-ssl-profile"
+  display_name = "default-balanced-client-ssl-profile"
 }
 
 data "nsxt_policy_lb_server_ssl_profile" "default" {
-     display_name = "default-balanced-server-ssl-profile"
+  display_name = "default-balanced-server-ssl-profile"
 }
 
 resource "nsxt_policy_lb_virtual_server" "test" {
@@ -868,16 +868,16 @@ resource "nsxt_policy_lb_virtual_server" "test" {
   ip_address               = "%s"
   ports                    = ["%s"]
   client_ssl {
-      client_auth              = "IGNORE"
-      certificate_chain_depth  = %s
-      ssl_profile_path         = data.nsxt_policy_lb_client_ssl_profile.default.path
-      default_certificate_path = data.nsxt_policy_certificate.test.path
+    client_auth              = "IGNORE"
+    certificate_chain_depth  = %s
+    ssl_profile_path         = data.nsxt_policy_lb_client_ssl_profile.default.path
+    default_certificate_path = data.nsxt_policy_certificate.test.path
   }
 
   server_ssl {
-      server_auth             = "IGNORE"
-      certificate_chain_depth = %s
-      ssl_profile_path        = data.nsxt_policy_lb_server_ssl_profile.default.path
+    server_auth             = "IGNORE"
+    certificate_chain_depth = %s
+    ssl_profile_path        = data.nsxt_policy_lb_server_ssl_profile.default.path
   }
 }`, getTestCertificateName(false), attrMap["display_name"], attrMap["ip_address"], attrMap["ports"], attrMap["certificate_chain_depth"], attrMap["certificate_chain_depth"])
 }
@@ -890,8 +890,8 @@ func testAccNsxtPolicyLBVirtualServerWithAccessList(createFlow bool) string {
 		attrMap = accTestPolicyLBVirtualServerUpdateAttributes
 	}
 	return fmt.Sprintf(`
-data "nsxt_policy_lb_app_profile" "default_tcp"{
-  type = "TCP"
+data "nsxt_policy_lb_app_profile" "default_tcp" {
+  type         = "TCP"
   display_name = "default-tcp-lb-app-profile"
 }
 
@@ -918,9 +918,9 @@ resource "nsxt_policy_lb_virtual_server" "test" {
   persistence_profile_path   = data.nsxt_policy_lb_persistence_profile.default.path
   log_significant_event_only = %s
   access_list_control {
-      action     = "%s"
-      enabled    = %s
-      group_path = nsxt_policy_group.group1.path
+    action     = "%s"
+    enabled    = %s
+    group_path = nsxt_policy_group.group1.path
   }
 }
 
@@ -937,8 +937,8 @@ func testAccNsxtPolicyLBVirtualServerUdp(createFlow bool) string {
 		attrMap = accTestPolicyLBVirtualServerUpdateAttributes
 	}
 	return fmt.Sprintf(`
-data "nsxt_policy_lb_app_profile" "default_udp"{
-  type = "UDP"
+data "nsxt_policy_lb_app_profile" "default_udp" {
+  type         = "UDP"
   display_name = "default-udp-lb-app-profile"
 }
 
@@ -975,8 +975,8 @@ func testAccNsxtPolicyLBVirtualServerWithRules(createFlow bool) string {
 		attrMap = accTestPolicyLBVirtualServerUpdateAttributes
 	}
 	return fmt.Sprintf(`
-data "nsxt_policy_lb_app_profile" "default_http"{
-  type = "HTTP"
+data "nsxt_policy_lb_app_profile" "default_http" {
+  type         = "HTTP"
   display_name = "default-http-lb-app-profile"
 }
 
@@ -1000,258 +1000,258 @@ resource "nsxt_policy_lb_virtual_server" "test" {
   display_name             = "%s"
   application_profile_path = data.nsxt_policy_lb_app_profile.default_http.path
   ip_address               = "%s"
-  ports                    = [ "80" ]
-  pool_path                  = nsxt_policy_lb_pool.pool.path
+  ports                    = ["80"]
+  pool_path                = nsxt_policy_lb_pool.pool.path
 
   rule {
-	display_name = "connection_drop_test"
-	action {
-	  connection_drop {}
-	}
+    display_name = "connection_drop_test"
+    action {
+      connection_drop {}
+    }
   }
   rule {
-	display_name = "http_redirect_test"
-	action {
-	  http_redirect {
-            redirect_status = "301"
-            redirect_url = "dummy"
-	  }
-	  http_redirect {
-            redirect_status = "302"
-            redirect_url = "other_dummy"
-	  }
-	}
-	condition {
-	  http_request_body {
-  	    body_value = "xyz"
-	    match_type = "REGEX"
-	  }
-	}
+    display_name = "http_redirect_test"
+    action {
+      http_redirect {
+        redirect_status = "301"
+        redirect_url    = "dummy"
+      }
+      http_redirect {
+        redirect_status = "302"
+        redirect_url    = "other_dummy"
+      }
+    }
+    condition {
+      http_request_body {
+        body_value = "xyz"
+        match_type = "REGEX"
+      }
+    }
   }
   rule {
-	display_name = "http_reject_test"
-	action {
-	  http_reject {
-  	    reply_status = "404"
-	  }
-	  http_reject {
-  	    reply_status = "400"
-	  }
-	}
-	condition {
-	  http_request_cookie {
-            cookie_name = "is"
-	    cookie_value = "brownie"
-	    match_type = "REGEX"
-	  }
-	}
+    display_name = "http_reject_test"
+    action {
+      http_reject {
+        reply_status = "404"
+      }
+      http_reject {
+        reply_status = "400"
+      }
+    }
+    condition {
+      http_request_cookie {
+        cookie_name  = "is"
+        cookie_value = "brownie"
+        match_type   = "REGEX"
+      }
+    }
   }
   rule {
-	display_name = "http_request_header_delete_test"
-	phase = "HTTP_REQUEST_REWRITE"
-	action {
-	  http_request_header_delete {
-	    header_name = "clever"
-	  }
-	  http_request_header_delete {
-	    header_name = "smart"
-	  }
-	}
-	condition {
-	  http_request_header {
-	    header_name = "my_head"
-	    header_value = "has_hair"
-	    match_type = "REGEX"
-	  }
-	}
+    display_name = "http_request_header_delete_test"
+    phase        = "HTTP_REQUEST_REWRITE"
+    action {
+      http_request_header_delete {
+        header_name = "clever"
+      }
+      http_request_header_delete {
+        header_name = "smart"
+      }
+    }
+    condition {
+      http_request_header {
+        header_name  = "my_head"
+        header_value = "has_hair"
+        match_type   = "REGEX"
+      }
+    }
   }
   rule {
-	display_name = "http_request_header_rewrite_test"
-	phase = "HTTP_REQUEST_REWRITE"
-	action {
-	  http_request_header_rewrite {
-	    header_name = "clever"
-	    header_value = "and"
-	  }
-	  http_request_header_rewrite {
-	    header_name = "smart"
-	    header_value = "!"
-	  }
-	}
-	condition {
-	  http_request_uri_arguments {
-	    uri_arguments = "foo=bar"
-	    match_type = "REGEX"
-	  }
-	  http_request_uri {
-	    uri = "xyz"
-	    match_type = "REGEX"
-	  }
-	}
+    display_name = "http_request_header_rewrite_test"
+    phase        = "HTTP_REQUEST_REWRITE"
+    action {
+      http_request_header_rewrite {
+        header_name  = "clever"
+        header_value = "and"
+      }
+      http_request_header_rewrite {
+        header_name  = "smart"
+        header_value = "!"
+      }
+    }
+    condition {
+      http_request_uri_arguments {
+        uri_arguments = "foo=bar"
+        match_type    = "REGEX"
+      }
+      http_request_uri {
+        uri        = "xyz"
+        match_type = "REGEX"
+      }
+    }
   }
   rule {
-	display_name = "http_request_uri_rewrite_test"
-	phase = "HTTP_REQUEST_REWRITE"
-	action {
-	  http_request_uri_rewrite {
-	    uri = "uri_test"
-	  }
-	  http_request_uri_rewrite {
-            uri = "uri_test2"
-	    uri_arguments = "foo=bar"
-	  }
-	}
-	condition {
-	  http_request_version {
-	    version = "HTTP_VERSION_1_0"
-	  }
-	}
+    display_name = "http_request_uri_rewrite_test"
+    phase        = "HTTP_REQUEST_REWRITE"
+    action {
+      http_request_uri_rewrite {
+        uri = "uri_test"
+      }
+      http_request_uri_rewrite {
+        uri           = "uri_test2"
+        uri_arguments = "foo=bar"
+      }
+    }
+    condition {
+      http_request_version {
+        version = "HTTP_VERSION_1_0"
+      }
+    }
   }
   rule {
-	display_name = "http_response_header_delete_test"
-	phase = "HTTP_RESPONSE_REWRITE"
-	action {
-	  http_response_header_delete {
-	    header_name = "clever"
-          }
-          http_response_header_delete {
-	    header_name = "smart"
-          }
-	}
-	condition {
-	  http_response_header {
-	    header_name = "clever"
-	    header_value = "smart"
-	    match_type = "REGEX"
-	  }
-	}
+    display_name = "http_response_header_delete_test"
+    phase        = "HTTP_RESPONSE_REWRITE"
+    action {
+      http_response_header_delete {
+        header_name = "clever"
+      }
+      http_response_header_delete {
+        header_name = "smart"
+      }
+    }
+    condition {
+      http_response_header {
+        header_name  = "clever"
+        header_value = "smart"
+        match_type   = "REGEX"
+      }
+    }
   }
   rule {
-	display_name = "http_response_header_rewrite_test"
-	phase = "HTTP_RESPONSE_REWRITE"
-	action {
-	  http_response_header_rewrite {
-	    header_name = "clever"
-	    header_value = "and"
-	  }
-	  http_response_header_rewrite {
-	    header_name = "smart"
-	    header_value = "!"
-	  }
-	}
-	condition {
-	  ip_header {
-	    source_address = "1.1.1.1"
-	  }
-	}
+    display_name = "http_response_header_rewrite_test"
+    phase        = "HTTP_RESPONSE_REWRITE"
+    action {
+      http_response_header_rewrite {
+        header_name  = "clever"
+        header_value = "and"
+      }
+      http_response_header_rewrite {
+        header_name  = "smart"
+        header_value = "!"
+      }
+    }
+    condition {
+      ip_header {
+        source_address = "1.1.1.1"
+      }
+    }
   }
   rule {
-	display_name = "select_pool_test"
-	phase = "HTTP_FORWARDING"
-	action {
-	  select_pool {
-            pool_id = nsxt_policy_lb_pool.pool.path
-	  }
-	}
-        condition {
-	  ssl_sni {
-	    match_type = "REGEX"
-	    sni = "HELO"
-	  }
-	}
+    display_name = "select_pool_test"
+    phase        = "HTTP_FORWARDING"
+    action {
+      select_pool {
+        pool_id = nsxt_policy_lb_pool.pool.path
+      }
+    }
+    condition {
+      ssl_sni {
+        match_type = "REGEX"
+        sni        = "HELO"
+      }
+    }
   }
   rule {
-	display_name = "variable_assignment_test"
-	phase = "HTTP_ACCESS"
-	action {
-	  variable_assignment {
-            variable_name = "foo"
-	    variable_value = "bar"
-	  }
-	}
-	condition {
-	  variable {
-	    variable_name = "my_var"
-	    variable_value = "my_value"
-	    match_type = "REGEX"
-	  }
-	  tcp_header {
-		source_port = "80"
-	  }
-	}
+    display_name = "variable_assignment_test"
+    phase        = "HTTP_ACCESS"
+    action {
+      variable_assignment {
+        variable_name  = "foo"
+        variable_value = "bar"
+      }
+    }
+    condition {
+      variable {
+        variable_name  = "my_var"
+        variable_value = "my_value"
+        match_type     = "REGEX"
+      }
+      tcp_header {
+        source_port = "80"
+      }
+    }
   }
   rule {
-	display_name = "variable_persistence_learn_test"
-	phase = "HTTP_RESPONSE_REWRITE"
-	action {
-	  variable_persistence_learn {
-            persistence_profile_path = data.nsxt_policy_lb_persistence_profile.generic.path
-	    variable_hash_enabled = true
-	    variable_name = "my_name"
-	  }
-	}
-	condition {
-	  http_ssl {
-	    session_reused = "IGNORE"
-	    used_protocol = "TLS_V1_2"
-	    used_ssl_cipher = "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
-	    client_certificate_issuer_dn {
-		  issuer_dn = "something"
-		  match_type = "REGEX"
-	    }
-	    client_certificate_subject_dn {
-		  subject_dn = "something"
-		  match_type = "REGEX"
-	    }
-	    client_supported_ssl_ciphers = [ "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256", "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384" ]
-	  }
-	}
+    display_name = "variable_persistence_learn_test"
+    phase        = "HTTP_RESPONSE_REWRITE"
+    action {
+      variable_persistence_learn {
+        persistence_profile_path = data.nsxt_policy_lb_persistence_profile.generic.path
+        variable_hash_enabled    = true
+        variable_name            = "my_name"
+      }
+    }
+    condition {
+      http_ssl {
+        session_reused  = "IGNORE"
+        used_protocol   = "TLS_V1_2"
+        used_ssl_cipher = "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+        client_certificate_issuer_dn {
+          issuer_dn  = "something"
+          match_type = "REGEX"
+        }
+        client_certificate_subject_dn {
+          subject_dn = "something"
+          match_type = "REGEX"
+        }
+        client_supported_ssl_ciphers = ["TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256", "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"]
+      }
+    }
   }
   rule {
-	display_name = "variable_persistence_learn_minimal_test"
-	phase = "HTTP_RESPONSE_REWRITE"
-	action {
-	  variable_persistence_learn {
-            persistence_profile_path = data.nsxt_policy_lb_persistence_profile.generic.path
-	    variable_name = "my_name"
-	  }
-	}
-	condition {
-	  http_ssl {
-	    used_protocol = "TLS_V1_2"
-	    used_ssl_cipher = "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
-	  }
-	}
+    display_name = "variable_persistence_learn_minimal_test"
+    phase        = "HTTP_RESPONSE_REWRITE"
+    action {
+      variable_persistence_learn {
+        persistence_profile_path = data.nsxt_policy_lb_persistence_profile.generic.path
+        variable_name            = "my_name"
+      }
+    }
+    condition {
+      http_ssl {
+        used_protocol   = "TLS_V1_2"
+        used_ssl_cipher = "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+      }
+    }
   }
   rule {
-	display_name = "variable_persistence_on_test"
-	phase = "HTTP_FORWARDING"
-	action {
-	  variable_persistence_on {
-            persistence_profile_path = data.nsxt_policy_lb_persistence_profile.generic.path
-	    variable_hash_enabled = false
-	    variable_name = "my_name"
-	  }
-	}
+    display_name = "variable_persistence_on_test"
+    phase        = "HTTP_FORWARDING"
+    action {
+      variable_persistence_on {
+        persistence_profile_path = data.nsxt_policy_lb_persistence_profile.generic.path
+        variable_hash_enabled    = false
+        variable_name            = "my_name"
+      }
+    }
   }
   rule {
-	display_name = "jwt_auth_test"
-	phase = "HTTP_ACCESS"
-	action {
-	  jwt_auth {
-	    key {
-	  	  // one of ...
-		  public_key_content = "xxx"
-		  //certificate_path = "/path/to/cert"
-		  // this one only indicates presence, the value is discarded
-		  //symmetric_key = "dummy_value"
-	    }
-	    pass_jwt_to_pool = true
-	    realm = "realm"
-	    // only one token allowed currently
-	    tokens = [ "a" ]
-	  }
-	}
+    display_name = "jwt_auth_test"
+    phase        = "HTTP_ACCESS"
+    action {
+      jwt_auth {
+        key {
+          // one of ...
+          public_key_content = "xxx"
+          //certificate_path = "/path/to/cert"
+          // this one only indicates presence, the value is discarded
+          //symmetric_key = "dummy_value"
+        }
+        pass_jwt_to_pool = true
+        realm            = "realm"
+        // only one token allowed currently
+        tokens = ["a"]
+      }
+    }
   }
 }
 

--- a/nsxt/resource_nsxt_policy_ldap_identity_source_test.go
+++ b/nsxt/resource_nsxt_policy_ldap_identity_source_test.go
@@ -173,28 +173,28 @@ func testAccNsxtPolicyLdapIdentitySourceCreate(serverType, domainName, baseDn, b
 	attrMap := accTestPolicyLdapIdentitySourceCreateAttributes
 	return fmt.Sprintf(`
 resource "nsxt_policy_ldap_identity_source" "test" {
-    nsx_id       = "%s"
-    description  = "%s"
-    type         = "%s"
-    domain_name  = "%s"
-    base_dn      = "%s"
+  nsx_id      = "%s"
+  description = "%s"
+  type        = "%s"
+  domain_name = "%s"
+  base_dn     = "%s"
 
-    ldap_server {
-        bind_identity = "%s"
-        password      = "%s"
-        url           = "%s"
-        certificates  = [
-            <<-EOT
+  ldap_server {
+    bind_identity = "%s"
+    password      = "%s"
+    url           = "%s"
+    certificates = [
+      <<-EOT
 %s
             EOT
-            ,
-        ]
-    }
+      ,
+    ]
+  }
 
-    tag {
-        scope = "scope1"
-        tag = "tag1"
-    }
+  tag {
+    scope = "scope1"
+    tag   = "tag1"
+  }
 }`, attrMap["nsx_id"], attrMap["description"], serverType, domainName, baseDn, bindUser, bindPwd, url, cert)
 }
 
@@ -202,22 +202,22 @@ func testAccNsxtPolicyLdapIdentitySourceUpdate(serverType, domainName, baseDn, b
 	attrMap := accTestPolicyLdapIdentitySourceUpdateAttributes
 	return fmt.Sprintf(`
 resource "nsxt_policy_ldap_identity_source" "test" {
-    nsx_id       = "%s"
-    description  = "%s"
-    type         = "%s"
-    domain_name  = "%s"
-    base_dn      = "%s"
+  nsx_id      = "%s"
+  description = "%s"
+  type        = "%s"
+  domain_name = "%s"
+  base_dn     = "%s"
 
-    ldap_server {
-        bind_identity = "%s"
-        password      = "%s"
-        url           = "%s"
-        certificates  = [
-            <<-EOT
+  ldap_server {
+    bind_identity = "%s"
+    password      = "%s"
+    url           = "%s"
+    certificates = [
+      <<-EOT
 %s
             EOT
-            ,
-        ]
-    }
+      ,
+    ]
+  }
 }`, attrMap["nsx_id"], attrMap["description"], serverType, domainName, baseDn, bindUser, bindPwd, url, cert)
 }

--- a/nsxt/resource_nsxt_policy_nat_rule_test.go
+++ b/nsxt/resource_nsxt_policy_nat_rule_test.go
@@ -532,11 +532,11 @@ func testAccNsxtPolicyNATRuleTier0MinimalCreateTemplate(name, sourceNet, transla
 	return testAccNsxtPolicyEdgeClusterReadTemplate(getEdgeClusterName()) +
 		testAccNsxtPolicyTier0WithEdgeClusterTemplate("test", false) + fmt.Sprintf(`
 resource "nsxt_policy_nat_rule" "test" {
-  display_name         = "%s"
-  gateway_path         = nsxt_policy_tier0_gateway.test.path
-  action               = "%s"
-  source_networks      = ["%s"]
-  translated_networks  = ["%s"]
+  display_name        = "%s"
+  gateway_path        = nsxt_policy_tier0_gateway.test.path
+  action              = "%s"
+  source_networks     = ["%s"]
+  translated_networks = ["%s"]
 }
 `, name, model.PolicyNatRule_ACTION_REFLEXIVE, sourceNet, translatedNet)
 }
@@ -549,15 +549,15 @@ data "nsxt_policy_service" "test" {
 }
 
 resource "nsxt_policy_nat_rule" "test" {
-  display_name          = "%s"
-  type                  = "%s"
-  description           = "Acceptance Test"
-  gateway_path          = nsxt_policy_tier1_gateway.test.path
-  action                = "%s"
-  source_networks       = ["%s"]
-  destination_networks  = ["%s"]
-  translated_networks   = ["44.11.11.2"]
-  service               = data.nsxt_policy_service.test.path
+  display_name         = "%s"
+  type                 = "%s"
+  description          = "Acceptance Test"
+  gateway_path         = nsxt_policy_tier1_gateway.test.path
+  action               = "%s"
+  source_networks      = ["%s"]
+  destination_networks = ["%s"]
+  translated_networks  = ["44.11.11.2"]
+  service              = data.nsxt_policy_service.test.path
 }
 `, name, natType, action, srcIP, dstIP)
 }
@@ -575,16 +575,16 @@ data "nsxt_policy_service" "test" {
 
 resource "nsxt_policy_nat_rule" "test" {
 %s
-  display_name          = "%s"
-  description           = "Acceptance Test"
-  gateway_path          = nsxt_policy_tier1_gateway.test.path
-  action                = "%s"
-  source_networks       = ["%s"]
-  destination_networks  = ["%s"]
-  translated_networks   = ["%s"]
-  logging               = false
-  firewall_match        = "%s"
-  service               = data.nsxt_policy_service.test.path
+  display_name         = "%s"
+  description          = "Acceptance Test"
+  gateway_path         = nsxt_policy_tier1_gateway.test.path
+  action               = "%s"
+  source_networks      = ["%s"]
+  destination_networks = ["%s"]
+  translated_networks  = ["%s"]
+  logging              = false
+  firewall_match       = "%s"
+  service              = data.nsxt_policy_service.test.path
 
   tag {
     scope = "scope1"
@@ -646,15 +646,15 @@ func testAccNsxtPolicyNATRuleTier1UpdateMultipleSourceNetworksTemplate(name stri
 		testAccNsxtPolicyTier1WithEdgeClusterTemplate("test", false, withContext) + fmt.Sprintf(`
 resource "nsxt_policy_nat_rule" "test" {
 %s
-  display_name          = "%s"
-  description           = "Acceptance Test"
-  gateway_path          = nsxt_policy_tier1_gateway.test.path
-  action                = "%s"
-  source_networks       = ["%s", "%s"]
-  destination_networks  = ["%s"]
-  translated_networks   = ["%s"]
-  logging               = false
-  firewall_match        = "%s"
+  display_name         = "%s"
+  description          = "Acceptance Test"
+  gateway_path         = nsxt_policy_tier1_gateway.test.path
+  action               = "%s"
+  source_networks      = ["%s", "%s"]
+  destination_networks = ["%s"]
+  translated_networks  = ["%s"]
+  logging              = false
+  firewall_match       = "%s"
 
   tag {
     scope = "scope1"
@@ -707,15 +707,15 @@ resource "nsxt_policy_tier0_gateway_interface" "test" {
 }
 
 resource "nsxt_policy_nat_rule" "test" {
-  display_name          = "%s"
-  description           = "Acceptance Test"
-  gateway_path          = nsxt_policy_tier0_gateway.test.path
-  action                = "%s"
-  source_networks       = ["%s"]
-  translated_networks   = ["%s"]
-  logging               = false
-  firewall_match        = "%s"
-  scope                 = [nsxt_policy_tier0_gateway_interface.test[1].path, nsxt_policy_tier0_gateway_interface.test[0].path]
+  display_name        = "%s"
+  description         = "Acceptance Test"
+  gateway_path        = nsxt_policy_tier0_gateway.test.path
+  action              = "%s"
+  source_networks     = ["%s"]
+  translated_networks = ["%s"]
+  logging             = false
+  firewall_match      = "%s"
+  scope               = [nsxt_policy_tier0_gateway_interface.test[1].path, nsxt_policy_tier0_gateway_interface.test[0].path]
 
   tag {
     scope = "scope1"
@@ -728,31 +728,32 @@ resource "nsxt_policy_nat_rule" "test" {
   }
 }
 
+
 `, interfaceSite, name, action, sourceNet, translatedNet, model.PolicyNatRule_FIREWALL_MATCH_MATCH_EXTERNAL_ADDRESS)
 }
 
 func testAccNsxPolicyNatRuleNoTranslatedNetworkTemplate(name string, action string, sourceNet string, destNet string) string {
 	return testAccNsxtPolicyEdgeClusterReadTemplate(getEdgeClusterName()) +
 		testAccNsxtPolicyTier1WithEdgeClusterTemplate("test", false, false) + fmt.Sprintf(`
-	resource "nsxt_policy_nat_rule" "test" {
-	  display_name          = "%s"
-	  description           = "Acceptance Test"
-	  gateway_path          = nsxt_policy_tier1_gateway.test.path
-	  action                = "%s"
-	  source_networks       = ["%s"]
-	  destination_networks  = ["%s"]
-	  logging               = false
-	  firewall_match        = "%s"
+resource "nsxt_policy_nat_rule" "test" {
+  display_name         = "%s"
+  description          = "Acceptance Test"
+  gateway_path         = nsxt_policy_tier1_gateway.test.path
+  action               = "%s"
+  source_networks      = ["%s"]
+  destination_networks = ["%s"]
+  logging              = false
+  firewall_match       = "%s"
 
-	  tag {
-		scope = "scope1"
-		tag   = "tag1"
-	  }
+  tag {
+    scope = "scope1"
+    tag   = "tag1"
+  }
 
-	  tag {
-		scope = "scope2"
-		tag   = "tag2"
-	  }
-	}
+  tag {
+    scope = "scope2"
+    tag   = "tag2"
+  }
+}
 	`, name, action, sourceNet, destNet, model.PolicyNatRule_FIREWALL_MATCH_MATCH_EXTERNAL_ADDRESS)
 }

--- a/nsxt/resource_nsxt_policy_parent_security_policy_test.go
+++ b/nsxt/resource_nsxt_policy_parent_security_policy_test.go
@@ -150,7 +150,7 @@ resource "nsxt_policy_parent_security_policy" "test" {
 %s
   display_name    = "%s"
   description     = "Acceptance Test"
-  domain = "default"
+  domain          = "default"
   category        = "Application"
   locked          = %s
   sequence_number = %s

--- a/nsxt/resource_nsxt_policy_predefined_gateway_policy_test.go
+++ b/nsxt/resource_nsxt_policy_predefined_gateway_policy_test.go
@@ -161,8 +161,9 @@ func testAccNsxtPolicyPredefinedGatewayPolicyPrerequisites() string {
 
 	return testAccNsxtPolicyEdgeClusterReadTemplate(getEdgeClusterName()) + fmt.Sprintf(`
 
+
 resource "nsxt_policy_tier0_gateway" "test" {
-  display_name      = "predefined-gw-policy-test"
+  display_name = "predefined-gw-policy-test"
   %s
 }
 
@@ -177,9 +178,10 @@ func testAccNsxtPolicyPredefinedGatewayPolicyPrerequisitesMultitenancy() string 
 	context := testAccNsxtPolicyMultitenancyContext()
 	return testAccNsxtPolicyEdgeClusterReadTemplate(getEdgeClusterName()) + fmt.Sprintf(`
 
+
 resource "nsxt_policy_tier1_gateway" "test" {
 %s
-  display_name      = "predefined-gw-policy-test"
+  display_name = "predefined-gw-policy-test"
   %s
 }
 
@@ -214,13 +216,13 @@ resource "nsxt_policy_predefined_gateway_policy" "test" {
 func testAccNsxtPolicyPredefinedGatewayPolicyDefaultRule(description string, action string, label string, tags string) string {
 	return testAccNsxtPolicyPredefinedGatewayPolicyPrerequisites() + fmt.Sprintf(`
 resource "nsxt_policy_predefined_gateway_policy" "test" {
-  path        = data.nsxt_policy_gateway_policy.test.path
+  path = data.nsxt_policy_gateway_policy.test.path
   default_rule {
-    scope        = nsxt_policy_tier0_gateway.test.path
-    description  = "%s"
-    action       = "%s"
-    log_label    = "%s"
-    logged       = true
+    scope       = nsxt_policy_tier0_gateway.test.path
+    description = "%s"
+    action      = "%s"
+    log_label   = "%s"
+    logged      = true
     %s
   }
 }`, description, action, label, tags)

--- a/nsxt/resource_nsxt_policy_predefined_security_policy_test.go
+++ b/nsxt/resource_nsxt_policy_predefined_security_policy_test.go
@@ -215,10 +215,10 @@ func testAccNsxtPolicyPredefinedSecurityPolicyDefaultRule(description string, ac
 resource "nsxt_policy_predefined_security_policy" "test" {
   path = data.nsxt_policy_security_policy.test.path
   default_rule {
-    description  = "%s"
-    action       = "%s"
-    log_label    = "%s"
-    logged       = true
+    description = "%s"
+    action      = "%s"
+    log_label   = "%s"
+    logged      = true
     %s
   }
 }`, description, action, label, tags)
@@ -230,11 +230,11 @@ resource "nsxt_policy_predefined_security_policy" "test" {
   path = data.nsxt_policy_security_policy.test.path
 
   rule {
-      display_name  = "rule2"
-      source_groups = [nsxt_policy_group.group2.path]
-      log_label     = "group2"
-      action        = "ALLOW"
-      disabled      = true
+    display_name  = "rule2"
+    source_groups = [nsxt_policy_group.group2.path]
+    log_label     = "group2"
+    action        = "ALLOW"
+    disabled      = true
   }
 }`
 }
@@ -245,17 +245,17 @@ resource "nsxt_policy_predefined_security_policy" "test" {
   path = data.nsxt_policy_security_policy.test.path
 
   rule {
-      display_name  = "rule1"
-      source_groups = [nsxt_policy_group.group1.path]
-      log_label     = "group1"
-      action        = "DROP"
+    display_name  = "rule1"
+    source_groups = [nsxt_policy_group.group1.path]
+    log_label     = "group1"
+    action        = "DROP"
   }
   rule {
-      display_name  = "rule2"
-      source_groups = [nsxt_policy_group.group2.path]
-      log_label     = "group2"
-      action        = "ALLOW"
-      disabled      = false
+    display_name  = "rule2"
+    source_groups = [nsxt_policy_group.group2.path]
+    log_label     = "group2"
+    action        = "ALLOW"
+    disabled      = false
   }
 }`
 }
@@ -266,14 +266,14 @@ resource "nsxt_policy_predefined_security_policy" "test" {
   path = data.nsxt_policy_security_policy.test.path
 
   rule {
-      display_name  = "rule2"
-      source_groups = [nsxt_policy_group.group1.path, nsxt_policy_group.group2.path]
-      log_label     = "group2"
-      action        = "ALLOW"
+    display_name  = "rule2"
+    source_groups = [nsxt_policy_group.group1.path, nsxt_policy_group.group2.path]
+    log_label     = "group2"
+    action        = "ALLOW"
   }
 
   default_rule {
-      action = "REJECT"
+    action = "REJECT"
   }
 }`
 }

--- a/nsxt/resource_nsxt_policy_qos_profile_test.go
+++ b/nsxt/resource_nsxt_policy_qos_profile_test.go
@@ -279,7 +279,7 @@ func testAccNSXPolicyQosProfileEmptyTemplate(name string, withContext bool) stri
 	return fmt.Sprintf(`
 resource "nsxt_policy_qos_profile" "test" {
 %s
-  display_name     = "%s"
+  display_name = "%s"
 }
 `, context, name)
 }

--- a/nsxt/resource_nsxt_policy_role_binding_test.go
+++ b/nsxt/resource_nsxt_policy_role_binding_test.go
@@ -248,23 +248,23 @@ func testAccNsxtPolicyRoleBindingCreate(user, userType, identType, overwrite, de
 
 	return fmt.Sprintf(`
 resource "nsxt_policy_user_management_role_binding" "test" {
-    display_name         = "%s"
-    description          = "%s"
-    name                 = "%s"
-    type                 = "%s"
-    overwrite_local_user = %s
+  display_name         = "%s"
+  description          = "%s"
+  name                 = "%s"
+  type                 = "%s"
+  overwrite_local_user = %s
     %s
     %s
 
-    roles_for_path {
-        path  = "/"
-        roles = ["network_engineer"]
-    }
+  roles_for_path {
+    path  = "/"
+    roles = ["network_engineer"]
+  }
 
-    roles_for_path {
-        path  = "/orgs/default"
-        roles = ["org_admin"]
-    }
+  roles_for_path {
+    path  = "/orgs/default"
+    roles = ["org_admin"]
+  }
 }`, attrMap["display_name"], attrMap["description"], user, userType, overwrite, identLine, dependsOnLine)
 }
 
@@ -279,17 +279,17 @@ func testAccNsxtPolicyRoleBindingUpdate(user, userType, identType, overwrite, de
 	}
 	return fmt.Sprintf(`
 resource "nsxt_policy_user_management_role_binding" "test" {
-    display_name         = "%s"
-    description          = "%s"
-    name                 = "%s"
-    type                 = "%s"
-    overwrite_local_user = %s
+  display_name         = "%s"
+  description          = "%s"
+  name                 = "%s"
+  type                 = "%s"
+  overwrite_local_user = %s
     %s
     %s
 
-    roles_for_path {
-        path  = "/"
-        roles = ["security_engineer"]
-    }
+  roles_for_path {
+    path  = "/"
+    roles = ["security_engineer"]
+  }
 }`, attrMap["display_name"], attrMap["description"], user, userType, overwrite, identLine, dependsOnLine)
 }

--- a/nsxt/resource_nsxt_policy_role_test.go
+++ b/nsxt/resource_nsxt_policy_role_test.go
@@ -162,20 +162,20 @@ func testAccNsxtPolicyRoleCreate(role string) string {
 	return fmt.Sprintf(`
 resource "nsxt_policy_user_management_role" "test_role" {
   display_name = "%s"
-  description = "%s"
-  role = "%s"
+  description  = "%s"
+  role         = "%s"
   feature {
-    feature = "policy_grouping"
+    feature    = "policy_grouping"
     permission = "read"
   }
 
   feature {
-    feature = "vm_vm_info"
+    feature    = "vm_vm_info"
     permission = "read"
   }
 
   feature {
-    feature = "policy_services"
+    feature    = "policy_services"
     permission = "read"
   }
 }`, attrMap["display_name"], attrMap["description"], role)
@@ -186,15 +186,15 @@ func testAccNsxtPolicyRoleUpdate(role string) string {
 	return fmt.Sprintf(`
 resource "nsxt_policy_user_management_role" "test_role" {
   display_name = "%s"
-  description = "%s"
-  role = "%s"
+  description  = "%s"
+  role         = "%s"
   feature {
-    feature = "policy_grouping"
+    feature    = "policy_grouping"
     permission = "crud"
   }
 
   feature {
-    feature = "vm_vm_info"
+    feature    = "vm_vm_info"
     permission = "crud"
   }
 }`, attrMap["display_name"], attrMap["description"], role)

--- a/nsxt/resource_nsxt_policy_security_policy_rule_test.go
+++ b/nsxt/resource_nsxt_policy_security_policy_rule_test.go
@@ -289,15 +289,15 @@ resource "nsxt_policy_security_policy_rule" "%s" {
   service_entries {
     igmp_entry {
     }
-    
+
     l4_port_set_entry {
       protocol          = "TCP"
-      destination_ports = [ "443" ]
+      destination_ports = ["443"]
     }
 
     l4_port_set_entry {
       protocol          = "TCP"
-      destination_ports = [ "80" ]
+      destination_ports = ["80"]
     }
   }
 

--- a/nsxt/resource_nsxt_policy_security_policy_test.go
+++ b/nsxt/resource_nsxt_policy_security_policy_test.go
@@ -792,11 +792,11 @@ func testAccNsxtPolicySecurityPolicyWithEthernetRule(name string, direction stri
 	if domainName == defaultDomain {
 		return fmt.Sprintf(`
 resource "nsxt_policy_security_policy" "test" {
-  display_name    = "%s"
-  description     = "Acceptance Test"
-  category        = "Ethernet"
-  locked          = false
-  stateful        = false
+  display_name = "%s"
+  description  = "Acceptance Test"
+  category     = "Ethernet"
+  locked       = false
+  stateful     = false
 
   tag {
     scope = "color"
@@ -834,10 +834,10 @@ resource "nsxt_policy_security_policy" "test" {
   }
 
   rule {
-    display_name = "%s"
-    direction    = "%s"
-    ip_version   = "%s"
-    log_label    = "%s"
+    display_name  = "%s"
+    direction     = "%s"
+    ip_version    = "%s"
+    log_label     = "%s"
     source_groups = [nsxt_policy_group.test.path]
 
     tag {
@@ -860,18 +860,18 @@ resource "nsxt_policy_group" "group2" {
 }
 
 resource "nsxt_policy_service" "icmp" {
-    display_name = "security-policy-test-icmp"
-    icmp_entry {
-        protocol = "ICMPv4"
-    }
+  display_name = "security-policy-test-icmp"
+  icmp_entry {
+    protocol = "ICMPv4"
+  }
 }
 
 resource "nsxt_policy_service" "tcp778" {
-    display_name = "security-policy-test-tcp"
-    l4_port_set_entry {
-        protocol          = "TCP"
-        destination_ports = [ "778" ]
-    }
+  display_name = "security-policy-test-tcp"
+  l4_port_set_entry {
+    protocol          = "TCP"
+    destination_ports = ["778"]
+  }
 }`
 }
 
@@ -944,78 +944,78 @@ resource "nsxt_policy_security_policy" "test" {
 
 func testAccNsxtPolicySecurityPolicyWithIPCidrRange(name string, destIP string, destCidr string, destIPRange string, sourceIP string, sourceCidr string, sourceIPRange string) string {
 	return testAccNsxtPolicySecurityPolicyDeps() + fmt.Sprintf(`
-	resource "nsxt_policy_security_policy" "test" {
-		display_name    = "%s"
-		description     = "Acceptance Test"
-		category        = "Application"
-		sequence_number = 3
-		locked          = false
-		stateful        = true
-		tcp_strict      = false
+resource "nsxt_policy_security_policy" "test" {
+  display_name    = "%s"
+  description     = "Acceptance Test"
+  category        = "Application"
+  sequence_number = 3
+  locked          = false
+  stateful        = true
+  tcp_strict      = false
 
-		tag {
-		  scope = "color"
-		  tag   = "orange"
-		}
+  tag {
+    scope = "color"
+    tag   = "orange"
+  }
 
-		rule {
-		  display_name          = "rule1"
-		  source_groups         = [nsxt_policy_group.group1.path]
-		  destination_groups    = ["%s"]
-		  services              = [nsxt_policy_service.icmp.path]
-		  action                = "ALLOW"
-		}
+  rule {
+    display_name       = "rule1"
+    source_groups      = [nsxt_policy_group.group1.path]
+    destination_groups = ["%s"]
+    services           = [nsxt_policy_service.icmp.path]
+    action             = "ALLOW"
+  }
 
-		rule {
-		  display_name          = "rule2"
-		  source_groups         = [nsxt_policy_group.group1.path]			
-		  destination_groups    = ["%s"]
-	          services              = [nsxt_policy_service.icmp.path]
-		  action                = "ALLOW"
-		}
+  rule {
+    display_name       = "rule2"
+    source_groups      = [nsxt_policy_group.group1.path]
+    destination_groups = ["%s"]
+    services           = [nsxt_policy_service.icmp.path]
+    action             = "ALLOW"
+  }
 
-		rule {
-		  display_name          = "rule3"
-		  source_groups         = [nsxt_policy_group.group1.path]
-		  destination_groups    = ["%s"]
-		  services              = [nsxt_policy_service.icmp.path]
-		  action                = "ALLOW"
-		  sequence_number       = 50
-		}
-		rule {
-		  display_name          = "rule4"
-		  source_groups         = ["%s"]
-		  destination_groups    = [nsxt_policy_group.group2.path]
-		  services              = [nsxt_policy_service.icmp.path]
-		  action                = "ALLOW"
-		}
+  rule {
+    display_name       = "rule3"
+    source_groups      = [nsxt_policy_group.group1.path]
+    destination_groups = ["%s"]
+    services           = [nsxt_policy_service.icmp.path]
+    action             = "ALLOW"
+    sequence_number    = 50
+  }
+  rule {
+    display_name       = "rule4"
+    source_groups      = ["%s"]
+    destination_groups = [nsxt_policy_group.group2.path]
+    services           = [nsxt_policy_service.icmp.path]
+    action             = "ALLOW"
+  }
 
-		rule {
-		  display_name          = "rule5"
-		  source_groups         = ["%s"]			
-		  destination_groups    = [nsxt_policy_group.group2.path]
-		  services              = [nsxt_policy_service.icmp.path]
-		  action                = "ALLOW"
-		  sequence_number       = 105
-                }
+  rule {
+    display_name       = "rule5"
+    source_groups      = ["%s"]
+    destination_groups = [nsxt_policy_group.group2.path]
+    services           = [nsxt_policy_service.icmp.path]
+    action             = "ALLOW"
+    sequence_number    = 105
+  }
 
-		rule {
-		  display_name          = "rule6"
-		  source_groups         = ["%s"]
-		  destination_groups    = [nsxt_policy_group.group2.path]
-		  service_entries {
-		    icmp_entry {
-			display_name = "test"
-			icmp_type    = "3"
-			protocol     = "ICMPv4"
-		    }
-		    l4_port_set_entry {
-			protocol          = "TCP"
-			destination_ports = ["8000-8080"]
-		    }
-		  }
-		  action                = "ALLOW"
-		}
+  rule {
+    display_name       = "rule6"
+    source_groups      = ["%s"]
+    destination_groups = [nsxt_policy_group.group2.path]
+    service_entries {
+      icmp_entry {
+        display_name = "test"
+        icmp_type    = "3"
+        protocol     = "ICMPv4"
+      }
+      l4_port_set_entry {
+        protocol          = "TCP"
+        destination_ports = ["8000-8080"]
+      }
+    }
+    action = "ALLOW"
+  }
 }`, name, destIP, destCidr, destIPRange, sourceIP, sourceCidr, sourceIPRange)
 }
 

--- a/nsxt/resource_nsxt_policy_segment_security_profile_test.go
+++ b/nsxt/resource_nsxt_policy_segment_security_profile_test.go
@@ -249,17 +249,17 @@ func testAccNsxtPolicySegmentSecurityProfileTemplate(createFlow, withContext boo
 	return fmt.Sprintf(`
 resource "nsxt_policy_segment_security_profile" "test" {
 %s
-  display_name = "%s"
-  description  = "%s"
-  bpdu_filter_allow = ["%s"]
-  bpdu_filter_enable = %s
-  dhcp_client_block_enabled = %s
+  display_name                 = "%s"
+  description                  = "%s"
+  bpdu_filter_allow            = ["%s"]
+  bpdu_filter_enable           = %s
+  dhcp_client_block_enabled    = %s
   dhcp_client_block_v6_enabled = %s
-  dhcp_server_block_enabled = %s
+  dhcp_server_block_enabled    = %s
   dhcp_server_block_v6_enabled = %s
   non_ip_traffic_block_enabled = %s
-  ra_guard_enabled = %s
-  rate_limits_enabled = %s
+  ra_guard_enabled             = %s
+  rate_limits_enabled          = %s
 
   rate_limit {
     rx_broadcast = %s

--- a/nsxt/resource_nsxt_policy_segment_test.go
+++ b/nsxt/resource_nsxt_policy_segment_test.go
@@ -604,13 +604,13 @@ func testAccNsxtPolicySegmentImportTemplate(tzName string, name string, withCont
 	return testAccNsxtPolicySegmentDeps(tzName, withContext) + fmt.Sprintf(`
 resource "nsxt_policy_segment" "test" {
 %s
-  display_name        = "%s"
-  description         = "Acceptance Test"
-  connectivity_path   = nsxt_policy_tier1_gateway.tier1ForSegments.path
+  display_name      = "%s"
+  description       = "Acceptance Test"
+  connectivity_path = nsxt_policy_tier1_gateway.tier1ForSegments.path
   %s
 
   subnet {
-     cidr = "12.12.2.1/24"
+    cidr = "12.12.2.1/24"
   }
 }
 `, context, name, tzSetting)
@@ -618,6 +618,7 @@ resource "nsxt_policy_segment" "test" {
 
 func testAccNsxtPolicySegmentBasicTemplate(tzName string, name string) string {
 	return testAccNsxtPolicySegmentDeps(tzName, false) + fmt.Sprintf(`
+
 
 resource "nsxt_policy_segment" "test" {
   display_name        = "%s"
@@ -628,7 +629,7 @@ resource "nsxt_policy_segment" "test" {
   connectivity_path   = nsxt_policy_tier1_gateway.tier1ForSegments.path
 
   subnet {
-     cidr = "12.12.2.1/24"
+    cidr = "12.12.2.1/24"
   }
 
   tag {
@@ -642,6 +643,7 @@ resource "nsxt_policy_segment" "test" {
 func testAccNsxtPolicySegmentIgnoreTagsCreateTemplate(tzName string, name string) string {
 	return testAccNsxtPolicySegmentDeps(tzName, false) + fmt.Sprintf(`
 
+
 resource "nsxt_policy_segment" "test" {
   display_name        = "%s"
   overlay_id          = 1011
@@ -649,7 +651,7 @@ resource "nsxt_policy_segment" "test" {
   connectivity_path   = nsxt_policy_tier1_gateway.tier1ForSegments.path
 
   subnet {
-     cidr = "12.12.2.1/24"
+    cidr = "12.12.2.1/24"
   }
 
   tag {
@@ -673,6 +675,7 @@ resource "nsxt_policy_segment" "test" {
 func testAccNsxtPolicySegmentIgnoreTagsUpdate1Template(tzName string, name string) string {
 	return testAccNsxtPolicySegmentDeps(tzName, false) + fmt.Sprintf(`
 
+
 resource "nsxt_policy_segment" "test" {
   display_name        = "%s"
   overlay_id          = 1011
@@ -680,7 +683,7 @@ resource "nsxt_policy_segment" "test" {
   connectivity_path   = nsxt_policy_tier1_gateway.tier1ForSegments.path
 
   subnet {
-     cidr = "12.12.2.1/24"
+    cidr = "12.12.2.1/24"
   }
 
   tag {
@@ -708,6 +711,7 @@ resource "nsxt_policy_segment" "test" {
 func testAccNsxtPolicySegmentIgnoreTagsUpdate2Template(tzName string, name string) string {
 	return testAccNsxtPolicySegmentDeps(tzName, false) + fmt.Sprintf(`
 
+
 resource "nsxt_policy_segment" "test" {
   display_name        = "%s"
   overlay_id          = 1011
@@ -715,7 +719,7 @@ resource "nsxt_policy_segment" "test" {
   connectivity_path   = nsxt_policy_tier1_gateway.tier1ForSegments.path
 
   subnet {
-     cidr = "12.12.2.1/24"
+    cidr = "12.12.2.1/24"
   }
 
   tag {
@@ -738,6 +742,7 @@ resource "nsxt_policy_segment" "test" {
 func testAccNsxtPolicySegmentIgnoreTagsUpdate3Template(tzName string, name string) string {
 	return testAccNsxtPolicySegmentDeps(tzName, false) + fmt.Sprintf(`
 
+
 resource "nsxt_policy_segment" "test" {
   display_name        = "%s"
   overlay_id          = 1011
@@ -745,14 +750,14 @@ resource "nsxt_policy_segment" "test" {
   connectivity_path   = nsxt_policy_tier1_gateway.tier1ForSegments.path
 
   subnet {
-     cidr = "12.12.2.1/24"
+    cidr = "12.12.2.1/24"
   }
 
   tag {
     scope = "color"
     tag   = "blue"
   }
- 
+
   tag {
     scope = "rack"
     tag   = "7"
@@ -764,6 +769,7 @@ resource "nsxt_policy_segment" "test" {
 func testAccNsxtPolicySegmentBasicUpdateTemplate(tzName string, name string) string {
 	return testAccNsxtPolicySegmentDeps(tzName, false) + fmt.Sprintf(`
 
+
 resource "nsxt_policy_segment" "test" {
   display_name        = "%s"
   description         = "Acceptance Test2"
@@ -773,7 +779,7 @@ resource "nsxt_policy_segment" "test" {
   connectivity_path   = nsxt_policy_tier1_gateway.tier1ForSegments.path
 
   subnet {
-     cidr = "22.22.22.1/24"
+    cidr = "22.22.22.1/24"
   }
 
   tag {
@@ -791,6 +797,7 @@ resource "nsxt_policy_segment" "test" {
 func testAccNsxtPolicySegmentUpdateConnectivityTemplate(tzName string, name string) string {
 	return testAccNsxtPolicySegmentDeps(tzName, false) + fmt.Sprintf(`
 
+
 resource "nsxt_policy_segment" "test" {
   display_name        = "%s"
   description         = "Acceptance Test2"
@@ -800,7 +807,7 @@ resource "nsxt_policy_segment" "test" {
   connectivity_path   = nsxt_policy_tier1_gateway.anotherTier1ForSegments.path
 
   subnet {
-     cidr = "22.22.22.1/24"
+    cidr = "22.22.22.1/24"
   }
 
   tag {
@@ -818,24 +825,25 @@ resource "nsxt_policy_segment" "test" {
 func testAccNsxtPolicySegmentWithProfileDeps(tzName string) string {
 	return testAccNSXPolicyTransportZoneReadTemplate(tzName, false, true) + fmt.Sprintf(`
 data "nsxt_policy_qos_profile" "test" {
-    display_name = "%s"
+  display_name = "%s"
 }
 
 data "nsxt_policy_segment_security_profile" "test" {
-    display_name = "default-segment-security-profile"
+  display_name = "default-segment-security-profile"
 }
 
 data "nsxt_policy_spoofguard_profile" "test" {
-    display_name = "default-spoofguard-profile"
+  display_name = "default-spoofguard-profile"
 }
 
 data "nsxt_policy_ip_discovery_profile" "test" {
-    display_name = "default-ip-discovery-profile"
+  display_name = "default-ip-discovery-profile"
 }
 
 data "nsxt_policy_mac_discovery_profile" "test" {
-    display_name = "default-mac-discovery-profile"
+  display_name = "default-mac-discovery-profile"
 }
+
 
 `, testAccSegmentQosProfileName)
 }
@@ -862,6 +870,7 @@ resource "nsxt_policy_segment" "test" {
 func testAccNsxtPolicySegmentWithProfilesUpdateTemplate(tzName string, name string) string {
 	return testAccNsxtPolicySegmentWithProfileDeps(tzName) + fmt.Sprintf(`
 
+
 resource "nsxt_policy_segment" "test" {
   display_name        = "%s"
   transport_zone_path = data.nsxt_policy_transport_zone.test.path
@@ -872,8 +881,8 @@ resource "nsxt_policy_segment" "test" {
   }
 
   discovery_profile {
-    ip_discovery_profile_path = data.nsxt_policy_ip_discovery_profile.test.path
-    mac_discovery_profile_path   = data.nsxt_policy_mac_discovery_profile.test.path
+    ip_discovery_profile_path  = data.nsxt_policy_ip_discovery_profile.test.path
+    mac_discovery_profile_path = data.nsxt_policy_mac_discovery_profile.test.path
   }
 }
 `, name)
@@ -925,6 +934,7 @@ resource "nsxt_policy_segment" "test" {
 func testAccNsxtPolicySegmentBasicAdvConfigTemplate(tzName string, name string) string {
 	return testAccNsxtPolicySegmentDeps(tzName, false) + fmt.Sprintf(`
 
+
 resource "nsxt_policy_segment" "test" {
   display_name = "%s"
   description  = "Acceptance Test"
@@ -935,7 +945,7 @@ resource "nsxt_policy_segment" "test" {
   transport_zone_path = data.nsxt_policy_transport_zone.test.path
 
   subnet {
-     cidr = "12.12.2.1/24"
+    cidr = "12.12.2.1/24"
   }
 
   tag {
@@ -955,6 +965,7 @@ resource "nsxt_policy_segment" "test" {
 func testAccNsxtPolicySegmentBasicAdvConfigUpdateTemplate(tzName string, name string) string {
 	return testAccNsxtPolicySegmentDeps(tzName, false) + fmt.Sprintf(`
 
+
 resource "nsxt_policy_segment" "test" {
   display_name = "%s"
   description  = "Acceptance Test"
@@ -965,7 +976,7 @@ resource "nsxt_policy_segment" "test" {
   transport_zone_path = data.nsxt_policy_transport_zone.test.path
 
   subnet {
-     cidr = "12.12.2.1/24"
+    cidr = "12.12.2.1/24"
   }
 
   tag {
@@ -1000,6 +1011,7 @@ func testAccNsxtPolicySegmentWithDhcpTemplate(tzName string, name string, dnsSer
 	return testAccNsxtPolicySegmentDeps(tzName, false) +
 		testAccNsxtPolicyEdgeCluster(getEdgeClusterName()) + fmt.Sprintf(`
 
+
 resource "nsxt_policy_dhcp_server" "test" {
   edge_cluster_path = data.nsxt_policy_edge_cluster.EC.path
   display_name      = "segment-test"
@@ -1013,40 +1025,40 @@ resource "nsxt_policy_segment" "test" {
   subnet {
     cidr = "12.12.2.1/24"
     dhcp_v4_config {
-        lease_time     = %s
-        server_address = "12.12.2.2/24"
-        dns_servers    = ["%s"]
-        dhcp_option_121 {
-          network  = "2.1.1.0/24"
-          next_hop = "2.3.1.3"
-        }
-        dhcp_option_121 {
-          network  = "3.1.1.0/24"
-          next_hop = "3.3.1.3"
-        }
-        dhcp_generic_option {
-          code   = "119"
-          values = ["abc", "def"]
-        }
+      lease_time     = %s
+      server_address = "12.12.2.2/24"
+      dns_servers    = ["%s"]
+      dhcp_option_121 {
+        network  = "2.1.1.0/24"
+        next_hop = "2.3.1.3"
+      }
+      dhcp_option_121 {
+        network  = "3.1.1.0/24"
+        next_hop = "3.3.1.3"
+      }
+      dhcp_generic_option {
+        code   = "119"
+        values = ["abc", "def"]
+      }
     }
   }
 
   subnet {
     cidr = "4012::1/64"
     dhcp_v6_config {
-        server_address = "4012::2/64"
-        lease_time     = %s
-        preferred_time = %s
-        dns_servers    = ["%s"]
-        sntp_servers   = ["3001::1", "3001::2"]
-        excluded_range {
-            start = "4012::400"
-            end   = "4012::500"
-        }
-        excluded_range {
-            start = "4012::a00"
-            end   = "4012::b00"
-        }
+      server_address = "4012::2/64"
+      lease_time     = %s
+      preferred_time = %s
+      dns_servers    = ["%s"]
+      sntp_servers   = ["3001::1", "3001::2"]
+      excluded_range {
+        start = "4012::400"
+        end   = "4012::500"
+      }
+      excluded_range {
+        start = "4012::a00"
+        end   = "4012::b00"
+      }
     }
   }
 
@@ -1063,22 +1075,23 @@ func testAccNsxtPolicySegmentNoTransportZoneTemplate(name string, cidr string, w
 	}
 	return fmt.Sprintf(`
 
+
 resource "nsxt_policy_tier1_gateway" "tier1ForSegments" {
 %s
-  display_name              = "terraform-segment-test"
-  failover_mode             = "NON_PREEMPTIVE"
+  display_name  = "terraform-segment-test"
+  failover_mode = "NON_PREEMPTIVE"
 }
 
 resource "nsxt_policy_segment" "test" {
 %s
-  display_name        = "%s"
-  description         = "Acceptance Test"
-  domain_name         = "tftest.org"
-  overlay_id          = 1011
-  connectivity_path   = nsxt_policy_tier1_gateway.tier1ForSegments.path
+  display_name      = "%s"
+  description       = "Acceptance Test"
+  domain_name       = "tftest.org"
+  overlay_id        = 1011
+  connectivity_path = nsxt_policy_tier1_gateway.tier1ForSegments.path
 
   subnet {
-     cidr = "%s"
+    cidr = "%s"
   }
 }
 `, context, context, name, cidr)

--- a/nsxt/resource_nsxt_policy_service_test.go
+++ b/nsxt/resource_nsxt_policy_service_test.go
@@ -821,11 +821,11 @@ resource "nsxt_policy_service" "test" {
   description  = "Acceptance Test"
 
   icmp_entry {
-	display_name = "%s"
-	description  = "Entry"
-	icmp_type    = "%s"
-	icmp_code    = "%s"
-	protocol     = "%s"
+    display_name = "%s"
+    description  = "Entry"
+    icmp_type    = "%s"
+    icmp_code    = "%s"
+    protocol     = "%s"
   }
 
   tag {
@@ -847,10 +847,10 @@ resource "nsxt_policy_service" "test" {
   description  = "Acceptance Test"
 
   icmp_entry {
-	display_name = "%s"
-	description  = "Entry"
-	icmp_type    = "%s"
-	protocol     = "%s"
+    display_name = "%s"
+    description  = "Entry"
+    icmp_type    = "%s"
+    protocol     = "%s"
   }
 
   tag {
@@ -891,10 +891,10 @@ resource "nsxt_policy_service" "test" {
   description  = "Acceptance Test"
 
   icmp_entry {
-	description  = "Entry"
-	icmp_type    = "%s"
-	icmp_code    = "%s"
-	protocol     = "%s"
+    description = "Entry"
+    icmp_type   = "%s"
+    icmp_code   = "%s"
+    protocol    = "%s"
   }
 
   tag {
@@ -945,15 +945,15 @@ resource "nsxt_policy_service" "test" {
 func testAccNsxtPolicyL4PortSetTypeServiceCreateTemplate(serviceName string, protocol string, port string) string {
 	return fmt.Sprintf(`
 resource "nsxt_policy_service" "test" {
-  description       = "l4 service"
-  display_name      = "%s"
+  description  = "l4 service"
+  display_name = "%s"
 
   l4_port_set_entry {
     display_name      = "%s"
     description       = "Entry"
     protocol          = "%s"
-    destination_ports = [ "%s" ]
-    source_ports      = [ "100", "200-300" ]
+    destination_ports = ["%s"]
+    source_ports      = ["100", "200-300"]
   }
 
   tag {
@@ -966,21 +966,21 @@ resource "nsxt_policy_service" "test" {
 func testAccNsxtPolicyL4PortSetTypeServiceUpdateTemplate(serviceName string) string {
 	return fmt.Sprintf(`
 resource "nsxt_policy_service" "test" {
-  description       = "updated l4 service"
-  display_name      = "%s"
+  description  = "updated l4 service"
+  display_name = "%s"
 
   l4_port_set_entry {
     display_name      = "entry-1"
     description       = "Entry-1"
     protocol          = "TCP"
-    destination_ports = [ "100" ]
+    destination_ports = ["100"]
   }
 
   l4_port_set_entry {
     display_name      = "entry-2"
     description       = "Entry-2"
     protocol          = "UDP"
-    destination_ports = [ "101" ]
+    destination_ports = ["101"]
   }
 
   tag {
@@ -998,14 +998,14 @@ resource "nsxt_policy_service" "test" {
 func testAccNsxtPolicyMixedServiceCreateTemplate(serviceName string) string {
 	return fmt.Sprintf(`
 resource "nsxt_policy_service" "test" {
-  description       = "mixed services"
-  display_name      = "%s"
+  description  = "mixed services"
+  display_name = "%s"
 
   l4_port_set_entry {
     display_name      = "entry-1"
     description       = "Entry-1"
     protocol          = "TCP"
-    destination_ports = [ "80" ]
+    destination_ports = ["80"]
   }
 
   icmp_entry {
@@ -1084,11 +1084,11 @@ resource "nsxt_policy_service" "test" {
   display_name = "%s"
 
   algorithm_entry {
-    display_name      = "%s"
-    description       = "Entry-1"
-    algorithm         = "%s"
-    source_ports      = ["%s"]
-    destination_port  = "%s"
+    display_name     = "%s"
+    description      = "Entry-1"
+    algorithm        = "%s"
+    source_ports     = ["%s"]
+    destination_port = "%s"
   }
 
   tag {
@@ -1107,7 +1107,7 @@ resource "nsxt_policy_service" "test" {
   nested_service_entry {
     display_name        = "%s"
     description         = "Entry-1"
-	nested_service_path = "%s"
+    nested_service_path = "%s"
   }
 
   tag {
@@ -1125,13 +1125,13 @@ func testAccNsxtPolicyNestedServiceUpdateTemplate(serviceName string, nestedServ
   nested_service_entry {
     display_name        = "%s"
     description         = "Entry-1"
-	nested_service_path	= "%s"
+    nested_service_path = "%s"
   }
 
   nested_service_entry {
     display_name        = "%s"
     description         = "Entry-2"
-	nested_service_path = "%s"
+    nested_service_path = "%s"
   }
 
   tag {
@@ -1157,7 +1157,7 @@ func testAccNsxtPolicyNestedServiceMixedTemplate(serviceName string, nestedServi
     display_name      = "entry-2"
     description       = "Entry-2"
     protocol          = "TCP"
-    destination_ports = [ "443" ]
+    destination_ports = ["443"]
   }
 
   tag {

--- a/nsxt/resource_nsxt_policy_shared_resource_test.go
+++ b/nsxt/resource_nsxt_policy_shared_resource_test.go
@@ -202,7 +202,7 @@ resource "nsxt_policy_shared_resource" "test" {
   display_name = "%s"
   description  = "%s"
 
-  share_path   = nsxt_policy_share.test.path
+  share_path = nsxt_policy_share.test.path
   resource_object {
     resource_path = data.nsxt_policy_context_profile.test.path
   }
@@ -225,7 +225,7 @@ resource "nsxt_policy_shared_resource" "test" {
   display_name = "%s"
   description  = "%s"
 
-  share_path   = nsxt_policy_share.test.path
+  share_path = nsxt_policy_share.test.path
   resource_object {
     resource_path = data.nsxt_policy_context_profile.test.path
   }

--- a/nsxt/resource_nsxt_policy_static_route_test.go
+++ b/nsxt/resource_nsxt_policy_static_route_test.go
@@ -277,16 +277,16 @@ func testAccNsxtPolicyStaticRouteCheckDestroy(state *terraform.State, displayNam
 func testAccNsxtPolicyStaticRouteTier0CreateTemplate(name string, network string) string {
 	return fmt.Sprintf(`
 resource "nsxt_policy_tier0_gateway" "t0test" {
-  display_name              = "terraform-t0-gw"
-  description               = "Acceptance Test"
+  display_name = "terraform-t0-gw"
+  description  = "Acceptance Test"
 
 }
 
 resource "nsxt_policy_static_route" "test" {
-  display_name        = "%s"
-  description         = "Acceptance Test"
-  gateway_path        = "${nsxt_policy_tier0_gateway.t0test.path}"
-  network             = "%s"
+  display_name = "%s"
+  description  = "Acceptance Test"
+  gateway_path = "${nsxt_policy_tier0_gateway.t0test.path}"
+  network      = "%s"
   next_hop {
     ip_address = "9.10.10.1"
   }
@@ -306,16 +306,16 @@ resource "nsxt_policy_static_route" "test" {
 func testAccNsxtPolicyStaticRouteMultipleHopsTier0CreateTemplate(name string, network string) string {
 	return fmt.Sprintf(`
 resource "nsxt_policy_tier0_gateway" "t0test" {
-  display_name              = "terraform-t0-gw"
-  description               = "Acceptance Test"
+  display_name = "terraform-t0-gw"
+  description  = "Acceptance Test"
 
 }
 
 resource "nsxt_policy_static_route" "test" {
-  display_name        = "%s"
-  description         = "Acceptance Test"
+  display_name = "%s"
+  description  = "Acceptance Test"
   gateway_path = "${nsxt_policy_tier0_gateway.t0test.path}"
-  network             = "%s"
+  network      = "%s"
   next_hop {
     ip_address = "9.10.10.1"
   }
@@ -346,17 +346,17 @@ func testAccNsxtPolicyStaticRouteTier1CreateTemplate(name string, network string
 	return fmt.Sprintf(`
 resource "nsxt_policy_tier1_gateway" "t1test" {
 %s
-  display_name              = "%s"
-  description               = "Acceptance Test"
+  display_name = "%s"
+  description  = "Acceptance Test"
 
 }
 
 resource "nsxt_policy_static_route" "test" {
 %s
-  display_name        = "%s"
-  description         = "Acceptance Test"
-  gateway_path        = "${nsxt_policy_tier1_gateway.t1test.path}"
-  network             = "%s"
+  display_name = "%s"
+  description  = "Acceptance Test"
+  gateway_path = "${nsxt_policy_tier1_gateway.t1test.path}"
+  network      = "%s"
   next_hop {
     ip_address = "9.10.10.1"
   }
@@ -382,17 +382,17 @@ func testAccNsxtPolicyStaticRouteMultipleHopsTier1CreateTemplate(name string, ne
 	return fmt.Sprintf(`
 resource "nsxt_policy_tier1_gateway" "t1test" {
 %s
-  display_name              = "%s"
-  description               = "Acceptance Test"
+  display_name = "%s"
+  description  = "Acceptance Test"
 
 }
 
 resource "nsxt_policy_static_route" "test" {
 %s
-  display_name        = "%s"
-  description         = "Acceptance Test"
-  gateway_path        = "${nsxt_policy_tier1_gateway.t1test.path}"
-  network             = "%s"
+  display_name = "%s"
+  description  = "Acceptance Test"
+  gateway_path = "${nsxt_policy_tier1_gateway.t1test.path}"
+  network      = "%s"
   next_hop {
     ip_address = "9.10.10.1"
   }

--- a/nsxt/resource_nsxt_policy_tier0_gateway_gm_test.go
+++ b/nsxt/resource_nsxt_policy_tier0_gateway_gm_test.go
@@ -182,7 +182,7 @@ resource "nsxt_policy_tier0_gateway" "test" {
   }
 
   intersite_config {
-    primary_site_path = data.nsxt_policy_site.site1.path
+    primary_site_path   = data.nsxt_policy_site.site1.path
     fallback_site_paths = [data.nsxt_policy_site.site2.path]
     %s
   }

--- a/nsxt/resource_nsxt_policy_tier0_gateway_gre_tunnel_test.go
+++ b/nsxt/resource_nsxt_policy_tier0_gateway_gre_tunnel_test.go
@@ -126,16 +126,16 @@ data "nsxt_policy_gateway_locale_service" "test" {
 }
 
 resource "nsxt_policy_tier0_gateway_gre_tunnel" "test" {
-  display_name = "%s"
-  description  = "Acceptance test GRE tunnel"
+  display_name        = "%s"
+  description         = "Acceptance test GRE tunnel"
   locale_service_path = data.nsxt_policy_gateway_locale_service.test.path
   destination_address = "192.168.221.221"
   tunnel_address {
     source_address = nsxt_policy_tier0_gateway_interface.test.ip_addresses[0]
-    edge_path = data.nsxt_policy_edge_node.EN.path
+    edge_path      = data.nsxt_policy_edge_node.EN.path
     tunnel_interface_subnet {
-       ip_addresses = ["192.168.243.243"]
-       prefix_len = 24
+      ip_addresses = ["192.168.243.243"]
+      prefix_len   = 24
     }
   }
   tunnel_keepalive {

--- a/nsxt/resource_nsxt_policy_tier0_gateway_ha_vip_config_test.go
+++ b/nsxt/resource_nsxt_policy_tier0_gateway_ha_vip_config_test.go
@@ -221,12 +221,13 @@ func testAccNsxtPolicyTier0HAVipConfigSiteTemplate() string {
 func testAccNsxtPolicyTier0HAVipConfigTemplate(tier0Name string, enabled string, subnet1 string, subnet2 string, vipSubnet string) string {
 	return testAccNsxtPolicyGatewayFabricDeps(true) + fmt.Sprintf(`
 
+
 resource "nsxt_policy_vlan_segment" "test1" {
   transport_zone_path = data.nsxt_policy_transport_zone.test.path
   display_name        = "interface_test1"
   vlan_ids            = [11]
   subnet {
-      cidr = "10.2.2.2/24"
+    cidr = "10.2.2.2/24"
   }
 }
 
@@ -235,7 +236,7 @@ resource "nsxt_policy_vlan_segment" "test2" {
   display_name        = "interface_test2"
   vlan_ids            = [11]
   subnet {
-      cidr = "10.2.2.2/24"
+    cidr = "10.2.2.2/24"
   }
 }
 
@@ -250,8 +251,8 @@ data "nsxt_policy_edge_node" "EN1" {
 }
 
 resource "nsxt_policy_tier0_gateway" "test" {
-  display_name      = "%s"
-  ha_mode           = "ACTIVE_STANDBY"
+  display_name = "%s"
+  ha_mode      = "ACTIVE_STANDBY"
   %s
 }
 
@@ -277,15 +278,15 @@ resource "nsxt_policy_tier0_gateway_interface" "test2" {
   subnets        = ["%s"]
   urpf_mode      = "STRICT"
   %s
-  depends_on     = ["nsxt_policy_tier0_gateway_interface.test1"]
+  depends_on = ["nsxt_policy_tier0_gateway_interface.test1"]
 }
 
 resource "nsxt_policy_tier0_gateway_ha_vip_config" "test" {
-	config {
-		enabled                  = %s
-		external_interface_paths = [nsxt_policy_tier0_gateway_interface.test1.path, nsxt_policy_tier0_gateway_interface.test2.path]
-		vip_subnets              = ["%s"]
-	}
+  config {
+    enabled                  = %s
+    external_interface_paths = [nsxt_policy_tier0_gateway_interface.test1.path, nsxt_policy_tier0_gateway_interface.test2.path]
+    vip_subnets              = ["%s"]
+  }
 }`, tier0Name, testAccNsxtPolicyLocaleServiceECTemplate(),
 		subnet1, testAccNsxtPolicyTier0HAVipConfigSiteTemplate(),
 		subnet2, testAccNsxtPolicyTier0HAVipConfigSiteTemplate(), enabled, vipSubnet)

--- a/nsxt/resource_nsxt_policy_tier0_gateway_interface_test.go
+++ b/nsxt/resource_nsxt_policy_tier0_gateway_interface_test.go
@@ -687,10 +687,10 @@ func testAccNsxtPolicyGatewayInterfaceDeps(vlans string, withContext bool) strin
 resource "nsxt_policy_vlan_segment" "test" {
 %s
   %s
-  display_name        = "interface_test"
-  vlan_ids            = [%s]
+  display_name = "interface_test"
+  vlan_ids     = [%s]
   subnet {
-      cidr = "10.2.2.2/24"
+    cidr = "10.2.2.2/24"
   }
 }`, context, tzSpec, vlans)
 }
@@ -723,7 +723,7 @@ func testAccNsxtPolicyTier0InterfaceRealizationTemplate() string {
 	if testAccIsGlobalManager() {
 		return `
 data "nsxt_policy_realization_info" "realization_info" {
-  path = nsxt_policy_tier0_gateway_interface.test.path
+  path      = nsxt_policy_tier0_gateway_interface.test.path
   site_path = data.nsxt_policy_site.test.path
 }
 
@@ -744,9 +744,10 @@ data "nsxt_policy_gateway_interface_realization" "gw_realization" {
 func testAccNsxtPolicyTier0InterfaceServiceTemplate(name string, subnet string, mtu string) string {
 	return testAccNsxtPolicyGatewayInterfaceDeps("11", false) + fmt.Sprintf(`
 
+
 resource "nsxt_policy_tier0_gateway" "test" {
-  display_name      = "%s"
-  ha_mode           = "ACTIVE_STANDBY"
+  display_name = "%s"
+  ha_mode      = "ACTIVE_STANDBY"
   %s
 }
 
@@ -771,8 +772,8 @@ resource "nsxt_policy_tier0_gateway_interface" "test" {
 func testAccNsxtPolicyTier0InterfaceThinTemplate(name string, subnet string) string {
 	return testAccNsxtPolicyGatewayInterfaceDeps("11", false) + fmt.Sprintf(`
 resource "nsxt_policy_tier0_gateway" "test" {
-  display_name      = "%s"
-  ha_mode           = "ACTIVE_STANDBY"
+  display_name = "%s"
+  ha_mode      = "ACTIVE_STANDBY"
   %s
 }
 
@@ -795,8 +796,8 @@ resource "nsxt_policy_dhcp_relay" "test" {
 }
 
 resource "nsxt_policy_tier0_gateway" "test" {
-  display_name      = "%s"
-  ha_mode           = "ACTIVE_STANDBY"
+  display_name = "%s"
+  ha_mode      = "ACTIVE_STANDBY"
   %s
 }
 
@@ -821,8 +822,8 @@ data "nsxt_policy_ipv6_ndra_profile" "default" {
 }
 
 resource "nsxt_policy_tier0_gateway" "test" {
-  display_name      = "%s"
-  ha_mode           = "ACTIVE_STANDBY"
+  display_name = "%s"
+  ha_mode      = "ACTIVE_STANDBY"
   %s
 }
 
@@ -873,8 +874,8 @@ data "nsxt_policy_edge_node" "EN" {
 }
 
 resource "nsxt_policy_tier0_gateway" "test" {
-  display_name      = "%s"
-  ha_mode           = "ACTIVE_STANDBY"
+  display_name = "%s"
+  ha_mode      = "ACTIVE_STANDBY"
   %s
 }
 
@@ -911,10 +912,10 @@ resource "nsxt_policy_tier0_gateway" "test" {
 }
 
 resource "nsxt_policy_tier0_gateway_interface" "test" {
-  display_name   = "%s"
-  gateway_path   = nsxt_policy_tier0_gateway.test.path
-  segment_path   = nsxt_policy_vlan_segment.test.path
-  subnets        = ["10.192.12.2/24", "1002::3:3/64"]
-  type           = "EXTERNAL"
+  display_name = "%s"
+  gateway_path = nsxt_policy_tier0_gateway.test.path
+  segment_path = nsxt_policy_vlan_segment.test.path
+  subnets      = ["10.192.12.2/24", "1002::3:3/64"]
+  type         = "EXTERNAL"
 }`, nsxtPolicyTier1GatewayName, edgeCluster, name)
 }

--- a/nsxt/resource_nsxt_policy_tier0_gateway_test.go
+++ b/nsxt/resource_nsxt_policy_tier0_gateway_test.go
@@ -702,8 +702,8 @@ data "nsxt_policy_edge_cluster" "EC" {
 }
 
 resource "nsxt_policy_dhcp_relay" "test" {
-  display_name      = "terraform-dhcp-relay"
-  server_addresses  = ["88.9.9.2"]
+  display_name     = "terraform-dhcp-relay"
+  server_addresses = ["88.9.9.2"]
 }
 
 resource "nsxt_policy_tier0_gateway" "test" {
@@ -724,8 +724,8 @@ data "nsxt_policy_edge_cluster" "EC" {
 }
 
 resource "nsxt_policy_dhcp_relay" "test" {
-  display_name      = "terraform-dhcp-relay"
-  server_addresses  = ["88.9.9.2"]
+  display_name     = "terraform-dhcp-relay"
+  server_addresses = ["88.9.9.2"]
 }
 
 resource "nsxt_policy_tier0_gateway" "test" {
@@ -741,16 +741,16 @@ data "nsxt_policy_realization_info" "realization_info" {
 func testAccNsxtPolicyTier0CreateTemplate(name string, failoverMode string) string {
 	config := testAccNsxtPolicyGatewayFabricDeps(true) + fmt.Sprintf(`
 resource "nsxt_policy_tier0_gateway" "test" {
-  display_name              = "%s"
-  description               = "Acceptance Test"
-  failover_mode             = "%s"
-  default_rule_logging      = "true"
-  enable_firewall           = "false"
-  force_whitelisting        = "false"
-  ha_mode                   = "ACTIVE_STANDBY"
-  ipv6_ndra_profile_path    = "/infra/ipv6-ndra-profiles/default"
-  ipv6_dad_profile_path     = "/infra/ipv6-dad-profiles/default"
-  rd_admin_address          = "192.168.0.2"
+  display_name           = "%s"
+  description            = "Acceptance Test"
+  failover_mode          = "%s"
+  default_rule_logging   = "true"
+  enable_firewall        = "false"
+  force_whitelisting     = "false"
+  ha_mode                = "ACTIVE_STANDBY"
+  ipv6_ndra_profile_path = "/infra/ipv6-ndra-profiles/default"
+  ipv6_dad_profile_path  = "/infra/ipv6-dad-profiles/default"
+  rd_admin_address       = "192.168.0.2"
   %s
 
   tag {
@@ -771,22 +771,22 @@ resource "nsxt_policy_tier0_gateway" "test" {
 func testAccNsxtPolicyTier0UpdateTemplate(name string, failoverMode string) string {
 	config := testAccNsxtPolicyGatewayFabricDeps(true) + fmt.Sprintf(`
 resource "nsxt_policy_tier0_gateway" "test" {
-  display_name              = "%s"
-  description               = "Acceptance Test Update"
-  failover_mode             = "%s"
-  default_rule_logging      = "false"
-  enable_firewall           = "true"
-  force_whitelisting        = "true"
-  ha_mode                   = "ACTIVE_ACTIVE"
-  ipv6_ndra_profile_path    = "/infra/ipv6-ndra-profiles/default"
-  ipv6_dad_profile_path     = "/infra/ipv6-dad-profiles/default"
+  display_name           = "%s"
+  description            = "Acceptance Test Update"
+  failover_mode          = "%s"
+  default_rule_logging   = "false"
+  enable_firewall        = "true"
+  force_whitelisting     = "true"
+  ha_mode                = "ACTIVE_ACTIVE"
+  ipv6_ndra_profile_path = "/infra/ipv6-ndra-profiles/default"
+  ipv6_dad_profile_path  = "/infra/ipv6-dad-profiles/default"
   %s
 
   tag {
     scope = "scope3"
     tag   = "tag3"
   }
-} `, name, failoverMode, testAccNsxtPolicyTier0EdgeClusterTemplate())
+}`, name, failoverMode, testAccNsxtPolicyTier0EdgeClusterTemplate())
 
 	return testAccAdjustPolicyInfraConfig(config)
 }
@@ -815,17 +815,17 @@ resource "nsxt_policy_tier0_gateway" "test" {
 func testAccNsxtPolicyTier0CreateWithLocaleTemplate(name string) string {
 	config := testAccNsxtPolicyGatewayFabricDeps(true) + fmt.Sprintf(`
 data "nsxt_policy_edge_node" "node1" {
-    edge_cluster_path = data.nsxt_policy_edge_cluster.EC.path
-    member_index      = 0
+  edge_cluster_path = data.nsxt_policy_edge_cluster.EC.path
+  member_index      = 0
 }
 
 resource "nsxt_policy_tier0_gateway" "test" {
-  display_name              = "%s"
-  failover_mode             = "PREEMPTIVE"
-  ha_mode                   = "ACTIVE_STANDBY"
+  display_name  = "%s"
+  failover_mode = "PREEMPTIVE"
+  ha_mode       = "ACTIVE_STANDBY"
 
   locale_service {
-    nsx_id = "%s"
+    nsx_id               = "%s"
     edge_cluster_path    = data.nsxt_policy_edge_cluster.EC.path
     preferred_edge_paths = [data.nsxt_policy_edge_node.node1.path]
   }
@@ -837,17 +837,17 @@ resource "nsxt_policy_tier0_gateway" "test" {
 func testAccNsxtPolicyTier0UpdateWithLocaleTemplate(name string) string {
 	config := testAccNsxtPolicyGatewayFabricDeps(true) + fmt.Sprintf(`
 data "nsxt_policy_edge_node" "node1" {
-    edge_cluster_path = data.nsxt_policy_edge_cluster.EC.path
-    member_index      = 1
+  edge_cluster_path = data.nsxt_policy_edge_cluster.EC.path
+  member_index      = 1
 }
 
 resource "nsxt_policy_tier0_gateway" "test" {
-  display_name              = "%s"
-  failover_mode             = "PREEMPTIVE"
-  ha_mode                   = "ACTIVE_STANDBY"
+  display_name  = "%s"
+  failover_mode = "PREEMPTIVE"
+  ha_mode       = "ACTIVE_STANDBY"
 
   locale_service {
-    nsx_id = "%s"
+    nsx_id               = "%s"
     edge_cluster_path    = data.nsxt_policy_edge_cluster.EC.path
     preferred_edge_paths = [data.nsxt_policy_edge_node.node1.path]
   }
@@ -859,16 +859,16 @@ resource "nsxt_policy_tier0_gateway" "test" {
 func testAccNsxtPolicyTier0SubnetsTemplate(name string) string {
 	return fmt.Sprintf(`
 resource "nsxt_policy_tier0_gateway" "test" {
-  display_name              = "%s"
-  description               = "Acceptance Test"
-  failover_mode             = "NON_PREEMPTIVE"
-  default_rule_logging      = "false"
-  enable_firewall           = "true"
-  force_whitelisting        = "true"
-  ha_mode                   = "ACTIVE_STANDBY"
-  ipv6_dad_profile_path     = "/infra/ipv6-dad-profiles/default"
-  internal_transit_subnets  = ["102.64.0.0/16"]
-  transit_subnets           = ["101.64.0.0/16"]
+  display_name             = "%s"
+  description              = "Acceptance Test"
+  failover_mode            = "NON_PREEMPTIVE"
+  default_rule_logging     = "false"
+  enable_firewall          = "true"
+  force_whitelisting       = "true"
+  ha_mode                  = "ACTIVE_STANDBY"
+  ipv6_dad_profile_path    = "/infra/ipv6-dad-profiles/default"
+  internal_transit_subnets = ["102.64.0.0/16"]
+  transit_subnets          = ["101.64.0.0/16"]
 
   tag {
     scope = "scope3"
@@ -884,17 +884,17 @@ data "nsxt_policy_realization_info" "realization_info" {
 func testAccNsxtPolicyTier0SubnetsWithVrfTemplate(name string, timer string) string {
 	return fmt.Sprintf(`
 resource "nsxt_policy_tier0_gateway" "test" {
-  display_name              = "%s"
-  description               = "Acceptance Test"
-  failover_mode             = "NON_PREEMPTIVE"
-  default_rule_logging      = "false"
-  enable_firewall           = "true"
-  force_whitelisting        = "true"
-  ha_mode                   = "ACTIVE_STANDBY"
-  ipv6_dad_profile_path     = "/infra/ipv6-dad-profiles/default"
-  internal_transit_subnets  = ["102.64.0.0/16"]
-  transit_subnets           = ["101.64.0.0/16"]
-  vrf_transit_subnets       = ["103.64.0.0/28"]
+  display_name             = "%s"
+  description              = "Acceptance Test"
+  failover_mode            = "NON_PREEMPTIVE"
+  default_rule_logging     = "false"
+  enable_firewall          = "true"
+  force_whitelisting       = "true"
+  ha_mode                  = "ACTIVE_STANDBY"
+  ipv6_dad_profile_path    = "/infra/ipv6-dad-profiles/default"
+  internal_transit_subnets = ["102.64.0.0/16"]
+  transit_subnets          = ["101.64.0.0/16"]
+  vrf_transit_subnets      = ["103.64.0.0/28"]
 
   advanced_config {
     connectivity        = "ON"
@@ -915,9 +915,9 @@ data "nsxt_policy_realization_info" "realization_info" {
 func testAccNsxtPolicyTier0SubnetsMinimalistic(name string) string {
 	return fmt.Sprintf(`
 resource "nsxt_policy_tier0_gateway" "test" {
-  display_name              = "%s"
-  failover_mode             = "NON_PREEMPTIVE"
-  ha_mode                   = "ACTIVE_STANDBY"
+  display_name  = "%s"
+  failover_mode = "NON_PREEMPTIVE"
+  ha_mode       = "ACTIVE_STANDBY"
 }`, name)
 }
 
@@ -942,9 +942,9 @@ func testAccNsxtPolicyTier0WithVRFTemplate(name string, targets bool, rdAdmin bo
 	if withBGP {
 		bgpConfig = `
 resource "nsxt_policy_bgp_config" "test" {
-	  gateway_path = nsxt_policy_tier0_gateway.test.path
-	  enabled      = true
-	  ecmp         = true
+  gateway_path = nsxt_policy_tier0_gateway.test.path
+  enabled      = true
+  ecmp         = true
 }`
 	}
 	return testAccNsxtPolicyGatewayInterfaceDeps("11, 12", false) + fmt.Sprintf(`
@@ -955,7 +955,7 @@ resource "nsxt_policy_tier0_gateway" "parent" {
 }
 
 resource "nsxt_policy_tier0_gateway" "test" {
-  display_name = "%s"
+  display_name      = "%s"
   edge_cluster_path = data.nsxt_policy_edge_cluster.EC.path
   vrf_config {
     gateway_path = nsxt_policy_tier0_gateway.parent.path
@@ -1060,8 +1060,8 @@ resource "nsxt_policy_tier0_gateway" "test" {
     enabled      = false
     ospf_enabled = false
     rule {
-        name = "test-rule-1"
-        types = ["TIER0_SEGMENT", "TIER0_EVPN_TEP_IP", "TIER1_CONNECTED"]
+      name  = "test-rule-1"
+      types = ["TIER0_SEGMENT", "TIER0_EVPN_TEP_IP", "TIER1_CONNECTED"]
     }
   }
 }
@@ -1084,11 +1084,11 @@ resource "nsxt_policy_tier0_gateway" "test" {
     enabled      = false
     ospf_enabled = false
     rule {
-        name = "test-rule-1"
+      name = "test-rule-1"
     }
     rule {
-        name  = "test-rule-3"
-        types = ["TIER1_CONNECTED"]
+      name  = "test-rule-3"
+      types = ["TIER1_CONNECTED"]
     }
   }
 }
@@ -1108,7 +1108,7 @@ resource "nsxt_policy_tier0_gateway" "test" {
   edge_cluster_path = data.nsxt_policy_edge_cluster.EC.path
 
   redistribution_config {
-    enabled  = false
+    enabled      = false
     ospf_enabled = true
   }
 }

--- a/nsxt/resource_nsxt_policy_tier0_inter_vrf_routing_test.go
+++ b/nsxt/resource_nsxt_policy_tier0_inter_vrf_routing_test.go
@@ -113,18 +113,18 @@ func testAccNsxtPolicyTier0InterVRFRoutingTemplate(name, subnets string) string 
 resource "nsxt_policy_tier0_inter_vrf_routing" "test" {
   display_name = "%s"
   gateway_path = nsxt_policy_tier0_gateway.parent.path
-  target_path = nsxt_policy_tier0_gateway.test.path
+  target_path  = nsxt_policy_tier0_gateway.test.path
 
   bgp_route_leaking {
     address_family = "IPV4"
   }
   static_route_advertisement {
     advertisement_rule {
-      name = "test"
-      action = "PERMIT"
-      prefix_operator = "GE"
+      name                      = "test"
+      action                    = "PERMIT"
+      prefix_operator           = "GE"
       route_advertisement_types = ["TIER0_CONNECTED", "TIER0_NAT"]
-      subnets = %s
+      subnets                   = %s
     }
     in_filter_prefix_list = [
       join("/", [nsxt_policy_tier0_gateway.parent.path, "prefix-lists/IPSEC_LOCAL_IP"]),

--- a/nsxt/resource_nsxt_policy_tier1_gateway_interface_test.go
+++ b/nsxt/resource_nsxt_policy_tier1_gateway_interface_test.go
@@ -490,7 +490,7 @@ func testAccNsxtPolicyTier1InterfaceTemplate(name string, subnet string, mtu str
 	return testAccNsxtPolicyGatewayInterfaceDeps("11", withContext) + fmt.Sprintf(`
 resource "nsxt_policy_tier1_gateway" "test" {
 %s
-  display_name      = "%s"
+  display_name = "%s"
   %s
 }
 
@@ -523,7 +523,7 @@ func testAccNsxtPolicyTier1InterfaceThinTemplate(name string, subnet string, wit
 	return testAccNsxtPolicyGatewayInterfaceDeps("11", withContext) + fmt.Sprintf(`
 resource "nsxt_policy_tier1_gateway" "test" {
 %s
-  display_name      = "%s"
+  display_name = "%s"
   %s
 }
 
@@ -575,7 +575,7 @@ data "nsxt_policy_ipv6_ndra_profile" "default" {
 }
 
 resource "nsxt_policy_tier1_gateway" "test" {
-  display_name      = "%s"
+  display_name = "%s"
   %s
 }
 
@@ -599,14 +599,14 @@ func testAccNsxtPolicyTier1InterfaceUpdateGatewayTemplate(name string, useLocale
 	}
 	return testAccNsxtPolicyGatewayInterfaceDeps("11", false) + fmt.Sprintf(`
 resource "nsxt_policy_tier1_gateway" "test" {
-  display_name      = "%s"
+  display_name = "%s"
   %s
 }
 
 resource "nsxt_policy_tier1_gateway_interface" "test" {
-  display_name           = "%s"
-  gateway_path           = nsxt_policy_tier1_gateway.test.path
-  segment_path           = nsxt_policy_vlan_segment.test.path
-  subnets                = ["10.192.12.2/24", "1002::3:3/64"]
+  display_name = "%s"
+  gateway_path = nsxt_policy_tier1_gateway.test.path
+  segment_path = nsxt_policy_vlan_segment.test.path
+  subnets      = ["10.192.12.2/24", "1002::3:3/64"]
 }`, nsxtPolicyTier1GatewayName, edgeCluster, name)
 }

--- a/nsxt/resource_nsxt_policy_tier1_gateway_test.go
+++ b/nsxt/resource_nsxt_policy_tier1_gateway_test.go
@@ -529,8 +529,8 @@ func testAccNsxtPolicyTier1CheckDestroy(state *terraform.State, displayName stri
 func testAccNsxtPolicyTier1CreateDHCPTemplate() string {
 	return `
 resource "nsxt_policy_dhcp_relay" "test" {
-  display_name      = "terraform-dhcp-relay"
-  server_addresses  = ["88.9.9.2"]
+  display_name     = "terraform-dhcp-relay"
+  server_addresses = ["88.9.9.2"]
 }
 `
 }
@@ -740,8 +740,8 @@ data "nsxt_policy_edge_cluster" "EC" {
 }
 
 resource "nsxt_policy_tier1_gateway" "test" {
-  display_name      = "%s"
-  description       = "Acceptance Test"
+  display_name = "%s"
+  description  = "Acceptance Test"
   locale_service {
     edge_cluster_path = data.nsxt_policy_edge_cluster.EC.path
   }
@@ -869,6 +869,6 @@ data "nsxt_policy_gateway_qos_profile" "test" {
 }
 
 resource "nsxt_policy_tier1_gateway" "test" {
-  display_name             = "%s"
+  display_name = "%s"
 }`, profileName, name)
 }

--- a/nsxt/resource_nsxt_policy_transit_gateway_attachment_test.go
+++ b/nsxt/resource_nsxt_policy_transit_gateway_attachment_test.go
@@ -164,14 +164,14 @@ resource "nsxt_policy_tier0_gateway" "test" {
 }
 
 resource "nsxt_policy_gateway_connection" "test" {
-  display_name      = "%s"
-  tier0_path = nsxt_policy_tier0_gateway.test.path
+  display_name     = "%s"
+  tier0_path       = nsxt_policy_tier0_gateway.test.path
   aggregate_routes = ["192.168.240.0/24"]
 }
 
 resource "nsxt_policy_project" "test" {
-  display_name      = "%s"
-  tier0_gateway_paths = [nsxt_policy_tier0_gateway.test.path]
+  display_name             = "%s"
+  tier0_gateway_paths      = [nsxt_policy_tier0_gateway.test.path]
   tgw_external_connections = [nsxt_policy_gateway_connection.test.path]
   site_info {
     edge_cluster_paths = [data.nsxt_policy_edge_cluster.test.path]
@@ -186,10 +186,10 @@ data "nsxt_policy_transit_gateway" "test" {
 }
 
 resource "nsxt_policy_transit_gateway_attachment" "test" {
-  parent_path  = data.nsxt_policy_transit_gateway.test.path
+  parent_path     = data.nsxt_policy_transit_gateway.test.path
   connection_path = nsxt_policy_gateway_connection.test.path
-  display_name = "%s"
-  description  = "%s"
+  display_name    = "%s"
+  description     = "%s"
 
   tag {
     scope = "scope1"

--- a/nsxt/resource_nsxt_policy_transit_gateway_nat_rule_test.go
+++ b/nsxt/resource_nsxt_policy_transit_gateway_nat_rule_test.go
@@ -293,20 +293,20 @@ resource "nsxt_policy_transit_gateway_nat_rule" "test" {
 func testAccNsxtTransitGatewayNatRuleSnatTemplate(name string, translatedNetwork string) string {
 	return testAccNsxtTransitGatewayNatRulePrerequisites() + fmt.Sprintf(`
 resource "nsxt_policy_transit_gateway_nat_rule" "test" {
-  parent_path         = data.nsxt_policy_transit_gateway_nat.test.path
-  display_name        = "%s"
-  translated_network  = "%s"
-  action              = "SNAT"
+  parent_path        = data.nsxt_policy_transit_gateway_nat.test.path
+  display_name       = "%s"
+  translated_network = "%s"
+  action             = "SNAT"
 }`, name, translatedNetwork)
 }
 
 func testAccNsxtTransitGatewayNatRuleReflexiveTemplate(name string, sourceIP string, translatedNetwork string) string {
 	return testAccNsxtTransitGatewayNatRulePrerequisites() + fmt.Sprintf(`
 resource "nsxt_policy_transit_gateway_nat_rule" "test" {
-  parent_path         = data.nsxt_policy_transit_gateway_nat.test.path
-  display_name        = "%s"
-  source_network      = "%s"
-  translated_network  = "%s"
-  action              = "REFLEXIVE"
+  parent_path        = data.nsxt_policy_transit_gateway_nat.test.path
+  display_name       = "%s"
+  source_network     = "%s"
+  translated_network = "%s"
+  action             = "REFLEXIVE"
 }`, name, sourceIP, translatedNetwork)
 }

--- a/nsxt/resource_nsxt_policy_transit_gateway_test.go
+++ b/nsxt/resource_nsxt_policy_transit_gateway_test.go
@@ -187,7 +187,7 @@ resource "nsxt_policy_transit_gateway" "test" {
 data "nsxt_policy_transit_gateway" "test" {
 %s
   display_name = "%s"
-  depends_on = [nsxt_policy_transit_gateway.test]
+  depends_on   = [nsxt_policy_transit_gateway.test]
 }`, testAccNsxtProjectContext(), attrMap["display_name"], attrMap["description"], attrMap["transit_subnets"],
 		testAccNsxtProjectContext(), attrMap["display_name"])
 }

--- a/nsxt/resource_nsxt_policy_transport_zone_test.go
+++ b/nsxt/resource_nsxt_policy_transport_zone_test.go
@@ -177,8 +177,8 @@ func testAccNsxtPolicyTransportZoneCreate() string {
 	attrMap := accTestPolicyTransportZoneCreateAttributes
 	return fmt.Sprintf(`
 resource "nsxt_policy_transport_zone" "test" {
-  display_name = "%s"
-  description  = "%s"
+  display_name   = "%s"
+  description    = "%s"
   transport_type = "%s"
 
   tag {
@@ -192,8 +192,8 @@ func testAccNsxtPolicyTransportZoneUpdate() string {
 	attrMap := accTestPolicyTransportZoneUpdateAttributes
 	return fmt.Sprintf(`
 resource "nsxt_policy_transport_zone" "test" {
-  display_name = "%s"
-  description  = "%s"
+  display_name   = "%s"
+  description    = "%s"
   transport_type = "%s"
 }`, attrMap["display_name"], attrMap["description"], attrMap["transport_type"])
 }

--- a/nsxt/resource_nsxt_policy_uplink_host_switch_profile_test.go
+++ b/nsxt/resource_nsxt_policy_uplink_host_switch_profile_test.go
@@ -278,26 +278,26 @@ resource "nsxt_policy_uplink_host_switch_profile" "test" {
   }
   teaming {
     active {
-	  uplink_name = "%s"
-	  uplink_type = "%s"
-    }
-    standby {
-	  uplink_name = "%s"
-	  uplink_type = "%s"
-    }
-    policy        = "%s"
-  }
-  named_teaming {
-    active {
-  	  uplink_name = "%s"
-	  uplink_type = "%s"
+      uplink_name = "%s"
+      uplink_type = "%s"
     }
     standby {
       uplink_name = "%s"
-	  uplink_type = "%s"
+      uplink_type = "%s"
     }
-    policy        = "%s"
-    name          = "%s"
+    policy = "%s"
+  }
+  named_teaming {
+    active {
+      uplink_name = "%s"
+      uplink_type = "%s"
+    }
+    standby {
+      uplink_name = "%s"
+      uplink_type = "%s"
+    }
+    policy = "%s"
+    name   = "%s"
   }
 
   tag {
@@ -308,7 +308,7 @@ resource "nsxt_policy_uplink_host_switch_profile" "test" {
 
 data "nsxt_policy_uplink_host_switch_profile" "test" {
   display_name = "%s"
-  depends_on = [nsxt_policy_uplink_host_switch_profile.test]
+  depends_on   = [nsxt_policy_uplink_host_switch_profile.test]
 }`, attrMap["display_name"], attrMap["description"], attrMap["mtu"], attrMap["transport_vlan"], attrMap["overlay_encap"], attrMap["lag_name"], attrMap["lag_load_balance_algorithm"], attrMap["lag_mode"], attrMap["lag_number_of_uplinks"], attrMap["lag_timeout_type"], attrMap["teaming_al_uplink_name"], attrMap["teaming_al_uplink_type"], attrMap["teaming_sl_uplink_name"], attrMap["teaming_sl_uplink_type"], attrMap["teaming_policy"], attrMap["named_teaming_al_uplink_name"], attrMap["named_teaming_al_uplink_type"], attrMap["named_teaming_sl_uplink_name"], attrMap["named_teaming_sl_uplink_type"], attrMap["named_teaming_policy"], attrMap["named_teaming_name"], attrMap["display_name"])
 }
 

--- a/nsxt/resource_nsxt_policy_vlan_segment_test.go
+++ b/nsxt/resource_nsxt_policy_vlan_segment_test.go
@@ -339,9 +339,9 @@ func testAccNsxtPolicyVlanSegmentImportTemplate(name string, withContext bool) s
 	s := fmt.Sprintf(`
 resource "nsxt_policy_vlan_segment" "test" {
 %s
-  display_name        = "%s"
-  description         = "Acceptance Test"
-  vlan_ids            = ["101"]
+  display_name = "%s"
+  description  = "Acceptance Test"
+  vlan_ids     = ["101"]
   %s
 }
 `, context, name, tzSetting)
@@ -362,13 +362,14 @@ func testAccNsxtPolicyVlanSegmentBasicTemplate(name string, withContext bool) st
 	}
 	return deps + fmt.Sprintf(`
 
+
 resource "nsxt_policy_vlan_segment" "test" {
 %s
-  display_name        = "%s"
-  description         = "Acceptance Test"
+  display_name = "%s"
+  description  = "Acceptance Test"
   %s
-  domain_name         = "tftest.org"
-  vlan_ids            = ["101"]
+  domain_name = "tftest.org"
+  vlan_ids    = ["101"]
 
   tag {
     scope = "color"
@@ -389,13 +390,14 @@ func testAccNsxtPolicyVlanSegmentBasicUpdateTemplate(name string, withContext bo
 	}
 	return deps + fmt.Sprintf(`
 
+
 resource "nsxt_policy_vlan_segment" "test" {
 %s
-  display_name        = "%s"
-  description         = "Acceptance Test2"
+  display_name = "%s"
+  description  = "Acceptance Test2"
   %s
-  domain_name         = "tftest2.org"
-  vlan_ids            = ["101", "104-110"]
+  domain_name = "tftest2.org"
+  vlan_ids    = ["101", "104-110"]
 
   tag {
     scope = "color"
@@ -460,6 +462,7 @@ resource "nsxt_policy_vlan_segment" "test" {
 func testAccNsxtPolicyVlanSegmentWithDhcpTemplate(name string, dnsServerV4 string, dnsServerV6 string, lease string, preferred string) string {
 	return testAccNsxtPolicyVlanSegmentDeps() + fmt.Sprintf(`
 
+
 data "nsxt_policy_edge_cluster" "EC" {
   display_name = "%s"
 }
@@ -477,40 +480,40 @@ resource "nsxt_policy_vlan_segment" "test" {
   subnet {
     cidr = "12.12.2.1/24"
     dhcp_v4_config {
-        server_address = "12.12.2.2/24"
-        lease_time     = %s
-        dns_servers    = ["%s"]
-        dhcp_option_121 {
-          network  = "2.1.1.0/24"
-          next_hop = "2.3.1.3"
-        }
-        dhcp_option_121 {
-          network  = "3.1.1.0/24"
-          next_hop = "3.3.1.3"
-        }
-        dhcp_generic_option {
-          code   = "119"
-          values = ["abc", "def"]
-        }
+      server_address = "12.12.2.2/24"
+      lease_time     = %s
+      dns_servers    = ["%s"]
+      dhcp_option_121 {
+        network  = "2.1.1.0/24"
+        next_hop = "2.3.1.3"
+      }
+      dhcp_option_121 {
+        network  = "3.1.1.0/24"
+        next_hop = "3.3.1.3"
+      }
+      dhcp_generic_option {
+        code   = "119"
+        values = ["abc", "def"]
+      }
     }
   }
 
   subnet {
     cidr = "4012::1/64"
     dhcp_v6_config {
-        server_address = "4012::2/64"
-        lease_time     = %s
-        preferred_time = %s
-        dns_servers    = ["%s"]
-        sntp_servers   = ["3001::1", "3001::2"]
-        excluded_range {
-            start = "4012::400"
-            end   = "4012::500"
-        }
-        excluded_range {
-            start = "4012::a00"
-            end   = "4012::b00"
-        }
+      server_address = "4012::2/64"
+      lease_time     = %s
+      preferred_time = %s
+      dns_servers    = ["%s"]
+      sntp_servers   = ["3001::1", "3001::2"]
+      excluded_range {
+        start = "4012::400"
+        end   = "4012::500"
+      }
+      excluded_range {
+        start = "4012::a00"
+        end   = "4012::b00"
+      }
     }
   }
 
@@ -523,14 +526,15 @@ resource "nsxt_policy_vlan_segment" "test" {
 func testAccNsxtPolicyVlanSegmentNoTransportZoneTemplate(name string, cidr string) string {
 	return fmt.Sprintf(`
 
+
 resource "nsxt_policy_vlan_segment" "test" {
-  display_name        = "%s"
-  description         = "Acceptance Test"
-  domain_name         = "tftest.org"
-  vlan_ids            = ["101"]
+  display_name = "%s"
+  description  = "Acceptance Test"
+  domain_name  = "tftest.org"
+  vlan_ids     = ["101"]
 
   subnet {
-     cidr = "%s"
+    cidr = "%s"
   }
 }
 `, name, cidr)

--- a/nsxt/resource_nsxt_policy_vni_pool_test.go
+++ b/nsxt/resource_nsxt_policy_vni_pool_test.go
@@ -154,7 +154,7 @@ resource "nsxt_policy_vni_pool" "test" {
   description  = "%s"
 
   start = %s
-  end = %s
+  end   = %s
 
   tag {
     scope = "scope1"
@@ -171,6 +171,6 @@ resource "nsxt_policy_vni_pool" "test" {
   description  = "%s"
 
   start = %s
-  end = %s
+  end   = %s
 }`, attrMap["display_name"], attrMap["description"], attrMap["start"], attrMap["end"])
 }

--- a/nsxt/resource_nsxt_policy_vtep_ha_host_switch_profile_test.go
+++ b/nsxt/resource_nsxt_policy_vtep_ha_host_switch_profile_test.go
@@ -182,13 +182,13 @@ func testAccNsxtVtepHAHostSwitchProfileTemplate(createFlow bool) string {
 	}
 	return fmt.Sprintf(`
 resource "nsxt_policy_vtep_ha_host_switch_profile" "test" {
-  display_name = "%s"
-  description  = "%s"
-  auto_recovery = "%s"
+  display_name               = "%s"
+  description                = "%s"
+  auto_recovery              = "%s"
   auto_recovery_initial_wait = "%s"
-  auto_recovery_max_backoff = "%s"
-  enabled = "%s"
-  failover_timeout = "%s"
+  auto_recovery_max_backoff  = "%s"
+  enabled                    = "%s"
+  failover_timeout           = "%s"
 
   tag {
     scope = "scope1"
@@ -197,7 +197,7 @@ resource "nsxt_policy_vtep_ha_host_switch_profile" "test" {
 }
 data "nsxt_policy_vtep_ha_host_switch_profile" "test" {
   display_name = "%s"
-  depends_on = [nsxt_policy_vtep_ha_host_switch_profile.test]
+  depends_on   = [nsxt_policy_vtep_ha_host_switch_profile.test]
 }`, attrMap["display_name"], attrMap["description"], attrMap["auto_recovery"], attrMap["auto_recovery_initial_wait"], attrMap["auto_recovery_max_backoff"], attrMap["enabled"], attrMap["failover_timeout"], attrMap["display_name"])
 }
 

--- a/nsxt/resource_nsxt_principal_identity_test.go
+++ b/nsxt/resource_nsxt_principal_identity_test.go
@@ -145,16 +145,16 @@ func testAccNsxtPrincipalIdentityCreate(certPem string) string {
 	attrMap := accTestPrincipalIdentityCreateAttributes
 	return fmt.Sprintf(`
 resource "nsxt_principal_identity" "test" {
-    certificate_pem = <<-EOT
+  certificate_pem = <<-EOT
 %s
     EOT
-    is_protected    = %s
-    name            = "%s"
-    node_id         = "%s"
+  is_protected    = %s
+  name            = "%s"
+  node_id         = "%s"
 
-    roles_for_path {
-        path  = "%s"
-        roles = ["%s"]
-    }
+  roles_for_path {
+    path  = "%s"
+    roles = ["%s"]
+  }
 }`, certPem, attrMap["is_protected"], attrMap["name"], attrMap["node_id"], attrMap["role_path"], attrMap["role"])
 }

--- a/nsxt/resource_nsxt_spoofguard_switching_profile_test.go
+++ b/nsxt/resource_nsxt_spoofguard_switching_profile_test.go
@@ -149,7 +149,7 @@ resource "nsxt_spoofguard_switching_profile" "test" {
 func testAccNSXSpoofGuardSwitchingProfileEmptyTemplate(name string) string {
 	return fmt.Sprintf(`
 resource "nsxt_spoofguard_switching_profile" "test" {
-  display_name                      = "%s"
+  display_name = "%s"
 }
 `, name)
 }

--- a/nsxt/resource_nsxt_switch_security_switching_profile_test.go
+++ b/nsxt/resource_nsxt_switch_security_switching_profile_test.go
@@ -165,7 +165,7 @@ resource "nsxt_switch_security_switching_profile" "test" {
   bpdu_filter_whitelist = ["01:80:c2:00:00:01"]
 
   rate_limits {
-    enabled = true
+    enabled      = true
     rx_broadcast = %s
     rx_multicast = %s
     tx_broadcast = %s
@@ -182,7 +182,7 @@ resource "nsxt_switch_security_switching_profile" "test" {
 func testAccNSXSwitchSecuritySwitchingProfileEmptyTemplate(name string) string {
 	return fmt.Sprintf(`
 resource "nsxt_switch_security_switching_profile" "test" {
-  display_name          = "%s"
+  display_name = "%s"
 }
 `, name)
 }

--- a/nsxt/resource_nsxt_vpc_connectivity_profile_test.go
+++ b/nsxt/resource_nsxt_vpc_connectivity_profile_test.go
@@ -193,8 +193,8 @@ func testAccNsxtVpcConnectivityProfileTemplate(createFlow bool) string {
 	return testAccNsxtVpcConnectivityProfilePrerequisite() + fmt.Sprintf(`
 resource "nsxt_vpc_connectivity_profile" "test" {
 %s
-  display_name = "%s"
-  description  = "%s"
+  display_name         = "%s"
+  description          = "%s"
   transit_gateway_path = data.nsxt_policy_transit_gateway.test.path
 
   service_gateway {

--- a/nsxt/resource_nsxt_vpc_dhcp_v4_static_binding_config_test.go
+++ b/nsxt/resource_nsxt_vpc_dhcp_v4_static_binding_config_test.go
@@ -206,7 +206,7 @@ resource "nsxt_vpc_subnet" "test" {
 %s
   display_name = "test-subnet"
   ip_addresses = ["192.168.240.0/26"]
-  access_mode = "Isolated"
+  access_mode  = "Isolated"
   dhcp_config {
     mode = "DHCP_SERVER"
     dhcp_server_additional_config {
@@ -226,28 +226,28 @@ func testAccNsxtVpcSubnetDhcpV4StaticBindingConfigTemplate(createFlow bool) stri
 	}
 	return testAccNsxtVpcSubnetDhcpV4StaticBindingConfigPrerequisites() + fmt.Sprintf(`
 resource "nsxt_vpc_dhcp_v4_static_binding" "test" {
-  parent_path = nsxt_vpc_subnet.test.path
-  display_name = "%s"
-  description  = "%s"
+  parent_path     = nsxt_vpc_subnet.test.path
+  display_name    = "%s"
+  description     = "%s"
   gateway_address = "%s"
-  host_name = "%s"
-  mac_address = "%s"
-  lease_time = %s
-  ip_address = "%s"
+  host_name       = "%s"
+  mac_address     = "%s"
+  lease_time      = %s
+  ip_address      = "%s"
 
   options {
     option121 {
       static_route {
         next_hop = "%s"
-        network = "%s"
+        network  = "%s"
       }
       static_route {
         next_hop = "%s"
-        network = "%s"
+        network  = "%s"
       }
     }
     other {
-      code = %s
+      code   = %s
       values = ["%s"]
     }
   }
@@ -265,7 +265,7 @@ func testAccNsxtVpcSubnetDhcpV4StaticBindingConfigMinimalistic() string {
 	return testAccNsxtVpcSubnetDhcpV4StaticBindingConfigPrerequisites() + fmt.Sprintf(`
 resource "nsxt_vpc_dhcp_v4_static_binding" "test" {
   display_name = "%s"
-  parent_path = nsxt_vpc_subnet.test.path
+  parent_path  = nsxt_vpc_subnet.test.path
   ip_address   = "%s"
   mac_address  = "%s"
 }`, accTestVpcSubnetDhcpV4StaticBindingConfigUpdateAttributes["display_name"], attrMap["ip_address"], attrMap["mac_address"])

--- a/nsxt/resource_nsxt_vpc_group_test.go
+++ b/nsxt/resource_nsxt_vpc_group_test.go
@@ -123,17 +123,17 @@ resource "nsxt_vpc_group" "test" {
 
   criteria {
     ipaddress_expression {
-	  ip_addresses = ["111.1.1.1", "222.2.2.2"]
+      ip_addresses = ["111.1.1.1", "222.2.2.2"]
     }
   }
 
   conjunction {
-	operator = "OR"
+    operator = "OR"
   }
 
   criteria {
     ipaddress_expression {
-	  ip_addresses = ["122.1.1.1"]
+      ip_addresses = ["122.1.1.1"]
     }
   }
 
@@ -167,7 +167,7 @@ resource "nsxt_vpc_group" "test" {
 
   criteria {
     ipaddress_expression {
-	  ip_addresses = ["122.1.1.1"]
+      ip_addresses = ["122.1.1.1"]
     }
   }
 }

--- a/nsxt/resource_nsxt_vpc_nat_rule_test.go
+++ b/nsxt/resource_nsxt_vpc_nat_rule_test.go
@@ -291,20 +291,20 @@ resource "nsxt_vpc_nat_rule" "test" {
 func testAccNsxtVpcNatRuleSnatTemplate(name string) string {
 	return testAccNsxtVpcNatRulePrerequisites() + fmt.Sprintf(`
 resource "nsxt_vpc_nat_rule" "test" {
-  parent_path         = data.nsxt_vpc_nat.test.path
-  display_name        = "%s"
-  translated_network  = nsxt_vpc_ip_address_allocation.test.allocation_ips
-  action              = "SNAT"
+  parent_path        = data.nsxt_vpc_nat.test.path
+  display_name       = "%s"
+  translated_network = nsxt_vpc_ip_address_allocation.test.allocation_ips
+  action             = "SNAT"
 }`, name)
 }
 
 func testAccNsxtVpcNatRuleReflexiveTemplate(name string, sourceIP string) string {
 	return testAccNsxtVpcNatRulePrerequisites() + fmt.Sprintf(`
 resource "nsxt_vpc_nat_rule" "test" {
-  parent_path         = data.nsxt_vpc_nat.test.path
-  display_name        = "%s"
-  source_network      = "%s"
-  translated_network  = nsxt_vpc_ip_address_allocation.test.allocation_ips
-  action              = "REFLEXIVE"
+  parent_path        = data.nsxt_vpc_nat.test.path
+  display_name       = "%s"
+  source_network     = "%s"
+  translated_network = nsxt_vpc_ip_address_allocation.test.allocation_ips
+  action             = "REFLEXIVE"
 }`, name, sourceIP)
 }

--- a/nsxt/resource_nsxt_vpc_service_profile_test.go
+++ b/nsxt/resource_nsxt_vpc_service_profile_test.go
@@ -237,7 +237,7 @@ resource "nsxt_policy_spoof_guard_profile" "test" {
   display_name = "%s"
 }
 
-resource "nsxt_policy_segment_security_profile" "test"{
+resource "nsxt_policy_segment_security_profile" "test" {
   %s
   display_name = "%s"
 }
@@ -274,7 +274,7 @@ resource "nsxt_vpc_service_profile" "test" {
   dhcp_config {
     dhcp_server_config {
       ntp_servers = ["%s"]
-      lease_time = %s
+      lease_time  = %s
 
       dns_client_config {
         dns_server_ips = ["%s"]
@@ -306,7 +306,7 @@ resource "nsxt_vpc_service_profile" "test" {
       server_addresses = ["%s"]
     }
   }
-  
+
 }`, testAccNsxtProjectContext(), accTestPolicyVpcServiceProfileUpdateAttributes["display_name"], accTestPolicyVpcServiceProfileUpdateAttributes["server_addresses"])
 }
 

--- a/nsxt/resource_nsxt_vpc_static_routes_test.go
+++ b/nsxt/resource_nsxt_vpc_static_routes_test.go
@@ -197,9 +197,9 @@ func testAccNsxtVpcStaticRoutesMinimalistic() string {
 resource "nsxt_vpc_static_route" "test" {
 %s
   display_name = "%s"
-  network = "%s"
+  network      = "%s"
   next_hop {
-    ip_address     = "%s"
+    ip_address = "%s"
   }
 }`, testAccNsxtPolicyMultitenancyContext(), accTestStaticRoutesUpdateAttributes["display_name"], accTestStaticRoutesUpdateAttributes["network"], accTestStaticRoutesUpdateAttributes["ip_address"])
 }

--- a/nsxt/resource_nsxt_vpc_subnet_test.go
+++ b/nsxt/resource_nsxt_vpc_subnet_test.go
@@ -301,7 +301,7 @@ resource "nsxt_vpc_subnet" "test" {
   description  = "%s"
 
   ip_addresses = ["%s"]
-  access_mode = "%s"
+  access_mode  = "%s"
   dhcp_config {
     mode = "DHCP_DEACTIVATED"
   }
@@ -336,14 +336,14 @@ resource "nsxt_vpc_subnet" "test" {
     dhcp_server_additional_config {
       options {
         option121 {
-	  static_route {
-	    network  = "2.1.1.0/24"
-	    next_hop = "2.3.1.3"
-	  }
+          static_route {
+            network  = "2.1.1.0/24"
+            next_hop = "2.3.1.3"
+          }
         }
         other {
-	  code   = "119"
-	  values = ["abc", "def"]
+          code   = "119"
+          values = ["abc", "def"]
         }
       }
     }
@@ -380,7 +380,7 @@ resource "nsxt_vpc_subnet" "test" {
   description  = "%s"
   ip_addresses = ["%s"]
 
-  access_mode      = "Public"
+  access_mode = "Public"
 
   dhcp_config {
     mode = "DHCP_SERVER"
@@ -388,14 +388,14 @@ resource "nsxt_vpc_subnet" "test" {
     dhcp_server_additional_config {
       options {
         option121 {
-	  static_route {
-	    network  = "2.1.1.0/24"
-	    next_hop = "2.3.1.3"
-	  }
+          static_route {
+            network  = "2.1.1.0/24"
+            next_hop = "2.3.1.3"
+          }
         }
         other {
-	  code   = "119"
-	  values = ["abc", "def"]
+          code   = "119"
+          values = ["abc", "def"]
         }
       }
       reserved_ip_ranges = ["%s"]

--- a/nsxt/resource_nsxt_vpc_test.go
+++ b/nsxt/resource_nsxt_vpc_test.go
@@ -280,7 +280,7 @@ resource "nsxt_vpc" "test" {
   display_name = "%s"
   short_id     = "%s"
   # TODO - remove when default profiles are supported
-  vpc_service_profile      = nsxt_vpc_service_profile.test.path
+  vpc_service_profile = nsxt_vpc_service_profile.test.path
 }`, testAccNsxtProjectContext(), accTestVpcUpdateAttributes["display_name"], accTestVpcUpdateAttributes["short_id"])
 }
 
@@ -300,9 +300,9 @@ func testAccNsxtVpcMinimalisticNoShortId() string {
 	return testAccNsxtVpcPrerequisites() + fmt.Sprintf(`
 resource "nsxt_vpc" "test" {
   %s
-  nsx_id = "%s"
+  nsx_id       = "%s"
   display_name = "%s"
   # TODO - remove when default profiles are supported
-  vpc_service_profile      = nsxt_vpc_service_profile.test.path
+  vpc_service_profile = nsxt_vpc_service_profile.test.path
 }`, testAccNsxtProjectContext(), accTestVpcUpdateAttributes["short_id"], accTestVpcUpdateAttributes["display_name"])
 }

--- a/nsxt/utils_test.go
+++ b/nsxt/utils_test.go
@@ -651,17 +651,17 @@ resource "nsxt_policy_tier0_gateway" "test" {
 func testAccNsxtPolicyTier1WithEdgeClusterForVPN() string {
 	return testAccNsxtPolicyEdgeClusterReadTemplate(getEdgeClusterName()) + fmt.Sprintf(`
 resource "nsxt_policy_tier0_gateway" "test" {
-	display_name = "%s"
-	description  = "Acceptance Test"
-	ha_mode = "ACTIVE_STANDBY"
+  display_name = "%s"
+  description  = "Acceptance Test"
+  ha_mode      = "ACTIVE_STANDBY"
 }
 resource "nsxt_policy_tier1_gateway" "test" {
-	description               = "Acceptance Test"
-	display_name              = "%s"
-	locale_service {
-		edge_cluster_path = data.nsxt_policy_edge_cluster.test.path
-	}
-	tier0_path                = nsxt_policy_tier0_gateway.test.path
+  description  = "Acceptance Test"
+  display_name = "%s"
+  locale_service {
+    edge_cluster_path = data.nsxt_policy_edge_cluster.test.path
+  }
+  tier0_path = nsxt_policy_tier0_gateway.test.path
 }`, testAccNsxtPolicyVPNGatewayHelperName, testAccNsxtPolicyVPNGatewayHelperName)
 }
 
@@ -858,7 +858,7 @@ resource "nsxt_policy_share" "test" {
 resource "nsxt_policy_shared_resource" "test" {
   display_name = "%s"
 
-  share_path   = nsxt_policy_share.test.path
+  share_path = nsxt_policy_share.test.path
   resource_object {
     resource_path    = %s
     include_children = true


### PR DESCRIPTION
Applies `terraform fmt` formatting to `_test.go` files as needed.

```shell
terrafmt fmt ./nsxt
```