### PR TITLE
[DOC] Fix some incorrect resource usage samples

### DIFF
--- a/docs/data-sources/policy_gateway_connection.md
+++ b/docs/data-sources/policy_gateway_connection.md
@@ -15,7 +15,7 @@ This data source is applicable to NSX Policy Manager.
 ```hcl
 data "nsxt_policy_gateway_connection" "test" {
   display_name = "test"
-  tier0_path   = data.nsxt_policy_tier0_gateway.path
+  tier0_path   = data.nsxt_policy_tier0_gateway.test.path
 }
 ```
 

--- a/docs/data-sources/policy_gateway_locale_service.md
+++ b/docs/data-sources/policy_gateway_locale_service.md
@@ -14,7 +14,7 @@ This data source is applicable to NSX Policy Manager, NSX Global Manager and VMC
 
 ```hcl
 data "nsxt_policy_gateway_locale_service" "test" {
-  gateway_path = data.nsxt_policy_tier0_gateway.path
+  gateway_path = data.nsxt_policy_tier0_gateway.test.path
   display_name = "london"
 }
 ```


### PR DESCRIPTION
Samples for nsxt_policy_gateway_connection and
nsxt_policy_gateway_connection_locale_service
were using an invalid path for the tier0 gateway.