### PR TITLE
Use singular naming for range attribute

### DIFF
--- a/docs/resources/policy_ip_block.md
+++ b/docs/resources/policy_ip_block.md
@@ -86,7 +86,7 @@ The following arguments are supported:
 * `cidr` - (Optional) Network address and the prefix length which will be associated with a layer-2 broadcast domain. Either cidr or cidrs should be set.
 * `cidrs` - (Optional) Array of contiguous IP address spaces represented by network address and prefix length. This attribute is supported with NSX 9.1.0 onwards. Either cidr or cidrs should be set.
 * `is_subnet_exclusive` - (Optional) If this property is set to true, then this block is reserved for direct vlan extension use case. This attribute is supported starting from NSX version 9.1.0.
-* `ranges` - (Optional) Represents list of IP address ranges in the form of start and end IPs. This attribute is supported with NSX 9.1.0 onwards.
+* `range` - (Optional) Represents an IP address range in the form of start and end IPs. This attribute is supported with NSX 9.1.0 onwards.
     * `start` - (Required) The start IP address for the allocation range.
     * `end` - (Required) The end IP address for the allocation range.
 * `excluded_ips` - (Optional) Represents list of excluded IP address in the form of start and end IPs. This attribute is supported with NSX 9.1.0 onwards.

--- a/nsxt/resource_nsxt_policy_ip_block.go
+++ b/nsxt/resource_nsxt_policy_ip_block.go
@@ -70,7 +70,7 @@ func resourceNsxtPolicyIPBlock() *schema.Resource {
 				Optional:    true,
 				Description: "If this property is set to true, then this block is reserved for direct vlan extension use case",
 			},
-			"ranges":       getAllocationRangesSchema(false, "Represents list of IP address ranges in the form of start and end IPs"),
+			"range":        getAllocationRangesSchema(false, "Represents list of IP address ranges in the form of start and end IPs"),
 			"excluded_ips": getAllocationRangesSchema(false, "Represents list of excluded IP address in the form of start and end IPs"),
 		},
 	}
@@ -125,7 +125,7 @@ func resourceNsxtPolicyIPBlockRead(d *schema.ResourceData, m interface{}) error 
 			d.Set("cidrs", block.Cidrs)
 		}
 		d.Set("is_subnet_exclusive", block.IsSubnetExclusive)
-		d.Set("ranges", setAllocationRangeListInSchema(block.Ranges))
+		d.Set("range", setAllocationRangeListInSchema(block.Ranges))
 		d.Set("excluded_ips", setAllocationRangeListInSchema(block.ExcludedIps))
 		if block.Cidr != nil {
 			d.Set("cidr", block.Cidr)
@@ -156,7 +156,7 @@ func resourceNsxtPolicyIPBlockCreate(d *schema.ResourceData, m interface{}) erro
 	tags := getPolicyTagsFromSchema(d)
 	cidrs := getStringListFromSchemaList(d, "cidrs")
 	isSubnetExclusive := d.Get("is_subnet_exclusive").(bool)
-	ranges := getAllocationRangeListFromSchema(d.Get("ranges").([]interface{}))
+	ranges := getAllocationRangeListFromSchema(d.Get("range").([]interface{}))
 	excludedIPs := getAllocationRangeListFromSchema(d.Get("excluded_ips").([]interface{}))
 
 	obj := model.IpAddressBlock{
@@ -211,7 +211,7 @@ func resourceNsxtPolicyIPBlockUpdate(d *schema.ResourceData, m interface{}) erro
 	tags := getPolicyTagsFromSchema(d)
 	cidrs := getStringListFromSchemaList(d, "cidrs")
 	isSubnetExclusive := d.Get("is_subnet_exclusive").(bool)
-	ranges := getAllocationRangeListFromSchema(d.Get("ranges").([]interface{}))
+	ranges := getAllocationRangeListFromSchema(d.Get("range").([]interface{}))
 	excludedIPs := getAllocationRangeListFromSchema(d.Get("excluded_ips").([]interface{}))
 
 	obj := model.IpAddressBlock{

--- a/nsxt/resource_nsxt_policy_ip_block_test.go
+++ b/nsxt/resource_nsxt_policy_ip_block_test.go
@@ -65,7 +65,7 @@ func TestAccResourceNsxtPolicyIPBlock_v910(t *testing.T) {
 					resource.TestCheckResourceAttr(testResourceName, "cidrs.#", "1"),
 					resource.TestCheckResourceAttr(testResourceName, "cidrs.0", cidr),
 					resource.TestCheckResourceAttr(testResourceName, "excluded_ips.#", "1"),
-					resource.TestCheckResourceAttr(testResourceName, "ranges.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "range.#", "1"),
 					resource.TestCheckResourceAttr(testResourceName, "tag.#", "0"),
 					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
 					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
@@ -126,7 +126,7 @@ func TestAccResourceNsxtPolicyIPBlock_v910_migrate(t *testing.T) {
 					resource.TestCheckResourceAttr(testResourceName, "cidrs.#", "1"),
 					resource.TestCheckResourceAttr(testResourceName, "cidrs.0", cidr),
 					resource.TestCheckResourceAttr(testResourceName, "excluded_ips.#", "1"),
-					resource.TestCheckResourceAttr(testResourceName, "ranges.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "range.#", "1"),
 					resource.TestCheckResourceAttr(testResourceName, "tag.#", "0"),
 					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
 					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
@@ -390,7 +390,7 @@ resource "nsxt_policy_ip_block" "test" {
     end   = "192.168.1.11"
   }
 
-  ranges {
+  range {
     start = "192.168.2.20"
     end   = "192.168.2.39"
   }


### PR DESCRIPTION
When the API has a list of complex objects, we use singular naming, e.g

```
range {
  start = ...
  end = ...
}
```
instead of:
```
ranges {
  start = ...
  end = ...
}
```
which is confusing - as each instance is represented by a separate block.