### PR TITLE
Force specification of either locale_service_path or gateway_path

### DIFF
--- a/nsxt/resource_nsxt_policy_ipsec_vpn_service.go
+++ b/nsxt/resource_nsxt_policy_ipsec_vpn_service.go
@@ -52,6 +52,7 @@ func resourceNsxtPolicyIPSecVpnService() *schema.Resource {
 				ForceNew:     true,
 				Deprecated:   "Use gateway_path instead.",
 				ValidateFunc: validatePolicyPath(),
+				AtLeastOneOf: []string{"locale_service_path", "gateway_path"},
 			},
 			"enabled": {
 				Type:        schema.TypeBool,


### PR DESCRIPTION
For nsxt_policy_ipsec_vpn_service resource, one of the above is required. Use AtLeastOneOf to fail the plan if both are missing.

Fixes: #1833