### PR TITLE
Set immutable VPCSecurityProfile attributes during patch request body

### DIFF
--- a/nsxt/resource_nsxt_policy_project.go
+++ b/nsxt/resource_nsxt_policy_project.go
@@ -270,9 +270,17 @@ func patchVpcSecurityProfile(d *schema.ResourceData, connector client.Connector,
 			}
 		}
 	}
+
+	clientSecurity := projects.NewVpcSecurityProfilesClient(connector)
+	objSec, err := clientSecurity.Get(defaultOrgID, projectID, "default")
+	if isNotFoundError(err) {
+		return fmt.Errorf("failed to fetch the details of the VPC security profile: %v", err)
+	}
 	// Default security profile is created by NSX, we can assume that it's there already
 	client := projects.NewVpcSecurityProfilesClient(connector)
 	obj := model.VpcSecurityProfile{
+		DisplayName: objSec.DisplayName,
+		Description: objSec.Description,
 		NorthSouthFirewall: &model.NorthSouthFirewall{
 			Enabled: &enabled,
 		},


### PR DESCRIPTION
Fix for https://bugzilla-vcf.lvn.broadcom.net/show_bug.cgi?id=3574782

Terraform was sending empty or nil strings for immutable attributes (displayName, description) in patch requests. NSX interprets these as updates, which triggers validation errors.

To fix this, we now:
Fetch the existing VpcSecurityProfile.
Extract immutable attributes.
Include them in the patch payload along with mutable fields.
This ensures partial patch requests succeed without violating NSX’s validation.

Testing results: 

**without patch header** 
curl -k -u admin:Admin\!23Admin -X PATCH "https://10.162.98.151/policy/api/v1/orgs/default/projects/proj_ext_connect/vpc-security-profiles/default" \
  -H "Content-Type: application/json" \
  -H "Cookie: JSESSIONID=0D6D08D9A3BC0FBE007F4FDAF6013295" \
  -H "X-Xsrf-Token: 492799ba-8969-49a6-b4f6-64a0d50527a8" \
  -H "nsx-enable-partial-patch:" \              
  -d '{"north_south_firewall":{"enabled":true}}'

{
  "httpStatus" : "BAD_REQUEST",
  "error_code" : 1004004,
  "module_name" : "policy",
  "error_message" : "Updating DisplayName and Description for a VPCSecurityProfile is not allowed."
}

**with patch header** 
poojav2@M42760H16N setup % curl -k -u admin:Admin\!23Admin -X PATCH "https://10.162.98.151/policy/api/v1/orgs/default/projects/proj_ext_connect/vpc-security-profiles/default" \
  -H "Content-Type: application/json" \
  -H "Cookie: JSESSIONID=0D6D08D9A3BC0FBE007F4FDAF6013295" \
  -H "X-Xsrf-Token: 492799ba-8969-49a6-b4f6-64a0d50527a8" \
  -H "nsx-enable-partial-patch: true" \
  -d '{"north_south_firewall":{"enabled":true}}'
poojav2@M42760H16N setup %




