### PR TITLE
Fix infinite loop in nsxt_policy_groups data source

### DIFF
--- a/docs/data-sources/policy_groups.md
+++ b/docs/data-sources/policy_groups.md
@@ -9,6 +9,8 @@ description: A policy groups data source. This data source builds "display name 
 This data source builds a "name to paths" map of the whole policy Groups table. Such map can be referenced in configuration to obtain object identifier attributes by display name at a cost of single roundtrip to NSX, which improves apply and refresh
 time at scale, compared to multiple instances of `nsxt_policy_group` data source.
 
+~> **NOTE:** If multiple groups with the same display name exist, only one will be included in the map.
+
 ## Example Usage
 
 ```hcl

--- a/nsxt/data_source_nsxt_policy_groups.go
+++ b/nsxt/data_source_nsxt_policy_groups.go
@@ -37,7 +37,6 @@ func dataSourceNsxtPolicyGroupsRead(d *schema.ResourceData, m interface{}) error
 
 	boolFalse := false
 	var cursor *string
-	total := 0
 	groupsMap := make(map[string]string)
 
 	for {
@@ -45,15 +44,11 @@ func dataSourceNsxtPolicyGroupsRead(d *schema.ResourceData, m interface{}) error
 		if err != nil {
 			return err
 		}
-		if total == 0 && results.ResultCount != nil {
-			// first response
-			total = int(*results.ResultCount)
-		}
 		for _, r := range results.Results {
 			groupsMap[*r.DisplayName] = *r.Path
 		}
 		cursor = results.Cursor
-		if len(groupsMap) >= total {
+		if cursor == nil {
 			break
 		}
 	}


### PR DESCRIPTION
The data source may enter an infinite loop when a duplicate display name for group exist. Fixes: #1933