### PR TITLE
Make DistributedVlanConnection displayname is optional

### DIFF
--- a/nsxt/data_source_nsxt_policy_distributed_vlan_connection.go
+++ b/nsxt/data_source_nsxt_policy_distributed_vlan_connection.go
@@ -15,7 +15,7 @@ func dataSourceNsxtPolicyDistributedVlanConnection() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"id":           getDataSourceIDSchema(),
 			"path":         getPathSchema(),
-			"display_name": getDisplayNameSchema(),
+			"display_name": getOptionalDisplayNameSchema(true),
 			"description":  getDescriptionSchema(),
 		},
 	}


### PR DESCRIPTION

The nsxt_policy_distributed_vlan_connection data source to make the display_name field optional.Display_name is not required to distributed VLAN conneciton

display_name was treated as a required attribute. Now, either id or display_name can be specified when referencing the resource.

data "nsxt_policy_distributed_vlan_connection" "test" {
 id = nsxt_policy_distributed_vlan_connection.big_corp_vlan.id
}
or 
data "nsxt_policy_distributed_vlan_connection" "test" {
 display_name = nsxt_policy_distributed_vlan_connection.big_corp_vlan.display_name
}