### PR TITLE
Fix schema set errors in policy edge resource

### DIFF
--- a/nsxt/resource_nsxt_policy_edge_transport_node.go
+++ b/nsxt/resource_nsxt_policy_edge_transport_node.go
@@ -1527,7 +1527,7 @@ func setPolicyIPAssignmentsInSchema(specs []*data.StructValue) (interface{}, err
 		}
 	}
 
-	return elem, nil
+	return []interface{}{elem}, nil
 }
 
 func resourceNsxtPolicyEdgeTransportNodeRead(d *schema.ResourceData, m interface{}) error {
@@ -1625,7 +1625,7 @@ func resourceNsxtPolicyEdgeTransportNodeRead(d *schema.ResourceData, m interface
 				tunnelEndpoints = append(tunnelEndpoints, t)
 			}
 			sw["tunnel_endpoint"] = tunnelEndpoints
-			d.Set("vlan_transport_zone_paths", switc.VlanTransportZonePaths)
+			sw["vlan_transport_zone_paths"] = switc.VlanTransportZonePaths
 
 			switches = append(switches, sw)
 		}


### PR DESCRIPTION
Some attributes were set incorrectly, which generated a schema set issues.