### PR TITLE
IPv6 for project, vpc_connectivity_profile resources

### DIFF
--- a/docs/data-sources/policy_ip_block.md
+++ b/docs/data-sources/policy_ip_block.md
@@ -46,3 +46,4 @@ In addition to arguments listed above, the following attributes are exported:
 
 * `description` - The description of the resource.
 * `path` - The NSX path of the policy resource.
+* `ip_address_type` - IP address type reported by NSX for the block: `IPV4` or `IPV6`. Present when the API returns it (for example on NSX 9.2.0 and later for IPv6-capable deployments).

--- a/docs/data-sources/policy_project.md
+++ b/docs/data-sources/policy_project.md
@@ -34,3 +34,4 @@ In addition to arguments listed above, the following attributes are exported:
     * `site_path` - This represents the path of the site which is managed by Global Manager. For the local manager the value would be 'default'.
 * `tier0_gateway_paths` - Policy paths of Tier0 gateways associated with the project.
 * `external_ipv4_blocks` - Policy paths of IPv4 blocks associated with the project. Available since NSX 9.0.0.
+* `ipv6_blocks` - Policy paths of IPv6 blocks associated with the project. Available since NSX 9.2.0.

--- a/docs/resources/policy_ip_block.md
+++ b/docs/resources/policy_ip_block.md
@@ -105,6 +105,7 @@ In addition to arguments listed above, the following attributes are exported:
 * `id` - ID of the IP Block.
 * `revision` - Indicates current revision number of the object as seen by NSX-T API server. This attribute can be useful for debugging.
 * `path` - The NSX path of the resource.
+* `ip_address_type` - IP address type reported by NSX for the block: `IPV4` or `IPV6`. Present when the API returns it (for example on NSX 9.2.0 and later for IPv6-capable deployments).
 
 ## Importing
 

--- a/docs/resources/policy_project.md
+++ b/docs/resources/policy_project.md
@@ -36,6 +36,7 @@ The following arguments are supported:
     * `site_path` - (Optional) This represents the path of the site which is managed by Global Manager. For the local manager, if set, this needs to point to 'default'.
 * `tier0_gateway_paths` - (Optional) The tier 0 has to be pre-created before Project is created. The tier 0 typically provides connectivity to external world. List of sites for Project has to be subset of sites where the tier 0 spans.
 * `external_ipv4_blocks` - (Optional) IP blocks used for allocating CIDR blocks for public subnets. These can be consumed by all the VPCs under this project. Available since NSX 4.1.1.
+* `ipv6_blocks` - (Optional) Policy paths of external IPv6 blocks. These blocks can be consumed by all the VPCs under this project. Only IP address blocks with EXTERNAL visibility and ip_address_type IPV6 are supported. Available since NSX 9.2.0.
 * `tgw_external_connections` - (Optional) Transit gateway connection objects available to the project. Gateway connection and distributed VLAN connection object path will be allowed. Available since NSX 9.0.0.
 * `default_security_profile`- (Optional) Default security profile properties for project.
     * `north_south_firewall` - (Required) North South firewall configuration.

--- a/docs/resources/vpc_connectivity_profile.md
+++ b/docs/resources/vpc_connectivity_profile.md
@@ -42,9 +42,11 @@ The following arguments are supported:
 * `transit_gateway_path` - (Required) Transit Gateway path.
 * `private_tgw_ip_blocks` - (Optional) Policy path of Private IP block
 * `external_ip_blocks` - (Optional) Policy path of External IP block
+* `ipv6_blocks` - (Optional) List of policy paths of external IPv6 blocks. These blocks must be a subset of the Project's ipv6_blocks. Only IP address blocks with EXTERNAL visibility and ip_address_type IPV6 are supported. Maximum 5 entries.
 * `service_gateway` - (Optional) Service Gateway configuration
     * `nat_config` - (Optional) NAT configuration
         * `enable_default_snat` - (Optional) Auto configured SNAT for private subnet.
+        * `auto_snat_ip_block` - (Optional) Policy path of the IP block used to share with VPC user for configuring default SNAT.
     * `qos_config` - (Optional) None
         * `ingress_qos_profile_path` - (Optional) Policy path to gateway QoS profile in ingress direction.
         * `egress_qos_profile_path` - (Optional) Policy path to gateway QoS profile in egress direction.

--- a/docs/resources/vpc_dhcp_v6_static_binding_config.md
+++ b/docs/resources/vpc_dhcp_v6_static_binding_config.md
@@ -1,0 +1,83 @@
+---
+subcategory: "VPC"
+page_title: "NSXT: nsxt_vpc_dhcp_v6_static_binding"
+description: A resource to configure a DHCP IPv6 Static Binding on a VPC subnet.
+---
+
+# nsxt_vpc_dhcp_v6_static_binding
+
+This resource provides a method for the management of a DhcpV6StaticBindingConfig under a VPC subnet (`.../vpcs/<vpc-id>/subnets/<subnet-id>/dhcp-static-binding-configs/<binding-id>`).
+
+This resource is applicable to NSX Policy Manager and is supported with NSX 9.2.0 onwards. The parent subnet must be configured for IPv6 DHCP as required by NSX (for example dual-stack addressing and DHCPv6 server mode on the subnet).
+
+## Example Usage
+
+```hcl
+data "nsxt_policy_project" "demoproj" {
+  display_name = "demoproj"
+}
+
+data "nsxt_vpc" "demovpc" {
+  context {
+    project_id = data.nsxt_policy_project.demoproj.id
+  }
+  display_name = "vpc1"
+}
+
+data "nsxt_vpc_subnet" "test" {
+  context {
+    project_id = data.nsxt_policy_project.demoproj.id
+    vpc_id     = data.nsxt_vpc.demovpc.id
+  }
+  display_name = "subnet1"
+}
+
+resource "nsxt_vpc_dhcp_v6_static_binding" "test" {
+  parent_path     = data.nsxt_vpc_subnet.test.path
+  display_name    = "test"
+  description     = "Terraform provisioned DhcpV6StaticBindingConfig"
+  mac_address     = "10:0e:00:11:22:02"
+  lease_time      = 86400
+  ip_addresses    = ["2001:db8:1::101"]
+  domain_names    = ["client.example.org"]
+  dns_nameservers = ["2001:db8:1::53"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `parent_path` - (Required) Policy path of parent VpcSubnet object, typically reference to `path` in `nsxt_vpc_subnet` data source or resource.
+* `display_name` - (Required) Display name of the resource.
+* `description` - (Optional) Description of the resource.
+* `tag` - (Optional) A list of scope + tag pairs to associate with this resource.
+* `nsx_id` - (Optional) The NSX ID of this resource. If set, this ID will be used to create the resource.
+* `dns_nameservers` - (Optional) List of DNS nameserver addresses or hostnames for the client.
+* `domain_names` - (Optional) List of domain names assigned to the client host.
+* `ip_addresses` - (Optional) List of IPv6 addresses assigned to the client.
+* `lease_time` - (Optional) DHCP lease time in seconds. Minimum 60. Default is 86400.
+* `preferred_time` - (Optional) Preferred lifetime in seconds for the prefix. Minimum 48. If omitted, the server may derive a value from `lease_time`.
+* `mac_address` - (Optional) MAC address of the client host.
+* `ntp_servers` - (Optional) List of NTP servers as FQDN or IPv6 address.
+* `sntp_servers` - (Optional) List of SNTP server IPv6 addresses.
+
+## Attributes Reference
+
+In addition to arguments listed above, the following attributes are exported:
+
+* `id` - ID of the resource.
+* `revision` - Indicates current revision number of the object as seen by NSX-T API server. This attribute can be useful for debugging.
+* `path` - The NSX path of the policy resource.
+
+## Importing
+
+An existing object can be [imported][docs-import] into this resource, via the following command:
+
+[docs-import]: https://developer.hashicorp.com/terraform/cli/import
+
+```shell
+terraform import nsxt_vpc_dhcp_v6_static_binding.test PATH
+```
+
+The above command imports DhcpV6StaticBindingConfig named `test` with the policy path `PATH`.

--- a/docs/resources/vpc_service_profile.md
+++ b/docs/resources/vpc_service_profile.md
@@ -8,7 +8,7 @@ description: A resource to configure a VPC Service Profile.
 
 This resource provides a method for the management of a VPC Service Profile.
 
-This resource is applicable to NSX Policy Manager and is supported with NSX 9.0.0 onwards.
+This resource is applicable to NSX Policy Manager and is supported with NSX 9.0.0 onwards. IPv6-related arguments (`dhcpv6_config`, `dns_forwarder_config`, `ipv6_profile_paths`, `service_subnet_cidrs`) require NSX 9.2.0 or later.
 
 ## Example Usage
 
@@ -44,6 +44,30 @@ resource "nsxt_vpc_service_profile" "vpc1_service_profile" {
       }
     }
   }
+
+  dhcpv6_config {
+    dhcpv6_server_config {
+      lease_time     = 86400
+      preferred_time = 69120
+      ntp_servers    = ["2001:db8::1"]
+      sntp_servers   = ["2001:db8::2"]
+      dns_client_config {
+        dns_server_ips = ["2001:db8::53"]
+      }
+      advanced_config {
+        is_distributed_dhcp = false
+      }
+    }
+  }
+
+  # Up to two paths: one IPv6 DAD profile and one NDRA profile (see data sources nsxt_policy_ipv6_dad_profile / nsxt_policy_ipv6_ndra_profile).
+  ipv6_profile_paths = ["/orgs/default/projects/myproj/infra/ipv6-dad-profiles/dad1", "/orgs/default/projects/myproj/infra/ipv6-ndra-profiles/ndra1"]
+
+  service_subnet_cidrs = ["fd12:3456::/64"]
+
+  dns_forwarder_config {
+    log_level = "INFO"
+  }
 }
 ```
 
@@ -63,7 +87,7 @@ The following arguments are supported:
 * `security_profile` - (Optional) Policy path for Security Profile
 * `qos_profile` - (Optional) Policy path for QoS profile
 * `dhcp_config` - (Required) DHCP configuration for this profile
-    * `dhcp_server_config` - (Optional) DHCP server configuration for this profile
+    * `dhcp_server_config` - (Optional / Computed) DHCP server configuration for this profile. NSX may supply defaults when this block is omitted or only partially specified.
         * `ntp_servers` - (Optional) List of NTP servers
         * `dns_client_config` - (Optional) DNS Client configuration
             * `dns_server_ips` - (Optional) List of IP addresses of the DNS servers which need to be configured on the workload VMs
@@ -74,6 +98,24 @@ The following arguments are supported:
         If value is `true`, edge cluster will not be required. This is a DHCP server that dynamically assigns IP per VM port.
     * `dhcp_relay_config` - (Optional) DHCP Relay configuration
         * `server_addresses` - (Optional) List of DHCP server IP addresses for DHCP relay configuration. Both IPv4 and IPv6 addresses are supported.
+* `dhcpv6_config` - (Optional) DHCPv6 profile template for VPC subnets (relay and/or server settings). Supported with NSX v9.2.0 and above.
+    * `dhcpv6_relay_config` - (Optional) DHCPv6 relay configuration
+        * `server_addresses` - (Optional) List of DHCPv6 server addresses for relay
+    * `dhcpv6_server_config` - (Optional) DHCPv6 server defaults for subnets using this profile
+        * `dns_client_config` - (Optional) Same structure as `dhcp_config.dhcp_server_config.dns_client_config` (DNS server IPs for clients)
+        * `lease_time` - (Optional) IPv6 lease time in seconds. Default is 86400.
+        * `preferred_time` - (Optional) Preferred lifetime in seconds for delegated prefixes. Minimum 48. If omitted, the server may derive a value from `lease_time`.
+        * `ntp_servers` - (Optional) NTP servers as FQDN or IPv6 address
+        * `sntp_servers` - (Optional) SNTP server IPv6 addresses
+        * `advanced_config` - (Optional) Same semantics as IPv4 `dhcp_config.dhcp_server_config.advanced_config`
+            * `is_distributed_dhcp` - (Optional / Computed) Distributed DHCP mode for DHCPv6
+* `dns_forwarder_config` - (Optional) VPC DNS forwarder settings. Supported with NSX v9.2.0 and above.
+    * `cache_size` - (Optional) DNS answer cache size
+    * `conditional_forwarder_zone_paths` - (Optional) Policy paths of conditional DNS forwarder zones
+    * `default_forwarder_zone_path` - (Optional) Policy path of the default forwarder zone
+    * `log_level` - (Optional) One of `DEBUG`, `INFO`, `WARNING`, `ERROR`, `FATAL`
+* `ipv6_profile_paths` - (Optional / Computed) List of policy paths for IPv6 DAD and/or NDRA profiles used on VPC subnets (up to two paths: one DAD profile and one NDRA profile). Supported with NSX v9.2.0 and above. NSX may populate this when omitted from the configuration.
+* `service_subnet_cidrs` - (Optional / Computed) Service subnet CIDRs in `ip/prefix` form (IPv4 and/or IPv6). Minimum IPv4 size /28; must not overlap private, private TGW, or external IP blocks. Supported with NSX v9.2.0 and above. The manager may return CIDRs on read when this argument is omitted; Terraform keeps them in state without forcing a change.
 
 ## Attributes Reference
 

--- a/docs/resources/vpc_subnet.md
+++ b/docs/resources/vpc_subnet.md
@@ -67,6 +67,7 @@ The following arguments are supported:
 * `ipv4_subnet_size` - (Optional) If IP Addresses are not provided, this field will be used to carve out the ips
   from respective ip block defined in the parent VPC. The default is 64. Conflicts with `ip_addresses`.
 * `ip_addresses` - (Optional) If not provided, Ip assignment will be done based on VPC CIDRs. Conflicts with `ipv4_subnet_size`. This argument is required when access_mode is set to `Isolated`
+* `ip_address_type` - (Optional) Addressing for the subnet: `IPV4`, `IPV6`, or `IPV4_IPV6` (dual-stack). When omitted, NSX defaults to `IPV4`. Use `IPV4_IPV6` when the subnet uses both IPv4 and IPv6 (for example, both families in `ip_addresses` or DHCPv6 alongside IPv4). Changing this value forces replacement of the subnet.
 * `access_mode` - (Optional) Subnet access mode, one of `Private`, `Public`, `Isolated`, `Private_TGW` or `L2_ONLY`. Default is `Private`
 * `advanced_config` - (Optional) Advanced Configuration for the Subnet
     * `gateway_addresses` - (Optional) List of Gateway IP Addresses per address family, in CIDR format
@@ -96,6 +97,12 @@ The following arguments are supported:
                         * `values` - (Optional) List of values in string format
         * `reserved_ip_ranges` - (Optional) Specifies IP ranges that are reserved and excluded from being assigned by the DHCP server to clients.
          This is a list of IP ranges or IP addresses.
+* `subnet_dhcpv6_config` - (Optional) DHCPv6 configuration for the subnet. Base settings may be inherited from the VPC service profile; values set here are applied on top. This attribute is supported with NSX v9.2.0 and above.
+    * `mode` - (Optional) Operational mode of DHCPv6 within the subnet. One of `DHCP_SERVER`, `DHCP_RELAY`, `DHCP_DEACTIVATED`, or `DHCP_SERVER_STATELESS`. When omitted, the effective mode is inherited from the VPC service profile `dhcpv6_config`.
+    * `dns_server_preference` - (Optional) DNS server IP preference for DHCPv6, same semantics as `dhcp_config.dns_server_preference`. One of `PROFILE_DNS_SERVERS_PREFERRED_OVER_DNS_FORWARDER` or `DNS_FORWARDER_PREFERRED_OVER_PROFILE_DNS_SERVERS`. Supported with NSX v9.2.0 and above.
+    * `dhcpv6_server_additional_config` - (Optional) Additional DHCPv6 server settings. Must not be set when `mode` is `DHCP_RELAY` or `DHCP_DEACTIVATED`.
+        * `domain_names` - (Optional) Domain names assigned to DHCPv6 clients.
+        * `reserved_ip_ranges` - (Optional) IPv6 addresses or ranges excluded from DHCPv6 assignment (for example `2001:db8::10` or `2001:db8::10-2001:db8::20`).
 * `ip_blocks` - (Optional) List of IP block path for subnet IP allocation
 
 ## Attributes Reference

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/vmware/go-vmware-nsxt v0.0.0-20220328155605-f49a14c1ef5f
 	github.com/vmware/vsphere-automation-sdk-go/lib v0.8.0
 	github.com/vmware/vsphere-automation-sdk-go/runtime v0.8.0
-	github.com/vmware/vsphere-automation-sdk-go/services/nsxt v0.12.1-0.20260310075027-d32fca6a7b22
+	github.com/vmware/vsphere-automation-sdk-go/services/nsxt v0.12.1-0.20260427173727-1f350a424144
 	github.com/vmware/vsphere-automation-sdk-go/services/nsxt-gm v0.9.1-0.20241118070726-666c7cd6e466
 	github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp v0.6.1-0.20241118070726-666c7cd6e466
 	golang.org/x/exp v0.0.0-20230801115018-d63ba01acd4b

--- a/go.sum
+++ b/go.sum
@@ -170,8 +170,8 @@ github.com/vmware/vsphere-automation-sdk-go/lib v0.8.0 h1:u1SXOTM6D4Ygb3jeidj2Rd
 github.com/vmware/vsphere-automation-sdk-go/lib v0.8.0/go.mod h1:8d5JTwjpM/Z03n/IZb0fwmXkJNWvWwuLXBqoakqYio4=
 github.com/vmware/vsphere-automation-sdk-go/runtime v0.8.0 h1:KnDIX9LY0nru7iMQTg0sy9vChhyorPo5OdASM2MaAcI=
 github.com/vmware/vsphere-automation-sdk-go/runtime v0.8.0/go.mod h1:DzLetYAmw1+vj7bqElRWEpuy40WYE/woL3alsymYa/c=
