### PR TITLE
Use product version instead of node version to determine manager version

### DIFF
--- a/nsxt/utils.go
+++ b/nsxt/utils.go
@@ -580,7 +580,7 @@ func getNSXVersion(connector client.Connector) (string, error) {
 
 	}
 	log.Printf("[DEBUG] NSX version is %s", *version.NodeVersion)
-	return *version.NodeVersion, nil
+	return *version.ProductVersion, nil
 }
 
 func initNSXVersion(connector client.Connector) error {


### PR DESCRIPTION
To avoid upgrade failure