### PR TITLE
Handle datasource and resource correctly in TestAccResourceNsxtPolicy…

### DIFF
--- a/nsxt/resource_nsxt_policy_gateway_prefix_list_test.go
+++ b/nsxt/resource_nsxt_policy_gateway_prefix_list_test.go
@@ -170,7 +170,11 @@ func testAccNsxtPolicyGWPrefixListCheckDestroy(state *terraform.State, displayNa
 		}
 
 		resourceID := rs.Primary.Attributes["id"]
-		gwPath := rs.Primary.Attributes["gateway_path"]
+		gwPath, ok := rs.Primary.Attributes["gateway_path"]
+		if !ok {
+			// This is the datasource which has no gateway_path attribute
+			continue
+		}
 		_, gwID := parseGatewayPolicyPath(gwPath)
 
 		var err error


### PR DESCRIPTION
…GatewayPrefixList_basic

The test retrieves the objects from state but doesn't distinguish resources and datasources. So it attempts to lookup the datasource using the gateway_path attribute from the resource which doesn't exist for the DS, resulting an untrapped error.