-github.com/vmware/vsphere-automation-sdk-go/services/nsxt v0.12.1-0.20260310075027-d32fca6a7b22 h1:zOi5ktjdhC3fVG6hyjZQaMutA4pijWBRL/ME+wmZwTU=
-github.com/vmware/vsphere-automation-sdk-go/services/nsxt v0.12.1-0.20260310075027-d32fca6a7b22/go.mod h1:C3JVOHRVLrGBQ8kTWAiGYlRz5UQC5qAcTdt3tvA+5P0=
+github.com/vmware/vsphere-automation-sdk-go/services/nsxt v0.12.1-0.20260427173727-1f350a424144 h1:29ljmH72TOVHj9L4EsSDQwFP2fFrbpE+/jBLbKOOtEg=
+github.com/vmware/vsphere-automation-sdk-go/services/nsxt v0.12.1-0.20260427173727-1f350a424144/go.mod h1:C3JVOHRVLrGBQ8kTWAiGYlRz5UQC5qAcTdt3tvA+5P0=
 github.com/vmware/vsphere-automation-sdk-go/services/nsxt-gm v0.9.1-0.20241118070726-666c7cd6e466 h1:SYBECpviZBcp/cUHKTDPQP7CSQb0lUfPPOClpGOFH44=
 github.com/vmware/vsphere-automation-sdk-go/services/nsxt-gm v0.9.1-0.20241118070726-666c7cd6e466/go.mod h1:gcEvyczWPFMZX2gkBiBVpOwvUGSNXSpxU19Sx9aiouY=
 github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp v0.6.1-0.20241118070726-666c7cd6e466 h1:yXUKHP/XDGp7Wrcbfl5BHV1VreCNPHRLUj2RQ5qDEmE=

--- a/nsxt/data_source_nsxt_policy_ip_block.go
+++ b/nsxt/data_source_nsxt_policy_ip_block.go
@@ -22,6 +22,11 @@ func dataSourceNsxtPolicyIPBlock() *schema.Resource {
 			"description":  getDataSourceDescriptionSchema(),
 			"path":         getPathSchema(),
 			"context":      getContextSchema(false, false, false),
+			"ip_address_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "IP address type for the block as reported by NSX (IPV4 or IPV6).",
+			},
 		},
 	}
 }
@@ -81,5 +86,8 @@ func dataSourceNsxtPolicyIPBlockRead(d *schema.ResourceData, m interface{}) erro
 	d.Set("display_name", obj.DisplayName)
 	d.Set("description", obj.Description)
 	d.Set("path", obj.Path)
+	if obj.IpAddressType != nil {
+		d.Set("ip_address_type", *obj.IpAddressType)
+	}
 	return nil
 }

--- a/nsxt/data_source_nsxt_policy_project.go
+++ b/nsxt/data_source_nsxt_policy_project.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+
+	"github.com/vmware/terraform-provider-nsxt/nsxt/util"
 )
 
 const defaultOrgID = "default"
@@ -36,6 +38,13 @@ func dataSourceNsxtPolicyProject() *schema.Resource {
 				Computed: true,
 			},
 			"external_ipv4_blocks": {
+				Type: schema.TypeList,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Computed: true,
+			},
+			"ipv6_blocks": {
 				Type: schema.TypeList,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
@@ -135,6 +144,9 @@ func dataSourceNsxtPolicyProjectRead(d *schema.ResourceData, m interface{}) erro
 	d.Set("site_info", siteInfosList)
 	d.Set("tier0_gateway_paths", obj.Tier0s)
 	d.Set("external_ipv4_blocks", obj.ExternalIpv4Blocks)
+	if util.NsxVersionHigherOrEqual("9.2.0") {
+		d.Set("ipv6_blocks", obj.Ipv6Blocks)
+	}
 
 	return nil
 }

