### PR TITLE
Handle empty service_entries block case in nsxt_policy_security_policy

### DIFF
--- a/nsxt/policy_common.go
+++ b/nsxt/policy_common.go
@@ -612,7 +612,7 @@ func getPolicyRulesFromSchema(d *schema.ResourceData) []model.Rule {
 		}
 
 		schemaServiceEntries := data["service_entries"].([]interface{})
-		if len(schemaServiceEntries) > 0 {
+		if len(schemaServiceEntries) > 0 && schemaServiceEntries[0] != nil {
 			schemaServiceEntry := schemaServiceEntries[0].(map[string]interface{})
 			serviceEntries, _ := getServiceEntriesFromSchema(schemaServiceEntry)
 			elem.ServiceEntries = serviceEntries


### PR DESCRIPTION
When a rule was created with an empty service_entries block, the provider crashed. This change addresses that bug.

Fixes: #1782