### PR TITLE
chore: comments of exported element

### DIFF
--- a/nsxt/metadata/metadata.go
+++ b/nsxt/metadata/metadata.go
@@ -20,7 +20,7 @@ import (
 // package level logger to include log.Lshortfile context
 var logger = log.New(os.Stderr, "", log.LstdFlags|log.Lshortfile)
 
-// common way NSX API defines polymorphic type
+// StandardTypeIdentifier is a common NSX API defines a polymorphic type.
 var StandardTypeIdentifier = TypeIdentifier{
 	SdkName:      "Type_",
 	APIFieldName: "type",

--- a/nsxt/resource_nsxt_policy_ipsec_vpn_local_endpoint.go
+++ b/nsxt/resource_nsxt_policy_ipsec_vpn_local_endpoint.go
@@ -101,7 +101,8 @@ func (c *localEndpointClient) Get(connector client.Connector, id string) (model.
 	return client.Get(c.gwID, c.serviceID, id)
 }
 
-// Note: we don't expect pagination to be relevant here
+// List retrieves a list of IPSecVpnLocalEndpoint objects for the specified gateway, service, and locale configuration.
+// Note: We don't expect pagination to be relevant here.
 func (c *localEndpointClient) List(connector client.Connector) ([]model.IPSecVpnLocalEndpoint, error) {
 	boolFalse := false
 	var cursor string


### PR DESCRIPTION
Comments of the exported element do not start with the name.