### PR TITLE
Handle default span retrieval authorization errors

### DIFF
--- a/nsxt/policy_errors.go
+++ b/nsxt/policy_errors.go
@@ -160,6 +160,14 @@ func logAPIError(message string, err error) error {
 	return err
 }
 
+func isUnauthorizedError(err error) bool {
+	if _, ok := err.(errors.Unauthorized); ok {
+		return true
+	}
+
+	return false
+}
+
 func isNotFoundError(err error) bool {
 	if _, ok := err.(errors.NotFound); ok {
 		return true

--- a/nsxt/resource_nsxt_policy_project.go
+++ b/nsxt/resource_nsxt_policy_project.go
@@ -289,6 +289,10 @@ func getDefaultSpan(connector client.Connector) (string, error) {
 	var cursor *string
 	client := infra2.NewNetworkSpansClient(connector)
 	spanList, err := client.List(cursor, nil, nil, nil, nil, nil)
+	if isUnauthorizedError(err) {
+		log.Printf("[WARNING] user is unauthorized to retrieve the default span")
+		return "", nil
+	}
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Only admin users are authorized to retrieve the default spans. However, default span is not required for most of the operations, so it is safe to ignore this error and resume with a warning.