### PR TITLE
Use is_default flag to fetch default transit gateway

### DIFF
--- a/nsxt/resource_nsxt_policy_transit_gateway_attachment_test.go
+++ b/nsxt/resource_nsxt_policy_transit_gateway_attachment_test.go
@@ -193,7 +193,7 @@ data "nsxt_policy_transit_gateway" "test" {
   context {
     project_id = nsxt_policy_project.test.id
   }
-  id = "default"
+  is_default = true
 }
 
 resource "nsxt_policy_transit_gateway_attachment" "test" {

--- a/nsxt/resource_nsxt_policy_transit_gateway_static_route_test.go
+++ b/nsxt/resource_nsxt_policy_transit_gateway_static_route_test.go
@@ -239,7 +239,7 @@ data "nsxt_policy_transit_gateway" "test" {
   context {
     project_id = nsxt_policy_project.test.id
   }
-  id = "default"
+  is_default = true
 }
 
 resource "nsxt_policy_transit_gateway_attachment" "test" {


### PR DESCRIPTION
The use of "default" name to fetch default TGW is not usable anymore with latest builds