### PR TITLE
Make policy edge RTEP named_teaming_policy attribute required

### DIFF
--- a/docs/resources/policy_edge_transport_node_rtep.md
+++ b/docs/resources/policy_edge_transport_node_rtep.md
@@ -44,7 +44,7 @@ The following arguments are supported:
           * `subnet_mask` - (Required) Subnet mask.
     * `static_ipv4_pool` - (Optional) IP assignment specification for Static IPv4 Pool. Input can be MP ip pool UUID or policy path of IP pool.
 * `vlan` - (Required) VLAN id for remote tunnel endpoint.
-* `named_teaming_policy` - (Optional) The named teaming policy to be used by the remote tunnel endpoint.
+* `named_teaming_policy` - (Required) The named teaming policy to be used by the remote tunnel endpoint.
 
 ## Importing
 

--- a/nsxt/resource_nsxt_policy_edge_transport_node_rtep.go
+++ b/nsxt/resource_nsxt_policy_edge_transport_node_rtep.go
@@ -46,7 +46,7 @@ func resourceNsxtPolicyEdgeTransportNodeRTEP() *schema.Resource {
 			"named_teaming_policy": {
 				Type:        schema.TypeString,
 				Description: "The named teaming policy to be used by the remote tunnel endpoint",
-				Optional:    true,
+				Required:    true,
 			},
 			"vlan": {
 				Type:         schema.TypeInt,


### PR DESCRIPTION
NSX requires this attribute even though the API spec doesn't specify it as required.