### PR TITLE
Fix LB UDP profile test failures with v9.1.0

### DIFF
--- a/nsxt/resource_nsxt_policy_lb_udp_monitor_profile_test.go
+++ b/nsxt/resource_nsxt_policy_lb_udp_monitor_profile_test.go
@@ -202,6 +202,8 @@ func testAccNsxtPolicyLBUdpMonitorProfileMinimalistic() string {
 	return fmt.Sprintf(`
 resource "nsxt_policy_lb_udp_monitor_profile" "test" {
   display_name = "%s"
+  receive = "%s"
+  send = "%s"
 
-}`, accTestPolicyLBUdpMonitorProfileUpdateAttributes["display_name"])
+}`, accTestPolicyLBUdpMonitorProfileUpdateAttributes["display_name"], accTestPolicyLBUdpMonitorProfileUpdateAttributes["receive"], accTestPolicyLBUdpMonitorProfileUpdateAttributes["send"])
 }


### PR DESCRIPTION
nsxt_policy_lb_udp_monitor_profile send and receive attributes became mandatory with v9.1.0.