### PR TITLE
Remove default audit username from policy edge TN

### DIFF
--- a/docs/resources/policy_edge_transport_node.md
+++ b/docs/resources/policy_edge_transport_node.md
@@ -127,7 +127,7 @@ The following arguments are supported:
         * `server` - (Required) Server IP or fqdn.
 * `credentials` - (Optional) Username and password settings for the node.
     * `audit_password` - (Optional) Node audit user password.
-    * `audit_username` - (Optional) CLI "audit" username.
+    * `audit_username` - (Optional) CLI "audit" username. Defaults to `audit` when `audit_password` is set.
     * `cli_password` - (Required) Node cli password.
     * `cli_username` - (Optional) CLI "admin" username.
     * `root_password` - (Required) Node root user password.

--- a/nsxt/resource_nsxt_policy_edge_transport_node.go
+++ b/nsxt/resource_nsxt_policy_edge_transport_node.go
@@ -434,8 +434,8 @@ func resourceNsxtPolicyEdgeTransportNode() *schema.Resource {
 						"audit_username": {
 							Type:        schema.TypeString,
 							Optional:    true,
-							Default:     "audit",
 							Description: "CLI \"audit\" username",
+							Computed:    true,
 						},
 						"cli_password": {
 							Type:        schema.TypeString,


### PR DESCRIPTION
NSX requires a password when this attribute contains a value. As Terraform will include this always - as it has a default, we shouldn't include it in the payload unless specified by the user.