### PR TITLE
[3.10.0]Set supported version for v9.0 resource, datasources

### DIFF
--- a/docs/data-sources/policy_edge_high_availability_profile.md
+++ b/docs/data-sources/policy_edge_high_availability_profile.md
@@ -7,7 +7,7 @@ description: A policy Edge high availability profile data source.
 # nsxt_policy_edge_high_availability_profile
 
 This data source provides information about policy Edge high availability profile configured on NSX.
-This data source is applicable to NSX Policy Manager.
+This data source is applicable to NSX Policy Manager and is supported with NSX 9.0.0 onwards.
 
 ## Example Usage
 

--- a/docs/data-sources/policy_edge_transport_node.md
+++ b/docs/data-sources/policy_edge_transport_node.md
@@ -7,8 +7,7 @@ description: An Edge transport node data source.
 # nsxt_policy_edge_transport_node
 
 This data source provides information about Edge transport node configured on NSX.
-This data source is applicable to NSX Policy Manager.
-
+This data source is applicable to NSX Policy Manager and is supported with NSX 9.0.0 onwards.
 ## Example Usage
 
 ```hcl

--- a/docs/resources/policy_edge_cluster.md
+++ b/docs/resources/policy_edge_cluster.md
@@ -8,8 +8,7 @@ description: A resource to configure a PolicyEdgeCluster.
 
 This resource provides a method for the management of a PolicyEdgeCluster.
 
-This resource is applicable to NSX Policy Manager.
-
+This resource is applicable to NSX Policy Manager and is supported with NSX 9.0.0 onwards.
 ## Example Usage
 
 ```hcl

--- a/docs/resources/policy_edge_high_availability_profile.md
+++ b/docs/resources/policy_edge_high_availability_profile.md
@@ -8,7 +8,7 @@ description: A resource to configure a PolicyEdgeHighAvailabilityProfile.
 
 This resource provides a method for the management of a PolicyEdgeHighAvailabilityProfile.
 
-This resource is applicable to NSX Global Manager, NSX Policy Manager and VMC.
+This resource is applicable to NSX Policy Manager and is supported with NSX 9.0.0 onwards.
 
 ## Example Usage
 

--- a/docs/resources/policy_edge_transport_node.md
+++ b/docs/resources/policy_edge_transport_node.md
@@ -7,8 +7,7 @@ description: A resource to configure a Policy Edge Transport Node.
 # nsxt_policy_edge_transport_node
 
 This resource provides a method for the management of a Policy Edge Transport Node.
-This resource is supported with NSX 9.0.0 onwards.
-
+This resource is applicable to NSX Policy Manager and is supported with NSX 9.0.0 onwards.
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION
These datasources and resources are only supported in v9.0 and above. Document accordingly.

Fixes: #1762, Fixes: #1765