### PR TITLE
Updating the password length of the bgp neighbor resource to 32

### DIFF
--- a/nsxt/resource_nsxt_policy_bgp_neighbor.go
+++ b/nsxt/resource_nsxt_policy_bgp_neighbor.go
@@ -123,7 +123,7 @@ func resourceNsxtPolicyBgpNeighbor() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Description:  "Password for BGP neighbor authentication",
-				ValidateFunc: validation.StringLenBetween(0, 20),
+				ValidateFunc: validation.StringLenBetween(0, 32),
 				Sensitive:    true,
 			},
 			"remote_as_num": {


### PR DESCRIPTION
Updating the password length of the bgp neighbor resource to 32 as per the NSX description

Fixes: #1867