### PR TITLE
Segment port basic tests should run only on local manager

### DIFF
--- a/nsxt/data_source_nsxt_policy_segment_port_test.go
+++ b/nsxt/data_source_nsxt_policy_segment_port_test.go
@@ -11,6 +11,7 @@ import (
 func TestAccDataSourceNsxtPolicySegmentPort_basic(t *testing.T) {
 	testAccDataSourceNsxtPolicySegmentPort_basic(t, false, func() {
 		testAccPreCheck(t)
+		testAccOnlyLocalManager(t)
 	})
 }
 

--- a/nsxt/resource_nsxt_policy_segment_port_test.go
+++ b/nsxt/resource_nsxt_policy_segment_port_test.go
@@ -76,6 +76,7 @@ func testAccResourceNsxtPolicySegmentPort_basic(t *testing.T, withContext bool, 
 func TestAccResourceNsxtPolicySegmentPort_importBasic(t *testing.T) {
 	testAccResourceNsxtPolicySegmentPort_importBasic(t, false, func() {
 		testAccPreCheck(t)
+		testAccOnlyLocalManager(t)
 	})
 }
 


### PR DESCRIPTION
As required APIs are missing from GM.