### PR TITLE
Various doc fixes

### DIFF
--- a/docs/resources/policy_host_transport_node_collection.md
+++ b/docs/resources/policy_host_transport_node_collection.md
@@ -32,8 +32,8 @@ resource "nsxt_policy_host_transport_node_collection" "htnc1" {
 
 The following arguments are supported:
 
-* `display_name` - (Optional) The Display Name of the Transport Zone.
-* `description` - (Optional) Description of the Transport Zone.
+* `display_name` - (Optional) The Display Name of the Transport Node Collection.
+* `description` - (Optional) Description of the Transport Node Collection.
 * `tag` - (Optional) A list of scope + tag pairs to associate with this resource.
 * `nsx_id` - (Optional) The NSX ID of this resource. If set, this ID will be used to create the policy resource.
 * `compute_collection_id` - (Required) Compute collection id.

--- a/docs/resources/vpc.md
+++ b/docs/resources/vpc.md
@@ -53,7 +53,6 @@ In addition to arguments listed above, the following attributes are exported:
 * `id` - ID of the resource.
 * `revision` - Indicates current revision number of the object as seen by NSX-T API server. This attribute can be useful for debugging.
 * `path` - The NSX path of the policy resource.
-* `private_ipv4_blocks` - (Optional) Policy paths of automatically created private IPv4 blocks, based on `private_ips` specified for the VPC.
 
 ## Importing
 


### PR DESCRIPTION
- Remove private_ipv4_blocks from VPC's attributes. The name is not correct. Also, it's not an attribute, but an argument.
- Fix display_name and description reference for policy_host_transport_node_collection