### PR TITLE
Add multicast attribute to segment resources

### DIFF
--- a/docs/resources/policy_fixed_segment.md
+++ b/docs/resources/policy_fixed_segment.md
@@ -130,6 +130,7 @@ The following arguments are supported:
     * `local_egress` - (Optional) Boolean flag to enable local egress when used in conjunction with L2VPN.
     * `uplink_teaming_policy` - (Optional) The name of the switching uplink teaming policy for the bridge endpoint. This name corresponds to one of the switching uplink teaming policy names listed in the transport zone.
     * `urpf_mode` - (Optional) URPF mode to be applied to gateway downlink interface. One of `STRICT`, `NONE`.
+    * `multicast` - (Optional) Enable multicast on the downlink LRP created to connect the segment to Tier0/Tier1 gateway.
 * `metadata_proxy_paths` - (Optional) Metadata Proxy Configuration Paths.
 
 ## Attributes Reference

--- a/docs/resources/policy_segment.md
+++ b/docs/resources/policy_segment.md
@@ -129,6 +129,7 @@ The following arguments are supported:
     * `local_egress` - (Optional) Boolean flag to enable local egress when used in conjunction with L2VPN.
     * `uplink_teaming_policy` - (Optional) The name of the switching uplink teaming policy for the bridge endpoint. This name corresponds to one of the switching uplink teaming policy names listed in the transport zone.
     * `urpf_mode` - (Optional) URPF mode to be applied to gateway downlink interface. One of `STRICT`, `NONE`.
+    * `multicast` - (Optional) Enable multicast on the downlink LRP created to connect the segment to Tier0/Tier1 gateway.
 * `discovery_profile` - (Optional) IP and MAC discovery profile specification for the segment.
     * `ip_discovery_profile_path` - (Optional) Path for IP discovery profile to be associated with the segment.
     * `mac_discovery_profile_path` - (Optional) Path for MAC discovery profile to be associated with the segment.

--- a/docs/resources/policy_vlan_segment.md
+++ b/docs/resources/policy_vlan_segment.md
@@ -143,6 +143,7 @@ The following arguments are supported:
     * `local_egress` - (Optional) Boolean flag to enable local egress.
     * `uplink_teaming_policy` - (Optional) The name of the switching uplink teaming policy for the bridge endpoint. This name corresponds to one of the switching uplink teaming policy names listed in the transport zone.
     * `urpf_mode` - (Optional) URPF mode to be applied to gateway downlink interface. One of `STRICT`, `NONE`.
+    * `multicast` - (Optional) Enable multicast on the downlink LRP created to connect the segment to Tier0/Tier1 gateway.
 * `discovery_profile` - (Optional) IP and MAC discovery profile specification for the segment.
     * `ip_discovery_profile_path` - (Optional) Path for IP discovery profile to be associated with the segment.
     * `mac_discovery_profile_path` - (Optional) Path for MAC discovery profile to be associated with the segment.

--- a/nsxt/resource_nsxt_policy_segment_test.go
+++ b/nsxt/resource_nsxt_policy_segment_test.go
@@ -176,6 +176,7 @@ func TestAccResourceNsxtPolicySegment_updateAdvConfig(t *testing.T) {
 					resource.TestCheckResourceAttr(testResourceName, "advanced_config.0.connectivity", "OFF"),
 					resource.TestCheckResourceAttr(testResourceName, "advanced_config.0.local_egress", "true"),
 					resource.TestCheckResourceAttr(testResourceName, "advanced_config.0.urpf_mode", "STRICT"),
+					resource.TestCheckResourceAttr(testResourceName, "advanced_config.0.multicast", "true"),
 				),
 			},
 			{
@@ -193,6 +194,7 @@ func TestAccResourceNsxtPolicySegment_updateAdvConfig(t *testing.T) {
 					resource.TestCheckResourceAttr(testResourceName, "advanced_config.0.connectivity", "ON"),
 					resource.TestCheckResourceAttr(testResourceName, "advanced_config.0.local_egress", "false"),
 					resource.TestCheckResourceAttr(testResourceName, "advanced_config.0.urpf_mode", "NONE"),
+					resource.TestCheckResourceAttr(testResourceName, "advanced_config.0.multicast", "false"),
 				),
 			},
 		},
@@ -957,6 +959,7 @@ resource "nsxt_policy_segment" "test" {
     connectivity = "OFF"
     local_egress = true
     urpf_mode    = "STRICT"
+    multicast    = true
   }
 }
 `, name)
@@ -988,6 +991,7 @@ resource "nsxt_policy_segment" "test" {
     connectivity = "ON"
     local_egress = false
     urpf_mode    = "NONE"
+    multicast    = false
   }
 }
 `, name)

--- a/nsxt/segment_common.go
+++ b/nsxt/segment_common.go
@@ -226,6 +226,11 @@ func getPolicySegmentAdvancedConfigurationSchema() *schema.Resource {
 				ValidateFunc: validation.StringInSlice(urpfModeValues, false),
 				Default:      model.SegmentAdvancedConfig_URPF_MODE_STRICT,
 			},
+			"multicast": {
+				Type:        schema.TypeBool,
+				Description: "Enable multicast on the downlink LRP created to connect the segment to Tier0/Tier1 gateway",
+				Optional:    true,
+			},
 		},
 	}
 }
@@ -798,6 +803,7 @@ func policySegmentResourceToInfraStruct(context utl.SessionContext, id string, d
 		connectivity := advConfigMap["connectivity"].(string)
 		hybrid := advConfigMap["hybrid"].(bool)
 		egress := advConfigMap["local_egress"].(bool)
+		multicast := advConfigMap["multicast"].(bool)
 		var poolPaths []string
 		if advConfigMap["cidr"] != nil {
 			poolPaths = append(poolPaths, advConfigMap["cidr"].(string))
@@ -806,6 +812,7 @@ func policySegmentResourceToInfraStruct(context utl.SessionContext, id string, d
 			AddressPoolPaths: poolPaths,
 			Hybrid:           &hybrid,
 			LocalEgress:      &egress,
+			Multicast:        &multicast,
 		}
 
 		if connectivity != "" {
@@ -1409,6 +1416,7 @@ func nsxtPolicySegmentRead(d *schema.ResourceData, m interface{}, isVlan bool, i
 		advConfig["connectivity"] = obj.AdvancedConfig.Connectivity
 		advConfig["hybrid"] = obj.AdvancedConfig.Hybrid
 		advConfig["local_egress"] = obj.AdvancedConfig.LocalEgress
+		advConfig["multicast"] = obj.AdvancedConfig.Multicast
 		if obj.AdvancedConfig.UplinkTeamingPolicyName != nil {
 			advConfig["uplink_teaming_policy"] = *obj.AdvancedConfig.UplinkTeamingPolicyName
 		}


### PR DESCRIPTION
Segment resources are missing multicast attribute in the advanced_config block.