### PR TITLE
[3.10.0]  Tier1/Segment DS: Allow fetching global resources, move is_global into context

### DIFF
--- a/api/utl/api_util.go
+++ b/api/utl/api_util.go
@@ -18,12 +18,21 @@ type SessionContext struct {
 	ClientType ClientType
 	ProjectID  string
 	VPCID      string
+	FromGlobal bool
 }
 type ClientContext struct {
 	Client     interface{}
 	ClientType ClientType
 	ProjectID  string
 	VPCID      string
+}
+
+type SessionContextSpec struct {
+	IsRequired          bool
+	IsComputed          bool
+	IsVpc               bool
+	AllowDefaultProject bool
+	FromGlobal          bool
 }
 
 func ConvertModelBindingType(obj interface{}, sourceType bindings.BindingType, destType bindings.BindingType) (interface{}, error) {

--- a/docs/data-sources/policy_segment.md
+++ b/docs/data-sources/policy_segment.md
@@ -32,12 +32,23 @@ data "nsxt_policy_segment" "demoseg" {
 }
 ```
 
+## Example Usage - Global infra
+
+```hcl
+data "nsxt_policy_segment" "test_global" {
+  context {
+    from_global = true
+  }
+  display_name = "test"
+}
+```
 ## Argument Reference
 
 * `id` - (Optional) The ID of Segment to retrieve. If ID is specified, no additional argument should be configured.
 * `display_name` - (Optional) The Display Name prefix of the Segment to retrieve.
 * `context` - (Optional) The context which the object belongs to
-  * `project_id` - (Required) The ID of the project which the object belongs to
+  * `project_id` - (Optional) The ID of the project which the object belongs to
+  * `from_global` - (Optional) Set to True if the data source will need to search Tier-1 gateway created in a global manager instance (/global-infra)
 
 ## Attributes Reference
 

--- a/docs/data-sources/policy_tier0_gateway.md
+++ b/docs/data-sources/policy_tier0_gateway.md
@@ -18,10 +18,23 @@ data "nsxt_policy_tier0_gateway" "tier0_gw_gateway" {
 }
 ```
 
+## Example Usage - Global infra
+
+```hcl
+data "nsxt_policy_tier0_gateway" "tier0_gw_gateway_global" {
+  context {
+    from_global = true
+  }
+  display_name = "tier0-gw"
+}
+```
+
 ## Argument Reference
 
 * `id` - (Optional) The ID of Tier-0 gateway to retrieve.
 * `display_name` - (Optional) The Display Name prefix of the Tier-0 gateway to retrieve.
+* `context` - (Optional) The context which the object belongs to
+  * `from_global` - (Optional) Set to True if the data source will need to search Tier-0 gateway created in a global manager instance (/global-infra)
 
 ## Attributes Reference
 

--- a/docs/data-sources/policy_tier1_gateway.md
+++ b/docs/data-sources/policy_tier1_gateway.md
@@ -33,12 +33,24 @@ data "nsxt_policy_tier1_gateway" "demotier1" {
 }
 ```
 
+## Example Usage - Global infra
+
+```hcl
+data "nsxt_policy_tier1_gateway" "tier1_router_global" {
+  context {
+    from_global = true
+  }
+  display_name = "tier1_gw"
+}
+```
+
 ## Argument Reference
 
 * `id` - (Optional) The ID of Tier-1 gateway to retrieve.
 * `display_name` - (Optional) The Display Name prefix of the Tier-1 gateway to retrieve.
 * `context` - (Optional) The context which the object belongs to
-  * `project_id` - (Required) The ID of the project which the object belongs to
+  * `project_id` - (Optional) The ID of the project which the object belongs to
+  * `from_global` - (Optional) Set to True if the data source will need to search Tier-1 gateway created in a global manager instance (/global-infra)
 
 ## Attributes Reference
 

--- a/nsxt/data_source_nsxt_policy_segment.go
+++ b/nsxt/data_source_nsxt_policy_segment.go
@@ -6,6 +6,8 @@ package nsxt
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
 )
 
 func dataSourceNsxtPolicySegment() *schema.Resource {
@@ -17,7 +19,7 @@ func dataSourceNsxtPolicySegment() *schema.Resource {
 			"display_name": getDataSourceExtendedDisplayNameSchema(),
 			"description":  getDataSourceDescriptionSchema(),
 			"path":         getPathSchema(),
-			"context":      getContextSchema(false, false, false),
+			"context":      getContextSchemaWithSpec(utl.SessionContextSpec{IsRequired: false, IsComputed: false, IsVpc: false, AllowDefaultProject: false, FromGlobal: true}),
 		},
 	}
 }

--- a/nsxt/data_source_nsxt_policy_tier0_gateway.go
+++ b/nsxt/data_source_nsxt_policy_tier0_gateway.go
@@ -25,13 +25,13 @@ func dataSourceNsxtPolicyTier0Gateway() *schema.Resource {
 			"display_name": getDataSourceDisplayNameSchema(),
 			"description":  getDataSourceDescriptionSchema(),
 			"path":         getPathSchema(),
-			"is_global":    getDataSourceGMBoolSchema(),
 			"edge_cluster_path": {
 				Type:        schema.TypeString,
 				Description: "The path of the edge cluster connected to this Tier0 gateway",
 				Optional:    true,
 				Computed:    true,
 			},
+			"context": getContextSchemaWithSpec(utl.SessionContextSpec{FromGlobal: true}),
 		},
 	}
 }

--- a/nsxt/data_source_nsxt_policy_tier1_gateway.go
+++ b/nsxt/data_source_nsxt_policy_tier1_gateway.go
@@ -10,6 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/bindings"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+
+	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
 )
 
 func dataSourceNsxtPolicyTier1Gateway() *schema.Resource {
@@ -27,7 +29,7 @@ func dataSourceNsxtPolicyTier1Gateway() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 			},
-			"context": getContextSchema(false, false, false),
+			"context": getContextSchemaWithSpec(utl.SessionContextSpec{IsRequired: false, IsComputed: false, IsVpc: false, AllowDefaultProject: false, FromGlobal: true}),
 		},
 	}
 }

--- a/nsxt/policy_common.go
+++ b/nsxt/policy_common.go
@@ -793,12 +793,3 @@ func getGatewayPathFromLocaleServicesPath(localeServicesPath string) string {
 	pathList := strings.Split(localeServicesPath, "/")[:4]
 	return strings.Join(pathList, "/")
 }
-
-func getDataSourceGMBoolSchema() *schema.Schema {
-	return &schema.Schema{
-		Type:        schema.TypeBool,
-		Description: "Whether to fetch the GM object instead of the LM object",
-		Optional:    true,
-		Default:     false,
-	}
-}

--- a/nsxt/policy_search.go
+++ b/nsxt/policy_search.go
@@ -90,10 +90,7 @@ func policyDataSourceResourceRead(d *schema.ResourceData, connector client.Conne
 func policyDataSourceResourceReadWithValidation(d *schema.ResourceData, connector client.Connector, context utl.SessionContext, resourceType string, additionalQuery map[string]string, paramsValidation bool) (*data.StructValue, error) {
 	objName := d.Get("display_name").(string)
 	objID := d.Get("id").(string)
-	isGlobal := false
-	if isGlobalRaw, ok := d.GetOk("is_global"); ok {
-		isGlobal, _ = isGlobalRaw.(bool)
-	}
+	isGlobal := context.FromGlobal
 	var err error
 	var resultValues []*data.StructValue
 	additionalQueryString := buildQueryStringFromMap(additionalQuery)

--- a/nsxt/policy_utils.go
+++ b/nsxt/policy_utils.go
@@ -472,8 +472,8 @@ func getVpcPathResourceImporter(pathExample string) func(d *schema.ResourceData,
 			return rd, err
 		}
 
-		// verify that both project and vpc were set in schema by the improter helper above
-		projectID, vpcID := getContextDataFromSchema(d)
+		// verify that both project and vpc were set in schema by the importer helper above
+		projectID, vpcID, _ := getContextDataFromSchema(d)
 		if projectID == "" || vpcID == "" {
 			return rd, fmt.Errorf("imported resource policy path should have both project_id and vpc_id fields")
 		}

--- a/nsxt/provider.go
+++ b/nsxt/provider.go
@@ -1280,21 +1280,24 @@ func getGlobalPolicyEnforcementPointPath(m interface{}, sitePath *string) string
 	return fmt.Sprintf("%s/enforcement-points/%s", *sitePath, getPolicyEnforcementPoint(m))
 }
 
-func getContextDataFromSchema(d *schema.ResourceData) (string, string) {
+func getContextDataFromSchema(d *schema.ResourceData) (string, string, bool) {
 	ctxPtr := d.Get("context")
 	if ctxPtr != nil {
 		contexts := ctxPtr.([]interface{})
 		for _, context := range contexts {
 			data := context.(map[string]interface{})
 			vpcID := ""
+			fromGlobal := false
 			if data["vpc_id"] != nil {
 				vpcID = data["vpc_id"].(string)
 			}
-
-			return data["project_id"].(string), vpcID
+			if data["from_global"] != nil {
+				fromGlobal = data["from_global"].(bool)
+			}
+			return data["project_id"].(string), vpcID, fromGlobal
 		}
 	}
-	return "", ""
+	return "", "", false
 }
 
 func getContextDataFromParentPath(parentPath string) (string, string) {
@@ -1321,10 +1324,17 @@ func getParentContext(d *schema.ResourceData, m interface{}, parentPath string) 
 func getSessionContextHelper(d *schema.ResourceData, m interface{}, parentPath string) tf_api.SessionContext {
 	var clientType tf_api.ClientType
 	var projectID, vpcID string
+	fromGlobal := false
 	if parentPath == "" {
-		projectID, vpcID = getContextDataFromSchema(d)
+		projectID, vpcID, fromGlobal = getContextDataFromSchema(d)
 	} else {
 		projectID, vpcID = getContextDataFromParentPath(parentPath)
+	}
+	// if fromGlobal = True values pertaining multitenancy should be ignored
+	// and clientType must be tf_api.Local
+	if fromGlobal {
+		projectID = ""
+		vpcID = ""
 	}
 	if projectID != "" {
 		clientType = tf_api.Multitenancy
@@ -1336,5 +1346,5 @@ func getSessionContextHelper(d *schema.ResourceData, m interface{}, parentPath s
 	} else {
 		clientType = tf_api.Local
 	}
-	return tf_api.SessionContext{ProjectID: projectID, VPCID: vpcID, ClientType: clientType}
+	return tf_api.SessionContext{ProjectID: projectID, VPCID: vpcID, ClientType: clientType, FromGlobal: fromGlobal}
 }

--- a/nsxt/resource_nsxt_policy_security_policy_rule.go
+++ b/nsxt/resource_nsxt_policy_security_policy_rule.go
@@ -66,7 +66,7 @@ func resourceNsxtPolicySecurityPolicyRuleCreate(d *schema.ResourceData, m interf
 }
 
 func setSecurityPolicyRuleContext(d *schema.ResourceData, projectID string) error {
-	providedProjectID, _ := getContextDataFromSchema(d)
+	providedProjectID, _, _ := getContextDataFromSchema(d)
 	if providedProjectID == "" {
 		contexts := make([]interface{}, 1)
 		ctxMap := make(map[string]interface{})


### PR DESCRIPTION
This change adds the ability to fetch globally created Tier-1 gateways and segments, using the relvant data sources, similarly to what is already available for the nsxt_policy_tier0_gateway data source.

This change also moves the is_global attribute into the context, renaming it to "from_global"

To this aim this change:
- adds the context schema to the T0 GW data source
- expands the context schema of the T1 GW data source to include from_global
- adds a from_global boolean setting in the context fro both T0 and T1 data sources
- changes TF session context generation to set the from_global setting. When this setting is true, project_id and vpc_id will be ignored as global resournces cannot have a multitenancy scope