### PR TITLE
Ignore edge transport node order in cluster

### DIFF
--- a/nsxt/resource_nsxt_policy_edge_cluster.go
+++ b/nsxt/resource_nsxt_policy_edge_cluster.go
@@ -99,7 +99,7 @@ var policyEdgeClusterSchema = map[string]*metadata.ExtendedSchema{
 	},
 	"policy_edge_node": {
 		Schema: schema.Schema{
-			Type: schema.TypeList,
+			Type: schema.TypeSet,
 			Elem: &metadata.ExtendedResource{
 				Schema: map[string]*metadata.ExtendedSchema{
 					"edge_transport_node_path": {
@@ -130,7 +130,7 @@ var policyEdgeClusterSchema = map[string]*metadata.ExtendedSchema{
 			Optional: true,
 		},
 		Metadata: metadata.Metadata{
-			SchemaType:   "list",
+			SchemaType:   "set",
 			SdkFieldName: "PolicyEdgeNodes",
 			ReflectType:  reflect.TypeOf(model.PolicyEdgeClusterMember{}),
 		},


### PR DESCRIPTION
NSX may not retain the order of the nodes within the cluster when index is not specified by the user.
So using order-less set is better in this case.