--- a/nsxt/data_source_nsxt_policy_project_test.go
+++ b/nsxt/data_source_nsxt_policy_project_test.go
@@ -47,6 +47,42 @@ func TestAccDataSourceNsxtPolicyProject_basic(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceNsxtPolicyProject_920ipv6Blocks(t *testing.T) {
+	testDSName := "data.nsxt_policy_project.ds"
+	expected := map[string]string{"ipv6_block_count": "1"}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccOnlyLocalManager(t)
+			testAccNSXVersion(t, "9.2.0")
+		},
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyProjectCheckDestroy(state, accTestPolicyProjectCreateAttributes["DisplayName"])
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceNsxtPolicyProject920Config(),
+				Check: resource.ComposeTestCheckFunc(
+					runChecksNsx920(testDSName, expected),
+					resource.TestCheckResourceAttrPair(testDSName, "ipv6_blocks.0", "nsxt_policy_ip_block.test_ipv6_block", "path"),
+					resource.TestCheckResourceAttr(testDSName, "display_name", accTestPolicyProjectCreateAttributes["DisplayName"]),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceNsxtPolicyProject920Config() string {
+	return testAccNsxtPolicyProjectTemplate920(true, true, true, true, true, false) + fmt.Sprintf(`
+data "nsxt_policy_project" "ds" {
+  display_name = "%s"
+  depends_on = [nsxt_policy_project.test]
+}
+`, accTestPolicyProjectCreateAttributes["DisplayName"])
+}
+
 func testAccDataSourceNsxtPolicyProjectCreate(name string) error {
 	connector, err := testAccGetPolicyConnector()
 	if err != nil {

--- a/nsxt/metadata/metadata.go
+++ b/nsxt/metadata/metadata.go
@@ -155,6 +155,37 @@ func getContextString(prefix, parent string, elemType reflect.Type) string {
 	return fmt.Sprintf("[%s %s]", prefix, ctx)
 }
 
+// structToSchemaGatedReadPlaceholder returns a Terraform state value for an attribute
+// that is not read from the API on managers below IntroducedInVersion. Using the
+// schema default when present keeps Optional+Default fields aligned with config on
+// those managers (otherwise state stays unset while config still applies Default).
+func structToSchemaGatedReadPlaceholder(item *ExtendedSchema) interface{} {
+	if len(item.Metadata.PolymorphicType) > 0 {
+		return nil
+	}
+	switch item.Metadata.SchemaType {
+	case "list", "set", "struct":
+		return []interface{}{}
+	case "string":
+		if item.Schema.Default != nil {
+			return item.Schema.Default
+		}
+		return ""
+	case "int":
+		if item.Schema.Default != nil {
+			return item.Schema.Default
+		}
+		return 0
+	case "bool":
+		if item.Schema.Default != nil {
+			return item.Schema.Default
+		}
+		return false
+	default:
+		return nil
+	}
+}
+
 // StructToSchema converts NSX model struct to terraform schema
 // currently supports nested subtype and trivial types
 func StructToSchema(elem reflect.Value, d *schema.ResourceData, metadata map[string]*ExtendedSchema, parent string, parentMap map[string]interface{}) (err error) {
@@ -170,6 +201,17 @@ func StructToSchema(elem reflect.Value, d *schema.ResourceData, metadata map[str
 		if item.Metadata.Skip {
 			continue
 		}
+		if item.Metadata.IntroducedInVersion != "" && util.NsxVersion != "" && util.NsxVersionLower(item.Metadata.IntroducedInVersion) {
+			metadataTraceLogger("%s skip key %s as NSX version is lower than %v (StructToSchema read)", ctx, key, item.Metadata.IntroducedInVersion)
+			if placeholder := structToSchemaGatedReadPlaceholder(item); placeholder != nil {
+				if len(parent) > 0 {
+					parentMap[key] = placeholder
+				} else {
+					d.Set(key, placeholder)
+				}
+			}
+			continue
+		}
 
 		metadataTraceLogger("%s inspecting key %s", ctx, key)
 		if len(parent) > 0 {
@@ -183,7 +225,20 @@ func StructToSchema(elem reflect.Value, d *schema.ResourceData, metadata map[str
 				ctx, key, elem.Type())
 			return
 		}
-		if elem.FieldByName(item.Metadata.SdkFieldName).IsNil() {
+		fieldVal := elem.FieldByName(item.Metadata.SdkFieldName)
+		if fieldVal.IsNil() {
+			// Nil slices/maps never reach the list/set switch below; write an empty
+			// collection so optional list attributes (e.g. NtpServers) match config
+			// that omits them (avoids perpetual + ntp_servers = [] drift).
+			if (item.Metadata.SchemaType == "list" || item.Metadata.SchemaType == "set") && fieldVal.Kind() == reflect.Slice {
+				if len(parent) > 0 {
+					parentMap[key] = []interface{}{}
+				} else {
+					d.Set(key, []interface{}{})
+				}
+				metadataTraceLogger("%s assign empty %s for nil API slice %s", ctx, item.Metadata.SchemaType, key)
+				continue
+			}
 			metadataTraceLogger("%s skip key %s with nil value", ctx, key)
 			continue
 		}
@@ -291,7 +346,7 @@ func SchemaToStruct(elem reflect.Value, d *schema.ResourceData, metadata map[str
 			metadataTraceLogger("%s skip key %s", ctx, key)
 			continue
 		}
-		if item.Metadata.IntroducedInVersion != "" && util.NsxVersionLower(item.Metadata.IntroducedInVersion) {
+		if item.Metadata.IntroducedInVersion != "" && util.NsxVersion != "" && util.NsxVersionLower(item.Metadata.IntroducedInVersion) {
 			metadataTraceLogger("%s skip key %s as NSX version is lower than %v", ctx, key, item.Metadata.IntroducedInVersion)
 			continue
 		}

--- a/nsxt/provider.go
+++ b/nsxt/provider.go
@@ -524,6 +524,7 @@ func Provider() *schema.Provider {
 			"nsxt_vpc_attachment":                                      resourceNsxtVpcAttachment(),
 			"nsxt_vpc_connectivity_profile":                            resourceNsxtVpcConnectivityProfile(),
 			"nsxt_vpc_dhcp_v4_static_binding":                          resourceNsxtVpcSubnetDhcpV4StaticBindingConfig(),
+			"nsxt_vpc_dhcp_v6_static_binding":                          resourceNsxtVpcSubnetDhcpV6StaticBindingConfig(),
 			"nsxt_vpc_external_address":                                resourceNsxtVpcExternalAddress(),
 			"nsxt_vpc_gateway_policy":                                  resourceNsxtVPCGatewayPolicy(),
 			"nsxt_vpc_group":                                           resourceNsxtVPCGroup(),

--- a/nsxt/resource_nsxt_policy_ip_block.go
+++ b/nsxt/resource_nsxt_policy_ip_block.go
@@ -74,6 +74,11 @@ func resourceNsxtPolicyIPBlock() *schema.Resource {
 			},
 			"range":        getAllocationRangesSchema(false, "Represents list of IP address ranges in the form of start and end IPs"),
 			"excluded_ips": getAllocationRangesSchema(false, "Represents list of excluded IP address in the form of start and end IPs"),
+			"ip_address_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "IP address type for the block as reported by NSX (IPV4 or IPV6).",
+			},
 		},
 	}
 }
@@ -134,6 +139,10 @@ func resourceNsxtPolicyIPBlockRead(d *schema.ResourceData, m interface{}) error 
 		}
 	} else {
 		d.Set("cidr", block.Cidr)
+	}
+
+	if block.IpAddressType != nil {
+		d.Set("ip_address_type", *block.IpAddressType)
 	}
 
 	return nil

--- a/nsxt/resource_nsxt_policy_project.go
+++ b/nsxt/resource_nsxt_policy_project.go
@@ -103,6 +103,13 @@ func resourceNsxtPolicyProject() *schema.Resource {
 				Elem:     getElemPolicyPathSchema(),
 				Optional: true,
 			},
+			// IntroducedInVersion: 9.2.0 (enforced in resourceNsxtPolicyProjectPatch / resourceNsxtPolicyProjectRead)
+			"ipv6_blocks": {
+				Type:        schema.TypeList,
+				Elem:        getElemPolicyPathSchema(),
+				Optional:    true,
+				Description: "Policy paths of external IPv6 blocks for VPCs under this project. Only EXTERNAL visibility IPv6 blocks are supported. Requires NSX 9.2.0 or later.",
+			},
 			"tgw_external_connections": {
 				Type:     schema.TypeList,
 				Elem:     getElemPolicyPathSchema(),
@@ -244,6 +251,10 @@ func resourceNsxtPolicyProjectPatch(connector client.Connector, d *schema.Resour
 		obj.TgwExternalConnections = tgwConnectionsList
 		obj.VcFolder = &vcFolder
 		obj.Limits = quotasList
+	}
+
+	if util.NsxVersionHigherOrEqual("9.2.0") {
+		obj.Ipv6Blocks = getStringListFromSchemaList(d, "ipv6_blocks")
 	}
 
 	if shortID != "" {
@@ -477,6 +488,10 @@ func resourceNsxtPolicyProjectRead(d *schema.ResourceData, m interface{}) error 
 		d.Set("tgw_external_connections", obj.TgwExternalConnections)
 		d.Set("vc_folder", obj.VcFolder)
 		d.Set("quotas", obj.Limits)
+	}
+
+	if util.NsxVersionHigherOrEqual("9.2.0") {
+		d.Set("ipv6_blocks", obj.Ipv6Blocks)
 	}
 
 	if util.NsxVersionHigherOrEqual("9.1.0") {

--- a/nsxt/resource_nsxt_policy_project_test.go
+++ b/nsxt/resource_nsxt_policy_project_test.go
@@ -97,6 +97,12 @@ func runChecksNsx910(testResourceName string, expectedValues map[string]string) 
 	)
 }
 
+func runChecksNsx920(testResourceName string, expectedValues map[string]string) resource.TestCheckFunc {
+	return resource.ComposeTestCheckFunc(
+		resource.TestCheckResourceAttr(testResourceName, "ipv6_blocks.#", expectedValues["ipv6_block_count"]),
+	)
+}
+
 func TestAccResourceNsxtPolicyProject_basic(t *testing.T) {
 	testResourceName := "nsxt_policy_project.test"
 	siteCount := getExpectedSiteInfoCount(t)
@@ -415,6 +421,78 @@ func TestAccResourceNsxtPolicyProject_910basic(t *testing.T) {
 	})
 }
 
+func TestAccResourceNsxtPolicyProject_920basic(t *testing.T) {
+	testResourceName := "nsxt_policy_project.test"
+	siteCount := getExpectedSiteInfoCount(t)
+	expectedValuesStep1 := map[string]string{
+		"t0_count":                   "1",
+		"ip_block_count":             "1",
+		"ipv6_block_count":           "1",
+		"tgw_ext_conn_count":         "1",
+		"span_reference_count":       "1",
+		"activate_default_dfw_rules": "true",
+		"site_count":                 siteCount,
+		"id_suffix":                  "test-suffix",
+	}
+	expectedValuesStep2 := map[string]string{
+		"t0_count":                   "1",
+		"ip_block_count":             "0",
+		"ipv6_block_count":           "0",
+		"tgw_ext_conn_count":         "1",
+		"span_reference_count":       "1",
+		"activate_default_dfw_rules": "false",
+		"site_count":                 siteCount,
+		"id_suffix":                  "test-suffix",
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccOnlyLocalManager(t)
+			testAccNSXVersion(t, "9.2.0")
+		},
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyProjectCheckDestroy(state, accTestPolicyProjectUpdateAttributes["DisplayName"])
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyProjectTemplate920(true, true, true, true, true, false),
+				Check: resource.ComposeTestCheckFunc(
+					runChecksNsx410(testResourceName, accTestPolicyProjectCreateAttributes, expectedValuesStep1),
+					runChecksNsx411(testResourceName, expectedValuesStep1),
+					runChecksNsx420(testResourceName, expectedValuesStep1),
+					runChecksNsx900(testResourceName, expectedValuesStep1),
+					runChecksNsx910(testResourceName, expectedValuesStep1),
+					runChecksNsx920(testResourceName, expectedValuesStep1),
+				),
+			},
+			{
+				Config: testAccNsxtPolicyProjectTemplate920(false, true, false, false, false, true),
+				Check: resource.ComposeTestCheckFunc(
+					runChecksNsx410(testResourceName, accTestPolicyProjectUpdateAttributes, expectedValuesStep2),
+					runChecksNsx411(testResourceName, expectedValuesStep2),
+					runChecksNsx420(testResourceName, expectedValuesStep2),
+					runChecksNsx900(testResourceName, expectedValuesStep2),
+					runChecksNsx910(testResourceName, expectedValuesStep2),
+					runChecksNsx920(testResourceName, expectedValuesStep2),
+				),
+			},
+			{
+				Config: testAccNsxtPolicyProjectTemplate920(false, true, false, false, false, false),
+				Check: resource.ComposeTestCheckFunc(
+					runChecksNsx410(testResourceName, accTestPolicyProjectUpdateAttributes, expectedValuesStep2),
+					runChecksNsx411(testResourceName, expectedValuesStep2),
+					runChecksNsx420(testResourceName, expectedValuesStep2),
+					runChecksNsx900(testResourceName, expectedValuesStep2),
+					runChecksNsx910(testResourceName, expectedValuesStep2),
+					runChecksNsx920(testResourceName, expectedValuesStep2),
+				),
+			},
+		},
+	})
+}
+
 func TestAccResourceNsxtPolicyProject_DefaultSpanCheck(t *testing.T) {
 	name := getAccTestResourceName()
 	testResourceName := "nsxt_policy_project.test"
@@ -557,6 +635,19 @@ func testAccNsxtPolicyProjectCheckDestroy(state *terraform.State, displayName st
 	return nil
 }
 
+// testAccPolicyProjectTgwAggregateRoute returns a /24 stable for the given display_name
+// (so multi-step project tests do not reshuffle aggregate_routes) while varying between
+// tests to avoid overlap with other gateway connections on the same Tier-0.
+func testAccPolicyProjectTgwAggregateRoute(displayName string) string {
+	sum := 0
+	for _, c := range displayName {
+		sum += int(c)
+	}
+	third := (sum % 180) + 20
+	fourth := ((sum / 11) % 250) + 1
+	return fmt.Sprintf("10.%d.%d.0/24", third, fourth)
+}
+
 // TODO: Visibility should not be set for 410 tests (attribute exists, different enum values since 411)
 var templateData = `
 data "nsxt_policy_edge_cluster" "EC" {
@@ -573,10 +664,16 @@ resource "nsxt_policy_ip_block" "test_ip_block" {
   {{if .SetIpBlockVisibility}}visibility   = "EXTERNAL"{{end}}
 }
 
+{{if eq .RenderIpv6Block "true"}}resource "nsxt_policy_ip_block" "test_ipv6_block" {
+  display_name      = "test_ipv6_block"
+  cidr              = "2001:db8::/32"
+  visibility        = "EXTERNAL"
+}{{end}}
+
 {{if .ExternalTGWConnectionPath}}resource "nsxt_policy_gateway_connection" "test_gw_conn" {
   display_name     = "test_gw_conn"
   tier0_path       = {{.T0GwPath}}
-  aggregate_routes = ["192.168.240.0/24"]
+  aggregate_routes = ["{{.TgwAggregateRoute}}"]
 }{{end}}
 
 {{if .PolicyNetworkSpan}}resource "nsxt_policy_network_span" "netspan" {
@@ -590,8 +687,11 @@ resource "nsxt_policy_project" "test" {
   {{if .ShortId}}short_id                   = "{{.ShortId}}"{{end}}
   {{if .IdSuffix}}id_suffix                  = "{{.IdSuffix}}"{{end}}
   {{if .T0GwPath}}tier0_gateway_paths        = [{{.T0GwPath}}]{{end}}
-  {{if .ExternalIPv4BlockPath}}external_ipv4_blocks       = [{{.ExternalIPv4BlockPath}}]{{end}}
+  {{if .ExternalIPv4BlockPath}}external_ipv4_blocks       = [{{.ExternalIPv4BlockPath}}]{{else}}external_ipv4_blocks       = []{{end}}
+  {{if eq .Ipv6BlocksMode "set"}}ipv6_blocks                = [{{.ExternalIPv6BlockPath}}]{{end}}
+  {{if eq .Ipv6BlocksMode "clear"}}ipv6_blocks                = []{{end}}
   {{if .ExternalTGWConnectionPath}}tgw_external_connections   = [{{.ExternalTGWConnectionPath}}]{{end}}
+  depends_on = [nsxt_policy_ip_block.test_ip_block{{if eq .RenderIpv6Block "true"}}, nsxt_policy_ip_block.test_ipv6_block{{end}}]
   {{if .ActivateDefaultDfwRules}}activate_default_dfw_rules = {{.ActivateDefaultDfwRules}}{{end}}
   {{if .PolicyNetworkSpan}}
   vc_folder = true
@@ -622,6 +722,7 @@ func getBasicAttrMap(createFlow, includeT0GW bool) map[string]string {
 	}
 	attrMap["T0Name"] = getTier0RouterName()
 	attrMap["ClusterName"] = getEdgeClusterName()
+	attrMap["RenderIpv6Block"] = "false"
 	return attrMap
 }
 
@@ -684,6 +785,7 @@ func testAccNsxtPolicyProjectTemplate900(createFlow, includeT0GW, includeExterna
 	attrMap["SetIpBlockVisibility"] = "true"
 	attrMap["ActivateDefaultDfwRules"] = strconv.FormatBool(activateDefaultDfwRules)
 	attrMap["ExternalTGWConnectionPath"] = "nsxt_policy_gateway_connection.test_gw_conn.path"
+	attrMap["TgwAggregateRoute"] = testAccPolicyProjectTgwAggregateRoute(attrMap["DisplayName"])
 	buffer := new(bytes.Buffer)
 	tmpl, err := template.New("testAccNsxtPolicyProjectTemplate900").Parse(templateData)
 	if err != nil {
@@ -704,6 +806,7 @@ func testAccNsxtPolicyProjectTemplate910(createFlow, includeT0GW, includeExterna
 	attrMap["SetIpBlockVisibility"] = "true"
 	attrMap["ActivateDefaultDfwRules"] = strconv.FormatBool(activateDefaultDfwRules)
 	attrMap["ExternalTGWConnectionPath"] = "nsxt_policy_gateway_connection.test_gw_conn.path"
+	attrMap["TgwAggregateRoute"] = testAccPolicyProjectTgwAggregateRoute(attrMap["DisplayName"])
 	attrMap["PolicyNetworkSpan"] = "nsxt_policy_network_span.netspan.path"
 
 	// Add id_suffix for NSX 9.1+ tests
@@ -711,6 +814,43 @@ func testAccNsxtPolicyProjectTemplate910(createFlow, includeT0GW, includeExterna
 
 	buffer := new(bytes.Buffer)
 	tmpl, err := template.New("testAccNsxtPolicyProjectTemplate910").Parse(templateData)
+	if err != nil {
+		panic(err)
+	}
+	err = tmpl.Execute(buffer, attrMap)
+	if err != nil {
+		panic(err)
+	}
+	return buffer.String()
+}
+
+func testAccNsxtPolicyProjectTemplate920(createFlow, includeT0GW, includeExternalIPv4Block, activateDefaultDfwRules, includeIPv6Block, orphanIPv6Block bool) string {
+	attrMap := getBasicAttrMap(createFlow, includeT0GW)
+	if includeExternalIPv4Block {
+		attrMap["ExternalIPv4BlockPath"] = "nsxt_policy_ip_block.test_ip_block.path"
+	}
+	if includeIPv6Block {
+		attrMap["ExternalIPv6BlockPath"] = "nsxt_policy_ip_block.test_ipv6_block.path"
+		attrMap["Ipv6BlocksMode"] = "set"
+		attrMap["RenderIpv6Block"] = "true"
+	} else {
+		attrMap["Ipv6BlocksMode"] = "clear"
+		delete(attrMap, "ExternalIPv6BlockPath")
+		if orphanIPv6Block {
+			attrMap["RenderIpv6Block"] = "true"
+		} else {
+			attrMap["RenderIpv6Block"] = "false"
+		}
+	}
+	attrMap["SetIpBlockVisibility"] = "true"
+	attrMap["ActivateDefaultDfwRules"] = strconv.FormatBool(activateDefaultDfwRules)
+	attrMap["ExternalTGWConnectionPath"] = "nsxt_policy_gateway_connection.test_gw_conn.path"
+	attrMap["TgwAggregateRoute"] = testAccPolicyProjectTgwAggregateRoute(attrMap["DisplayName"])
+	attrMap["PolicyNetworkSpan"] = "nsxt_policy_network_span.netspan.path"
+	attrMap["IdSuffix"] = "test-suffix"
+
+	buffer := new(bytes.Buffer)
+	tmpl, err := template.New("testAccNsxtPolicyProjectTemplate920").Parse(templateData)
 	if err != nil {
 		panic(err)
 	}

--- a/nsxt/resource_nsxt_policy_transit_gateway_attachment_test.go
+++ b/nsxt/resource_nsxt_policy_transit_gateway_attachment_test.go
@@ -174,9 +174,6 @@ resource "nsxt_policy_gateway_connection" "test" {
   display_name     = "%s"
   tier0_path       = nsxt_policy_tier0_gateway.test.path
   aggregate_routes = ["192.168.240.0/24"]
-  advertise_outbound_networks {
-    allow_external_blocks = [nsxt_policy_ip_block.extblk.path]
-  }
 }
 
 resource "nsxt_policy_project" "test" {

--- a/nsxt/resource_nsxt_vpc_connectivity_profile.go
+++ b/nsxt/resource_nsxt_vpc_connectivity_profile.go
@@ -78,6 +78,27 @@ var vpcConnectivityProfileSchema = map[string]*metadata.ExtendedSchema{
 			SdkFieldName: "ExternalIpBlocks",
 		},
 	},
+	"ipv6_blocks": {
+		Schema: schema.Schema{
+			Type:        schema.TypeList,
+			Description: "External IPv6 policy paths; subset of the project's ipv6_blocks. Requires NSX 9.2.0 or later.",
+			Elem: &metadata.ExtendedSchema{
+				Schema: schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validatePolicyPath(),
+				},
+				Metadata: metadata.Metadata{
+					SchemaType: "string",
+				},
+			},
+			Optional: true,
+		},
+		Metadata: metadata.Metadata{
+			SchemaType:          "list",
+			SdkFieldName:        "Ipv6Blocks",
+			IntroducedInVersion: "9.2.0",
+		},
+	},
 	"service_gateway": {
 		Schema: schema.Schema{
 			Type:     schema.TypeList,
@@ -98,6 +119,19 @@ var vpcConnectivityProfileSchema = map[string]*metadata.ExtendedSchema{
 										Metadata: metadata.Metadata{
 											SchemaType:   "bool",
 											SdkFieldName: "EnableDefaultSnat",
+										},
+									},
+									"auto_snat_ip_block": {
+										Schema: schema.Schema{
+											Type:         schema.TypeString,
+											ValidateFunc: validatePolicyPath(),
+											Optional:     true,
+											Description:  "Policy path of the IP block for default SNAT. Requires NSX 9.2.0 or later.",
+										},
+										Metadata: metadata.Metadata{
+											SchemaType:          "string",
+											SdkFieldName:        "AutoSnatIpBlock",
+											IntroducedInVersion: "9.2.0",
 										},
 									},
 								},

--- a/nsxt/resource_nsxt_vpc_dhcp_v6_static_binding_config.go
+++ b/nsxt/resource_nsxt_vpc_dhcp_v6_static_binding_config.go
@@ -1,0 +1,357 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package nsxt
+
+import (
+	"fmt"
+	"log"
+	"reflect"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/vmware/terraform-provider-nsxt/api/orgs/projects/vpcs/subnets"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/bindings"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/data"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+
+	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
+	"github.com/vmware/terraform-provider-nsxt/nsxt/metadata"
+	"github.com/vmware/terraform-provider-nsxt/nsxt/util"
+)
+
+var cliVpcSubnetDhcpV6StaticBindingConfigsClient = subnets.NewDhcpStaticBindingConfigsClient
+
+var dhcpV6StaticBindingConfigSchema = map[string]*metadata.ExtendedSchema{
+	"nsx_id":       metadata.GetExtendedSchema(getNsxIDSchema()),
+	"path":         metadata.GetExtendedSchema(getPathSchema()),
+	"display_name": metadata.GetExtendedSchema(getDisplayNameSchema()),
+	"description":  metadata.GetExtendedSchema(getDescriptionSchema()),
+	"revision":     metadata.GetExtendedSchema(getRevisionSchema()),
+	"tag":          metadata.GetExtendedSchema(getTagsSchema()),
+	"parent_path":  metadata.GetExtendedSchema(getPolicyPathSchema(true, true, "Policy path of the parent")),
+	"dns_nameservers": {
+		Schema: schema.Schema{
+			Type:        schema.TypeList,
+			Description: "DNS nameservers for the DHCPv6 client.",
+			Optional:    true,
+			Elem: &metadata.ExtendedSchema{
+				Schema: schema.Schema{
+					Type: schema.TypeString,
+				},
+				Metadata: metadata.Metadata{
+					SchemaType: "string",
+				},
+			},
+		},
+		Metadata: metadata.Metadata{
+			SchemaType:   "list",
+			SdkFieldName: "DnsNameservers",
+		},
+	},
+	"domain_names": {
+		Schema: schema.Schema{
+			Type:        schema.TypeList,
+			Description: "Domain names assigned to the client host.",
+			Optional:    true,
+			Elem: &metadata.ExtendedSchema{
+				Schema: schema.Schema{
+					Type: schema.TypeString,
+				},
+				Metadata: metadata.Metadata{
+					SchemaType: "string",
+				},
+			},
+		},
+		Metadata: metadata.Metadata{
+			SchemaType:   "list",
+			SdkFieldName: "DomainNames",
+		},
+	},
+	"ip_addresses": {
+		Schema: schema.Schema{
+			Type:        schema.TypeList,
+			Description: "IPv6 addresses assigned to the client.",
+			Optional:    true,
+			Elem: &metadata.ExtendedSchema{
+				Schema: schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validation.IsIPv6Address,
+				},
+				Metadata: metadata.Metadata{
+					SchemaType: "string",
+				},
+			},
+		},
+		Metadata: metadata.Metadata{
+			SchemaType:   "list",
+			SdkFieldName: "IpAddresses",
+		},
+	},
+	"lease_time": {
+		Schema: *getDhcpLeaseTimeSchema(),
+		Metadata: metadata.Metadata{
+			SchemaType:   "int",
+			SdkFieldName: "LeaseTime",
+		},
+	},
+	"preferred_time": {
+		Schema: *getDhcpPreferredTimeSchema(),
+		Metadata: metadata.Metadata{
+			SchemaType:   "int",
+			SdkFieldName: "PreferredTime",
+			OmitIfEmpty:  true,
+		},
+	},
+	"mac_address": {
+		Schema: schema.Schema{
+			Type:         schema.TypeString,
+			Description:  "MAC address of the client host.",
+			Optional:     true,
+			ValidateFunc: validation.IsMACAddress,
+		},
+		Metadata: metadata.Metadata{
+			SchemaType:   "string",
+			SdkFieldName: "MacAddress",
+		},
+	},
+	"ntp_servers": {
+		Schema: schema.Schema{
+			Type:        schema.TypeList,
+			Description: "NTP servers as FQDN or IPv6 address.",
+			Optional:    true,
+			Elem: &metadata.ExtendedSchema{
+				Schema: schema.Schema{
+					Type: schema.TypeString,
+				},
+				Metadata: metadata.Metadata{
+					SchemaType: "string",
+				},
+			},
+		},
+		Metadata: metadata.Metadata{
+			SchemaType:   "list",
+			SdkFieldName: "NtpServers",
+		},
+	},
+	"sntp_servers": {
+		Schema: schema.Schema{
+			Type:        schema.TypeList,
+			Description: "SNTP server IPv6 addresses.",
+			Optional:    true,
+			Elem: &metadata.ExtendedSchema{
+				Schema: schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validation.IsIPv6Address,
+				},
+				Metadata: metadata.Metadata{
+					SchemaType: "string",
+				},
+			},
+		},
+		Metadata: metadata.Metadata{
+			SchemaType:   "list",
+			SdkFieldName: "SntpServers",
+		},
+	},
+}
+
+func resourceNsxtVpcSubnetDhcpV6StaticBindingConfig() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceNsxtVpcSubnetDhcpV6StaticBindingConfigCreate,
+		Read:   resourceNsxtVpcSubnetDhcpV6StaticBindingConfigRead,
+		Update: resourceNsxtVpcSubnetDhcpV6StaticBindingConfigUpdate,
+		Delete: resourceNsxtVpcSubnetDhcpV6StaticBindingConfigDelete,
+		Importer: &schema.ResourceImporter{
+			State: nsxtVersionCheckImporter("9.2.0", "VPC DHCP v6 Static Binding", nsxtParentPathResourceImporter),
+		},
+		Schema: metadata.GetSchemaFromExtendedSchema(dhcpV6StaticBindingConfigSchema),
+	}
+}
+
+func resourceNsxtVpcSubnetDhcpV6StaticBindingConfigExists(sessionContext utl.SessionContext, parentPath string, id string, connector client.Connector) (bool, error) {
+	parents, pathErr := parseStandardPolicyPathVerifySize(parentPath, 4, vpcSubnetPathExample)
+	if pathErr != nil {
+		return false, pathErr
+	}
+	client := cliVpcSubnetDhcpV6StaticBindingConfigsClient(sessionContext, connector)
+	_, err := client.Get(parents[0], parents[1], parents[2], parents[3], id)
+	if err == nil {
+		return true, nil
+	}
+
+	if isNotFoundError(err) {
+		return false, nil
+	}
+
+	return false, logAPIError("Error retrieving resource", err)
+}
+
+func resourceNsxtVpcSubnetDhcpV6StaticBindingConfigCreate(d *schema.ResourceData, m interface{}) error {
+	if !util.NsxVersionHigherOrEqual("9.2.0") {
+		return fmt.Errorf("VPC Subnet DHCP v6 Static Binding Config resource requires NSX version 9.2.0 or higher")
+	}
+	connector := getPolicyConnector(m)
+
+	id, err := getOrGenerateIDWithParent(d, m, resourceNsxtVpcSubnetDhcpV6StaticBindingConfigExists)
+	if err != nil {
+		return err
+	}
+
+	parentPath := d.Get("parent_path").(string)
+	parents, pathErr := parseStandardPolicyPathVerifySize(parentPath, 4, vpcSubnetPathExample)
+	if pathErr != nil {
+		return pathErr
+	}
+	displayName := d.Get("display_name").(string)
+	description := d.Get("description").(string)
+	tags := getPolicyTagsFromSchema(d)
+
+	obj := model.DhcpV6StaticBindingConfig{
+		DisplayName:  &displayName,
+		Description:  &description,
+		Tags:         tags,
+		ResourceType: model.DhcpStaticBindingConfig_RESOURCE_TYPE_DHCPV6STATICBINDINGCONFIG,
+	}
+
+	elem := reflect.ValueOf(&obj).Elem()
+	if err := metadata.SchemaToStruct(elem, d, dhcpV6StaticBindingConfigSchema, "", nil); err != nil {
+		return err
+	}
+
+	log.Printf("[INFO] Creating DhcpV6StaticBindingConfig with ID %s", id)
+
+	converter := bindings.NewTypeConverter()
+	convObj, convErrs := converter.ConvertToVapi(obj, model.DhcpV6StaticBindingConfigBindingType())
+	if convErrs != nil {
+		return convErrs[0]
+	}
+
+	sessionContext := getSessionContext(d, m)
+	client := cliVpcSubnetDhcpV6StaticBindingConfigsClient(sessionContext, connector)
+	err = client.Patch(parents[0], parents[1], parents[2], parents[3], id, convObj.(*data.StructValue))
+	if err != nil {
+		return handleCreateError("DhcpV6StaticBindingConfig", id, err)
+	}
+	d.SetId(id)
+	d.Set("nsx_id", id)
+
+	return resourceNsxtVpcSubnetDhcpV6StaticBindingConfigRead(d, m)
+}
+
+func resourceNsxtVpcSubnetDhcpV6StaticBindingConfigRead(d *schema.ResourceData, m interface{}) error {
+	connector := getPolicyConnector(m)
+
+	id := d.Id()
+	if id == "" {
+		return fmt.Errorf("Error obtaining DhcpV6StaticBindingConfig ID")
+	}
+
+	parentPath := d.Get("parent_path").(string)
+	sessionContext := getParentContext(d, m, parentPath)
+	client := cliVpcSubnetDhcpV6StaticBindingConfigsClient(sessionContext, connector)
+	parents, pathErr := parseStandardPolicyPathVerifySize(parentPath, 4, vpcSubnetPathExample)
+	if pathErr != nil {
+		return pathErr
+	}
+	dhcpObj, err := client.Get(parents[0], parents[1], parents[2], parents[3], id)
+	if err != nil {
+		return handleReadError(d, "DhcpV6StaticBindingConfig", id, err)
+	}
+
+	converter := bindings.NewTypeConverter()
+	convObj, errs := converter.ConvertToGolang(dhcpObj, model.DhcpV6StaticBindingConfigBindingType())
+	if errs != nil {
+		return errs[0]
+	}
+	obj := convObj.(model.DhcpV6StaticBindingConfig)
+	if obj.ResourceType != model.DhcpV6StaticBindingConfig__TYPE_IDENTIFIER {
+		return handleReadError(d, "DhcpV6 Static Binding Config", id, fmt.Errorf("Unexpected ResourceType %s", obj.ResourceType))
+	}
+
+	setPolicyTagsInSchema(d, obj.Tags)
+	d.Set("nsx_id", id)
+	d.Set("display_name", obj.DisplayName)
+	d.Set("description", obj.Description)
+	d.Set("revision", obj.Revision)
+	d.Set("path", obj.Path)
+
+	elem := reflect.ValueOf(&obj).Elem()
+	return metadata.StructToSchema(elem, d, dhcpV6StaticBindingConfigSchema, "", nil)
+}
+
+func resourceNsxtVpcSubnetDhcpV6StaticBindingConfigUpdate(d *schema.ResourceData, m interface{}) error {
+
+	connector := getPolicyConnector(m)
+
+	id := d.Id()
+	if id == "" {
+		return fmt.Errorf("Error obtaining DhcpV6StaticBindingConfig ID")
+	}
+
+	parentPath := d.Get("parent_path").(string)
+	parents, pathErr := parseStandardPolicyPathVerifySize(parentPath, 4, vpcSubnetPathExample)
+	if pathErr != nil {
+		return pathErr
+	}
+	description := d.Get("description").(string)
+	displayName := d.Get("display_name").(string)
+	tags := getPolicyTagsFromSchema(d)
+
+	revision := int64(d.Get("revision").(int))
+
+	obj := model.DhcpV6StaticBindingConfig{
+		DisplayName:  &displayName,
+		Description:  &description,
+		Tags:         tags,
+		Revision:     &revision,
+		ResourceType: model.DhcpStaticBindingConfig_RESOURCE_TYPE_DHCPV6STATICBINDINGCONFIG,
+	}
+
+	elem := reflect.ValueOf(&obj).Elem()
+	if err := metadata.SchemaToStruct(elem, d, dhcpV6StaticBindingConfigSchema, "", nil); err != nil {
+		return err
+	}
+
+	converter := bindings.NewTypeConverter()
+	convObj, convErrs := converter.ConvertToVapi(obj, model.DhcpV6StaticBindingConfigBindingType())
+	if convErrs != nil {
+		return convErrs[0]
+	}
+
+	sessionContext := getParentContext(d, m, parentPath)
+	client := cliVpcSubnetDhcpV6StaticBindingConfigsClient(sessionContext, connector)
+	_, err := client.Update(parents[0], parents[1], parents[2], parents[3], id, convObj.(*data.StructValue))
+	if err != nil {
+		d.Partial(true)
+		return handleUpdateError("DhcpV6StaticBindingConfig", id, err)
+	}
+
+	return resourceNsxtVpcSubnetDhcpV6StaticBindingConfigRead(d, m)
+}
+
+func resourceNsxtVpcSubnetDhcpV6StaticBindingConfigDelete(d *schema.ResourceData, m interface{}) error {
+	id := d.Id()
+	if id == "" {
+		return fmt.Errorf("Error obtaining DhcpV6StaticBindingConfig ID")
+	}
+
+	connector := getPolicyConnector(m)
+	parentPath := d.Get("parent_path").(string)
+	parents, pathErr := parseStandardPolicyPathVerifySize(parentPath, 4, vpcSubnetPathExample)
+	if pathErr != nil {
+		return pathErr
+	}
+
+	sessionContext := getParentContext(d, m, parentPath)
+	client := cliVpcSubnetDhcpV6StaticBindingConfigsClient(sessionContext, connector)
+	err := client.Delete(parents[0], parents[1], parents[2], parents[3], id)
+
+	if err != nil {
+		return handleDeleteError("DhcpV6StaticBindingConfig", id, err)
+	}
+
+	return nil
+}

--- a/nsxt/resource_nsxt_vpc_dhcp_v6_static_binding_config_test.go
+++ b/nsxt/resource_nsxt_vpc_dhcp_v6_static_binding_config_test.go
@@ -1,0 +1,351 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package nsxt
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+var accTestVpcSubnetDhcpV6StaticBindingConfigCreateAttributes = map[string]string{
+	"display_name":    getAccTestResourceName(),
+	"description":     "terraform created",
+	"mac_address":     "10:0e:00:11:22:02",
+	"lease_time":      "7200",
+	"preferred_time":  "5760",
+	"ip_addresses":    "fd00:240:2400::41",
+	"domain_names":    "client-create.example.org",
+	"dns_nameservers": "fd00:240:2400::2",
+	"ntp_servers":     "ntp-create.example.org",
+	"sntp_servers":    "fd00:240:2400::3",
+}
+
+var accTestVpcSubnetDhcpV6StaticBindingConfigUpdateAttributes = map[string]string{
+	"display_name":    getAccTestResourceName(),
+	"description":     "terraform updated",
+	"mac_address":     "10:ff:22:11:cc:02",
+	"lease_time":      "10800",
+	"preferred_time":  "8640",
+	"ip_addresses":    "fd00:240:2400::42",
+	"domain_names":    "client-update.example.org",
+	"dns_nameservers": "fd00:240:2400::4",
+	"ntp_servers":     "ntp-update.example.org",
+	"sntp_servers":    "fd00:240:2400::5",
+}
+
+func TestAccResourceNsxtVpcSubnetDhcpV6StaticBindingConfig920_basic(t *testing.T) {
+	testResourceName := "nsxt_vpc_dhcp_v6_static_binding.test"
+	subnetResourceName := "nsxt_vpc_subnet.test"
+	// One stable name for the VPC fixture across all steps; NSX rejects changing vpc short_id after create.
+	fixtureBase := getAccTestResourceName()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccOnlyVPC(t)
+			testAccNSXVersion(t, "9.2.0")
+		},
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtVpcSubnetDhcpV6StaticBindingConfigCheckDestroy(state, accTestVpcSubnetDhcpV6StaticBindingConfigUpdateAttributes["display_name"])
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtVpcSubnetDhcpV6StaticBindingConfigTemplate(true, fixtureBase),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtVpcSubnetDhcpV6StaticBindingConfigExists(accTestVpcSubnetDhcpV6StaticBindingConfigCreateAttributes["display_name"], testResourceName),
+					resource.TestCheckResourceAttr(subnetResourceName, "ip_address_type", "IPV4_IPV6"),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestVpcSubnetDhcpV6StaticBindingConfigCreateAttributes["display_name"]),
+					resource.TestCheckResourceAttrSet(testResourceName, "parent_path"),
+					resource.TestCheckResourceAttr(testResourceName, "description", accTestVpcSubnetDhcpV6StaticBindingConfigCreateAttributes["description"]),
+					resource.TestCheckResourceAttr(testResourceName, "mac_address", accTestVpcSubnetDhcpV6StaticBindingConfigCreateAttributes["mac_address"]),
+					resource.TestCheckResourceAttr(testResourceName, "lease_time", accTestVpcSubnetDhcpV6StaticBindingConfigCreateAttributes["lease_time"]),
+					resource.TestCheckResourceAttr(testResourceName, "preferred_time", accTestVpcSubnetDhcpV6StaticBindingConfigCreateAttributes["preferred_time"]),
+					resource.TestCheckResourceAttr(testResourceName, "ip_addresses.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "ip_addresses.0", accTestVpcSubnetDhcpV6StaticBindingConfigCreateAttributes["ip_addresses"]),
+					resource.TestCheckResourceAttr(testResourceName, "domain_names.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "domain_names.0", accTestVpcSubnetDhcpV6StaticBindingConfigCreateAttributes["domain_names"]),
+					resource.TestCheckResourceAttr(testResourceName, "dns_nameservers.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "dns_nameservers.0", accTestVpcSubnetDhcpV6StaticBindingConfigCreateAttributes["dns_nameservers"]),
+					resource.TestCheckResourceAttr(testResourceName, "ntp_servers.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "ntp_servers.0", accTestVpcSubnetDhcpV6StaticBindingConfigCreateAttributes["ntp_servers"]),
+					resource.TestCheckResourceAttr(testResourceName, "sntp_servers.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "sntp_servers.0", accTestVpcSubnetDhcpV6StaticBindingConfigCreateAttributes["sntp_servers"]),
+					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
+				),
+			},
+			{
+				Config: testAccNsxtVpcSubnetDhcpV6StaticBindingConfigTemplate(false, fixtureBase),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtVpcSubnetDhcpV6StaticBindingConfigExists(accTestVpcSubnetDhcpV6StaticBindingConfigUpdateAttributes["display_name"], testResourceName),
+					resource.TestCheckResourceAttr(subnetResourceName, "ip_address_type", "IPV4_IPV6"),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestVpcSubnetDhcpV6StaticBindingConfigUpdateAttributes["display_name"]),
+					resource.TestCheckResourceAttrSet(testResourceName, "parent_path"),
+					resource.TestCheckResourceAttr(testResourceName, "description", accTestVpcSubnetDhcpV6StaticBindingConfigUpdateAttributes["description"]),
+					resource.TestCheckResourceAttr(testResourceName, "mac_address", accTestVpcSubnetDhcpV6StaticBindingConfigUpdateAttributes["mac_address"]),
+					resource.TestCheckResourceAttr(testResourceName, "lease_time", accTestVpcSubnetDhcpV6StaticBindingConfigUpdateAttributes["lease_time"]),
+					resource.TestCheckResourceAttr(testResourceName, "preferred_time", accTestVpcSubnetDhcpV6StaticBindingConfigUpdateAttributes["preferred_time"]),
+					resource.TestCheckResourceAttr(testResourceName, "ip_addresses.0", accTestVpcSubnetDhcpV6StaticBindingConfigUpdateAttributes["ip_addresses"]),
+					resource.TestCheckResourceAttr(testResourceName, "domain_names.0", accTestVpcSubnetDhcpV6StaticBindingConfigUpdateAttributes["domain_names"]),
+					resource.TestCheckResourceAttr(testResourceName, "dns_nameservers.0", accTestVpcSubnetDhcpV6StaticBindingConfigUpdateAttributes["dns_nameservers"]),
+					resource.TestCheckResourceAttr(testResourceName, "ntp_servers.0", accTestVpcSubnetDhcpV6StaticBindingConfigUpdateAttributes["ntp_servers"]),
+					resource.TestCheckResourceAttr(testResourceName, "sntp_servers.0", accTestVpcSubnetDhcpV6StaticBindingConfigUpdateAttributes["sntp_servers"]),
+					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
+				),
+			},
+			{
+				Config: testAccNsxtVpcSubnetDhcpV6StaticBindingConfigMinimalistic(fixtureBase),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtVpcSubnetDhcpV6StaticBindingConfigExists(accTestVpcSubnetDhcpV6StaticBindingConfigCreateAttributes["display_name"], testResourceName),
+					resource.TestCheckResourceAttr(subnetResourceName, "ip_address_type", "IPV4_IPV6"),
+					resource.TestCheckResourceAttrSet(testResourceName, "parent_path"),
+					resource.TestCheckResourceAttr(testResourceName, "description", ""),
+					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+					resource.TestCheckResourceAttr(testResourceName, "tag.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceNsxtVpcSubnetDhcpV6StaticBindingConfig920_importBasic(t *testing.T) {
+	name := getAccTestResourceName()
+	fixtureBase := getAccTestResourceName()
+	testResourceName := "nsxt_vpc_dhcp_v6_static_binding.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccOnlyVPC(t)
+			testAccNSXVersion(t, "9.2.0")
+		},
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtVpcSubnetDhcpV6StaticBindingConfigCheckDestroy(state, name)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtVpcSubnetDhcpV6StaticBindingConfigMinimalisticImport(name, fixtureBase),
+			},
+			{
+				ResourceName:      testResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccResourceNsxtPolicyImportIDRetriever(testResourceName),
+			},
+		},
+	})
+}
+
+func testAccNsxtVpcSubnetDhcpV6StaticBindingConfigExists(displayName string, resourceName string) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+
+		connector := getPolicyConnector(testAccProvider.Meta().(nsxtClients))
+
+		rs, ok := state.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("DhcpV6StaticBindingConfig resource %s not found in resources", resourceName)
+		}
+
+		resourceID := rs.Primary.ID
+		if resourceID == "" {
+			return fmt.Errorf("DhcpV6StaticBindingConfig resource ID not set in resources")
+		}
+
+		parentPath := rs.Primary.Attributes["parent_path"]
+
+		exists, err := resourceNsxtVpcSubnetDhcpV6StaticBindingConfigExists(getSessionContextFromParentPath(testAccProvider.Meta(), parentPath), parentPath, resourceID, connector)
+		if err != nil {
+			return err
+		}
+		if !exists {
+			return fmt.Errorf("DhcpV6StaticBindingConfig %s does not exist", resourceID)
+		}
+
+		return nil
+	}
+}
+
+func testAccNsxtVpcSubnetDhcpV6StaticBindingConfigCheckDestroy(state *terraform.State, displayName string) error {
+	connector := getPolicyConnector(testAccProvider.Meta().(nsxtClients))
+	for _, rs := range state.RootModule().Resources {
+
+		if rs.Type != "nsxt_vpc_dhcp_v6_static_binding" {
+			continue
+		}
+
+		resourceID := rs.Primary.Attributes["id"]
+		parentPath := rs.Primary.Attributes["parent_path"]
+
+		exists, err := resourceNsxtVpcSubnetDhcpV6StaticBindingConfigExists(getSessionContextFromParentPath(testAccProvider.Meta(), parentPath), parentPath, resourceID, connector)
+		if err != nil {
+			return err
+		}
+
+		if exists {
+			return fmt.Errorf("DhcpV6StaticBindingConfig %s still exists", displayName)
+		}
+	}
+	return nil
+}
+
+func testAccNsxtVpcSubnetDhcpV6StaticBindingConfigPrerequisites(base string) string {
+	// CI default VPC service profile may omit dhcpv6_server_config; NSX 641028 requires it when the
+	// subnet uses DHCPv6 DHCP_SERVER. Provision a dedicated VPC + profile with dhcpv6_server_config.
+	shortID := base
+	if len(shortID) > 8 {
+		shortID = shortID[len(shortID)-8:]
+	}
+	projCtx := testAccNsxtMultitenancyContext(false)
+	vpcProjectID := os.Getenv("NSXT_VPC_PROJECT_ID")
+
+	return fmt.Sprintf(`
+data "nsxt_policy_transit_gateway" "dhcpv6_bind_tgw" {
+%s
+  is_default = true
+}
+
+resource "nsxt_vpc_service_profile" "dhcpv6_bind_sp" {
+%s
+  display_name = "%s-sp"
+  dhcp_config {
+    dhcp_server_config {
+      lease_time = 86400
+    }
+  }
+  dhcpv6_config {
+    dhcpv6_server_config {
+      lease_time     = 86400
+      preferred_time = 3600
+    }
+  }
+}
+
+resource "nsxt_vpc_connectivity_profile" "dhcpv6_bind_cp" {
+%s
+  display_name         = "%s-cp"
+  transit_gateway_path = data.nsxt_policy_transit_gateway.dhcpv6_bind_tgw.path
+  service_gateway {
+    enable = false
+  }
+}
+
+resource "nsxt_vpc" "dhcpv6_bind_vpc" {
+%s
+  display_name        = "%s-vpc"
+  description         = "tf acc dhcpv6 static binding vpc"
+  private_ips         = ["192.168.246.0/24"]
+  short_id            = "%s"
+  vpc_service_profile = nsxt_vpc_service_profile.dhcpv6_bind_sp.path
+  load_balancer_vpc_endpoint {
+    enabled = false
+  }
+}
+
+resource "nsxt_vpc_attachment" "dhcpv6_bind_att" {
+  display_name             = "%s-att"
+  parent_path              = nsxt_vpc.dhcpv6_bind_vpc.path
+  vpc_connectivity_profile = nsxt_vpc_connectivity_profile.dhcpv6_bind_cp.path
+}
+
+resource "nsxt_vpc_subnet" "test" {
+  context {
+    project_id = "%s"
+    vpc_id     = nsxt_vpc.dhcpv6_bind_vpc.id
+  }
+  display_name = "test-subnet-dhcpv6-acc"
+  depends_on   = [nsxt_vpc_attachment.dhcpv6_bind_att]
+
+  # Dual-stack: both CIDRs in ip_addresses. NSX 9.2 allows one IPv4 and one IPv6 across ip_addresses
+  # and gateway_addresses combined (610716); do not repeat IPv4 in gateway_addresses.
+  ip_address_type = "IPV4_IPV6"
+  ip_addresses    = ["10.203.240.0/26", "fd00:240:2400::/64"]
+  advanced_config {
+    connectivity_state = "DISCONNECTED"
+    # NSX fills gateway and DHCP server addresses from the subnet CIDRs; omitting them causes
+    # post-apply plan drift (non-empty plan after refresh) in acceptance tests.
+    gateway_addresses     = ["10.203.240.1/26", "fd00:240:2400::1/64"]
+    dhcp_server_addresses = ["10.203.240.2/26", "fd00:240:2400:0:0:0:0:2/64"]
+  }
+  access_mode = "Isolated"
+  dhcp_config {
+    mode = "DHCP_SERVER"
+    dhcp_server_additional_config {
+      reserved_ip_ranges = ["10.203.240.40-10.203.240.60"]
+    }
+  }
+  subnet_dhcpv6_config {
+    mode = "DHCP_SERVER"
+    dhcpv6_server_additional_config {
+      domain_names       = []
+      reserved_ip_ranges = ["fd00:240:2400::40-fd00:240:2400::5f"]
+    }
+  }
+}
+`, projCtx, projCtx, base, projCtx, base, projCtx, base, shortID, base, vpcProjectID)
+}
+
+func testAccNsxtVpcSubnetDhcpV6StaticBindingConfigTemplate(createFlow bool, fixtureBase string) string {
+	var attrMap map[string]string
+	if createFlow {
+		attrMap = accTestVpcSubnetDhcpV6StaticBindingConfigCreateAttributes
+	} else {
+		attrMap = accTestVpcSubnetDhcpV6StaticBindingConfigUpdateAttributes
+	}
+	return testAccNsxtVpcSubnetDhcpV6StaticBindingConfigPrerequisites(fixtureBase) + fmt.Sprintf(`
+resource "nsxt_vpc_dhcp_v6_static_binding" "test" {
+  parent_path       = nsxt_vpc_subnet.test.path
+  display_name      = "%s"
+  description       = "%s"
+  mac_address       = "%s"
+  lease_time        = %s
+  preferred_time    = %s
+  ip_addresses      = ["%s"]
+  domain_names      = ["%s"]
+  dns_nameservers   = ["%s"]
+  ntp_servers       = ["%s"]
+  sntp_servers      = ["%s"]
+
+  tag {
+    scope = "scope1"
+    tag   = "tag1"
+  }
+}`, attrMap["display_name"], attrMap["description"], attrMap["mac_address"],
+		attrMap["lease_time"], attrMap["preferred_time"], attrMap["ip_addresses"],
+		attrMap["domain_names"], attrMap["dns_nameservers"], attrMap["ntp_servers"], attrMap["sntp_servers"])
+}
+
+func testAccNsxtVpcSubnetDhcpV6StaticBindingConfigMinimalistic(fixtureBase string) string {
+	attrMap := accTestVpcSubnetDhcpV6StaticBindingConfigCreateAttributes
+	return testAccNsxtVpcSubnetDhcpV6StaticBindingConfigPrerequisites(fixtureBase) + fmt.Sprintf(`
+resource "nsxt_vpc_dhcp_v6_static_binding" "test" {
+  display_name = "%s"
+  parent_path  = nsxt_vpc_subnet.test.path
+  ip_addresses = ["%s"]
+  mac_address  = "%s"
+}`, accTestVpcSubnetDhcpV6StaticBindingConfigUpdateAttributes["display_name"], attrMap["ip_addresses"], attrMap["mac_address"])
+}
+
+func testAccNsxtVpcSubnetDhcpV6StaticBindingConfigMinimalisticImport(displayName string, fixtureBase string) string {
+	return testAccNsxtVpcSubnetDhcpV6StaticBindingConfigPrerequisites(fixtureBase) + fmt.Sprintf(`
+resource "nsxt_vpc_dhcp_v6_static_binding" "test" {
+  display_name = "%s"
+  parent_path  = nsxt_vpc_subnet.test.path
+  ip_addresses = ["fd00:240:2400::41"]
+  mac_address  = "10:0e:00:11:22:03"
+}`, displayName)
+}

--- a/nsxt/resource_nsxt_vpc_service_profile.go
+++ b/nsxt/resource_nsxt_vpc_service_profile.go
@@ -10,6 +10,7 @@ import (
 	"reflect"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/vmware/terraform-provider-nsxt/api/orgs/projects"
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
@@ -207,6 +208,309 @@ var vpcServiceProfileSchema = map[string]*metadata.ExtendedSchema{
 			SchemaType:   "struct",
 			SdkFieldName: "DhcpConfig",
 			ReflectType:  reflect.TypeOf(model.VpcProfileDhcpConfig{}),
+		},
+	},
+	"dhcpv6_config": {
+		Schema: schema.Schema{
+			Type:     schema.TypeList,
+			MaxItems: 1,
+			Optional: true,
+			Elem: &metadata.ExtendedResource{
+				Schema: map[string]*metadata.ExtendedSchema{
+					"dhcpv6_relay_config": {
+						Schema: schema.Schema{
+							Type:     schema.TypeList,
+							MaxItems: 1,
+							Elem: &metadata.ExtendedResource{
+								Schema: map[string]*metadata.ExtendedSchema{
+									"server_addresses": {
+										Schema: schema.Schema{
+											Type: schema.TypeList,
+											Elem: &metadata.ExtendedSchema{
+												Schema: schema.Schema{
+													Type: schema.TypeString,
+												},
+												Metadata: metadata.Metadata{
+													SchemaType: "string",
+												},
+											},
+											Optional: true,
+										},
+										Metadata: metadata.Metadata{
+											SchemaType:   "list",
+											SdkFieldName: "ServerAddresses",
+										},
+									},
+								},
+							},
+							Optional: true,
+						},
+						Metadata: metadata.Metadata{
+							SchemaType:   "struct",
+							SdkFieldName: "Dhcpv6RelayConfig",
+							ReflectType:  reflect.TypeOf(model.VpcDhcpRelayConfig{}),
+						},
+					},
+					"dhcpv6_server_config": {
+						Schema: schema.Schema{
+							Type:     schema.TypeList,
+							MaxItems: 1,
+							Elem: &metadata.ExtendedResource{
+								Schema: map[string]*metadata.ExtendedSchema{
+									"dns_client_config": {
+										Schema: schema.Schema{
+											Type:     schema.TypeList,
+											MaxItems: 1,
+											Elem: &metadata.ExtendedResource{
+												Schema: map[string]*metadata.ExtendedSchema{
+													"dns_server_ips": {
+														Schema: schema.Schema{
+															Type: schema.TypeList,
+															Elem: &metadata.ExtendedSchema{
+																Schema: schema.Schema{
+																	Type: schema.TypeString,
+																},
+																Metadata: metadata.Metadata{
+																	SchemaType: "string",
+																},
+															},
+															Optional: true,
+														},
+														Metadata: metadata.Metadata{
+															SchemaType:   "list",
+															SdkFieldName: "DnsServerIps",
+														},
+													},
+												},
+											},
+											Optional: true,
+										},
+										Metadata: metadata.Metadata{
+											SchemaType:   "struct",
+											SdkFieldName: "DnsClientConfig",
+											ReflectType:  reflect.TypeOf(model.DnsClientConfig{}),
+										},
+									},
+									"lease_time": {
+										Schema: schema.Schema{
+											Type:     schema.TypeInt,
+											Optional: true,
+											Default:  86400,
+										},
+										Metadata: metadata.Metadata{
+											SchemaType:   "int",
+											SdkFieldName: "LeaseTime",
+										},
+									},
+									"preferred_time": {
+										Schema: *getDhcpPreferredTimeSchema(),
+										Metadata: metadata.Metadata{
+											SchemaType:   "int",
+											SdkFieldName: "PreferredTime",
+											OmitIfEmpty:  true,
+										},
+									},
+									"ntp_servers": {
+										Schema: schema.Schema{
+											Type: schema.TypeList,
+											Elem: &metadata.ExtendedSchema{
+												Schema: schema.Schema{
+													Type:         schema.TypeString,
+													ValidateFunc: validateSingleIPOrHostName(),
+												},
+												Metadata: metadata.Metadata{
+													SchemaType: "string",
+												},
+											},
+											Optional: true,
+										},
+										Metadata: metadata.Metadata{
+											SchemaType:   "list",
+											SdkFieldName: "NtpServers",
+										},
+									},
+									"sntp_servers": {
+										Schema: schema.Schema{
+											Type: schema.TypeList,
+											Elem: &metadata.ExtendedSchema{
+												Schema: schema.Schema{
+													Type:         schema.TypeString,
+													ValidateFunc: validation.IsIPv6Address,
+												},
+												Metadata: metadata.Metadata{
+													SchemaType: "string",
+												},
+											},
+											Optional: true,
+										},
+										Metadata: metadata.Metadata{
+											SchemaType:   "list",
+											SdkFieldName: "SntpServers",
+										},
+									},
+									"advanced_config": {
+										Schema: schema.Schema{
+											Type:     schema.TypeList,
+											MaxItems: 1,
+											Elem: &metadata.ExtendedResource{
+												Schema: map[string]*metadata.ExtendedSchema{
+													"is_distributed_dhcp": {
+														Schema: schema.Schema{
+															Type:     schema.TypeBool,
+															Optional: true,
+														},
+														Metadata: metadata.Metadata{
+															SchemaType:   "bool",
+															SdkFieldName: "IsDistributedDhcp",
+														},
+													},
+												},
+											},
+											Optional: true,
+											Computed: true,
+										},
+										Metadata: metadata.Metadata{
+											SchemaType:   "struct",
+											SdkFieldName: "AdvancedConfig",
+											ReflectType:  reflect.TypeOf(model.VpcDhcpAdvancedConfig{}),
+										},
+									},
+								},
+							},
+							Optional: true,
+						},
+						Metadata: metadata.Metadata{
+							SchemaType:   "struct",
+							SdkFieldName: "Dhcpv6ServerConfig",
+							ReflectType:  reflect.TypeOf(model.VpcDhcpv6ServerConfig{}),
+						},
+					},
+				},
+			},
+		},
+		Metadata: metadata.Metadata{
+			IntroducedInVersion: "9.2.0",
+			SchemaType:          "struct",
+			SdkFieldName:        "Dhcpv6Config",
+			ReflectType:         reflect.TypeOf(model.VpcProfileDhcpV6Config{}),
+		},
+	},
+	"dns_forwarder_config": {
+		Schema: schema.Schema{
+			Type:     schema.TypeList,
+			MaxItems: 1,
+			Optional: true,
+			Elem: &metadata.ExtendedResource{
+				Schema: map[string]*metadata.ExtendedSchema{
+					"cache_size": {
+						Schema: schema.Schema{
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						Metadata: metadata.Metadata{
+							SchemaType:   "int",
+							SdkFieldName: "CacheSize",
+							OmitIfEmpty:  true,
+						},
+					},
+					"conditional_forwarder_zone_paths": {
+						Schema: schema.Schema{
+							Type: schema.TypeList,
+							Elem: &metadata.ExtendedSchema{
+								Schema: schema.Schema{
+									Type:         schema.TypeString,
+									ValidateFunc: validatePolicyPath(),
+								},
+								Metadata: metadata.Metadata{
+									SchemaType: "string",
+								},
+							},
+							Optional: true,
+						},
+						Metadata: metadata.Metadata{
+							SchemaType:   "list",
+							SdkFieldName: "ConditionalForwarderZonePaths",
+						},
+					},
+					"default_forwarder_zone_path": {
+						Schema: schema.Schema{
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validatePolicyPath(),
+						},
+						Metadata: metadata.Metadata{
+							SchemaType:   "string",
+							SdkFieldName: "DefaultForwarderZonePath",
+							OmitIfEmpty:  true,
+						},
+					},
+					"log_level": {
+						Schema: schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								model.PolicyVpcDnsForwarder_LOG_LEVEL_DEBUG,
+								model.PolicyVpcDnsForwarder_LOG_LEVEL_INFO,
+								model.PolicyVpcDnsForwarder_LOG_LEVEL_WARNING,
+								model.PolicyVpcDnsForwarder_LOG_LEVEL_ERROR,
+								model.PolicyVpcDnsForwarder_LOG_LEVEL_FATAL,
+							}, false),
+						},
+						Metadata: metadata.Metadata{
+							SchemaType:   "string",
+							SdkFieldName: "LogLevel",
+							OmitIfEmpty:  true,
+						},
+					},
+				},
+			},
+		},
+		Metadata: metadata.Metadata{
+			IntroducedInVersion: "9.2.0",
+			SchemaType:          "struct",
+			SdkFieldName:        "DnsForwarderConfig",
+			ReflectType:         reflect.TypeOf(model.PolicyVpcDnsForwarder{}),
+		},
+	},
+	"ipv6_profile_paths": {
+		Schema: schema.Schema{
+			Type: schema.TypeList,
+			Elem: &metadata.ExtendedSchema{
+				Schema: schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validatePolicyPath(),
+				},
+				Metadata: metadata.Metadata{
+					SchemaType: "string",
+				},
+			},
+			Optional: true,
+		},
+		Metadata: metadata.Metadata{
+			IntroducedInVersion: "9.2.0",
+			SchemaType:          "list",
+			SdkFieldName:        "Ipv6ProfilePaths",
+		},
+	},
+	"service_subnet_cidrs": {
+		Schema: schema.Schema{
+			Type: schema.TypeList,
+			Elem: &metadata.ExtendedSchema{
+				Schema: schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validateIPCidr(),
+				},
+				Metadata: metadata.Metadata{
+					SchemaType: "string",
+				},
+			},
+			Computed: true,
+			Optional: true,
+		},
+		Metadata: metadata.Metadata{
+			IntroducedInVersion: "9.2.0",
+			SchemaType:          "list",
+			SdkFieldName:        "ServiceSubnetCidrs",
 		},
 	},
 	"ip_discovery_profile": {

--- a/nsxt/resource_nsxt_vpc_service_profile_test.go
+++ b/nsxt/resource_nsxt_vpc_service_profile_test.go
@@ -148,6 +148,113 @@ func TestAccResourceNsxtVpcServiceProfile_basic(t *testing.T) {
 	})
 }
 
+var accTestPolicyVpcServiceProfile920Ipv6Create = map[string]string{
+	"display_name": getAccTestResourceName(),
+	"description":  "terraform ipv6 create",
+	"v6_lease":     "86400",
+	"v6_pref":      "48000",
+	"v6_ntp":       "2001:db8:acc1::1",
+	"v6_sntp":      "2001:db8:acc1::2",
+	"v6_dns":       "2001:db8:acc1::53",
+	"fwd_log":      "INFO",
+	"svc_cidr":     "10.210.240.0/28",
+}
+
+var accTestPolicyVpcServiceProfile920Ipv6Update = map[string]string{
+	"display_name": getAccTestResourceName(),
+	"description":  "terraform ipv6 update",
+	"v6_lease":     "7200",
+	"v6_pref":      "5760",
+	"v6_ntp":       "2001:db8:acc2::1",
+	"v6_sntp":      "2001:db8:acc2::2",
+	"v6_dns":       "2001:db8:acc2::53",
+	"fwd_log":      "WARNING",
+	"svc_cidr":     "10.210.240.16/28",
+}
+
+func TestAccResourceNsxtVpcServiceProfile920_ipv6Extensions(t *testing.T) {
+	testResourceName := "nsxt_vpc_service_profile.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccOnlyVPC(t)
+			testAccNSXVersion(t, "9.2.0")
+		},
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtVpcServiceProfileCheckDestroy(state, accTestPolicyVpcServiceProfile920Ipv6Update["display_name"])
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtVpcServiceProfile920Ipv6Template(true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtVpcServiceProfileExists(testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestPolicyVpcServiceProfile920Ipv6Create["display_name"]),
+					resource.TestCheckResourceAttr(testResourceName, "description", accTestPolicyVpcServiceProfile920Ipv6Create["description"]),
+					resource.TestCheckResourceAttr(testResourceName, "dhcpv6_config.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "dhcpv6_config.0.dhcpv6_server_config.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "dhcpv6_config.0.dhcpv6_server_config.0.lease_time", accTestPolicyVpcServiceProfile920Ipv6Create["v6_lease"]),
+					resource.TestCheckResourceAttr(testResourceName, "dhcpv6_config.0.dhcpv6_server_config.0.preferred_time", accTestPolicyVpcServiceProfile920Ipv6Create["v6_pref"]),
+					resource.TestCheckResourceAttr(testResourceName, "dhcpv6_config.0.dhcpv6_server_config.0.ntp_servers.0", accTestPolicyVpcServiceProfile920Ipv6Create["v6_ntp"]),
+					resource.TestCheckResourceAttr(testResourceName, "dhcpv6_config.0.dhcpv6_server_config.0.sntp_servers.0", accTestPolicyVpcServiceProfile920Ipv6Create["v6_sntp"]),
+					resource.TestCheckResourceAttr(testResourceName, "dhcpv6_config.0.dhcpv6_server_config.0.dns_client_config.0.dns_server_ips.0", accTestPolicyVpcServiceProfile920Ipv6Create["v6_dns"]),
+					resource.TestCheckResourceAttr(testResourceName, "dns_forwarder_config.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "dns_forwarder_config.0.log_level", accTestPolicyVpcServiceProfile920Ipv6Create["fwd_log"]),
+					resource.TestCheckResourceAttr(testResourceName, "service_subnet_cidrs.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "service_subnet_cidrs.0", accTestPolicyVpcServiceProfile920Ipv6Create["svc_cidr"]),
+					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+				),
+			},
+			{
+				Config: testAccNsxtVpcServiceProfile920Ipv6Template(false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtVpcServiceProfileExists(testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestPolicyVpcServiceProfile920Ipv6Update["display_name"]),
+					resource.TestCheckResourceAttr(testResourceName, "description", accTestPolicyVpcServiceProfile920Ipv6Update["description"]),
+					resource.TestCheckResourceAttr(testResourceName, "dhcpv6_config.0.dhcpv6_server_config.0.lease_time", accTestPolicyVpcServiceProfile920Ipv6Update["v6_lease"]),
+					resource.TestCheckResourceAttr(testResourceName, "dhcpv6_config.0.dhcpv6_server_config.0.preferred_time", accTestPolicyVpcServiceProfile920Ipv6Update["v6_pref"]),
+					resource.TestCheckResourceAttr(testResourceName, "dhcpv6_config.0.dhcpv6_server_config.0.ntp_servers.0", accTestPolicyVpcServiceProfile920Ipv6Update["v6_ntp"]),
+					resource.TestCheckResourceAttr(testResourceName, "dhcpv6_config.0.dhcpv6_server_config.0.sntp_servers.0", accTestPolicyVpcServiceProfile920Ipv6Update["v6_sntp"]),
+					resource.TestCheckResourceAttr(testResourceName, "dhcpv6_config.0.dhcpv6_server_config.0.dns_client_config.0.dns_server_ips.0", accTestPolicyVpcServiceProfile920Ipv6Update["v6_dns"]),
+					resource.TestCheckResourceAttr(testResourceName, "dns_forwarder_config.0.log_level", accTestPolicyVpcServiceProfile920Ipv6Update["fwd_log"]),
+					resource.TestCheckResourceAttr(testResourceName, "service_subnet_cidrs.0", accTestPolicyVpcServiceProfile920Ipv6Update["svc_cidr"]),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceNsxtVpcServiceProfile920_ipv6Extensions_import(t *testing.T) {
+	name := accTestPolicyVpcServiceProfile920Ipv6Create["display_name"]
+	testResourceName := "nsxt_vpc_service_profile.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccOnlyVPC(t)
+			testAccNSXVersion(t, "9.2.0")
+		},
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtVpcServiceProfileCheckDestroy(state, name)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtVpcServiceProfile920Ipv6Template(true),
+			},
+			{
+				ResourceName:      testResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccResourceNsxtPolicyImportIDRetriever(testResourceName),
+			},
+		},
+	})
+}
+
 func TestAccResourceNsxtVpcServiceProfile_importBasic(t *testing.T) {
 	name := getAccTestResourceName()
 	testResourceName := "nsxt_vpc_service_profile.test"
@@ -320,4 +427,58 @@ resource "nsxt_vpc_service_profile" "test" {
   dhcp_config {
   }
 }`, testAccNsxtProjectContext(), displayName)
+}
+
+func testAccNsxtVpcServiceProfile920Ipv6Template(createFlow bool) string {
+	var attrMap map[string]string
+	if createFlow {
+		attrMap = accTestPolicyVpcServiceProfile920Ipv6Create
+	} else {
+		attrMap = accTestPolicyVpcServiceProfile920Ipv6Update
+	}
+	return fmt.Sprintf(`
+resource "nsxt_policy_dns_forwarder_zone" "vsp920_dns_fwd" {
+%s
+  display_name     = "%s-dnsfwd"
+  upstream_servers = ["8.8.8.8"]
+}
+
+resource "nsxt_vpc_service_profile" "test" {
+  %s
+  display_name = "%s"
+  description  = "%s"
+
+  dhcp_config {
+    dhcp_server_config {
+      lease_time  = 86400
+      ntp_servers = ["5.5.5.5"]
+      dns_client_config {
+        dns_server_ips = ["1.1.1.1"]
+      }
+    }
+  }
+
+  dhcpv6_config {
+    dhcpv6_server_config {
+      lease_time       = %s
+      preferred_time   = %s
+      ntp_servers      = ["%s"]
+      sntp_servers     = ["%s"]
+      dns_client_config {
+        dns_server_ips = ["%s"]
+      }
+    }
+  }
+
+  dns_forwarder_config {
+    cache_size                  = 1024
+    default_forwarder_zone_path = nsxt_policy_dns_forwarder_zone.vsp920_dns_fwd.path
+    log_level                   = "%s"
+  }
+
+  service_subnet_cidrs = ["%s"]
+}
+`, testAccNsxtProjectContext(), attrMap["display_name"], testAccNsxtProjectContext(), attrMap["display_name"], attrMap["description"],
+		attrMap["v6_lease"], attrMap["v6_pref"], attrMap["v6_ntp"], attrMap["v6_sntp"], attrMap["v6_dns"],
+		attrMap["fwd_log"], attrMap["svc_cidr"])
 }

