### PR TITLE
Correct nsxt_policy_host_transport_node_collection_realization example

### DIFF
--- a/docs/data-sources/policy_host_transport_node_collection_realization.md
+++ b/docs/data-sources/policy_host_transport_node_collection_realization.md
@@ -15,8 +15,15 @@ This data source is applicable to NSX Policy Manager.
 ## Example Usage
 
 ```hcl
+resource "nsxt_policy_host_transport_node_collection" "htnc1" {
+  display_name                = "HostTransportNodeCollection1"
+  compute_collection_id       = data.nsxt_compute_collection.compute_cluster_collection.id
+  transport_node_profile_path = nsxt_policy_host_transport_node_profile.tnp.path
+}
+
+// Execution will pend until nsxt_policy_host_transport_node_collection.htnc1 is realized on NSX 
 data "nsxt_policy_host_transport_node_collection_realization" "test" {
-  path = data.nsxt_policy_host_transport_node_collection.path
+  path = nsxt_policy_host_transport_node_collection.htnc1.path
 }
 ```
 


### PR DESCRIPTION
This datasource example was not syntactically correct. Also used the resource instead of a data source, as this is the common use pattern.