### PR TITLE
refactor: use nil slice declaration

### DIFF
--- a/nsxt/data_source_nsxt_policy_vms.go
+++ b/nsxt/data_source_nsxt_policy_vms.go
@@ -23,7 +23,7 @@ var stateMap = map[string]string{
 }
 
 func dataSourceNsxtPolicyVMs() *schema.Resource {
-	stateMapKeys := []string{}
+	var stateMapKeys []string
 	for k := range stateMap {
 		stateMapKeys = append(stateMapKeys, k)
 	}

--- a/nsxt/gateway_common.go
+++ b/nsxt/gateway_common.go
@@ -86,7 +86,7 @@ func getPolicyEdgeClusterPathSchema() *schema.Schema {
 }
 
 func getPolicyLocaleServiceSchema(isTier1 bool) *schema.Schema {
-	nodeConficts := []string{}
+	var nodeConficts []string
 	if isTier1 {
 		// for Tier1, enable_standby_relocation can not be enabled if
 		// preferred nodes are specified

--- a/nsxt/metadata/metadata_poly_test.go
+++ b/nsxt/metadata/metadata_poly_test.go
@@ -29,7 +29,7 @@ func testCatStructBindingType() vapiBindings_.BindingType {
 	fieldNameMap["name"] = "Name"
 	fields["type"] = vapiBindings_.NewStringType()
 	fieldNameMap["type"] = "Type"
-	var validators = []vapiBindings_.Validator{}
+	var validators []vapiBindings_.Validator
 	return vapiBindings_.NewStructType("com.vmware.nsx.fake.cat", fields,
 		reflect.TypeOf(testCatStruct{}), fieldNameMap, validators)
 }
@@ -66,7 +66,7 @@ func testCoffeeStructBindingType() vapiBindings_.BindingType {
 	fieldNameMap["name"] = "Name"
 	fields["type"] = vapiBindings_.NewStringType()
 	fieldNameMap["type"] = "Type"
-	var validators = []vapiBindings_.Validator{}
+	var validators []vapiBindings_.Validator
 	return vapiBindings_.NewStructType("com.vmware.nsx.fake.coffee", fields,
 		reflect.TypeOf(testCoffeeStruct{}), fieldNameMap, validators)
 }

--- a/nsxt/resource_nsxt_manager_cluster.go
+++ b/nsxt/resource_nsxt_manager_cluster.go
@@ -249,7 +249,7 @@ func getClusterInfoFromHostNode(d *schema.ResourceData, m interface{}) (string, 
 	minRetryInterval := c.CommonConfig.MinRetryInterval
 	maxRetryInterval := c.CommonConfig.MaxRetryInterval
 	maxRetries := c.CommonConfig.MaxRetries
-	hostIPs := []string{}
+	var hostIPs []string
 	for i := 0; i < maxRetries; i++ {
 		clusterConfig, err := client.Get()
 		if err != nil {

--- a/nsxt/resource_nsxt_policy_service.go
+++ b/nsxt/resource_nsxt_policy_service.go
@@ -260,7 +260,7 @@ func setServiceEntryListInSchemaOrMap(d interface{}, attrName string, entries []
 
 func getServiceEntriesFromSchema(d interface{}) ([]*data.StructValue, error) {
 	converter := bindings.NewTypeConverter()
-	serviceEntries := []*data.StructValue{}
+	var serviceEntries []*data.StructValue
 
 	// ICMP Type service entries
 	icmpEntries := getServiceEntryListFromSchemaOrMap(d, "icmp_entry")

--- a/nsxt/resource_nsxt_qos_switching_profile.go
+++ b/nsxt/resource_nsxt_qos_switching_profile.go
@@ -189,7 +189,7 @@ func resourceNsxtQosSwitchingProfileCreate(d *schema.ResourceData, m interface{}
 		dscpTrusted = "TRUSTED"
 	}
 	dscpPriority := int32(d.Get("dscp_priority").(int))
-	shapers := []manager.QosBaseRateShaper{}
+	var shapers []manager.QosBaseRateShaper
 	for index := ingressRateShaperIndex; index <= egressRateShaperIndex; index++ {
 
 		shaper := getQosRateShaperFromSchema(d, index)
@@ -284,7 +284,7 @@ func resourceNsxtQosSwitchingProfileUpdate(d *schema.ResourceData, m interface{}
 		dscpTrusted = "TRUSTED"
 	}
 	dscpPriority := int32(d.Get("dscp_priority").(int))
-	shapers := []manager.QosBaseRateShaper{}
+	var shapers []manager.QosBaseRateShaper
 	for index := ingressRateShaperIndex; index <= egressRateShaperIndex; index++ {
 		shaper := getQosRateShaperFromSchema(d, index)
 		if shaper != nil {

--- a/nsxt/resource_nsxt_spoofguard_switching_profile.go
+++ b/nsxt/resource_nsxt_spoofguard_switching_profile.go
@@ -56,7 +56,7 @@ func resourceNsxtSpoofGuardSwitchingProfileCreate(d *schema.ResourceData, m inte
 	description := d.Get("description").(string)
 	displayName := d.Get("display_name").(string)
 	tags := getTagsFromSchema(d)
-	whiteListProviders := []string{}
+	var whiteListProviders []string
 	if d.Get("address_binding_whitelist_enabled").(bool) {
 		whiteListProviders = append(whiteListProviders, "LPORT_BINDINGS")
 	}
@@ -131,7 +131,7 @@ func resourceNsxtSpoofGuardSwitchingProfileUpdate(d *schema.ResourceData, m inte
 	displayName := d.Get("display_name").(string)
 	tags := getTagsFromSchema(d)
 	revision := int64(d.Get("revision").(int))
-	whiteListProviders := []string{}
+	var whiteListProviders []string
 	if d.Get("address_binding_whitelist_enabled").(bool) {
 		whiteListProviders = append(whiteListProviders, "LPORT_BINDINGS")
 	}


### PR DESCRIPTION
Replaces empty slice declaration with nil slice declaration.

An empty slice can be represented by nil or an empty slice literal. They are functionally equivalent — their len and cap are both zero — but the nil slice is the preferred style.