--- a/nsxt/resource_nsxt_vpc_subnet.go
+++ b/nsxt/resource_nsxt_vpc_subnet.go
@@ -37,6 +37,12 @@ var vpcSubnetAccessModeValues = []string{
 	model.VpcSubnet_ACCESS_MODE_L2_ONLY,
 }
 
+var vpcSubnetIPAddressTypeValues = []string{
+	model.VpcSubnet_IP_ADDRESS_TYPE_IPV4,
+	model.VpcSubnet_IP_ADDRESS_TYPE_IPV6,
+	model.VpcSubnet_IP_ADDRESS_TYPE_IPV4_IPV6,
+}
+
 var vpcSubnetConnectivityStateValues = []string{
 	model.SubnetAdvancedConfig_CONNECTIVITY_STATE_CONNECTED,
 	model.SubnetAdvancedConfig_CONNECTIVITY_STATE_DISCONNECTED,
@@ -46,6 +52,13 @@ var vpcSubnetModeValues = []string{
 	model.SubnetDhcpConfig_MODE_SERVER,
 	model.SubnetDhcpConfig_MODE_RELAY,
 	model.SubnetDhcpConfig_MODE_DEACTIVATED,
+}
+
+var vpcSubnetDhcpv6ModeValues = []string{
+	model.SubnetDhcpv6Config_MODE_SERVER,
+	model.SubnetDhcpv6Config_MODE_RELAY,
+	model.SubnetDhcpv6Config_MODE_DEACTIVATED,
+	model.SubnetDhcpv6Config_MODE_SERVER_STATELESS,
 }
 
 var dnsServerPreferenceValues = []string{
@@ -80,6 +93,21 @@ var vpcSubnetSchema = map[string]*metadata.ExtendedSchema{
 		Metadata: metadata.Metadata{
 			SchemaType:   "list",
 			SdkFieldName: "IpBlocks",
+		},
+	},
+	"ip_address_type": {
+		Schema: schema.Schema{
+			Type:         schema.TypeString,
+			ValidateFunc: validation.StringInSlice(vpcSubnetIPAddressTypeValues, false),
+			Optional:     true,
+			Computed:     true,
+			ForceNew:     true,
+		},
+		Metadata: metadata.Metadata{
+			IntroducedInVersion: "9.2.0",
+			SchemaType:          "string",
+			SdkFieldName:        "IpAddressType",
+			OmitIfEmpty:         true,
 		},
 	},
 	"advanced_config": {
@@ -164,7 +192,7 @@ var vpcSubnetSchema = map[string]*metadata.ExtendedSchema{
 							Elem: &metadata.ExtendedSchema{
 								Schema: schema.Schema{
 									Type:         schema.TypeString,
-									ValidateFunc: validateSingleIP(),
+									ValidateFunc: validateCidrOrIPOrRangeAllowHostPrefix(),
 								},
 								Metadata: metadata.Metadata{
 									SchemaType: "string",
@@ -480,6 +508,102 @@ var vpcSubnetSchema = map[string]*metadata.ExtendedSchema{
 			ReflectType:  reflect.TypeOf(model.SubnetDhcpConfig{}),
 		},
 	},
+	"subnet_dhcpv6_config": {
+		Schema: schema.Schema{
+			Type:     schema.TypeList,
+			MaxItems: 1,
+			Optional: true,
+			Computed: true,
+			Elem: &metadata.ExtendedResource{
+				Schema: map[string]*metadata.ExtendedSchema{
+					"dns_server_preference": {
+						Schema: schema.Schema{
+							Type:         schema.TypeString,
+							ValidateFunc: validation.StringInSlice(dnsServerPreferenceValues, false),
+							Optional:     true,
+						},
+						Metadata: metadata.Metadata{
+							IntroducedInVersion: "9.2.0",
+							SchemaType:          "string",
+							SdkFieldName:        "DnsServerPreference",
+							OmitIfEmpty:         true,
+						},
+					},
+					"mode": {
+						Schema: schema.Schema{
+							Type:         schema.TypeString,
+							ValidateFunc: validation.StringInSlice(vpcSubnetDhcpv6ModeValues, false),
+							Optional:     true,
+						},
+						Metadata: metadata.Metadata{
+							SchemaType:   "string",
+							SdkFieldName: "Mode",
+						},
+					},
+					"dhcpv6_server_additional_config": {
+						Schema: schema.Schema{
+							Type:     schema.TypeList,
+							MaxItems: 1,
+							Elem: &metadata.ExtendedResource{
+								Schema: map[string]*metadata.ExtendedSchema{
+									"domain_names": {
+										Schema: schema.Schema{
+											Type: schema.TypeList,
+											Elem: &metadata.ExtendedSchema{
+												Schema: schema.Schema{
+													Type: schema.TypeString,
+												},
+												Metadata: metadata.Metadata{
+													SchemaType: "string",
+												},
+											},
+											Optional: true,
+										},
+										Metadata: metadata.Metadata{
+											SchemaType:   "list",
+											SdkFieldName: "DomainNames",
+										},
+									},
+									"reserved_ip_ranges": {
+										Schema: schema.Schema{
+											Type: schema.TypeList,
+											Elem: &metadata.ExtendedSchema{
+												Schema: schema.Schema{
+													Type:         schema.TypeString,
+													ValidateFunc: validateCidrOrIPOrRange(),
+												},
+												Metadata: metadata.Metadata{
+													SchemaType: "string",
+												},
+											},
+											Optional: true,
+										},
+										Metadata: metadata.Metadata{
+											SchemaType:   "list",
+											SdkFieldName: "ReservedIpRanges",
+										},
+									},
+								},
+							},
+							Optional: true,
+							Computed: true,
+						},
+						Metadata: metadata.Metadata{
+							SchemaType:   "struct",
+							SdkFieldName: "Dhcpv6ServerAdditionalConfig",
+							ReflectType:  reflect.TypeOf(model.DhcpV6ServerAdditionalConfig{}),
+						},
+					},
+				},
+			},
+		},
+		Metadata: metadata.Metadata{
+			IntroducedInVersion: "9.2.0",
+			SchemaType:          "struct",
+			SdkFieldName:        "SubnetDhcpv6Config",
+			ReflectType:         reflect.TypeOf(model.SubnetDhcpv6Config{}),
+		},
+	},
 }
 
 func resourceNsxtVpcSubnet() *schema.Resource {
@@ -523,6 +647,9 @@ func resourceNsxtVpcSubnetCreate(d *schema.ResourceData, m interface{}) error {
 	}
 
 	if err = validateDhcpConfig(d); err != nil {
+		return err
+	}
+	if err = validateSubnetDhcpv6Config(d); err != nil {
 		return err
 	}
 
@@ -581,6 +708,37 @@ func validateDhcpConfig(d *schema.ResourceData) error {
 	return nil
 }
 
+func validateSubnetDhcpv6Config(d *schema.ResourceData) error {
+	v6, ok := d.GetOk("subnet_dhcpv6_config")
+	if !ok {
+		return nil
+	}
+	list := v6.([]interface{})
+	if len(list) == 0 {
+		return nil
+	}
+	cfg := list[0].(map[string]interface{})
+	mode, _ := cfg["mode"].(string)
+	if mode != model.SubnetDhcpv6Config_MODE_RELAY && mode != model.SubnetDhcpv6Config_MODE_DEACTIVATED {
+		return nil
+	}
+	ac, ok := cfg["dhcpv6_server_additional_config"]
+	if !ok {
+		return nil
+	}
+	addList := ac.([]interface{})
+	if len(addList) == 0 {
+		return nil
+	}
+	add := addList[0].(map[string]interface{})
+	domains := add["domain_names"].([]interface{})
+	ranges := add["reserved_ip_ranges"].([]interface{})
+	if len(domains) > 0 || len(ranges) > 0 {
+		return fmt.Errorf("dhcpv6_server_additional_config can not be specified when subnet_dhcpv6_config mode is DHCP_RELAY or DHCP_DEACTIVATED")
+	}
+	return nil
+}
+
 func resourceNsxtVpcSubnetRead(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
 
@@ -623,6 +781,9 @@ func resourceNsxtVpcSubnetUpdate(d *schema.ResourceData, m interface{}) error {
 	if err := validateDhcpConfig(d); err != nil {
 		return err
 	}
+	if err := validateSubnetDhcpv6Config(d); err != nil {
+		return err
+	}
 
 	parents := getVpcParentsFromContext(getSessionContext(d, m))
 	description := d.Get("description").(string)
@@ -648,6 +809,13 @@ func resourceNsxtVpcSubnetUpdate(d *schema.ResourceData, m interface{}) error {
 	// NSX throws an error
 	if (obj.SubnetDhcpConfig != nil) && (obj.SubnetDhcpConfig.Mode != nil && *obj.SubnetDhcpConfig.Mode == model.SubnetDhcpConfig_MODE_RELAY) {
 		obj.SubnetDhcpConfig.DhcpServerAdditionalConfig = nil
+	}
+
+	if obj.SubnetDhcpv6Config != nil && obj.SubnetDhcpv6Config.Mode != nil {
+		dhcpv6Mode := *obj.SubnetDhcpv6Config.Mode
+		if dhcpv6Mode == model.SubnetDhcpv6Config_MODE_RELAY || dhcpv6Mode == model.SubnetDhcpv6Config_MODE_DEACTIVATED {
+			obj.SubnetDhcpv6Config.Dhcpv6ServerAdditionalConfig = nil
+		}
 	}
 
 	sessionContext := getSessionContext(d, m)

--- a/nsxt/resource_nsxt_vpc_subnet_test.go
+++ b/nsxt/resource_nsxt_vpc_subnet_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 )
 
 var accTestVpcSubnetCreateAttributes = map[string]string{
@@ -395,6 +396,58 @@ func TestAccResourceNsxtVpcSubnet920_reservedIPRange(t *testing.T) {
 	})
 }
 
+var accTestVpcSubnet920SubnetDhcpv6Create = map[string]string{
+	"display_name": getAccTestResourceName(),
+}
+
+var accTestVpcSubnet920SubnetDhcpv6Update = map[string]string{
+	"display_name": getAccTestResourceName(),
+}
+
+func TestAccResourceNsxtVpcSubnet920_subnetDhcpv6Config(t *testing.T) {
+	testResourceName := "nsxt_vpc_subnet.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccOnlyVPC(t)
+			testAccNSXVersion(t, "9.2.0")
+		},
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtVpcSubnetCheckDestroy(state, accTestVpcSubnet920SubnetDhcpv6Update["display_name"])
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtVpcSubnetSubnetDhcpv6Template(true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtVpcSubnetExists(accTestVpcSubnet920SubnetDhcpv6Create["display_name"], testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestVpcSubnet920SubnetDhcpv6Create["display_name"]),
+					resource.TestCheckResourceAttr(testResourceName, "subnet_dhcpv6_config.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "subnet_dhcpv6_config.0.mode", model.SubnetDhcpv6Config_MODE_DEACTIVATED),
+					resource.TestCheckResourceAttr(testResourceName, "subnet_dhcpv6_config.0.dns_server_preference", model.SubnetDhcpv6Config_DNS_SERVER_PREFERENCE_PROFILE_DNS_SERVERS_PREFERRED_OVER_DNS_FORWARDER),
+					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+				),
+			},
+			{
+				Config: testAccNsxtVpcSubnetSubnetDhcpv6Template(false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtVpcSubnetExists(accTestVpcSubnet920SubnetDhcpv6Update["display_name"], testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestVpcSubnet920SubnetDhcpv6Update["display_name"]),
+					resource.TestCheckResourceAttr(testResourceName, "subnet_dhcpv6_config.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "subnet_dhcpv6_config.0.mode", model.SubnetDhcpv6Config_MODE_DEACTIVATED),
+					resource.TestCheckResourceAttr(testResourceName, "subnet_dhcpv6_config.0.dns_server_preference", model.SubnetDhcpv6Config_DNS_SERVER_PREFERENCE_DNS_FORWARDER_PREFERRED_OVER_PROFILE_DNS_SERVERS),
+					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccResourceNsxtVpcSubnet_importBasic(t *testing.T) {
 	name := getAccTestResourceName()
 	testResourceName := "nsxt_vpc_subnet.test"
@@ -459,7 +512,7 @@ func testAccNsxtVpcSubnetCheckDestroy(state *terraform.State, displayName string
 
 		resourceID := rs.Primary.Attributes["id"]
 		exists, err := resourceNsxtVpcSubnetExists(testAccGetSessionContext(), resourceID, connector)
-		if err == nil {
+		if err != nil {
 			return err
 		}
 
@@ -622,4 +675,38 @@ resource "nsxt_vpc_subnet" "test" {
     }
   }
 }`, testAccNsxtPolicyMultitenancyContext(), attrMap["display_name"], attrMap["description"], attrMap["ip_addresses"], attrMap["reserved_ip_ranges"])
+}
+
+func testAccNsxtVpcSubnetSubnetDhcpv6Template(createFlow bool) string {
+	var attrMap map[string]string
+	var mode, dnsPref string
+	if createFlow {
+		attrMap = accTestVpcSubnet920SubnetDhcpv6Create
+		mode = model.SubnetDhcpv6Config_MODE_DEACTIVATED
+		dnsPref = model.SubnetDhcpv6Config_DNS_SERVER_PREFERENCE_PROFILE_DNS_SERVERS_PREFERRED_OVER_DNS_FORWARDER
+	} else {
+		attrMap = accTestVpcSubnet920SubnetDhcpv6Update
+		mode = model.SubnetDhcpv6Config_MODE_DEACTIVATED
+		dnsPref = model.SubnetDhcpv6Config_DNS_SERVER_PREFERENCE_DNS_FORWARDER_PREFERRED_OVER_PROFILE_DNS_SERVERS
+	}
+	return fmt.Sprintf(`
+resource "nsxt_vpc_subnet" "test" {
+%s
+  display_name = "%s"
+  ip_addresses = ["192.168.240.0/26"]
+  access_mode  = "Isolated"
+
+  dhcp_config {
+    mode = "DHCP_SERVER"
+    dhcp_server_additional_config {
+      reserved_ip_ranges = ["192.168.240.40-192.168.240.60"]
+    }
+  }
+
+  subnet_dhcpv6_config {
+    mode                  = "%s"
+    dns_server_preference = "%s"
+  }
+}
+`, testAccNsxtPolicyMultitenancyContext(), attrMap["display_name"], mode, dnsPref)
 }

--- a/nsxt/utgomock_data_source_nsxt_policy_project_test.go
+++ b/nsxt/utgomock_data_source_nsxt_policy_project_test.go
@@ -17,6 +17,7 @@ import (
 	nsxModel "github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 
 	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
+	"github.com/vmware/terraform-provider-nsxt/nsxt/util"
 )
 
 func TestMockDataSourceNsxtPolicyProjectRead(t *testing.T) {
@@ -125,5 +126,68 @@ func TestMockDataSourceNsxtPolicyProjectRead(t *testing.T) {
 
 		err := dataSourceNsxtPolicyProjectRead(d, newGoMockProviderClient())
 		require.Error(t, err)
+	})
+}
+
+func TestMockDataSourceNsxtPolicyProjectRead_ipv6Blocks(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupProjectMock(t, ctrl)
+	defer restore()
+
+	t.Run("by ID sets ipv6_blocks when NSX 9.2.0+", func(t *testing.T) {
+		util.NsxVersion = "9.2.0"
+		defer func() { util.NsxVersion = "" }()
+
+		mockSDK.EXPECT().Get(utl.DefaultOrgID, projectID, gomock.Any()).Return(projectAPIResponseWithIPv6Blocks(), nil)
+
+		ds := dataSourceNsxtPolicyProject()
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{
+			"id": projectID,
+		})
+
+		err := dataSourceNsxtPolicyProjectRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		blocks := d.Get("ipv6_blocks").([]interface{})
+		require.Len(t, blocks, 1)
+		assert.Equal(t, ipv6BlockPath, blocks[0])
+	})
+
+	t.Run("by ID does not populate ipv6_blocks when NSX below 9.2", func(t *testing.T) {
+		util.NsxVersion = "9.1.0"
+		defer func() { util.NsxVersion = "" }()
+
+		mockSDK.EXPECT().Get(utl.DefaultOrgID, projectID, gomock.Any()).Return(projectAPIResponseWithIPv6Blocks(), nil)
+
+		ds := dataSourceNsxtPolicyProject()
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{
+			"id": projectID,
+		})
+
+		err := dataSourceNsxtPolicyProjectRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		_, ok := d.GetOk("ipv6_blocks")
+		assert.False(t, ok)
+	})
+
+	t.Run("by display_name sets ipv6_blocks when NSX 9.2.0+", func(t *testing.T) {
+		util.NsxVersion = "9.2.0"
+		defer func() { util.NsxVersion = "" }()
+
+		mockSDK.EXPECT().List(utl.DefaultOrgID, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(nsxModel.ProjectListResult{
+				Results: []nsxModel.Project{projectAPIResponseWithIPv6Blocks()},
+			}, nil)
+
+		ds := dataSourceNsxtPolicyProject()
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{
+			"display_name": projectDisplayName,
+		})
+
+		err := dataSourceNsxtPolicyProjectRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		blocks := d.Get("ipv6_blocks").([]interface{})
+		require.Len(t, blocks, 1)
+		assert.Equal(t, ipv6BlockPath, blocks[0])
 	})
 }

--- a/nsxt/utgomock_resource_nsxt_policy_project_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_project_test.go
@@ -16,8 +16,10 @@ import (
 	vapiErrors "github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
 	vapiProtocolClient "github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
 	nsxModel "github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+	sdkprojects "github.com/vmware/vsphere-automation-sdk-go/services/nsxt/orgs/projects"
 
 	orgsapi "github.com/vmware/terraform-provider-nsxt/api/orgs"
+	"github.com/vmware/terraform-provider-nsxt/api/orgs/projects"
 	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
 	orgsmocks "github.com/vmware/terraform-provider-nsxt/mocks/orgs"
 	"github.com/vmware/terraform-provider-nsxt/nsxt/util"
@@ -29,6 +31,7 @@ var (
 	projectDescription = "Test Project"
 	projectRevision    = int64(1)
 	projectPath        = "/orgs/default/projects/test-project-id"
+	ipv6BlockPath      = "/orgs/default/projects/default/ip-blocks/test-ipv6-block"
 )
 
 func projectAPIResponse() nsxModel.Project {
@@ -39,6 +42,12 @@ func projectAPIResponse() nsxModel.Project {
 		Revision:    &projectRevision,
 		Path:        &projectPath,
 	}
+}
+
+func projectAPIResponseWithIPv6Blocks() nsxModel.Project {
+	p := projectAPIResponse()
+	p.Ipv6Blocks = []string{ipv6BlockPath}
+	return p
 }
 
 func minimalProjectData() map[string]interface{} {
@@ -62,6 +71,42 @@ func setupProjectMock(t *testing.T, ctrl *gomock.Controller) (*orgsmocks.MockPro
 	}
 
 	return mockSDK, func() { cliProjectsClient = original }
+}
+
+// vpcSecurityProfilesClientStub implements sdkprojects.VpcSecurityProfilesClient for unit tests.
+// Get returns NotFound so setVpcSecurityProfileInSchema exits without further API calls.
+type vpcSecurityProfilesClientStub struct{}
+
+func (vpcSecurityProfilesClientStub) Get(string, string, string) (nsxModel.VpcSecurityProfile, error) {
+	return nsxModel.VpcSecurityProfile{}, vapiErrors.NotFound{}
+}
+
+func (vpcSecurityProfilesClientStub) List(string, string, *string, *bool, *string, *int64, *bool, *string) (nsxModel.VpcSecurityProfileListResult, error) {
+	return nsxModel.VpcSecurityProfileListResult{}, nil
+}
+
+func (vpcSecurityProfilesClientStub) Patch(string, string, string, nsxModel.VpcSecurityProfile) error {
+	return nil
+}
+
+func (vpcSecurityProfilesClientStub) Update(string, string, string, nsxModel.VpcSecurityProfile) (nsxModel.VpcSecurityProfile, error) {
+	return nsxModel.VpcSecurityProfile{}, nil
+}
+
+var _ sdkprojects.VpcSecurityProfilesClient = vpcSecurityProfilesClientStub{}
+
+func setupVpcSecurityProfilesStub(t *testing.T) func() {
+	t.Helper()
+	stub := vpcSecurityProfilesClientStub{}
+	mockWrapper := &projects.VpcSecurityProfileClientContext{
+		Client:     stub,
+		ClientType: utl.Multitenancy,
+	}
+	original := cliVpcSecurityProfilesClient
+	cliVpcSecurityProfilesClient = func(_ utl.SessionContext, _ vapiProtocolClient.Connector) *projects.VpcSecurityProfileClientContext {
+		return mockWrapper
+	}
+	return func() { cliVpcSecurityProfilesClient = original }
 }
 
 func TestMockResourceNsxtPolicyProjectCreate(t *testing.T) {
@@ -122,6 +167,45 @@ func TestMockResourceNsxtPolicyProjectRead(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, projectDisplayName, d.Get("display_name"))
 		assert.Equal(t, projectDescription, d.Get("description"))
+	})
+
+	t.Run("Read sets ipv6_blocks when NSX 9.2.0+", func(t *testing.T) {
+		util.NsxVersion = "9.2.0"
+		defer func() { util.NsxVersion = "" }()
+
+		restoreSec := setupVpcSecurityProfilesStub(t)
+		defer restoreSec()
+
+		mockSDK.EXPECT().Get(utl.DefaultOrgID, projectID, gomock.Any()).Return(projectAPIResponseWithIPv6Blocks(), nil)
+
+		res := resourceNsxtPolicyProject()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalProjectData())
+		d.SetId(projectID)
+
+		err := resourceNsxtPolicyProjectRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		blocks := d.Get("ipv6_blocks").([]interface{})
+		require.Len(t, blocks, 1)
+		assert.Equal(t, ipv6BlockPath, blocks[0])
+	})
+
+	t.Run("Read does not populate ipv6_blocks when NSX below 9.2", func(t *testing.T) {
+		util.NsxVersion = "9.1.0"
+		defer func() { util.NsxVersion = "" }()
+
+		restoreSec := setupVpcSecurityProfilesStub(t)
+		defer restoreSec()
+
+		mockSDK.EXPECT().Get(utl.DefaultOrgID, projectID, gomock.Any()).Return(projectAPIResponseWithIPv6Blocks(), nil)
+
+		res := resourceNsxtPolicyProject()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalProjectData())
+		d.SetId(projectID)
+
+		err := resourceNsxtPolicyProjectRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		_, ok := d.GetOk("ipv6_blocks")
+		assert.False(t, ok)
 	})
 
 	t.Run("Read not found clears ID", func(t *testing.T) {

--- a/nsxt/utgomock_resource_nsxt_vpc_connectivity_profile_test.go
+++ b/nsxt/utgomock_resource_nsxt_vpc_connectivity_profile_test.go
@@ -24,10 +24,12 @@ import (
 )
 
 var (
-	cpID          = "conn-profile-id"
-	cpDisplayName = "test-connectivity-profile"
-	cpDescription = "Test Connectivity Profile"
-	cpRevision    = int64(1)
+	cpID            = "conn-profile-id"
+	cpDisplayName   = "test-connectivity-profile"
+	cpDescription   = "Test Connectivity Profile"
+	cpRevision      = int64(1)
+	cpIpv6Block     = "/orgs/default/projects/default/ip-blocks/ipv6-block1"
+	cpAutoSnatBlock = "/orgs/default/projects/default/ip-blocks/snat-block1"
 )
 
 func cpAPIResponse() nsxModel.VpcConnectivityProfile {
@@ -39,11 +41,50 @@ func cpAPIResponse() nsxModel.VpcConnectivityProfile {
 	}
 }
 
+func cpAPIResponseWithNewAttrs() nsxModel.VpcConnectivityProfile {
+	enableSnat := true
+	return nsxModel.VpcConnectivityProfile{
+		Id:          &cpID,
+		DisplayName: &cpDisplayName,
+		Description: &cpDescription,
+		Revision:    &cpRevision,
+		Ipv6Blocks:  []string{cpIpv6Block},
+		ServiceGateway: &nsxModel.VpcServiceGatewayConfig{
+			NatConfig: &nsxModel.VpcNatConfig{
+				EnableDefaultSnat: &enableSnat,
+				AutoSnatIpBlock:   &cpAutoSnatBlock,
+			},
+		},
+	}
+}
+
 func minimalCpData() map[string]interface{} {
 	return map[string]interface{}{
 		"display_name": cpDisplayName,
 		"description":  cpDescription,
 		"nsx_id":       cpID,
+	}
+}
+
+func cpDataWithNewAttrs() map[string]interface{} {
+	return map[string]interface{}{
+		"display_name": cpDisplayName,
+		"description":  cpDescription,
+		"nsx_id":       cpID,
+		"ipv6_blocks":  []interface{}{cpIpv6Block},
+		"service_gateway": []interface{}{
+			map[string]interface{}{
+				"enable": false,
+				"nat_config": []interface{}{
+					map[string]interface{}{
+						"enable_default_snat": true,
+						"auto_snat_ip_block":  cpAutoSnatBlock,
+					},
+				},
+				"qos_config":         []interface{}{},
+				"edge_cluster_paths": []interface{}{},
+			},
+		},
 	}
 }
 
@@ -172,5 +213,74 @@ func TestMockResourceNsxtVpcConnectivityProfileDelete(t *testing.T) {
 
 		err := resourceNsxtVpcConnectivityProfileDelete(d, newGoMockProviderClient())
 		require.NoError(t, err)
+	})
+}
+
+func TestMockResourceNsxtVpcConnectivityProfile_v920(t *testing.T) {
+	t.Run("Create with ipv6_blocks and auto_snat_ip_block", func(t *testing.T) {
+		util.NsxVersion = "9.2.0"
+		defer func() { util.NsxVersion = "" }()
+
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSDK, restore := setupCpMock(t, ctrl)
+		defer restore()
+
+		notFoundErr := vapiErrors.NotFound{}
+		gomock.InOrder(
+			mockSDK.EXPECT().Get(gomock.Any(), gomock.Any(), cpID).Return(nsxModel.VpcConnectivityProfile{}, notFoundErr),
+			mockSDK.EXPECT().Patch(gomock.Any(), gomock.Any(), cpID, gomock.Any()).Return(nil),
+			mockSDK.EXPECT().Get(gomock.Any(), gomock.Any(), cpID).Return(cpAPIResponseWithNewAttrs(), nil),
+		)
+
+		res := resourceNsxtVpcConnectivityProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, cpDataWithNewAttrs())
+
+		err := resourceNsxtVpcConnectivityProfileCreate(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, cpID, d.Id())
+
+		ipv6Blocks := d.Get("ipv6_blocks").([]interface{})
+		require.Len(t, ipv6Blocks, 1)
+		assert.Equal(t, cpIpv6Block, ipv6Blocks[0])
+
+		sgList := d.Get("service_gateway").([]interface{})
+		require.Len(t, sgList, 1)
+		sg := sgList[0].(map[string]interface{})
+		natList := sg["nat_config"].([]interface{})
+		require.Len(t, natList, 1)
+		nat := natList[0].(map[string]interface{})
+		assert.Equal(t, cpAutoSnatBlock, nat["auto_snat_ip_block"])
+	})
+
+	t.Run("Read populates ipv6_blocks and auto_snat_ip_block", func(t *testing.T) {
+		util.NsxVersion = "9.2.0"
+		defer func() { util.NsxVersion = "" }()
+
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSDK, restore := setupCpMock(t, ctrl)
+		defer restore()
+
+		mockSDK.EXPECT().Get(gomock.Any(), gomock.Any(), cpID).Return(cpAPIResponseWithNewAttrs(), nil)
+
+		res := resourceNsxtVpcConnectivityProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalCpData())
+		d.SetId(cpID)
+
+		err := resourceNsxtVpcConnectivityProfileRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+
+		ipv6Blocks := d.Get("ipv6_blocks").([]interface{})
+		require.Len(t, ipv6Blocks, 1)
+		assert.Equal(t, cpIpv6Block, ipv6Blocks[0])
+
+		sgList := d.Get("service_gateway").([]interface{})
+		require.Len(t, sgList, 1)
+		sg := sgList[0].(map[string]interface{})
+		natList := sg["nat_config"].([]interface{})
+		require.Len(t, natList, 1)
+		nat := natList[0].(map[string]interface{})
+		assert.Equal(t, cpAutoSnatBlock, nat["auto_snat_ip_block"])
 	})
 }

--- a/nsxt/utgomock_resource_nsxt_vpc_dhcp_v6_static_binding_config_test.go
+++ b/nsxt/utgomock_resource_nsxt_vpc_dhcp_v6_static_binding_config_test.go
@@ -1,0 +1,199 @@
+//go:build unittest
+
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package nsxt
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	vapiErrors "github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/bindings"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/data"
+	vapiProtocolClient "github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
+	nsxModel "github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+
+	apisubnets "github.com/vmware/terraform-provider-nsxt/api/orgs/projects/vpcs/subnets"
+	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
+	subnetsmocks "github.com/vmware/terraform-provider-nsxt/mocks/orgs/projects/vpcs/subnets"
+	"github.com/vmware/terraform-provider-nsxt/nsxt/util"
+)
+
+var (
+	dhcpV6BindingID          = "dhcp-v6-binding-id"
+	dhcpV6BindingDisplayName = "test-dhcp-v6-binding"
+	dhcpV6BindingDescription = "Test DHCP v6 Static Binding"
+	dhcpV6BindingRevision    = int64(1)
+	dhcpV6BindingParentPath  = "/orgs/default/projects/project1/vpcs/vpc1/subnets/subnet1"
+	dhcpV6BindingMacAddr     = "AA:BB:CC:DD:EE:FF"
+	dhcpV6BindingIPAddr      = "2001:db8::10"
+)
+
+func dhcpV6BindingStructValue() *data.StructValue {
+	displayName := dhcpV6BindingDisplayName
+	description := dhcpV6BindingDescription
+	revision := dhcpV6BindingRevision
+	macAddr := dhcpV6BindingMacAddr
+	lease := int64(86400)
+	obj := nsxModel.DhcpV6StaticBindingConfig{
+		Id:           &dhcpV6BindingID,
+		DisplayName:  &displayName,
+		Description:  &description,
+		Revision:     &revision,
+		ResourceType: nsxModel.DhcpStaticBindingConfig_RESOURCE_TYPE_DHCPV6STATICBINDINGCONFIG,
+		MacAddress:   &macAddr,
+		LeaseTime:    &lease,
+		IpAddresses:  []string{dhcpV6BindingIPAddr},
+	}
+	converter := bindings.NewTypeConverter()
+	structVal, errs := converter.ConvertToVapi(obj, nsxModel.DhcpV6StaticBindingConfigBindingType())
+	if errs != nil {
+		panic(errs[0])
+	}
+	return structVal.(*data.StructValue)
+}
+
+func minimalDhcpV6BindingData() map[string]interface{} {
+	return map[string]interface{}{
+		"display_name": dhcpV6BindingDisplayName,
+		"description":  dhcpV6BindingDescription,
+		"nsx_id":       dhcpV6BindingID,
+		"parent_path":  dhcpV6BindingParentPath,
+		"mac_address":  dhcpV6BindingMacAddr,
+		"ip_addresses": []interface{}{dhcpV6BindingIPAddr},
+	}
+}
+
+func setupDhcpV6BindingMock(t *testing.T, ctrl *gomock.Controller) (*subnetsmocks.MockDhcpStaticBindingConfigsClient, func()) {
+	mockSDK := subnetsmocks.NewMockDhcpStaticBindingConfigsClient(ctrl)
+	mockWrapper := &apisubnets.VpcDhcpStaticBindingClientContext{
+		Client:     mockSDK,
+		ClientType: utl.VPC,
+		ProjectID:  "project1",
+		VPCID:      "vpc1",
+	}
+
+	orig := cliVpcSubnetDhcpV6StaticBindingConfigsClient
+	cliVpcSubnetDhcpV6StaticBindingConfigsClient = func(_ utl.SessionContext, _ vapiProtocolClient.Connector) *apisubnets.VpcDhcpStaticBindingClientContext {
+		return mockWrapper
+	}
+	return mockSDK, func() { cliVpcSubnetDhcpV6StaticBindingConfigsClient = orig }
+}
+
+func TestMockResourceNsxtVpcDhcpV6StaticBindingCreate(t *testing.T) {
+	t.Run("Create success", func(t *testing.T) {
+		util.NsxVersion = "9.2.0"
+		defer func() { util.NsxVersion = "" }()
+
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSDK, restore := setupDhcpV6BindingMock(t, ctrl)
+		defer restore()
+
+		notFoundErr := vapiErrors.NotFound{}
+		gomock.InOrder(
+			mockSDK.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), dhcpV6BindingID).Return(nil, notFoundErr),
+			mockSDK.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), dhcpV6BindingID, gomock.Any()).Return(nil),
+			mockSDK.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), dhcpV6BindingID).Return(dhcpV6BindingStructValue(), nil),
+		)
+
+		res := resourceNsxtVpcSubnetDhcpV6StaticBindingConfig()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalDhcpV6BindingData())
+
+		err := resourceNsxtVpcSubnetDhcpV6StaticBindingConfigCreate(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, dhcpV6BindingID, d.Id())
+	})
+
+	t.Run("Create fails on old NSX version", func(t *testing.T) {
+		util.NsxVersion = "9.0.0"
+		defer func() { util.NsxVersion = "" }()
+
+		res := resourceNsxtVpcSubnetDhcpV6StaticBindingConfig()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalDhcpV6BindingData())
+
+		err := resourceNsxtVpcSubnetDhcpV6StaticBindingConfigCreate(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtVpcDhcpV6StaticBindingRead(t *testing.T) {
+	t.Run("Read success", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSDK, restore := setupDhcpV6BindingMock(t, ctrl)
+		defer restore()
+
+		mockSDK.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), dhcpV6BindingID).Return(dhcpV6BindingStructValue(), nil)
+
+		res := resourceNsxtVpcSubnetDhcpV6StaticBindingConfig()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalDhcpV6BindingData())
+		d.SetId(dhcpV6BindingID)
+
+		err := resourceNsxtVpcSubnetDhcpV6StaticBindingConfigRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, dhcpV6BindingDisplayName, d.Get("display_name"))
+	})
+
+	t.Run("Read not found clears ID", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSDK, restore := setupDhcpV6BindingMock(t, ctrl)
+		defer restore()
+
+		mockSDK.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), dhcpV6BindingID).Return(nil, vapiErrors.NotFound{})
+
+		res := resourceNsxtVpcSubnetDhcpV6StaticBindingConfig()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalDhcpV6BindingData())
+		d.SetId(dhcpV6BindingID)
+
+		err := resourceNsxtVpcSubnetDhcpV6StaticBindingConfigRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Empty(t, d.Id())
+	})
+}
+
+func TestMockResourceNsxtVpcDhcpV6StaticBindingUpdate(t *testing.T) {
+	t.Run("Update success", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSDK, restore := setupDhcpV6BindingMock(t, ctrl)
+		defer restore()
+
+		gomock.InOrder(
+			mockSDK.EXPECT().Update(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), dhcpV6BindingID, gomock.Any()).Return(dhcpV6BindingStructValue(), nil),
+			mockSDK.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), dhcpV6BindingID).Return(dhcpV6BindingStructValue(), nil),
+		)
+
+		res := resourceNsxtVpcSubnetDhcpV6StaticBindingConfig()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalDhcpV6BindingData())
+		d.SetId(dhcpV6BindingID)
+
+		err := resourceNsxtVpcSubnetDhcpV6StaticBindingConfigUpdate(d, newGoMockProviderClient())
+		require.NoError(t, err)
+	})
+}
+
+func TestMockResourceNsxtVpcDhcpV6StaticBindingDelete(t *testing.T) {
+	t.Run("Delete success", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSDK, restore := setupDhcpV6BindingMock(t, ctrl)
+		defer restore()
+
+		mockSDK.EXPECT().Delete(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), dhcpV6BindingID).Return(nil)
+
+		res := resourceNsxtVpcSubnetDhcpV6StaticBindingConfig()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalDhcpV6BindingData())
+		d.SetId(dhcpV6BindingID)
+
+		err := resourceNsxtVpcSubnetDhcpV6StaticBindingConfigDelete(d, newGoMockProviderClient())
+		require.NoError(t, err)
+	})
+}

--- a/nsxt/utgomock_resource_nsxt_vpc_service_profile_test.go
+++ b/nsxt/utgomock_resource_nsxt_vpc_service_profile_test.go
@@ -39,12 +39,74 @@ func vspAPIResponse() nsxModel.VpcServiceProfile {
 	}
 }
 
+func vspAPIResponse920() nsxModel.VpcServiceProfile {
+	leaseV6 := int64(86400)
+	prefV6 := int64(48000)
+	cache := int64(1024)
+	logLevel := nsxModel.PolicyVpcDnsForwarder_LOG_LEVEL_INFO
+	dist := false
+	return nsxModel.VpcServiceProfile{
+		Id:          &vspID,
+		DisplayName: &vspDisplayName,
+		Description: &vspDescription,
+		Revision:    &vspRevision,
+		Dhcpv6Config: &nsxModel.VpcProfileDhcpV6Config{
+			Dhcpv6ServerConfig: &nsxModel.VpcDhcpv6ServerConfig{
+				LeaseTime:     &leaseV6,
+				PreferredTime: &prefV6,
+				NtpServers:    []string{"2001:db8:1::1"},
+				SntpServers:   []string{"2001:db8:1::2"},
+				DnsClientConfig: &nsxModel.DnsClientConfig{
+					DnsServerIps: []string{"2001:db8:1::53"},
+				},
+				AdvancedConfig: &nsxModel.VpcDhcpAdvancedConfig{
+					IsDistributedDhcp: &dist,
+				},
+			},
+		},
+		DnsForwarderConfig: &nsxModel.PolicyVpcDnsForwarder{
+			CacheSize: &cache,
+			LogLevel:  &logLevel,
+		},
+		Ipv6ProfilePaths:   []string{"/orgs/default/projects/project1/infra/ipv6-dad-profiles/dad1"},
+		ServiceSubnetCidrs: []string{"fd12:3456:789a::/64"},
+	}
+}
+
 func minimalVspData() map[string]interface{} {
 	return map[string]interface{}{
 		"display_name": vspDisplayName,
 		"description":  vspDescription,
 		"nsx_id":       vspID,
+		"dhcp_config": []interface{}{
+			map[string]interface{}{},
+		},
 	}
+}
+
+func minimalVspData920Ipv6() map[string]interface{} {
+	data := minimalVspData()
+	data["dhcpv6_config"] = []interface{}{map[string]interface{}{
+		"dhcpv6_server_config": []interface{}{map[string]interface{}{
+			"lease_time":     86400,
+			"preferred_time": 48000,
+			"ntp_servers":    []interface{}{"2001:db8:1::1"},
+			"sntp_servers":   []interface{}{"2001:db8:1::2"},
+			"dns_client_config": []interface{}{map[string]interface{}{
+				"dns_server_ips": []interface{}{"2001:db8:1::53"},
+			}},
+			"advanced_config": []interface{}{map[string]interface{}{
+				"is_distributed_dhcp": false,
+			}},
+		}},
+	}}
+	data["dns_forwarder_config"] = []interface{}{map[string]interface{}{
+		"log_level":  "INFO",
+		"cache_size": 1024,
+	}}
+	data["ipv6_profile_paths"] = []interface{}{"/orgs/default/projects/project1/infra/ipv6-dad-profiles/dad1"}
+	data["service_subnet_cidrs"] = []interface{}{"fd12:3456:789a::/64"}
+	return data
 }
 
 func setupVspMock(t *testing.T, ctrl *gomock.Controller) (*projectmocks.MockVpcServiceProfilesClient, func()) {
@@ -87,6 +149,32 @@ func TestMockResourceNsxtVpcServiceProfileCreate(t *testing.T) {
 		assert.Equal(t, vspID, d.Id())
 	})
 
+	t.Run("Create success with IPv6 fields on NSX 9.2", func(t *testing.T) {
+		util.NsxVersion = "9.2.0"
+		defer func() { util.NsxVersion = "" }()
+
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSDK, restore := setupVspMock(t, ctrl)
+		defer restore()
+
+		notFoundErr := vapiErrors.NotFound{}
+		gomock.InOrder(
+			mockSDK.EXPECT().Get(gomock.Any(), gomock.Any(), vspID).Return(nsxModel.VpcServiceProfile{}, notFoundErr),
+			mockSDK.EXPECT().Patch(gomock.Any(), gomock.Any(), vspID, gomock.Any()).Return(nil),
+			mockSDK.EXPECT().Get(gomock.Any(), gomock.Any(), vspID).Return(vspAPIResponse920(), nil),
+		)
+
+		res := resourceNsxtVpcServiceProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalVspData920Ipv6())
+
+		err := resourceNsxtVpcServiceProfileCreate(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, vspID, d.Id())
+		assert.Equal(t, 1, d.Get("dhcpv6_config.#"))
+		assert.Equal(t, 1, d.Get("service_subnet_cidrs.#"))
+	})
+
 	t.Run("Create fails on old NSX version", func(t *testing.T) {
 		util.NsxVersion = "4.0.0"
 		defer func() { util.NsxVersion = "" }()
@@ -115,6 +203,38 @@ func TestMockResourceNsxtVpcServiceProfileRead(t *testing.T) {
 		err := resourceNsxtVpcServiceProfileRead(d, newGoMockProviderClient())
 		require.NoError(t, err)
 		assert.Equal(t, vspDisplayName, d.Get("display_name"))
+	})
+
+	t.Run("Read maps IPv6 and DNS forwarder fields from API", func(t *testing.T) {
+		util.NsxVersion = "9.2.0"
+		defer func() { util.NsxVersion = "" }()
+
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSDK, restore := setupVspMock(t, ctrl)
+		defer restore()
+
+		mockSDK.EXPECT().Get(gomock.Any(), gomock.Any(), vspID).Return(vspAPIResponse920(), nil)
+
+		res := resourceNsxtVpcServiceProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalVspData920Ipv6())
+		d.SetId(vspID)
+
+		err := resourceNsxtVpcServiceProfileRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, vspDisplayName, d.Get("display_name"))
+		assert.Equal(t, 1, d.Get("dhcpv6_config.#"))
+		assert.Equal(t, 86400, d.Get("dhcpv6_config.0.dhcpv6_server_config.0.lease_time"))
+		assert.Equal(t, 48000, d.Get("dhcpv6_config.0.dhcpv6_server_config.0.preferred_time"))
+		assert.Equal(t, "2001:db8:1::1", d.Get("dhcpv6_config.0.dhcpv6_server_config.0.ntp_servers.0"))
+		assert.Equal(t, "2001:db8:1::2", d.Get("dhcpv6_config.0.dhcpv6_server_config.0.sntp_servers.0"))
+		assert.Equal(t, "2001:db8:1::53", d.Get("dhcpv6_config.0.dhcpv6_server_config.0.dns_client_config.0.dns_server_ips.0"))
+		assert.Equal(t, false, d.Get("dhcpv6_config.0.dhcpv6_server_config.0.advanced_config.0.is_distributed_dhcp"))
+		assert.Equal(t, 1, d.Get("dns_forwarder_config.#"))
+		assert.Equal(t, "INFO", d.Get("dns_forwarder_config.0.log_level"))
+		assert.Equal(t, 1024, d.Get("dns_forwarder_config.0.cache_size"))
+		assert.Equal(t, "/orgs/default/projects/project1/infra/ipv6-dad-profiles/dad1", d.Get("ipv6_profile_paths.0"))
+		assert.Equal(t, "fd12:3456:789a::/64", d.Get("service_subnet_cidrs.0"))
 	})
 
 	t.Run("Read not found clears ID", func(t *testing.T) {
@@ -153,6 +273,30 @@ func TestMockResourceNsxtVpcServiceProfileUpdate(t *testing.T) {
 
 		err := resourceNsxtVpcServiceProfileUpdate(d, newGoMockProviderClient())
 		require.NoError(t, err)
+	})
+
+	t.Run("Update success with IPv6 fields on NSX 9.2", func(t *testing.T) {
+		util.NsxVersion = "9.2.0"
+		defer func() { util.NsxVersion = "" }()
+
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSDK, restore := setupVspMock(t, ctrl)
+		defer restore()
+
+		gomock.InOrder(
+			mockSDK.EXPECT().Update(gomock.Any(), gomock.Any(), vspID, gomock.Any()).Return(vspAPIResponse920(), nil),
+			mockSDK.EXPECT().Get(gomock.Any(), gomock.Any(), vspID).Return(vspAPIResponse920(), nil),
+		)
+
+		res := resourceNsxtVpcServiceProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalVspData920Ipv6())
+		d.SetId(vspID)
+		d.Set("revision", 1)
+
+		err := resourceNsxtVpcServiceProfileUpdate(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, 1, d.Get("dhcpv6_config.#"))
 	})
 }
 

--- a/nsxt/utgomock_resource_nsxt_vpc_subnet_test.go
+++ b/nsxt/utgomock_resource_nsxt_vpc_subnet_test.go
@@ -230,3 +230,43 @@ func TestMockResourceNsxtVpcSubnetDelete(t *testing.T) {
 		require.Error(t, err)
 	})
 }
+
+func TestValidateSubnetDhcpv6Config(t *testing.T) {
+	res := resourceNsxtVpcSubnet()
+	t.Run("DHCP_RELAY with dhcpv6_server_additional_config is rejected", func(t *testing.T) {
+		data := minimalSubnetData()
+		data["subnet_dhcpv6_config"] = []interface{}{map[string]interface{}{
+			"mode": nsxModel.SubnetDhcpv6Config_MODE_RELAY,
+			"dhcpv6_server_additional_config": []interface{}{map[string]interface{}{
+				"domain_names": []interface{}{"example.com"},
+			}},
+		}}
+		d := schema.TestResourceDataRaw(t, res.Schema, data)
+		err := validateSubnetDhcpv6Config(d)
+		require.Error(t, err)
+	})
+	t.Run("DHCP_DEACTIVATED with reserved_ip_ranges is rejected", func(t *testing.T) {
+		data := minimalSubnetData()
+		data["subnet_dhcpv6_config"] = []interface{}{map[string]interface{}{
+			"mode": nsxModel.SubnetDhcpv6Config_MODE_DEACTIVATED,
+			"dhcpv6_server_additional_config": []interface{}{map[string]interface{}{
+				"reserved_ip_ranges": []interface{}{"2001:db8::10"},
+			}},
+		}}
+		d := schema.TestResourceDataRaw(t, res.Schema, data)
+		err := validateSubnetDhcpv6Config(d)
+		require.Error(t, err)
+	})
+	t.Run("DHCP_SERVER with additional config is allowed", func(t *testing.T) {
+		data := minimalSubnetData()
+		data["subnet_dhcpv6_config"] = []interface{}{map[string]interface{}{
+			"mode": nsxModel.SubnetDhcpv6Config_MODE_SERVER,
+			"dhcpv6_server_additional_config": []interface{}{map[string]interface{}{
+				"domain_names": []interface{}{"example.com"},
+			}},
+		}}
+		d := schema.TestResourceDataRaw(t, res.Schema, data)
+		err := validateSubnetDhcpv6Config(d)
+		require.NoError(t, err)
+	})
+}

--- a/nsxt/validator_test.go
+++ b/nsxt/validator_test.go
@@ -68,6 +68,30 @@ func TestUnitNsxt_ValidateCidrOrIPOrRange(t *testing.T) {
 	}
 }
 
+func TestUnitNsxt_ValidateCidrOrIPOrRangeAllowHostPrefix(t *testing.T) {
+	validator := validateCidrOrIPOrRangeAllowHostPrefix()
+	cases := map[string]struct {
+		value  interface{}
+		result bool
+	}{
+		"hostIpv4WithPrefix": {value: "10.203.240.2/26", result: true},
+		"hostIpv6WithPrefix": {value: "fd00:240:2400:0:0:0:0:2/64", result: true},
+		"networkCidr":        {value: "10.203.240.0/26", result: true},
+		"plainIp":            {value: "10.203.240.2", result: true},
+		"invalid":            {value: "not-an-ip", result: false},
+	}
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+			_, errors := validator(tc.value, tn)
+			if len(errors) > 0 && tc.result {
+				t.Errorf("unexpected error for %v: %v", tc.value, errors)
+			} else if len(errors) == 0 && !tc.result {
+				t.Errorf("expected error for %v", tc.value)
+			}
+		})
+	}
+}
+
 func TestUnitNsxt_ValidateCidrOrIPOrRangeList(t *testing.T) {
 
 	cases := map[string]struct {

--- a/nsxt/validators.go
+++ b/nsxt/validators.go
@@ -129,6 +129,25 @@ func validateCidrOrIPOrRange() schema.SchemaValidateFunc {
 	}
 }
 
+// validateCidrOrIPOrRangeAllowHostPrefix is like validateCidrOrIPOrRange but accepts CIDR strings
+// where the address may include host bits (e.g. 10.0.0.2/26 as returned by NSX for DHCP server
+// addresses), not only network-prefix CIDRs.
+func validateCidrOrIPOrRangeAllowHostPrefix() schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (s []string, es []error) {
+		v, ok := i.(string)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be string", k))
+			return
+		}
+
+		if !isCidr(v, true, true) && !isSingleIP(v) && !isIPRange(v) {
+			es = append(es, fmt.Errorf(
+				"expected %s to contain a valid CIDR or IP or Range, got: %s", k, v))
+		}
+		return
+	}
+}
+
 func validateCidrOrIPOrRangeList() schema.SchemaValidateFunc {
 	return func(i interface{}, k string) (s []string, es []error) {
 		v, ok := i.(string)


### PR DESCRIPTION
Add IPv6 support to the following resources:
nsxt_policy_project
nsxt_vpc_connectivity_profile
nsxt_policy_ip_block
resource_nsxt_vpc_service_profile
resource_nsxt_vpc_subnet

New resources:
nsxt_vpc_dhcp_v6_static_binding_config

Also, address metadata library issue where version specific attributes were still copied into
SDK structs.
