### PR TITLE
Address test failures with v4.2, v9.1

### DIFF
--- a/nsxt/data_source_nsxt_vpc_test.go
+++ b/nsxt/data_source_nsxt_vpc_test.go
@@ -23,7 +23,7 @@ func TestAccDataSourceNsxtVPC_basic(t *testing.T) {
 		PreCheck: func() {
 			testAccOnlyMultitenancy(t)
 			testAccPreCheck(t)
-			testAccNSXVersion(t, "4.1.2")
+			testAccNSXVersion(t, "9.0.0")
 		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {

--- a/nsxt/resource_nsxt_policy_connectivity_policy_test.go
+++ b/nsxt/resource_nsxt_policy_connectivity_policy_test.go
@@ -168,7 +168,7 @@ func testAccNsxtPolicyConnectivityPolicyPrerequisites() string {
 	return fmt.Sprintf(`
 data "nsxt_policy_transit_gateway" "default" {
   %s
-  id = "default"
+  is_default = true
 }
 
 resource "nsxt_policy_group" "test" {

--- a/nsxt/utils_test.go
+++ b/nsxt/utils_test.go
@@ -346,7 +346,7 @@ func testAccOnlyMultitenancy(t *testing.T) {
 }
 
 func testAccOnlyVPC(t *testing.T) {
-	testAccNSXVersion(t, "4.1.2")
+	testAccNSXVersion(t, "9.0.0")
 	if !testAccIsVPC() {
 		t.Skipf("This test requires a VPC environment")
 	}


### PR DESCRIPTION
VPC tests should not run against v4.2 setups
Use is_default attribute instead of using hardcoded "default" name in tests
In transit gateway test with span, the project is required to be associated with the span - so create a project for that purpose.