### PR TITLE
docs: cleanup guides rendering

### DIFF
--- a/docs/guides/faq.md
+++ b/docs/guides/faq.md
@@ -79,7 +79,7 @@ resource "nsxt_policy_group" "test" {
 
 ## VM tagging and port tagging is not working on big environments
 
-Due to [NSX issue](https://kb.vmware.com/s/article/89437), `vif` API is not working as expected with > 1K objects. Please upgrade your NSX to more recent version.
+Due to [NSX issue](https://knowledge.broadcom.com/external/article?articleNumber=318424), `vif` API is not working as expected with > 1K objects. Please upgrade your NSX to more recent version.
 
 ## I cannot import a segment
 

--- a/docs/guides/federation.md
+++ b/docs/guides/federation.md
@@ -1,16 +1,16 @@
 ---
-page_title: "VMware NSX-T Terraform Provider support for Federation (Global Manager)"
+page_title: "Support for NSX Federation"
 description: |-
-  The VMware NSX-T Terraform Provider support for Federation (Global Manager)
+  Support for NSX Federation
 ---
 
-# Terraform Provider for NSX-T extension for Federation
+# Support for NSX Federation
 
-The NSX Terraform Resources and Data Sources are now extended to support Federation (Global Manager). More information on Federation that was introduced in NSX-T 3.0 can be found on the [NSX-T Product Page for Federation](https://docs.vmware.com/en/VMware-NSX-T-Data-Center/3.0/administration/GUID-D5B6DC79-6733-44A7-8072-50221CF2122A.html)
+The provider includes support NSX Federation (Global Manager).
 
-Documentation on the NSX platform can be found on the [NSX Documentation Page](https://docs.vmware.com/en/VMware-NSX-T/index.html)
+For more information on NSX, refer to the [NSX documentation](https://techdocs.broadcom.com/us/en/vmware-cis/nsx.html).
 
-## Basic Authentication with Federation
+## Basic Authentication with NSX Federation
 
 ```hcl
 provider "nsxt" {
@@ -21,9 +21,9 @@ provider "nsxt" {
 }
 ```
 
-**NOTE:** Authentication with the Global Manager uses the same NSX-T Terraform provider but uses a `global_manager = true` flag for identification.
+~> **NOTE:**  Authentication with the Global Manager uses the same NSX Terraform provider but uses a `global_manager = true` flag for identification.
 
-**NOTE:** In order to use both Global Manager and Local Manager within same configuration, please use [Provider Aliasing] (<https://www.terraform.io/docs/configuration/providers.html#alias-multiple-provider-configurations>).
+~> **NOTE:**  In order to use both Global Manager and Local Manager within same configuration, please use [Provider Aliasing] (<https://www.terraform.io/docs/configuration/providers.html#alias-multiple-provider-configurations>).
 
 ## Using Resources and Data Sources
 
@@ -33,9 +33,9 @@ For example, consider the resource nsxt_policy_tier0_gateway. While the same res
 
 Remember to check out the documentation for the resource you are interested in for such differences.
 
-**NOTE:** Only Policy resources are available to use with Federation.
+~> **NOTE:**  Only Policy resources are available to use with Federation.
 
-## Available Resources for use with NSX-T Federation
+## Available Resources for use with NSX Federation
 
 The following Resources are available to use with Federation:
 
@@ -51,7 +51,7 @@ The following Resources are available to use with Federation:
 * Gateway Policy [nsxt_policy_gateway_policy](https://www.terraform.io/docs/providers/nsxt/r/policy_gateway_policy)
 * NAT Rule [nsxt_policy_nat_rule](https://www.terraform.io/docs/providers/nsxt/r/policy_nat_rule)
 
-## Available Data Sources for use with NSX-T Federation
+## Available Data Sources for use with NSX Federation
 
 The following Data Sources are available to use with Federation:
 

--- a/docs/guides/multitenancy.md
+++ b/docs/guides/multitenancy.md
@@ -1,14 +1,14 @@
 ---
-page_title: "VMware NSX Terraform Provider support for Multi-tenancy"
+page_title: "Support for NSX Multi-tenancy"
 description: |-
-  The VMware NSX Terraform Provider support for Multi-tenancy
+  Support for NSX Multi-tenancy
 ---
 
-# NSX Provider for NSX Multi-tenancy
+# Support for NSX Multi-tenancy
 
-NSX Terraform Provider offers support for NSX [multi-tenancy feature](https://docs.vmware.com/en/VMware-NSX/4.1/administration/GUID-52180BC5-A1AB-4BC2-B1CE-666292505317.html).
+The provider includes support for [NSX Multi-tenancy](https://techdocs.broadcom.com/us/en/vmware-cis/nsx/vmware-nsx/4-1/administration-guide/nsx-multi-tenancy.html).
 
-## NSX Multi-Tenancy
+## NSX Multi-tenancy
 
 NSX introduced a new construct called Project in order to offer tenancy by isolating security and networking objects across tenants in a single NSX deployment.
 
@@ -20,7 +20,7 @@ NSX also introduced NSX VPCs, offering a second level of tenancy and cloud consu
 
 NSX Project objects can be created and referenced with the `nsxt_policy_project` [resource](../resources/policy_project.md) and [data source](../data-sources/policy_project.md).
 
-For example, an NSX multi-tenancy Project could be created as below:
+For example, an NSX Multi-tenancy Project could be created as below:
 
 ```hcl
 resource "nsxt_policy_project" "test" {

--- a/docs/guides/upgrade.md
+++ b/docs/guides/upgrade.md
@@ -1,19 +1,21 @@
 ---
-page_title: "VMware NSX Terraform Provider NSX upgrade support"
+page_title: "Support for NSX Upgrades"
 description: |-
-  VMware NSX Terraform Provider NSX upgrade support
+  Support for NSX Upgrades
 ---
 
-# NSX Provider for NSX Upgrade
+# Support for NSX Upgrades
 
-NSX Terraform Provider offers support for [upgrading NSX components](https://docs.vmware.com/en/VMware-NSX/4.1/upgrade/GUID-E04242D7-EF09-4601-8906-3FA77FBB06BD.html).
+The provider includes support for upgrading NSX components](https://techdocs.broadcom.com/us/en/vmware-cis/nsx/vmware-nsx/4-1/upgrade-guide.html).
 
 The provider support consists of several resources and data sources which can perform a complete upgrade cycle.
-The NSX Terraform provider support upgrades for NSX on ESX hosts, NSX Edge appliances, and NSX manager appliances.
 
-**NOTE:** The upgrade process using the Terraform NSXT provider assumes that the Terraform NSX provider uses NSX upgrade
-components exclusively. Therefore, concurrent changess to upgrade components via other means, e.g. UI, might fail the process.
-**NOTE:** The NSX upgrade process should start each upgrade with a clean state. So whenever an upgrade is executed, e.g.
+The provider supports upgrades for NSX on ESX hosts, NSX Edge appliances, and NSX Manager appliances.
+
+~> **NOTE:** The upgrade process using the provider assumes that only the provider is used to upgrade NSX components.
+Therefore, concurrent changes to upgrade components via other means, e.g. UI, might fail the process.
+
+~> **NOTE:** The NSX upgrade process should start each upgrade with a clean state. So whenever an upgrade is executed, e.g.
 from v3.2.3 to v4.1.1 the Terraform state file should be retained until the upgrade is completed. Then, if the same plan
 is used later on to upgrade from v4.1.1 to v4.2.0, the Terraform state file should be deleted prior to applying the plan.
 
@@ -27,7 +29,7 @@ Upgrade preparation consists of several actions, and is performed using [nsxt_up
 * Acceptance of the user agreement.
 * Reporting of failed pre-checks.
 
-**NOTE:** Only one `nsxt_upgrade_prepare` resource should be used in the upgrade plan.
+~> **NOTE:** Only one `nsxt_upgrade_prepare` resource should be used in the upgrade plan.
 
 ```hcl
 resource "nsxt_upgrade_prepare" "prepare_res" {
@@ -37,8 +39,9 @@ resource "nsxt_upgrade_prepare" "prepare_res" {
 }
 ```
 
-**NOTE:** Acceptance of the license agreement is required to initiate the upgrade process.
-**NOTE:** Precheck bundle is usable only while upgrading a NSX manager of version v4.1.1 and above.
+~> **NOTE:** Acceptance of the license agreement is required to initiate the upgrade process.
+
+~> **NOTE:** Precheck bundle is usable only while upgrading a NSX manager of version v4.1.1 and above.
 
 ### Checking the readiness for upgrade
 
@@ -107,7 +110,7 @@ In the example below, host_group `HostWithDifferentSettings` will use different 
 group configuration is initiated with the `nsxt_upgrade_run` while the other groups in this example are predefined and
 consumed using the data sources `nsxt_edge_upgrade_group` and `nsxt_host_upgrade_group`.
 
-**NOTE:** Only one `nsxt_upgrade_run` resource should be used in the upgrade plan.
+~> **NOTE:** Only one `nsxt_upgrade_run` resource should be used in the upgrade plan.
 
 ```hcl
 data "nsxt_policy_host_transport_node" "host_transport_node1" {

--- a/docs/guides/vmc.md
+++ b/docs/guides/vmc.md
@@ -1,16 +1,18 @@
 ---
-page_title: "VMware NSX-T Terraform Provider for VMConAWS"
+page_title: "Support for VMware Cloud on AWS"
 description: |-
-  The VMware NSX-T Terraform Provider for VMConAWS
+  Support for VMware Cloud on AWS
 ---
 
-# Terraform Provider for NSX-T support extended to VMConAWS
+# Support for VMware Cloud on AWS
 
-The NSX Terraform Resources and Data Sources applicable to NSX-T on VMConAWS are supported. More information on VMConAWS can be found on the [VMConAWS Product Page](https://cloud.vmware.com/vmc-aws)
+The provider includes support for resources and datasources applicable on VMware Cloud on AWS.
 
-Documentation on the NSX platform can be found on the [NSX Documentation Page](https://docs.vmware.com/en/VMware-NSX-T/index.html)
+For more information on VMware Cloud on AWS, refer to the [VMware Cloud on AWS product site](https://www.vmware.com/solutions/partner-managed-services/vmc-on-aws)
 
-## Basic Authentication with VMConAWS
+For more information on NSX, refer to the [NSX documentation](https://techdocs.broadcom.com/us/en/vmware-cis/nsx.html).
+
+## Basic Authentication with VMware Cloud on AWS
 
 ```hcl
 provider "nsxt" {
@@ -19,69 +21,68 @@ provider "nsxt" {
   allow_unverified_ssl = true
   enforcement_point    = "vmc-enforcementpoint"
 }
-
 ```
 
 Note that `host` is the ProxyURL and `vmc_token` is the API Access Token
 
-## Available Resources for use with VMConAWS
+## Available Resources for use with VMware Cloud on AWS
 
-The following Resources are available to use with VMConAWS:
+The following Resources are available to use with VMware Cloud on AWS:
 
-* Flexible Segment: [nsxt_policy_segment](https://www.terraform.io/docs/providers/nsxt/r/policy_segment)
-* Fixed Segment: [nsxt_policy_fixed_segment](https://www.terraform.io/docs/providers/nsxt/r/policy_fixed_segment)
-* Tier1 Gateway: [nsxt_policy_tier1_gateway](https://www.terraform.io/docs/providers/nsxt/r/policy_tier1_gateway)
-* Distributed Firewall Section: [nsxt_policy_security_policy](https://www.terraform.io/docs/providers/nsxt/r/policy_security_policy)
-* Predefined Distributed Firewall Section: [nsxt_policy_predefined_security_policy](https://www.terraform.io/docs/providers/nsxt/r/policy_predefined_security_policy)
-* Predefined Gateway Firewall Section: [nsxt_policy_predefined_gateway_policy](https://www.terraform.io/docs/providers/nsxt/r/policy_predefined_gateway_policy)
-* NAT: [nsxt_policy_nat_rule](https://www.terraform.io/docs/providers/nsxt/r/policy_nat_rule)
-* Security Group: [nsxt_policy_group](https://www.terraform.io/docs/providers/nsxt/r/policy_group)
-* Service: [nsxt_policy_service](https://www.terraform.io/docs/providers/nsxt/r/policy_service)
-* DHCP Relay: [nsxt_policy_dhcp_relay](https://www.terraform.io/docs/providers/nsxt/r/policy_dhcp_relay)
-* DHCP Service: [nsxt_policy_dhcp_service](https://www.terraform.io/docs/providers/nsxt/r/policy_dhcp_service)
-* Virtual Machine Tags: [nsxt_policy_vm_tag](https://www.terraform.io/docs/providers/nsxt/r/policy_vm_tags)
-* Context Profile: [nsxt_policy_context_profile](https://www.terraform.io/docs/providers/nsxt/r/policy_context_profile)
-* Gateway QoS Profile: [nsxt_policy_gateway_qos_profile](https://www.terraform.io/docs/providers/nsxt/r/policy_gateway_qos_profile)
-* IDS Policy: [nsxt_policy_intrusion_service_policy](https://www.terraform.io/docs/providers/nsxt/r/policy_intrusion_service_policy)
-* IDS Profile: [nsxt_policy_intrusion_service_profile](https://www.terraform.io/docs/providers/nsxt/r/policy_intrusion_service_profile)
-* DNS Forwarder Zone: [nsxt_policy_dns_forwarder_zone](https://www.terraform.io/docs/providers/nsxt/r/policy_dns_forwarder_zone)
-* Gateway DNS Forwarder: [nsxt_policy_gateway_dns_forwarder](https://www.terraform.io/docs/providers/nsxt/r/policy_gateway_dns_forwarder)
-* IPSec VPN DPD Profile: [nsxt_policy_ipsec_vpn_dpd_profile](https://www.terraform.io/docs/providers/nsxt/r/policy_ipsec_vpn_dpd_profile)
-* IPSec VPN IKE Profile: [nsxt_policy_ipsec_vpn_ike_profile](https://www.terraform.io/docs/providers/nsxt/r/policy_ipsec_vpn_ike_profile)
-* IPSec VPN Tunnel Profile: [nsxt_policy_ipsec_vpn_tunnel_profile](https://www.terraform.io/docs/providers/nsxt/r/policy_ipsec_vpn_tunnel_profile)
-* IPSec VPN Local Endpoint: [nsxt_policy_ipsec_vpn_local_endpoint](https://www.terraform.io/docs/providers/nsxt/r/policy_ipsec_vpn_local_endpoint)
-* IPSec VPN Service: [nsxt_policy_ipsec_vpn_service](https://www.terraform.io/docs/providers/nsxt/r/policy_ipsec_vpn_service)
-* IPSec VPN Session: [nsxt_policy_ipsec_vpn_session](https://www.terraform.io/docs/providers/nsxt/r/policy_ipsec_vpn_session)
-* L2 VPN Service: [nsxt_policy_l2_vpn_service](https://www.terraform.io/docs/providers/nsxt/r/policy_l2_vpn_service)
-* L2 VPN Session: [nsxt_policy_l2_vpn_session](https://www.terraform.io/docs/providers/nsxt/r/policy_l2_vpn_session)
+* Flexible Segment: [nsxt_policy_segment](https://registry.terraform.io/providers/vmware/nsxt/latest/docs/resources/policy_segment)
+* Fixed Segment: [nsxt_policy_fixed_segment](https://registry.terraform.io/providers/vmware/nsxt/latest/docs/resources/policy_fixed_segment)
+* Tier1 Gateway: [nsxt_policy_tier1_gateway](https://registry.terraform.io/providers/vmware/nsxt/latest/docs/resources/policy_tier1_gateway)
+* Distributed Firewall Section: [nsxt_policy_security_policy](https://registry.terraform.io/providers/vmware/nsxt/latest/docs/resources/policy_security_policy)
+* Predefined Distributed Firewall Section: [nsxt_policy_predefined_security_policy](https://registry.terraform.io/providers/vmware/nsxt/latest/docs/resources/policy_predefined_security_policy)
+* Predefined Gateway Firewall Section: [nsxt_policy_predefined_gateway_policy](https://registry.terraform.io/providers/vmware/nsxt/latest/docs/resources/policy_predefined_gateway_policy)
+* NAT: [nsxt_policy_nat_rule](https://registry.terraform.io/providers/vmware/nsxt/latest/docs/resources/policy_nat_rule)
+* Security Group: [nsxt_policy_group](https://registry.terraform.io/providers/vmware/nsxt/latest/docs/resources/policy_group)
+* Service: [nsxt_policy_service](https://registry.terraform.io/providers/vmware/nsxt/latest/docs/resources/policy_service)
+* DHCP Relay: [nsxt_policy_dhcp_relay](https://registry.terraform.io/providers/vmware/nsxt/latest/docs/resources/policy_dhcp_relay)
+* DHCP Service: [nsxt_policy_dhcp_service](https://registry.terraform.io/providers/vmware/nsxt/latest/docs/resources/policy_dhcp_service)
+* Virtual Machine Tags: [nsxt_policy_vm_tag](https://registry.terraform.io/providers/vmware/nsxt/latest/docs/resources/policy_vm_tags)
+* Context Profile: [nsxt_policy_context_profile](https://registry.terraform.io/providers/vmware/nsxt/latest/docs/resources/policy_context_profile)
+* Gateway QoS Profile: [nsxt_policy_gateway_qos_profile](https://registry.terraform.io/providers/vmware/nsxt/latest/docs/resources/policy_gateway_qos_profile)
+* IDS Policy: [nsxt_policy_intrusion_service_policy](https://registry.terraform.io/providers/vmware/nsxt/latest/docs/resources/policy_intrusion_service_policy)
+* IDS Profile: [nsxt_policy_intrusion_service_profile](https://registry.terraform.io/providers/vmware/nsxt/latest/docs/resources/policy_intrusion_service_profile)
+* DNS Forwarder Zone: [nsxt_policy_dns_porwarder_zone](https://registry.terraform.io/providers/vmware/nsxt/latest/docs/resources/policy_dns_forwarder_zone)
+* Gateway DNS Forwarder: [nsxt_policy_gateway_dns_forwarder](https://registry.terraform.io/providers/vmware/nsxt/latest/docs/resources/policy_gateway_dns_forwarder)
+* IPSec VPN DPD Profile: [nsxt_policy_ipsec_vpn_dpd_profile](https://registry.terraform.io/providers/vmware/nsxt/latest/docs/resources/policy_ipsec_vpn_dpd_profile)
+* IPSec VPN IKE Profile: [nsxt_policy_ipsec_vpn_ike_profile](https://registry.terraform.io/providers/vmware/nsxt/latest/docs/resources/policy_ipsec_vpn_ike_profile)
+* IPSec VPN Tunnel Profile: [nsxt_policy_ipsec_vpn_tunnel_profile](https://registry.terraform.io/providers/vmware/nsxt/latest/docs/resources/policy_ipsec_vpn_tunnel_profile)
+* IPSec VPN Local Endpoint: [nsxt_policy_ipsec_vpn_local_endpoint](https://registry.terraform.io/providers/vmware/nsxt/latest/docs/resources/policy_ipsec_vpn_local_endpoint)
+* IPSec VPN Service: [nsxt_policy_ipsec_vpn_service](https://registry.terraform.io/providers/vmware/nsxt/latest/docs/resources/policy_ipsec_vpn_service)
+* IPSec VPN Session: [nsxt_policy_ipsec_vpn_session](https://registry.terraform.io/providers/vmware/nsxt/latest/docs/resources/policy_ipsec_vpn_session)
+* L2 VPN Service: [nsxt_policy_l2_vpn_service](https://registry.terraform.io/providers/vmware/nsxt/latest/docs/resources/policy_l2_vpn_service)
+* L2 VPN Session: [nsxt_policy_l2_vpn_session](https://registry.terraform.io/providers/vmware/nsxt/latest/docs/resources/policy_l2_vpn_session)
 
-## Available Data Sources for use with VMConAWS
+## Available Data Sources for use with VMware Cloud on AWS
 
-The following Data Sources are available to use with VMConAWS:
+The following Data Sources are available to use with VMware Cloud on AWS:
 
-* Service: [nsxt_policy_service](https://www.terraform.io/docs/providers/nsxt/d/policy_service)
-* Group: [nsxt_policy_group](https://www.terraform.io/docs/providers/nsxt/d/policy_group)
-* Edge Cluster: [nsxt_policy_edge_cluster](https://www.terraform.io/docs/providers/nsxt/d/policy_edge_cluster)
-* Transport Zone: [nsxt_policy_transport_zone](https://www.terraform.io/docs/providers/nsxt/d/policy_transport_zone)
-* Tier-0 Gateway: [nsxt_policy_tier0_gateway](https://www.terraform.io/docs/providers/nsxt/d/policy_tier0_gateway)
-* Tier-1 Gateway: [nsxt_policy_tier1_gateway](https://www.terraform.io/docs/providers/nsxt/d/policy_tier1_gateway)
-* IPSec VPN Service: [nsxt_policy_ipsec_vpn_service](https://www.terraform.io/docs/providers/nsxt/d/policy_ipsec_vpn_service)
-* IPSec VPN Local Endpoint: [nsxt_policy_ipsec_vpn_local_endpoint](https://www.terraform.io/docs/providers/nsxt/d/policy_ipsec_vpn_local_endpoint)
-* L2 VPN Service: [nsxt_policy_l2_vpn_service](https://www.terraform.io/docs/providers/nsxt/d/policy_l2_vpn_service)
-* Intrusion Service Profile: [nsxt_policy_intrusion_service_profile](https://www.terraform.io/docs/providers/nsxt/d/policy_intrusion_service_profile)
-* DHCP Server: [nsxt_policy_dhcp_server](https://www.terraform.io/docs/providers/nsxt/d/policy_dhcp_server)
-* IP Discovery Segment Profile: [nsxt_policy_ip_discovery_profile](https://www.terraform.io/docs/providers/nsxt/d/policy_ip_discovery_profile)
-* MAC Discovery Segment Profile: [nsxt_policy_mac_discovery_profile](https://www.terraform.io/docs/providers/nsxt/d/policy_mac_discovery_profile)
-* QoS Segment Profile: [nsxt_policy_qos_profile](https://www.terraform.io/docs/providers/nsxt/d/policy_qos_profile)
-* Segment Security Profile: [nsxt_policy_segment_security_profile](https://www.terraform.io/docs/providers/nsxt/d/policy_segment_security_profile)
-* Spoofguard Segment Profile: [nsxt_policy_spoof_guard_profile](https://www.terraform.io/docs/providers/nsxt/d/policy_spoof_guard_profile)
-* Certificate: [nsxt_policy_certificate](https://www.terraform.io/docs/providers/nsxt/d/policy_certificate)
-* Virtual Machine: [nsxt_policy_vm](https://www.terraform.io/docs/providers/nsxt/d/policy_vm)
-* Virtual Machines with filters: [nsxt_policy_vms](https://www.terraform.io/docs/providers/nsxt/d/policy_vms)
-* Security Policy: [nsxt_policy_security_policy](https://www.terraform.io/docs/providers/nsxt/d/policy_security_policy)
-* Gateway Policy: [nsxt_policy_gateway_policy](https://www.terraform.io/docs/providers/nsxt/d/policy_gateway_policy)
+* Service: [nsxt_policy_service](https://registry.terraform.io/providers/vmware/nsxt/latest/docs/data-sources/policy_service)
+* Group: [nsxt_policy_group](https://registry.terraform.io/providers/vmware/nsxt/latest/docs/data-sources/policy_group)
+* Edge Cluster: [nsxt_policy_edge_cluster](https://registry.terraform.io/providers/vmware/nsxt/latest/docs/data-sources/policy_edge_cluster)
+* Transport Zone: [nsxt_policy_transport_zone](https://registry.terraform.io/providers/vmware/nsxt/latest/docs/data-sources/policy_transport_zone)
+* Tier-0 Gateway: [nsxt_policy_tier0_gateway](https://registry.terraform.io/providers/vmware/nsxt/latest/docs/data-sources/policy_tier0_gateway)
+* Tier-1 Gateway: [nsxt_policy_tier1_gateway](https://registry.terraform.io/providers/vmware/nsxt/latest/docs/data-sources/policy_tier1_gateway)
+* IPSec VPN Service: [nsxt_policy_ipsec_vpn_service](https://registry.terraform.io/providers/vmware/nsxt/latest/docs/data-sources/policy_ipsec_vpn_service)
+* IPSec VPN Local Endpoint: [nsxt_policy_ipsec_vpn_local_endpoint](https://registry.terraform.io/providers/vmware/nsxt/latest/docs/data-sources/policy_ipsec_vpn_local_endpoint)
+* L2 VPN Service: [nsxt_policy_l2_vpn_service](https://registry.terraform.io/providers/vmware/nsxt/latest/docs/data-sources/policy_l2_vpn_service)
+* Intrusion Service Profile: [nsxt_policy_intrusion_service_profile](https://registry.terraform.io/providers/vmware/nsxt/latest/docs/data-sources/policy_intrusion_service_profile)
+* DHCP Server: [nsxt_policy_dhcp_server](https://registry.terraform.io/providers/vmware/nsxt/latest/docs/data-sources/policy_dhcp_server)
+* IP Discovery Segment Profile: [nsxt_policy_ip_discovery_profile](https://registry.terraform.io/providers/vmware/nsxt/latest/docs/data-sources/policy_ip_discovery_profile)
+* MAC Discovery Segment Profile: [nsxt_policy_mac_discovery_profile](https://registry.terraform.io/providers/vmware/nsxt/latest/docs/data-sources/policy_mac_discovery_profile)
+* QoS Segment Profile: [nsxt_policy_qos_profile](https://registry.terraform.io/providers/vmware/nsxt/latest/docs/data-sources/policy_qos_profile)
+* Segment Security Profile: [nsxt_policy_segment_security_profile](https://registry.terraform.io/providers/vmware/nsxt/latest/docs/data-sources/policy_segment_security_profile)
+* Spoofguard Segment Profile: [nsxt_policy_spoof_guard_profile](https://registry.terraform.io/providers/vmware/nsxt/latest/docs/data-sources/policy_spoof_guard_profile)
+* Certificate: [nsxt_policy_certificate](https://registry.terraform.io/providers/vmware/nsxt/latest/docs/data-sources/policy_certificate)
+* Virtual Machine: [nsxt_policy_vm](https://registry.terraform.io/providers/vmware/nsxt/latest/docs/data-sources/policy_vm)
+* Virtual Machines with filters: [nsxt_policy_vms](https://registry.terraform.io/providers/vmware/nsxt/latest/docs/data-sources/policy_vms)
+* Security Policy: [nsxt_policy_security_policy](https://registry.terraform.io/providers/vmware/nsxt/latest/docs/data-sources/policy_security_policy)
+* Gateway Policy: [nsxt_policy_gateway_policy](https://registry.terraform.io/providers/vmware/nsxt/latest/docs/data-sources/policy_gateway_policy)
 
-Note that in relevant resources, a domain needs to be specified, since on VMC the domain is different from `default` domain. For example:
+Note that in relevant resources, a domain needs to be specified, since on VMware Cloud on AWS the domain is different from `default` domain. For example:
 
 ```hcl
 resource "nsxt_policy_group" "test" {


### PR DESCRIPTION
Cleans up the rendering for the providers guides:

- Update use of NSX-T to NSX.
- Updates titles and headers.
- Updates URLs as needed.
- Clarifys context, as needed.

This will clean up the following navigation and some of the included content.

Current:

![image](https://github.com/user-attachments/assets/b13daf9a-c881-4e99-ad03-d4cb3109a557)
