### PR TITLE
Additional unit test coverage

### DIFF
--- a/.github/workflows/fmt-check.yml
+++ b/.github/workflows/fmt-check.yml
@@ -1,23 +1,26 @@
 ---
-name: Tests
+name: Formatting check (nsxt)
 
 on:
+  push:
+    paths:
+      - 'nsxt/**'
+      - '.github/workflows/fmt-check.yml'
   pull_request:
     paths:
-      - 'nsxt/metadata/**.go'
+      - 'nsxt/**'
+      - '.github/workflows/fmt-check.yml'
 
 permissions:
   contents: read
 
 jobs:
-  test:
+  unit-test:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Go
         uses: ./.github/actions/setup-go
-      - name: Build
-        run: go build -v ./...
-      - name: Test
-        run: go test -v ./nsxt/metadata/...
+      - name: Run unit tests
+        run: make fmtcheck

--- a/.github/workflows/metadata-test.yml
+++ b/.github/workflows/metadata-test.yml
@@ -1,0 +1,23 @@
+---
+name: Tests
+
+on:
+  pull_request:
+    paths:
+      - 'nsxt/metadata/**.go'
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Setup Go
+        uses: ./.github/actions/setup-go
+      - name: Build
+        run: go build -v ./...
+      - name: Test
+        run: go test -v ./nsxt/metadata/...  -coverpkg=./nsxt/metadata/...

--- a/.github/workflows/unit-tests-nsxt.yml
+++ b/.github/workflows/unit-tests-nsxt.yml
@@ -23,4 +23,21 @@ jobs:
       - name: Setup Go
         uses: ./.github/actions/setup-go
       - name: Run unit tests
-        run: make testacc TEST="./nsxt/" TESTARGS="-run=TestMockResourceNsxt.* -coverpkg=./..."
+        run: |
+          set -euo pipefail
+          go test ./nsxt/ -tags=unittest \
+            -run='^(TestMock.*Nsxt.*|TestUnitNsxt_.*)' \
+            -coverpkg=./nsxt/... \
+            -coverprofile=coverage.out
+          total_line=$(go tool cover -func=coverage.out | grep '^total:' || true)
+          pct=$(echo "$total_line" | grep -oE '[0-9]+\.[0-9]+%' | tail -1)
+          {
+            echo "## Unit test coverage"
+            echo ""
+            echo "Merged coverage for \`-coverpkg=./nsxt/...\`: **${pct:-n/a}**"
+            echo ""
+            echo '```'
+            echo "$total_line"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "::notice title=nsxt unit test coverage::${pct:-n/a}"

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ dist/
 
 # Ignore macOS desktop services store files.
 **/.DS_Store
+
+# UT files to ignore
+nsxt.test
+metadata.test

--- a/nsxt/policy_utils_test.go
+++ b/nsxt/policy_utils_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0
@@ -5,9 +7,11 @@
 package nsxt
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	sdkerrors "github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
 )
 
 type policyPathTest struct {
@@ -15,7 +19,7 @@ type policyPathTest struct {
 	parents []string
 }
 
-func TestParseStandardPolicyPath(t *testing.T) {
+func TestUnitNsxt_ParseStandardPolicyPath(t *testing.T) {
 
 	testData := []policyPathTest{
 		{
@@ -59,7 +63,7 @@ func TestParseStandardPolicyPath(t *testing.T) {
 	}
 }
 
-func TestIsPolicyPath(t *testing.T) {
+func TestUnitNsxt_IsPolicyPath(t *testing.T) {
 
 	testData := []string{
 		"/infra/tier-1s/mygw1",
@@ -75,12 +79,12 @@ func TestIsPolicyPath(t *testing.T) {
 	}
 }
 
-func TestNegativeParseStandardPolicyPath(t *testing.T) {
+func TestUnitNsxt_NegativeParseStandardPolicyPath(t *testing.T) {
 
 	testData := []string{
-		"/some-infra/tier-1s/mygw1",
+		"/a",
 		"orgs/infra/tier-1s/mygw1-1",
-		"orgs/infra  /tier-1s/mygw1-1",
+		"/orgs/myorg",
 	}
 
 	for _, test := range testData {
@@ -89,7 +93,7 @@ func TestNegativeParseStandardPolicyPath(t *testing.T) {
 	}
 }
 
-func TestParseStandardPolicyPathVerifySize(t *testing.T) {
+func TestUnitNsxt_ParseStandardPolicyPathVerifySize(t *testing.T) {
 
 	_, err := parseStandardPolicyPathVerifySize("/infra/things/thing1/sub-things/sub-thing1", 3, "sample")
 	assert.NotNil(t, err)
@@ -100,4 +104,125 @@ func TestParseStandardPolicyPathVerifySize(t *testing.T) {
 
 	_, err = parseStandardPolicyPathVerifySize("/global-infra/things/1/sub-things/2/fine-tuned-thing/3", 1, "sample")
 	assert.NotNil(t, err)
+}
+
+func TestUnitNsxt_GetResourceIDFromResourcePath(t *testing.T) {
+	assert.Equal(t, "default", getResourceIDFromResourcePath("/infra/domains/default/groups/g1", "domains"))
+	assert.Equal(t, "myproj", getResourceIDFromResourcePath("/orgs/acme/projects/myproj/infra/tier-1s/t1", "projects"))
+	assert.Equal(t, "", getResourceIDFromResourcePath("/infra/tier-1s/t1", "domains"))
+}
+
+func TestUnitNsxt_GetDomainFromResourcePath(t *testing.T) {
+	assert.Equal(t, "default", getDomainFromResourcePath("/infra/domains/default/gateway-policies/gw1"))
+}
+
+func TestUnitNsxt_GetProjectIDFromResourcePath(t *testing.T) {
+	assert.Equal(t, "p1", getProjectIDFromResourcePath("/orgs/o1/projects/p1/infra/domains/d1"))
+}
+
+func TestUnitNsxt_GetPolicyIDFromPath(t *testing.T) {
+	assert.Equal(t, "rule-a", getPolicyIDFromPath("/infra/domains/default/gateway-policies/pol/rules/rule-a"))
+}
+
+func TestUnitNsxt_GetParameterFromPolicyPath(t *testing.T) {
+	v, err := getParameterFromPolicyPath("pre-", "-post", "pre-value-post")
+	assert.NoError(t, err)
+	assert.Equal(t, "value", v)
+
+	_, err = getParameterFromPolicyPath("x", "y", "nope")
+	assert.Error(t, err)
+}
+
+func TestUnitNsxt_ShouldIgnoreScope(t *testing.T) {
+	assert.True(t, shouldIgnoreScope("s1", []string{"s0", "s1", "s2"}))
+	assert.False(t, shouldIgnoreScope("sx", []string{"s0", "s1"}))
+	assert.False(t, shouldIgnoreScope("s1", nil))
+}
+
+func TestUnitNsxt_CollectSeparatedStringListToMap(t *testing.T) {
+	m := collectSeparatedStringListToMap([]string{"a:1", "b:2", "no-sep", "c:"}, ":")
+	assert.Equal(t, "1", m["a"])
+	assert.Equal(t, "2", m["b"])
+	assert.NotContains(t, m, "no-sep")
+}
+
+func TestUnitNsxt_StringListCommaSeparatedRoundTrip(t *testing.T) {
+	s := stringListToCommaSeparatedString([]string{"a", "b", "c"})
+	assert.NotNil(t, s)
+	assert.Equal(t, "a,b,c", *s)
+	assert.Nil(t, stringListToCommaSeparatedString(nil))
+
+	assert.Empty(t, commaSeparatedStringToStringList(""))
+	assert.Equal(t, []string{"x", "y"}, commaSeparatedStringToStringList("x,y"))
+	assert.Equal(t, []string{"x", "y"}, commaSeparatedStringToStringList("x,,y"))
+}
+
+func TestUnitNsxt_InterfaceListToStringList(t *testing.T) {
+	assert.Equal(t, []string{"a", "b"}, interfaceListToStringList([]interface{}{"a", "b"}))
+}
+
+func TestUnitNsxt_IsValidResourceID(t *testing.T) {
+	assert.True(t, isValidResourceID("abc-123"))
+	assert.False(t, isValidResourceID(""))
+	assert.False(t, isValidResourceID("   "))
+	assert.False(t, isValidResourceID("a/b"))
+	assert.False(t, isValidResourceID(string(make([]byte, 1025))))
+}
+
+func TestUnitNsxt_IsValidID(t *testing.T) {
+	assert.True(t, isValidID("id-1"))
+	assert.False(t, isValidID("a/b"))
+	assert.False(t, isValidID("a&b"))
+}
+
+func TestUnitNsxt_IsSpaceString(t *testing.T) {
+	assert.True(t, isSpaceString(""))
+	assert.True(t, isSpaceString("  \t "))
+	assert.False(t, isSpaceString("x"))
+}
+
+func TestUnitNsxt_RetryUponPreconditionFailed(t *testing.T) {
+	t.Run("stops on success", func(t *testing.T) {
+		calls := 0
+		err := retryUponPreconditionFailed(func() error {
+			calls++
+			return nil
+		}, 3)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, calls)
+	})
+
+	t.Run("retries InvalidRequest then succeeds", func(t *testing.T) {
+		calls := 0
+		err := retryUponPreconditionFailed(func() error {
+			calls++
+			if calls < 2 {
+				return sdkerrors.InvalidRequest{}
+			}
+			return nil
+		}, 3)
+		assert.NoError(t, err)
+		assert.Equal(t, 2, calls)
+	})
+
+	t.Run("non-retryable error returns immediately", func(t *testing.T) {
+		boom := errors.New("boom")
+		calls := 0
+		err := retryUponPreconditionFailed(func() error {
+			calls++
+			return boom
+		}, 3)
+		assert.Equal(t, boom, err)
+		assert.Equal(t, 1, calls)
+	})
+
+	t.Run("returns last error after max attempts", func(t *testing.T) {
+		calls := 0
+		err := retryUponPreconditionFailed(func() error {
+			calls++
+			return sdkerrors.InvalidRequest{}
+		}, 1)
+		assert.Error(t, err)
+		assert.Equal(t, 2, calls)
+	})
 }

--- a/nsxt/ut_utils_test.go
+++ b/nsxt/ut_utils_test.go
@@ -1,3 +1,7 @@
+//go:build unittest
+
+// Shared helpers for unittest-tagged mock tests (see utgomock_*_test.go).
+
 package nsxt
 
 import (

--- a/nsxt/utgomock_data_source_nsxt_policy_lb_app_profile_test.go
+++ b/nsxt/utgomock_data_source_nsxt_policy_lb_app_profile_test.go
@@ -1,0 +1,76 @@
+//go:build unittest
+
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package nsxt
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	vapiErrors "github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
+	nsxModel "github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+)
+
+// setupLBAppProfileMock is defined in utgomock_resource_nsxt_policy_lb_fast_tcp_application_profile_test.go
+
+func TestMockDataSourceNsxtPolicyLBAppProfileErrors(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupLBAppProfileMock(t, ctrl)
+	defer restore()
+
+	t.Run("Read by ID - API error is propagated", func(t *testing.T) {
+		mockSDK.EXPECT().Get(lbFastTcpID).Return(nil, vapiErrors.InternalServerError{})
+
+		ds := dataSourceNsxtPolicyLBAppProfile()
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{
+			"id": lbFastTcpID,
+		})
+
+		err := dataSourceNsxtPolicyLBAppProfileRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+
+	t.Run("Read by ID - not found returns error", func(t *testing.T) {
+		mockSDK.EXPECT().Get(lbFastTcpID).Return(nil, vapiErrors.NotFound{})
+
+		ds := dataSourceNsxtPolicyLBAppProfile()
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{
+			"id": lbFastTcpID,
+		})
+
+		err := dataSourceNsxtPolicyLBAppProfileRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+
+	t.Run("Read by name - List API error is propagated", func(t *testing.T) {
+		mockSDK.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nsxModel.LBAppProfileListResult{}, vapiErrors.InternalServerError{})
+
+		ds := dataSourceNsxtPolicyLBAppProfile()
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{
+			"display_name": "test-profile",
+		})
+
+		err := dataSourceNsxtPolicyLBAppProfileRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+
+	t.Run("Read by name - not found returns error", func(t *testing.T) {
+		mockSDK.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nsxModel.LBAppProfileListResult{}, nil)
+
+		ds := dataSourceNsxtPolicyLBAppProfile()
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{
+			"display_name": "nonexistent",
+		})
+
+		err := dataSourceNsxtPolicyLBAppProfileRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}

--- a/nsxt/utgomock_data_source_nsxt_policy_lb_client_ssl_profile_test.go
+++ b/nsxt/utgomock_data_source_nsxt_policy_lb_client_ssl_profile_test.go
@@ -1,0 +1,161 @@
+//go:build unittest
+
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package nsxt
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	vapiErrors "github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
+	nsxModel "github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+)
+
+// setupLBClientSslMock is defined in utgomock_resource_nsxt_policy_lb_client_ssl_profile_test.go
+
+func TestMockDataSourceNsxtPolicyLBClientSslProfileGetByID(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupLBClientSslMock(t, ctrl)
+	defer restore()
+
+	t.Run("Read by ID success", func(t *testing.T) {
+		mockSDK.EXPECT().Get(lbClientSslID).Return(lbClientSslAPIResponse(), nil)
+
+		ds := dataSourceNsxtPolicyLBClientSslProfile()
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{
+			"id": lbClientSslID,
+		})
+
+		err := dataSourceNsxtPolicyLBClientSslProfileRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, lbClientSslID, d.Id())
+		assert.Equal(t, lbClientSslDisplayName, d.Get("display_name"))
+	})
+
+	t.Run("Read by ID not found returns error", func(t *testing.T) {
+		mockSDK.EXPECT().Get(lbClientSslID).Return(nsxModel.LBClientSslProfile{}, vapiErrors.NotFound{})
+
+		ds := dataSourceNsxtPolicyLBClientSslProfile()
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{
+			"id": lbClientSslID,
+		})
+
+		err := dataSourceNsxtPolicyLBClientSslProfileRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+
+	t.Run("Read by ID API error is propagated", func(t *testing.T) {
+		mockSDK.EXPECT().Get(lbClientSslID).Return(nsxModel.LBClientSslProfile{}, vapiErrors.InternalServerError{})
+
+		ds := dataSourceNsxtPolicyLBClientSslProfile()
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{
+			"id": lbClientSslID,
+		})
+
+		err := dataSourceNsxtPolicyLBClientSslProfileRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockDataSourceNsxtPolicyLBClientSslProfileListByName(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupLBClientSslMock(t, ctrl)
+	defer restore()
+
+	t.Run("Read by name perfect match", func(t *testing.T) {
+		listResult := nsxModel.LBClientSslProfileListResult{
+			Results: []nsxModel.LBClientSslProfile{lbClientSslAPIResponse()},
+		}
+		mockSDK.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(listResult, nil)
+
+		ds := dataSourceNsxtPolicyLBClientSslProfile()
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{
+			"display_name": lbClientSslDisplayName,
+		})
+
+		err := dataSourceNsxtPolicyLBClientSslProfileRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, lbClientSslID, d.Id())
+		assert.Equal(t, lbClientSslDisplayName, d.Get("display_name"))
+	})
+
+	t.Run("Read by name prefix match", func(t *testing.T) {
+		listResult := nsxModel.LBClientSslProfileListResult{
+			Results: []nsxModel.LBClientSslProfile{lbClientSslAPIResponse()},
+		}
+		mockSDK.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(listResult, nil)
+
+		ds := dataSourceNsxtPolicyLBClientSslProfile()
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{
+			"display_name": "Test LB",
+		})
+
+		err := dataSourceNsxtPolicyLBClientSslProfileRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, lbClientSslID, d.Id())
+	})
+
+	t.Run("Read by name not found returns error", func(t *testing.T) {
+		listResult := nsxModel.LBClientSslProfileListResult{
+			Results: []nsxModel.LBClientSslProfile{},
+		}
+		mockSDK.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(listResult, nil)
+
+		ds := dataSourceNsxtPolicyLBClientSslProfile()
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{
+			"display_name": "nonexistent",
+		})
+
+		err := dataSourceNsxtPolicyLBClientSslProfileRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("Read by name multiple perfect matches returns error", func(t *testing.T) {
+		dup := lbClientSslAPIResponse()
+		listResult := nsxModel.LBClientSslProfileListResult{
+			Results: []nsxModel.LBClientSslProfile{lbClientSslAPIResponse(), dup},
+		}
+		mockSDK.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(listResult, nil)
+
+		ds := dataSourceNsxtPolicyLBClientSslProfile()
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{
+			"display_name": lbClientSslDisplayName,
+		})
+
+		err := dataSourceNsxtPolicyLBClientSslProfileRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "multiple")
+	})
+
+	t.Run("Read by name List API error is propagated", func(t *testing.T) {
+		mockSDK.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nsxModel.LBClientSslProfileListResult{}, vapiErrors.InternalServerError{})
+
+		ds := dataSourceNsxtPolicyLBClientSslProfile()
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{
+			"display_name": lbClientSslDisplayName,
+		})
+
+		err := dataSourceNsxtPolicyLBClientSslProfileRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockDataSourceNsxtPolicyLBClientSslProfileNoIDOrName(t *testing.T) {
+	t.Run("No ID or display_name returns error", func(t *testing.T) {
+		ds := dataSourceNsxtPolicyLBClientSslProfile()
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{})
+
+		err := dataSourceNsxtPolicyLBClientSslProfileRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Error obtaining")
+	})
+}

--- a/nsxt/utgomock_data_source_nsxt_policy_lb_monitor_test.go
+++ b/nsxt/utgomock_data_source_nsxt_policy_lb_monitor_test.go
@@ -1,0 +1,76 @@
+//go:build unittest
+
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package nsxt
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	vapiErrors "github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
+	nsxModel "github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+)
+
+// setupLBMonitorProfileMock is defined in utgomock_resource_nsxt_policy_lb_http_monitor_profile_test.go
+
+func TestMockDataSourceNsxtPolicyLBMonitorErrors(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupLBMonitorProfileMock(t, ctrl)
+	defer restore()
+
+	t.Run("Read by ID - API error is propagated", func(t *testing.T) {
+		mockSDK.EXPECT().Get(lbHttpMonitorID).Return(nil, vapiErrors.InternalServerError{})
+
+		ds := dataSourceNsxtPolicyLBMonitor()
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{
+			"id": lbHttpMonitorID,
+		})
+
+		err := dataSourceNsxtPolicyLBMonitorRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+
+	t.Run("Read by ID - not found returns error", func(t *testing.T) {
+		mockSDK.EXPECT().Get(lbHttpMonitorID).Return(nil, vapiErrors.NotFound{})
+
+		ds := dataSourceNsxtPolicyLBMonitor()
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{
+			"id": lbHttpMonitorID,
+		})
+
+		err := dataSourceNsxtPolicyLBMonitorRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+
+	t.Run("Read by name - List API error is propagated", func(t *testing.T) {
+		mockSDK.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nsxModel.LBMonitorProfileListResult{}, vapiErrors.InternalServerError{})
+
+		ds := dataSourceNsxtPolicyLBMonitor()
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{
+			"display_name": "test-monitor",
+		})
+
+		err := dataSourceNsxtPolicyLBMonitorRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+
+	t.Run("Read by name - not found returns error", func(t *testing.T) {
+		mockSDK.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nsxModel.LBMonitorProfileListResult{}, nil)
+
+		ds := dataSourceNsxtPolicyLBMonitor()
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{
+			"display_name": "nonexistent",
+		})
+
+		err := dataSourceNsxtPolicyLBMonitorRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}

--- a/nsxt/utgomock_data_source_nsxt_policy_lb_persistence_profile_test.go
+++ b/nsxt/utgomock_data_source_nsxt_policy_lb_persistence_profile_test.go
@@ -1,0 +1,76 @@
+//go:build unittest
+
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package nsxt
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	vapiErrors "github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
+	nsxModel "github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+)
+
+// setupLBPersistenceProfileMock is defined in utgomock_resource_nsxt_policy_lb_cookie_persistence_profile_test.go
+
+func TestMockDataSourceNsxtPolicyLbPersistenceProfileErrors(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupLBPersistenceProfileMock(t, ctrl)
+	defer restore()
+
+	t.Run("Read by ID - API error is propagated", func(t *testing.T) {
+		mockSDK.EXPECT().Get(lbCookieID).Return(nil, vapiErrors.InternalServerError{})
+
+		ds := dataSourceNsxtPolicyLbPersistenceProfile()
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{
+			"id": lbCookieID,
+		})
+
+		err := dataSourceNsxtPolicyLbPersistenceProfileRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+
+	t.Run("Read by ID - not found returns error", func(t *testing.T) {
+		mockSDK.EXPECT().Get(lbCookieID).Return(nil, vapiErrors.NotFound{})
+
+		ds := dataSourceNsxtPolicyLbPersistenceProfile()
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{
+			"id": lbCookieID,
+		})
+
+		err := dataSourceNsxtPolicyLbPersistenceProfileRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+
+	t.Run("Read by name - List API error is propagated", func(t *testing.T) {
+		mockSDK.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nsxModel.LBPersistenceProfileListResult{}, vapiErrors.InternalServerError{})
+
+		ds := dataSourceNsxtPolicyLbPersistenceProfile()
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{
+			"display_name": "test-profile",
+		})
+
+		err := dataSourceNsxtPolicyLbPersistenceProfileRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+
+	t.Run("Read by name - not found returns error", func(t *testing.T) {
+		mockSDK.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nsxModel.LBPersistenceProfileListResult{}, nil)
+
+		ds := dataSourceNsxtPolicyLbPersistenceProfile()
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{
+			"display_name": "nonexistent",
+		})
+
+		err := dataSourceNsxtPolicyLbPersistenceProfileRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}

--- a/nsxt/utgomock_data_source_nsxt_policy_lb_server_ssl_profile_test.go
+++ b/nsxt/utgomock_data_source_nsxt_policy_lb_server_ssl_profile_test.go
@@ -1,0 +1,161 @@
+//go:build unittest
+
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package nsxt
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	vapiErrors "github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
+	nsxModel "github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+)
+
+// setupLBServerSslMock is defined in utgomock_resource_nsxt_policy_lb_server_ssl_profile_test.go
+
+func TestMockDataSourceNsxtPolicyLBServerSslProfileGetByID(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupLBServerSslMock(t, ctrl)
+	defer restore()
+
+	t.Run("Read by ID success", func(t *testing.T) {
+		mockSDK.EXPECT().Get(lbServerSslID).Return(lbServerSslAPIResponse(), nil)
+
+		ds := dataSourceNsxtPolicyLBServerSslProfile()
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{
+			"id": lbServerSslID,
+		})
+
+		err := dataSourceNsxtPolicyLBServerSslProfileRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, lbServerSslID, d.Id())
+		assert.Equal(t, lbServerSslDisplayName, d.Get("display_name"))
+	})
+
+	t.Run("Read by ID not found returns error", func(t *testing.T) {
+		mockSDK.EXPECT().Get(lbServerSslID).Return(nsxModel.LBServerSslProfile{}, vapiErrors.NotFound{})
+
+		ds := dataSourceNsxtPolicyLBServerSslProfile()
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{
+			"id": lbServerSslID,
+		})
+
+		err := dataSourceNsxtPolicyLBServerSslProfileRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+
+	t.Run("Read by ID API error is propagated", func(t *testing.T) {
+		mockSDK.EXPECT().Get(lbServerSslID).Return(nsxModel.LBServerSslProfile{}, vapiErrors.InternalServerError{})
+
+		ds := dataSourceNsxtPolicyLBServerSslProfile()
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{
+			"id": lbServerSslID,
+		})
+
+		err := dataSourceNsxtPolicyLBServerSslProfileRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockDataSourceNsxtPolicyLBServerSslProfileListByName(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupLBServerSslMock(t, ctrl)
+	defer restore()
+
+	t.Run("Read by name perfect match", func(t *testing.T) {
+		listResult := nsxModel.LBServerSslProfileListResult{
+			Results: []nsxModel.LBServerSslProfile{lbServerSslAPIResponse()},
+		}
+		mockSDK.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(listResult, nil)
+
+		ds := dataSourceNsxtPolicyLBServerSslProfile()
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{
+			"display_name": lbServerSslDisplayName,
+		})
+
+		err := dataSourceNsxtPolicyLBServerSslProfileRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, lbServerSslID, d.Id())
+		assert.Equal(t, lbServerSslDisplayName, d.Get("display_name"))
+	})
+
+	t.Run("Read by name prefix match", func(t *testing.T) {
+		listResult := nsxModel.LBServerSslProfileListResult{
+			Results: []nsxModel.LBServerSslProfile{lbServerSslAPIResponse()},
+		}
+		mockSDK.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(listResult, nil)
+
+		ds := dataSourceNsxtPolicyLBServerSslProfile()
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{
+			"display_name": "Test LB",
+		})
+
+		err := dataSourceNsxtPolicyLBServerSslProfileRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, lbServerSslID, d.Id())
+	})
+
+	t.Run("Read by name not found returns error", func(t *testing.T) {
+		listResult := nsxModel.LBServerSslProfileListResult{
+			Results: []nsxModel.LBServerSslProfile{},
+		}
+		mockSDK.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(listResult, nil)
+
+		ds := dataSourceNsxtPolicyLBServerSslProfile()
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{
+			"display_name": "nonexistent",
+		})
+
+		err := dataSourceNsxtPolicyLBServerSslProfileRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("Read by name multiple perfect matches returns error", func(t *testing.T) {
+		dup := lbServerSslAPIResponse()
+		listResult := nsxModel.LBServerSslProfileListResult{
+			Results: []nsxModel.LBServerSslProfile{lbServerSslAPIResponse(), dup},
+		}
+		mockSDK.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(listResult, nil)
+
+		ds := dataSourceNsxtPolicyLBServerSslProfile()
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{
+			"display_name": lbServerSslDisplayName,
+		})
+
+		err := dataSourceNsxtPolicyLBServerSslProfileRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "multiple")
+	})
+
+	t.Run("Read by name List API error is propagated", func(t *testing.T) {
+		mockSDK.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nsxModel.LBServerSslProfileListResult{}, vapiErrors.InternalServerError{})
+
+		ds := dataSourceNsxtPolicyLBServerSslProfile()
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{
+			"display_name": lbServerSslDisplayName,
+		})
+
+		err := dataSourceNsxtPolicyLBServerSslProfileRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockDataSourceNsxtPolicyLBServerSslProfileNoIDOrName(t *testing.T) {
+	t.Run("No ID or display_name returns error", func(t *testing.T) {
+		ds := dataSourceNsxtPolicyLBServerSslProfile()
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{})
+
+		err := dataSourceNsxtPolicyLBServerSslProfileRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Error obtaining")
+	})
+}

--- a/nsxt/utgomock_data_source_nsxt_policy_tags_test.go
+++ b/nsxt/utgomock_data_source_nsxt_policy_tags_test.go
@@ -1,0 +1,97 @@
+//go:build unittest
+
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package nsxt
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	vapiErrors "github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
+	vapiProtocolClient "github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
+	nsxModel "github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+
+	infraapi "github.com/vmware/terraform-provider-nsxt/api/infra"
+	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
+	inframocks "github.com/vmware/terraform-provider-nsxt/mocks/infra"
+)
+
+func setupTagsMock(t *testing.T, ctrl *gomock.Controller) (*inframocks.MockTagsClient, func()) {
+	mockSDK := inframocks.NewMockTagsClient(ctrl)
+	mockWrapper := &infraapi.TagsClientContext{
+		Client:     mockSDK,
+		ClientType: utl.Local,
+	}
+	original := cliTagsClient
+	cliTagsClient = func(_ utl.SessionContext, _ vapiProtocolClient.Connector) *infraapi.TagsClientContext {
+		return mockWrapper
+	}
+	return mockSDK, func() { cliTagsClient = original }
+}
+
+func TestMockDataSourceNsxtTagsRead(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupTagsMock(t, ctrl)
+	defer restore()
+
+	t.Run("Read success returns tags", func(t *testing.T) {
+		scope := "env"
+		tag1 := "production"
+		tag2 := "staging"
+		listResult := nsxModel.TagInfoListResult{
+			Results: []nsxModel.TagInfo{
+				{Tag: &tag1},
+				{Tag: &tag2},
+			},
+		}
+		mockSDK.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(listResult, nil)
+
+		ds := dataSourceNsxtTags()
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{
+			"scope": scope,
+		})
+
+		err := dataSourceNsxtTagsRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		items := d.Get("items").([]interface{})
+		assert.Len(t, items, 2)
+		assert.Equal(t, tag1, items[0])
+		assert.Equal(t, tag2, items[1])
+	})
+
+	t.Run("Read with empty results returns empty items", func(t *testing.T) {
+		listResult := nsxModel.TagInfoListResult{
+			Results: []nsxModel.TagInfo{},
+		}
+		mockSDK.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(listResult, nil)
+
+		ds := dataSourceNsxtTags()
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{
+			"scope": "empty-scope",
+		})
+
+		err := dataSourceNsxtTagsRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		items := d.Get("items").([]interface{})
+		assert.Empty(t, items)
+	})
+
+	t.Run("Read List API error is propagated", func(t *testing.T) {
+		mockSDK.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nsxModel.TagInfoListResult{}, vapiErrors.InternalServerError{})
+
+		ds := dataSourceNsxtTags()
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{
+			"scope": "test-scope",
+		})
+
+		err := dataSourceNsxtTagsRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}

--- a/nsxt/utgomock_data_source_nsxt_policy_transit_gateway_nat_test.go
+++ b/nsxt/utgomock_data_source_nsxt_policy_transit_gateway_nat_test.go
@@ -1,0 +1,39 @@
+//go:build unittest
+
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package nsxt
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMockDataSourceNsxtPolicyTransitGatewayNatInvalidPath(t *testing.T) {
+	t.Run("Invalid transit_gateway_path returns error immediately", func(t *testing.T) {
+		ds := dataSourceNsxtPolicyTransitGatewayNat()
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{
+			"transit_gateway_path": "/invalid/path",
+		})
+
+		err := dataSourceNsxtPolicyTransitGatewayNatRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid transit_gateway_path")
+	})
+
+	t.Run("Too-short transit_gateway_path returns error immediately", func(t *testing.T) {
+		ds := dataSourceNsxtPolicyTransitGatewayNat()
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{
+			"transit_gateway_path": "/orgs/default",
+		})
+
+		err := dataSourceNsxtPolicyTransitGatewayNatRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid transit_gateway_path")
+	})
+}

--- a/nsxt/utgomock_data_source_nsxt_policy_vni_pool_test.go
+++ b/nsxt/utgomock_data_source_nsxt_policy_vni_pool_test.go
@@ -1,0 +1,161 @@
+//go:build unittest
+
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package nsxt
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	vapiErrors "github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
+	vapiProtocolClient "github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
+	nsxModel "github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+
+	apinfra "github.com/vmware/terraform-provider-nsxt/api/infra"
+	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
+	inframocks "github.com/vmware/terraform-provider-nsxt/mocks/infra"
+)
+
+var (
+	vniPoolTestID          = "vni-pool-id-1"
+	vniPoolTestName        = "test-vni-pool"
+	vniPoolTestPath        = "/infra/vni-pool-configs/vni-pool-id-1"
+	vniPoolTestDescription = "test description"
+	vniPoolTestStart       = int64(70000)
+	vniPoolTestEnd         = int64(71000)
+)
+
+func vniPoolModel() nsxModel.VniPoolConfig {
+	return nsxModel.VniPoolConfig{
+		Id:          &vniPoolTestID,
+		DisplayName: &vniPoolTestName,
+		Description: &vniPoolTestDescription,
+		Path:        &vniPoolTestPath,
+		Start:       &vniPoolTestStart,
+		End:         &vniPoolTestEnd,
+	}
+}
+
+func setupVniPoolDataSourceMock(t *testing.T, ctrl *gomock.Controller) (*inframocks.MockVniPoolsClient, func()) {
+	t.Helper()
+	mockSDK := inframocks.NewMockVniPoolsClient(ctrl)
+	wrapper := &apinfra.VniPoolConfigClientContext{
+		Client:     mockSDK,
+		ClientType: utl.Local,
+	}
+	orig := cliVniPoolsClient
+	cliVniPoolsClient = func(_ utl.SessionContext, _ vapiProtocolClient.Connector) *apinfra.VniPoolConfigClientContext {
+		return wrapper
+	}
+	return mockSDK, func() { cliVniPoolsClient = orig }
+}
+
+func TestMockDataSourceNsxtPolicyVniPoolRead(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupVniPoolDataSourceMock(t, ctrl)
+	defer restore()
+
+	t.Run("by ID success", func(t *testing.T) {
+		mockSDK.EXPECT().Get(vniPoolTestID).Return(vniPoolModel(), nil)
+
+		ds := dataSourceNsxtPolicyVniPool()
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{
+			"id": vniPoolTestID,
+		})
+
+		err := dataSourceNsxtPolicyVniPoolRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, vniPoolTestID, d.Id())
+		assert.Equal(t, vniPoolTestName, d.Get("display_name"))
+		assert.Equal(t, int(vniPoolTestStart), d.Get("start"))
+		assert.Equal(t, int(vniPoolTestEnd), d.Get("end"))
+	})
+
+	t.Run("by ID not found", func(t *testing.T) {
+		mockSDK.EXPECT().Get(vniPoolTestID).Return(nsxModel.VniPoolConfig{}, vapiErrors.NotFound{})
+
+		ds := dataSourceNsxtPolicyVniPool()
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{
+			"id": vniPoolTestID,
+		})
+
+		err := dataSourceNsxtPolicyVniPoolRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "was not found")
+	})
+
+	t.Run("by ID API error", func(t *testing.T) {
+		mockSDK.EXPECT().Get(vniPoolTestID).Return(nsxModel.VniPoolConfig{}, vapiErrors.InternalServerError{})
+
+		ds := dataSourceNsxtPolicyVniPool()
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{
+			"id": vniPoolTestID,
+		})
+
+		err := dataSourceNsxtPolicyVniPoolRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Error while reading")
+	})
+
+	t.Run("by display_name single match", func(t *testing.T) {
+		inc := false
+		mockSDK.EXPECT().List(nil, &inc, nil, nil, nil, nil).Return(nsxModel.VniPoolConfigListResult{
+			Results: []nsxModel.VniPoolConfig{vniPoolModel()},
+		}, nil)
+
+		ds := dataSourceNsxtPolicyVniPool()
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{
+			"display_name": vniPoolTestName,
+		})
+
+		err := dataSourceNsxtPolicyVniPoolRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, vniPoolTestID, d.Id())
+	})
+
+	t.Run("by display_name list error", func(t *testing.T) {
+		inc := false
+		mockSDK.EXPECT().List(nil, &inc, nil, nil, nil, nil).Return(nsxModel.VniPoolConfigListResult{}, vapiErrors.InternalServerError{})
+
+		ds := dataSourceNsxtPolicyVniPool()
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{
+			"display_name": vniPoolTestName,
+		})
+
+		err := dataSourceNsxtPolicyVniPoolRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Error while reading VniPoolConfigs")
+	})
+
+	t.Run("missing id and name", func(t *testing.T) {
+		ds := dataSourceNsxtPolicyVniPool()
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{})
+
+		err := dataSourceNsxtPolicyVniPoolRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "ID or name")
+	})
+
+	t.Run("by name not found", func(t *testing.T) {
+		inc := false
+		mockSDK.EXPECT().List(nil, &inc, nil, nil, nil, nil).Return(nsxModel.VniPoolConfigListResult{
+			Results: []nsxModel.VniPoolConfig{},
+		}, nil)
+
+		ds := dataSourceNsxtPolicyVniPool()
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{
+			"display_name": "does-not-exist",
+		})
+
+		err := dataSourceNsxtPolicyVniPoolRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "was not found")
+	})
+}

--- a/nsxt/utgomock_resource_nsxt_cluster_virtual_ip_test.go
+++ b/nsxt/utgomock_resource_nsxt_cluster_virtual_ip_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_compute_manager_test.go
+++ b/nsxt/utgomock_resource_nsxt_compute_manager_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_edge_cluster_test.go
+++ b/nsxt/utgomock_resource_nsxt_edge_cluster_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_edge_high_availability_profile_test.go
+++ b/nsxt/utgomock_resource_nsxt_edge_high_availability_profile_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_edge_transport_node_rtep_test.go
+++ b/nsxt/utgomock_resource_nsxt_edge_transport_node_rtep_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_edge_transport_node_test.go
+++ b/nsxt/utgomock_resource_nsxt_edge_transport_node_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_failure_domain_test.go
+++ b/nsxt/utgomock_resource_nsxt_failure_domain_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_manager_cluster_test.go
+++ b/nsxt/utgomock_resource_nsxt_manager_cluster_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_node_user_test.go
+++ b/nsxt/utgomock_resource_nsxt_node_user_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_bgp_config_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_bgp_config_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_bgp_neighbor_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_bgp_neighbor_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_cluster_security_config_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_cluster_security_config_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_compute_sub_cluster_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_compute_sub_cluster_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_connectivity_policy_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_connectivity_policy_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_constraint_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_constraint_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_context_profile_custom_attribute_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_context_profile_custom_attribute_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_context_profile_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_context_profile_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_dhcp_relay_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_dhcp_relay_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_dhcp_server_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_dhcp_server_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_dhcp_v4_static_binding_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_dhcp_v4_static_binding_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_dhcp_v6_static_binding_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_dhcp_v6_static_binding_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_distributed_flood_protection_profile_binding_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_distributed_flood_protection_profile_binding_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_distributed_flood_protection_profile_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_distributed_flood_protection_profile_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_distributed_vlan_connection_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_distributed_vlan_connection_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_dns_forwarder_zone_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_dns_forwarder_zone_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_domain_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_domain_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_edge_cluster_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_edge_cluster_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_edge_high_availability_profile_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_edge_high_availability_profile_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_edge_transport_node_rtep_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_edge_transport_node_rtep_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_edge_transport_node_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_edge_transport_node_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_evpn_config_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_evpn_config_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_evpn_tenant_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_evpn_tenant_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_evpn_tunnel_endpoint_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_evpn_tunnel_endpoint_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_firewall_exclude_list_member_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_firewall_exclude_list_member_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_fixed_segment_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_fixed_segment_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_gateway_community_list_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_gateway_community_list_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_gateway_connection_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_gateway_connection_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_gateway_dns_forwarder_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_gateway_dns_forwarder_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_gateway_flood_protection_profile_binding_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_gateway_flood_protection_profile_binding_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_gateway_flood_protection_profile_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_gateway_flood_protection_profile_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_gateway_policy_rule_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_gateway_policy_rule_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_gateway_policy_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_gateway_policy_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_gateway_prefix_list_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_gateway_prefix_list_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_gateway_qos_profile_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_gateway_qos_profile_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_gateway_redistribution_config_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_gateway_redistribution_config_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_gateway_route_map_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_gateway_route_map_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_global_manager_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_global_manager_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_group_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_group_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_host_transport_node_collection_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_host_transport_node_collection_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_host_transport_node_profile_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_host_transport_node_profile_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_host_transport_node_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_host_transport_node_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_idps_cluster_config_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_idps_cluster_config_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_idps_custom_signature_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_idps_custom_signature_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_idps_settings_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_idps_settings_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_idps_signature_version_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_idps_signature_version_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_intrusion_service_gateway_policy_rule_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_intrusion_service_gateway_policy_rule_test.go
@@ -1,0 +1,212 @@
+//go:build unittest
+
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package nsxt
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	vapiErrors "github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
+	vapiProtocolClient "github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
+	nsxModel "github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+
+	intrusionservicegatewaypolicies "github.com/vmware/terraform-provider-nsxt/api/infra/domains/intrusion_service_gateway_policies"
+	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
+	isgwrulemocks "github.com/vmware/terraform-provider-nsxt/mocks/infra/domains/intrusion_service_gateway_policies"
+)
+
+var (
+	idsGwRuleID          = "ids-gw-rule-1"
+	idsGwRuleDisplayName = "Test IDS Gateway Policy Rule"
+	idsGwRuleDescription = "Test IDS gateway policy rule"
+	idsGwRuleRevision    = int64(1)
+	idsGwRuleDomain      = "default"
+	idsGwRulePolicyID    = "ids-gw-policy-001"
+	idsGwRulePolicyPath  = "/infra/domains/default/ids-gateway-policies/ids-gw-policy-001"
+	idsGwRuleAction      = "DETECT"
+	idsGwRuleDirection   = "IN_OUT"
+	idsGwRuleIPVersion   = "IPV4_IPV6"
+	idsGwRuleScopePath   = "/infra/domains/default/gateway-policies/gw-policy-001"
+	idsGwRuleProfilePath = "/infra/domains/default/ids-profiles/default"
+)
+
+func idsGwRuleAPIResponse() nsxModel.IdsRule {
+	resourceType := "IdsRule"
+	seq := int64(1)
+	logged := false
+	disabled := false
+	srcEx := false
+	dstEx := false
+	return nsxModel.IdsRule{
+		Id:                   &idsGwRuleID,
+		DisplayName:          &idsGwRuleDisplayName,
+		Description:          &idsGwRuleDescription,
+		Revision:             &idsGwRuleRevision,
+		ResourceType:         &resourceType,
+		Action:               &idsGwRuleAction,
+		Direction:            &idsGwRuleDirection,
+		IpProtocol:           &idsGwRuleIPVersion,
+		SequenceNumber:       &seq,
+		Logged:               &logged,
+		Disabled:             &disabled,
+		SourcesExcluded:      &srcEx,
+		DestinationsExcluded: &dstEx,
+		Scope:                []string{idsGwRuleScopePath},
+		IdsProfiles:          []string{idsGwRuleProfilePath},
+	}
+}
+
+func minimalIdsGwRuleData() map[string]interface{} {
+	return map[string]interface{}{
+		"display_name":    idsGwRuleDisplayName,
+		"description":     idsGwRuleDescription,
+		"policy_path":     idsGwRulePolicyPath,
+		"action":          idsGwRuleAction,
+		"direction":       idsGwRuleDirection,
+		"ip_version":      idsGwRuleIPVersion,
+		"logged":          false,
+		"disabled":        false,
+		"sequence_number": 1,
+		"scope":           []interface{}{idsGwRuleScopePath},
+		"ids_profiles":    []interface{}{idsGwRuleProfilePath},
+	}
+}
+
+func setupIdsGwRuleMock(t *testing.T, ctrl *gomock.Controller) (*isgwrulemocks.MockRulesClient, func()) {
+	t.Helper()
+	mockSDK := isgwrulemocks.NewMockRulesClient(ctrl)
+	mockWrapper := &intrusionservicegatewaypolicies.IntrusionServiceGatewayRuleClientContext{
+		Client:     mockSDK,
+		ClientType: utl.Local,
+	}
+
+	original := cliIntrusionServiceGatewayPolicyRulesClient
+	cliIntrusionServiceGatewayPolicyRulesClient = func(_ utl.SessionContext, _ vapiProtocolClient.Connector) *intrusionservicegatewaypolicies.IntrusionServiceGatewayRuleClientContext {
+		return mockWrapper
+	}
+	return mockSDK, func() { cliIntrusionServiceGatewayPolicyRulesClient = original }
+}
+
+func TestMockResourceNsxtPolicyIntrusionServiceGatewayPolicyRuleCreate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupIdsGwRuleMock(t, ctrl)
+	defer restore()
+
+	t.Run("Create success with auto-generated ID", func(t *testing.T) {
+		gomock.InOrder(
+			mockSDK.EXPECT().Patch(idsGwRuleDomain, idsGwRulePolicyID, gomock.Any(), gomock.Any()).Return(nil),
+			mockSDK.EXPECT().Get(idsGwRuleDomain, idsGwRulePolicyID, gomock.Any()).Return(idsGwRuleAPIResponse(), nil),
+		)
+
+		res := resourceNsxtPolicyIntrusionServiceGatewayPolicyRule()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalIdsGwRuleData())
+
+		err := resourceNsxtPolicyIntrusionServiceGatewayPolicyRuleCreate(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.NotEmpty(t, d.Id())
+	})
+}
+
+func TestMockResourceNsxtPolicyIntrusionServiceGatewayPolicyRuleRead(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupIdsGwRuleMock(t, ctrl)
+	defer restore()
+
+	t.Run("Read success", func(t *testing.T) {
+		mockSDK.EXPECT().Get(idsGwRuleDomain, idsGwRulePolicyID, idsGwRuleID).Return(idsGwRuleAPIResponse(), nil)
+
+		res := resourceNsxtPolicyIntrusionServiceGatewayPolicyRule()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalIdsGwRuleData())
+		d.SetId(idsGwRuleID)
+
+		err := resourceNsxtPolicyIntrusionServiceGatewayPolicyRuleRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, idsGwRuleDisplayName, d.Get("display_name"))
+		assert.Equal(t, idsGwRuleAction, d.Get("action"))
+	})
+
+	t.Run("Read not found clears ID", func(t *testing.T) {
+		mockSDK.EXPECT().Get(idsGwRuleDomain, idsGwRulePolicyID, idsGwRuleID).Return(nsxModel.IdsRule{}, vapiErrors.NotFound{})
+
+		res := resourceNsxtPolicyIntrusionServiceGatewayPolicyRule()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalIdsGwRuleData())
+		d.SetId(idsGwRuleID)
+
+		err := resourceNsxtPolicyIntrusionServiceGatewayPolicyRuleRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, "", d.Id())
+	})
+
+	t.Run("Read fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyIntrusionServiceGatewayPolicyRule()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalIdsGwRuleData())
+
+		err := resourceNsxtPolicyIntrusionServiceGatewayPolicyRuleRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyIntrusionServiceGatewayPolicyRuleUpdate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupIdsGwRuleMock(t, ctrl)
+	defer restore()
+
+	t.Run("Update success", func(t *testing.T) {
+		gomock.InOrder(
+			mockSDK.EXPECT().Patch(idsGwRuleDomain, idsGwRulePolicyID, idsGwRuleID, gomock.Any()).Return(nil),
+			mockSDK.EXPECT().Get(idsGwRuleDomain, idsGwRulePolicyID, idsGwRuleID).Return(idsGwRuleAPIResponse(), nil),
+		)
+
+		res := resourceNsxtPolicyIntrusionServiceGatewayPolicyRule()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalIdsGwRuleData())
+		d.SetId(idsGwRuleID)
+
+		err := resourceNsxtPolicyIntrusionServiceGatewayPolicyRuleUpdate(d, newGoMockProviderClient())
+		require.NoError(t, err)
+	})
+
+	t.Run("Update fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyIntrusionServiceGatewayPolicyRule()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalIdsGwRuleData())
+
+		err := resourceNsxtPolicyIntrusionServiceGatewayPolicyRuleUpdate(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyIntrusionServiceGatewayPolicyRuleDelete(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupIdsGwRuleMock(t, ctrl)
+	defer restore()
+
+	t.Run("Delete success with nsx_id set", func(t *testing.T) {
+		mockSDK.EXPECT().Delete(idsGwRuleDomain, idsGwRulePolicyID, idsGwRuleID).Return(nil)
+
+		res := resourceNsxtPolicyIntrusionServiceGatewayPolicyRule()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalIdsGwRuleData())
+		d.SetId(idsGwRuleID)
+		d.Set("nsx_id", idsGwRuleID)
+
+		err := resourceNsxtPolicyIntrusionServiceGatewayPolicyRuleDelete(d, newGoMockProviderClient())
+		require.NoError(t, err)
+	})
+
+	t.Run("Delete fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyIntrusionServiceGatewayPolicyRule()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalIdsGwRuleData())
+
+		err := resourceNsxtPolicyIntrusionServiceGatewayPolicyRuleDelete(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}

--- a/nsxt/utgomock_resource_nsxt_policy_intrusion_service_gateway_policy_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_intrusion_service_gateway_policy_test.go
@@ -1,0 +1,225 @@
+//go:build unittest
+
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package nsxt
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	vapiErrors "github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
+	vapiProtocolClient "github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
+	nsxModel "github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+
+	apipkg "github.com/vmware/terraform-provider-nsxt/api"
+	apidomains "github.com/vmware/terraform-provider-nsxt/api/infra/domains"
+	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
+	inframocks "github.com/vmware/terraform-provider-nsxt/mocks/infra"
+	domainmocks "github.com/vmware/terraform-provider-nsxt/mocks/infra/domains"
+)
+
+var (
+	idsGwPolicyID          = "ids-gw-policy-1"
+	idsGwPolicyDisplayName = "Test IDS Gateway Policy"
+	idsGwPolicyDescription = "Test IDS gateway policy"
+	idsGwPolicyRevision    = int64(1)
+	idsGwPolicyDomain      = "default"
+	idsGwPolicyPath        = "/infra/domains/default/ids-gateway-policies/ids-gw-policy-1"
+	idsGwPolicyCategory    = "LocalGatewayRules"
+)
+
+func idsGwPolicyAPIResponse() nsxModel.IdsGatewayPolicy {
+	resourceType := "IdsGatewayPolicy"
+	seq := int64(0)
+	stateful := true
+	locked := false
+	comments := ""
+	return nsxModel.IdsGatewayPolicy{
+		Id:             &idsGwPolicyID,
+		DisplayName:    &idsGwPolicyDisplayName,
+		Description:    &idsGwPolicyDescription,
+		Revision:       &idsGwPolicyRevision,
+		Path:           &idsGwPolicyPath,
+		Category:       &idsGwPolicyCategory,
+		ResourceType:   &resourceType,
+		SequenceNumber: &seq,
+		Stateful:       &stateful,
+		Locked:         &locked,
+		Comments:       &comments,
+		Rules:          nil,
+	}
+}
+
+func minimalIdsGwPolicyData() map[string]interface{} {
+	return map[string]interface{}{
+		"display_name":    idsGwPolicyDisplayName,
+		"description":     idsGwPolicyDescription,
+		"nsx_id":          idsGwPolicyID,
+		"domain":          idsGwPolicyDomain,
+		"locked":          false,
+		"stateful":        true,
+		"sequence_number": 0,
+		"category":        idsGwPolicyCategory,
+	}
+}
+
+func setupIdsGwPolicyMock(t *testing.T, ctrl *gomock.Controller) (*domainmocks.MockIntrusionServiceGatewayPoliciesClient, *inframocks.MockInfraClient, func()) {
+	t.Helper()
+	mockSDK := domainmocks.NewMockIntrusionServiceGatewayPoliciesClient(ctrl)
+	mockWrapper := &apidomains.IntrusionServiceGatewayPolicyClientContext{
+		Client:     mockSDK,
+		ClientType: utl.Local,
+	}
+
+	original := cliIntrusionServiceGatewayPoliciesClient
+	cliIntrusionServiceGatewayPoliciesClient = func(_ utl.SessionContext, _ vapiProtocolClient.Connector) *apidomains.IntrusionServiceGatewayPolicyClientContext {
+		return mockWrapper
+	}
+
+	mockInfraSDK := inframocks.NewMockInfraClient(ctrl)
+	originalInfra := cliInfraClient
+	cliInfraClient = func(_ utl.SessionContext, _ vapiProtocolClient.Connector) *apipkg.InfraClientContext {
+		return &apipkg.InfraClientContext{Client: mockInfraSDK, ClientType: utl.Local}
+	}
+
+	return mockSDK, mockInfraSDK, func() {
+		cliIntrusionServiceGatewayPoliciesClient = original
+		cliInfraClient = originalInfra
+	}
+}
+
+func TestMockResourceNsxtPolicyIntrusionServiceGatewayPolicyCreate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, mockInfra, restore := setupIdsGwPolicyMock(t, ctrl)
+	defer restore()
+
+	t.Run("Create success", func(t *testing.T) {
+		notFoundErr := vapiErrors.NotFound{}
+		gomock.InOrder(
+			mockSDK.EXPECT().Get(idsGwPolicyDomain, idsGwPolicyID).Return(nsxModel.IdsGatewayPolicy{}, notFoundErr),
+			mockInfra.EXPECT().Patch(gomock.Any(), gomock.Any()).Return(nil),
+			mockSDK.EXPECT().Get(idsGwPolicyDomain, idsGwPolicyID).Return(idsGwPolicyAPIResponse(), nil),
+		)
+
+		res := resourceNsxtPolicyIntrusionServiceGatewayPolicy()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalIdsGwPolicyData())
+
+		err := resourceNsxtPolicyIntrusionServiceGatewayPolicyCreate(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, idsGwPolicyID, d.Id())
+		assert.Equal(t, idsGwPolicyDisplayName, d.Get("display_name"))
+	})
+
+	t.Run("Create fails when already exists", func(t *testing.T) {
+		mockSDK.EXPECT().Get(idsGwPolicyDomain, idsGwPolicyID).Return(idsGwPolicyAPIResponse(), nil)
+
+		res := resourceNsxtPolicyIntrusionServiceGatewayPolicy()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalIdsGwPolicyData())
+
+		err := resourceNsxtPolicyIntrusionServiceGatewayPolicyCreate(d, newGoMockProviderClient())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "already exists")
+	})
+}
+
+func TestMockResourceNsxtPolicyIntrusionServiceGatewayPolicyRead(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, _, restore := setupIdsGwPolicyMock(t, ctrl)
+	defer restore()
+
+	t.Run("Read success", func(t *testing.T) {
+		mockSDK.EXPECT().Get(idsGwPolicyDomain, idsGwPolicyID).Return(idsGwPolicyAPIResponse(), nil)
+
+		res := resourceNsxtPolicyIntrusionServiceGatewayPolicy()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalIdsGwPolicyData())
+		d.SetId(idsGwPolicyID)
+
+		err := resourceNsxtPolicyIntrusionServiceGatewayPolicyRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, idsGwPolicyDisplayName, d.Get("display_name"))
+		assert.Equal(t, idsGwPolicyCategory, d.Get("category"))
+	})
+
+	t.Run("Read not found clears ID", func(t *testing.T) {
+		mockSDK.EXPECT().Get(idsGwPolicyDomain, idsGwPolicyID).Return(nsxModel.IdsGatewayPolicy{}, vapiErrors.NotFound{})
+
+		res := resourceNsxtPolicyIntrusionServiceGatewayPolicy()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalIdsGwPolicyData())
+		d.SetId(idsGwPolicyID)
+
+		err := resourceNsxtPolicyIntrusionServiceGatewayPolicyRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, "", d.Id())
+	})
+
+	t.Run("Read fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyIntrusionServiceGatewayPolicy()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalIdsGwPolicyData())
+
+		err := resourceNsxtPolicyIntrusionServiceGatewayPolicyRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyIntrusionServiceGatewayPolicyUpdate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, mockInfra, restore := setupIdsGwPolicyMock(t, ctrl)
+	defer restore()
+
+	t.Run("Update success", func(t *testing.T) {
+		gomock.InOrder(
+			mockInfra.EXPECT().Patch(gomock.Any(), gomock.Any()).Return(nil),
+			mockSDK.EXPECT().Get(idsGwPolicyDomain, idsGwPolicyID).Return(idsGwPolicyAPIResponse(), nil),
+		)
+
+		res := resourceNsxtPolicyIntrusionServiceGatewayPolicy()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalIdsGwPolicyData())
+		d.SetId(idsGwPolicyID)
+
+		err := resourceNsxtPolicyIntrusionServiceGatewayPolicyUpdate(d, newGoMockProviderClient())
+		require.NoError(t, err)
+	})
+
+	t.Run("Update fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyIntrusionServiceGatewayPolicy()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalIdsGwPolicyData())
+
+		err := resourceNsxtPolicyIntrusionServiceGatewayPolicyUpdate(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyIntrusionServiceGatewayPolicyDelete(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, _, restore := setupIdsGwPolicyMock(t, ctrl)
+	defer restore()
+
+	t.Run("Delete success", func(t *testing.T) {
+		mockSDK.EXPECT().Delete(idsGwPolicyDomain, idsGwPolicyID).Return(nil)
+
+		res := resourceNsxtPolicyIntrusionServiceGatewayPolicy()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalIdsGwPolicyData())
+		d.SetId(idsGwPolicyID)
+
+		err := resourceNsxtPolicyIntrusionServiceGatewayPolicyDelete(d, newGoMockProviderClient())
+		require.NoError(t, err)
+	})
+
+	t.Run("Delete fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyIntrusionServiceGatewayPolicy()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalIdsGwPolicyData())
+
+		err := resourceNsxtPolicyIntrusionServiceGatewayPolicyDelete(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}

--- a/nsxt/utgomock_resource_nsxt_policy_intrusion_service_policy_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_intrusion_service_policy_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_intrusion_service_profile_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_intrusion_service_profile_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_ip_address_allocation_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_ip_address_allocation_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_ip_block_quota_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_ip_block_quota_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_ip_block_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_ip_block_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_ip_discovery_profile_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_ip_discovery_profile_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_ip_pool_block_subnet_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_ip_pool_block_subnet_test.go
@@ -1,0 +1,139 @@
+//go:build unittest
+
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package nsxt
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	vapiErrors "github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
+	vapiProtocolClient "github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
+
+	ippoolsapi "github.com/vmware/terraform-provider-nsxt/api/infra/ip_pools"
+	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
+	ipSubnetMocks "github.com/vmware/terraform-provider-nsxt/mocks/infra/ip_pools"
+)
+
+var (
+	blockSubnetID       = "block-subnet-1"
+	blockSubnetPoolPath = "/infra/ip-pools/pool-1"
+	blockSubnetPoolID   = "pool-1"
+	blockSubnetBlock    = "/infra/ip-blocks/block-1"
+)
+
+func minimalBlockSubnetData() map[string]interface{} {
+	return map[string]interface{}{
+		"display_name": "Test Block Subnet",
+		"description":  "Test block subnet",
+		"nsx_id":       blockSubnetID,
+		"pool_path":    blockSubnetPoolPath,
+		"block_path":   blockSubnetBlock,
+		"size":         16,
+	}
+}
+
+func setupBlockSubnetMock(t *testing.T, ctrl *gomock.Controller) (*ipSubnetMocks.MockIpSubnetsClient, func()) {
+	mockSDK := ipSubnetMocks.NewMockIpSubnetsClient(ctrl)
+	mockWrapper := &ippoolsapi.StructValueClientContext{
+		Client:     mockSDK,
+		ClientType: utl.Local,
+	}
+	original := cliIpSubnetsClient
+	cliIpSubnetsClient = func(_ utl.SessionContext, _ vapiProtocolClient.Connector) *ippoolsapi.StructValueClientContext {
+		return mockWrapper
+	}
+	return mockSDK, func() { cliIpSubnetsClient = original }
+}
+
+func TestMockResourceNsxtPolicyIPPoolBlockSubnetCreate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupBlockSubnetMock(t, ctrl)
+	defer restore()
+
+	t.Run("Create fails when already exists", func(t *testing.T) {
+		mockSDK.EXPECT().Get(blockSubnetPoolID, blockSubnetID).Return(nil, nil)
+
+		res := resourceNsxtPolicyIPPoolBlockSubnet()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalBlockSubnetData())
+
+		err := resourceNsxtPolicyIPPoolBlockSubnetCreate(d, newGoMockProviderClient())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "already exists")
+	})
+}
+
+func TestMockResourceNsxtPolicyIPPoolBlockSubnetRead(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupBlockSubnetMock(t, ctrl)
+	defer restore()
+
+	t.Run("Read not found clears ID", func(t *testing.T) {
+		mockSDK.EXPECT().Get(blockSubnetPoolID, blockSubnetID).Return(nil, vapiErrors.NotFound{})
+
+		res := resourceNsxtPolicyIPPoolBlockSubnet()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalBlockSubnetData())
+		d.SetId(blockSubnetID)
+
+		err := resourceNsxtPolicyIPPoolBlockSubnetRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, "", d.Id())
+	})
+
+	t.Run("Read API error is propagated", func(t *testing.T) {
+		mockSDK.EXPECT().Get(blockSubnetPoolID, blockSubnetID).Return(nil, vapiErrors.InternalServerError{})
+
+		res := resourceNsxtPolicyIPPoolBlockSubnet()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalBlockSubnetData())
+		d.SetId(blockSubnetID)
+
+		err := resourceNsxtPolicyIPPoolBlockSubnetRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+
+	t.Run("Read fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyIPPoolBlockSubnet()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalBlockSubnetData())
+
+		err := resourceNsxtPolicyIPPoolBlockSubnetRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyIPPoolBlockSubnetUpdate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	_, restore := setupBlockSubnetMock(t, ctrl)
+	defer restore()
+
+	t.Run("Update fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyIPPoolBlockSubnet()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalBlockSubnetData())
+
+		err := resourceNsxtPolicyIPPoolBlockSubnetUpdate(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyIPPoolBlockSubnetDelete(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	_, restore := setupBlockSubnetMock(t, ctrl)
+	defer restore()
+
+	t.Run("Delete fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyIPPoolBlockSubnet()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalBlockSubnetData())
+
+		err := resourceNsxtPolicyIPPoolBlockSubnetDelete(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}

--- a/nsxt/utgomock_resource_nsxt_policy_ip_pool_static_subnet_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_ip_pool_static_subnet_test.go
@@ -1,0 +1,144 @@
+//go:build unittest
+
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package nsxt
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	vapiErrors "github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
+	vapiProtocolClient "github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
+
+	ippoolsapi "github.com/vmware/terraform-provider-nsxt/api/infra/ip_pools"
+	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
+	ipSubnetMocks "github.com/vmware/terraform-provider-nsxt/mocks/infra/ip_pools"
+)
+
+var (
+	staticSubnetID       = "static-subnet-1"
+	staticSubnetPoolPath = "/infra/ip-pools/pool-2"
+	staticSubnetPoolID   = "pool-2"
+	staticSubnetCIDR     = "10.0.0.0/24"
+)
+
+func minimalStaticSubnetData() map[string]interface{} {
+	return map[string]interface{}{
+		"display_name": "Test Static Subnet",
+		"description":  "Test static subnet",
+		"nsx_id":       staticSubnetID,
+		"pool_path":    staticSubnetPoolPath,
+		"cidr":         staticSubnetCIDR,
+		"allocation_range": []interface{}{
+			map[string]interface{}{
+				"start": "10.0.0.2",
+				"end":   "10.0.0.254",
+			},
+		},
+	}
+}
+
+func setupStaticSubnetMock(t *testing.T, ctrl *gomock.Controller) (*ipSubnetMocks.MockIpSubnetsClient, func()) {
+	mockSDK := ipSubnetMocks.NewMockIpSubnetsClient(ctrl)
+	mockWrapper := &ippoolsapi.StructValueClientContext{
+		Client:     mockSDK,
+		ClientType: utl.Local,
+	}
+	original := cliIpSubnetsClient
+	cliIpSubnetsClient = func(_ utl.SessionContext, _ vapiProtocolClient.Connector) *ippoolsapi.StructValueClientContext {
+		return mockWrapper
+	}
+	return mockSDK, func() { cliIpSubnetsClient = original }
+}
+
+func TestMockResourceNsxtPolicyIPPoolStaticSubnetCreate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupStaticSubnetMock(t, ctrl)
+	defer restore()
+
+	t.Run("Create fails when already exists", func(t *testing.T) {
+		mockSDK.EXPECT().Get(staticSubnetPoolID, staticSubnetID).Return(nil, nil)
+
+		res := resourceNsxtPolicyIPPoolStaticSubnet()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalStaticSubnetData())
+
+		err := resourceNsxtPolicyIPPoolStaticSubnetCreate(d, newGoMockProviderClient())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "already exists")
+	})
+}
+
+func TestMockResourceNsxtPolicyIPPoolStaticSubnetRead(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupStaticSubnetMock(t, ctrl)
+	defer restore()
+
+	t.Run("Read not found clears ID", func(t *testing.T) {
+		mockSDK.EXPECT().Get(staticSubnetPoolID, staticSubnetID).Return(nil, vapiErrors.NotFound{})
+
+		res := resourceNsxtPolicyIPPoolStaticSubnet()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalStaticSubnetData())
+		d.SetId(staticSubnetID)
+
+		err := resourceNsxtPolicyIPPoolStaticSubnetRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, "", d.Id())
+	})
+
+	t.Run("Read API error is propagated", func(t *testing.T) {
+		mockSDK.EXPECT().Get(staticSubnetPoolID, staticSubnetID).Return(nil, vapiErrors.InternalServerError{})
+
+		res := resourceNsxtPolicyIPPoolStaticSubnet()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalStaticSubnetData())
+		d.SetId(staticSubnetID)
+
+		err := resourceNsxtPolicyIPPoolStaticSubnetRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+
+	t.Run("Read fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyIPPoolStaticSubnet()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalStaticSubnetData())
+
+		err := resourceNsxtPolicyIPPoolStaticSubnetRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyIPPoolStaticSubnetUpdate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	_, restore := setupStaticSubnetMock(t, ctrl)
+	defer restore()
+
+	t.Run("Update fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyIPPoolStaticSubnet()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalStaticSubnetData())
+
+		err := resourceNsxtPolicyIPPoolStaticSubnetUpdate(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyIPPoolStaticSubnetDelete(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	_, restore := setupStaticSubnetMock(t, ctrl)
+	defer restore()
+
+	t.Run("Delete fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyIPPoolStaticSubnet()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalStaticSubnetData())
+
+		err := resourceNsxtPolicyIPPoolStaticSubnetDelete(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}

--- a/nsxt/utgomock_resource_nsxt_policy_ip_pool_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_ip_pool_test.go
@@ -1,0 +1,190 @@
+//go:build unittest
+
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package nsxt
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	vapiErrors "github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
+	vapiProtocolClient "github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
+	nsxModel "github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+
+	infraapi "github.com/vmware/terraform-provider-nsxt/api/infra"
+	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
+	infraMocks "github.com/vmware/terraform-provider-nsxt/mocks/infra"
+)
+
+var (
+	ipPoolID          = "ip-pool-1"
+	ipPoolDisplayName = "Test IP Pool"
+	ipPoolDescription = "Test ip pool"
+	ipPoolRevision    = int64(1)
+	ipPoolPath        = "/infra/ip-pools/ip-pool-1"
+)
+
+func ipPoolAPIResponse() nsxModel.IpAddressPool {
+	return nsxModel.IpAddressPool{
+		Id:          &ipPoolID,
+		DisplayName: &ipPoolDisplayName,
+		Description: &ipPoolDescription,
+		Revision:    &ipPoolRevision,
+		Path:        &ipPoolPath,
+	}
+}
+
+func minimalIPPoolData() map[string]interface{} {
+	return map[string]interface{}{
+		"display_name": ipPoolDisplayName,
+		"description":  ipPoolDescription,
+		"nsx_id":       ipPoolID,
+	}
+}
+
+func setupIPPoolMock(t *testing.T, ctrl *gomock.Controller) (*infraMocks.MockIpPoolsClient, func()) {
+	mockSDK := infraMocks.NewMockIpPoolsClient(ctrl)
+	mockWrapper := &infraapi.IpAddressPoolClientContext{
+		Client:     mockSDK,
+		ClientType: utl.Local,
+	}
+	original := cliIpPoolsClient
+	cliIpPoolsClient = func(_ utl.SessionContext, _ vapiProtocolClient.Connector) *infraapi.IpAddressPoolClientContext {
+		return mockWrapper
+	}
+	return mockSDK, func() { cliIpPoolsClient = original }
+}
+
+func TestMockResourceNsxtPolicyIPPoolCreate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupIPPoolMock(t, ctrl)
+	defer restore()
+
+	t.Run("Create success", func(t *testing.T) {
+		gomock.InOrder(
+			mockSDK.EXPECT().Get(ipPoolID).Return(nsxModel.IpAddressPool{}, vapiErrors.NotFound{}),
+			mockSDK.EXPECT().Patch(ipPoolID, gomock.Any()).Return(nil),
+			mockSDK.EXPECT().Get(ipPoolID).Return(ipPoolAPIResponse(), nil),
+		)
+
+		res := resourceNsxtPolicyIPPool()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalIPPoolData())
+
+		err := resourceNsxtPolicyIPPoolCreate(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, ipPoolID, d.Id())
+		assert.Equal(t, ipPoolDisplayName, d.Get("display_name"))
+	})
+
+	t.Run("Create fails when already exists", func(t *testing.T) {
+		mockSDK.EXPECT().Get(ipPoolID).Return(ipPoolAPIResponse(), nil)
+
+		res := resourceNsxtPolicyIPPool()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalIPPoolData())
+
+		err := resourceNsxtPolicyIPPoolCreate(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyIPPoolRead(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupIPPoolMock(t, ctrl)
+	defer restore()
+
+	t.Run("Read success", func(t *testing.T) {
+		mockSDK.EXPECT().Get(ipPoolID).Return(ipPoolAPIResponse(), nil)
+
+		res := resourceNsxtPolicyIPPool()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalIPPoolData())
+		d.SetId(ipPoolID)
+
+		err := resourceNsxtPolicyIPPoolRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, ipPoolDisplayName, d.Get("display_name"))
+		assert.Equal(t, ipPoolID, d.Id())
+	})
+
+	t.Run("Read not found clears ID", func(t *testing.T) {
+		mockSDK.EXPECT().Get(ipPoolID).Return(nsxModel.IpAddressPool{}, vapiErrors.NotFound{})
+
+		res := resourceNsxtPolicyIPPool()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalIPPoolData())
+		d.SetId(ipPoolID)
+
+		err := resourceNsxtPolicyIPPoolRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, "", d.Id())
+	})
+
+	t.Run("Read fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyIPPool()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalIPPoolData())
+
+		err := resourceNsxtPolicyIPPoolRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyIPPoolUpdate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupIPPoolMock(t, ctrl)
+	defer restore()
+
+	t.Run("Update success", func(t *testing.T) {
+		gomock.InOrder(
+			mockSDK.EXPECT().Patch(ipPoolID, gomock.Any()).Return(nil),
+			mockSDK.EXPECT().Get(ipPoolID).Return(ipPoolAPIResponse(), nil),
+		)
+
+		res := resourceNsxtPolicyIPPool()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalIPPoolData())
+		d.SetId(ipPoolID)
+
+		err := resourceNsxtPolicyIPPoolUpdate(d, newGoMockProviderClient())
+		require.NoError(t, err)
+	})
+
+	t.Run("Update fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyIPPool()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalIPPoolData())
+
+		err := resourceNsxtPolicyIPPoolUpdate(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyIPPoolDelete(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupIPPoolMock(t, ctrl)
+	defer restore()
+
+	t.Run("Delete success", func(t *testing.T) {
+		mockSDK.EXPECT().Delete(ipPoolID).Return(nil)
+
+		res := resourceNsxtPolicyIPPool()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalIPPoolData())
+		d.SetId(ipPoolID)
+
+		err := resourceNsxtPolicyIPPoolDelete(d, newGoMockProviderClient())
+		require.NoError(t, err)
+	})
+
+	t.Run("Delete fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyIPPool()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalIPPoolData())
+
+		err := resourceNsxtPolicyIPPoolDelete(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}

--- a/nsxt/utgomock_resource_nsxt_policy_ipsec_vpn_dpd_profile_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_ipsec_vpn_dpd_profile_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_ipsec_vpn_ike_profile_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_ipsec_vpn_ike_profile_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_ipsec_vpn_local_endpoint_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_ipsec_vpn_local_endpoint_test.go
@@ -1,0 +1,182 @@
+//go:build unittest
+
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package nsxt
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	vapiErrors "github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
+	vapiProtocolClient "github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
+	nsxModel "github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+
+	ipsecvpnapi "github.com/vmware/terraform-provider-nsxt/api/infra/tier_1s/ipsec_vpn_services"
+	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
+	t1IpsecMocks "github.com/vmware/terraform-provider-nsxt/mocks/infra/tier_1s/ipsec_vpn_services"
+)
+
+var (
+	ipsecEPID          = "ep-1"
+	ipsecEPDisplayName = "Test IPSec Local Endpoint"
+	ipsecEPDescription = "Test ipsec local endpoint"
+	ipsecEPRevision    = int64(1)
+	ipsecEPServicePath = "/infra/tier-1s/t1-gw-1/ipsec-vpn-services/svc-1"
+	ipsecEPGwID        = "t1-gw-1"
+	ipsecEPSvcID       = "svc-1"
+	ipsecEPLocalAddr   = "192.168.1.1"
+)
+
+func ipsecEPAPIResponse() nsxModel.IPSecVpnLocalEndpoint {
+	return nsxModel.IPSecVpnLocalEndpoint{
+		Id:           &ipsecEPID,
+		DisplayName:  &ipsecEPDisplayName,
+		Description:  &ipsecEPDescription,
+		Revision:     &ipsecEPRevision,
+		LocalAddress: &ipsecEPLocalAddr,
+	}
+}
+
+func minimalIPSecEPData() map[string]interface{} {
+	return map[string]interface{}{
+		"display_name":  ipsecEPDisplayName,
+		"description":   ipsecEPDescription,
+		"nsx_id":        ipsecEPID,
+		"service_path":  ipsecEPServicePath,
+		"local_address": ipsecEPLocalAddr,
+	}
+}
+
+func setupIPSecEPMock(t *testing.T, ctrl *gomock.Controller) (*t1IpsecMocks.MockLocalEndpointsClient, func()) {
+	mockSDK := t1IpsecMocks.NewMockLocalEndpointsClient(ctrl)
+	mockWrapper := &ipsecvpnapi.IPSecVpnLocalEndpointClientContext{
+		Client:     mockSDK,
+		ClientType: utl.Local,
+	}
+	original := cliTier1IpsecVpnLocalEndpointsClient
+	cliTier1IpsecVpnLocalEndpointsClient = func(_ utl.SessionContext, _ vapiProtocolClient.Connector) *ipsecvpnapi.IPSecVpnLocalEndpointClientContext {
+		return mockWrapper
+	}
+	return mockSDK, func() { cliTier1IpsecVpnLocalEndpointsClient = original }
+}
+
+func TestMockResourceNsxtPolicyIPSecVpnLocalEndpointCreate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupIPSecEPMock(t, ctrl)
+	defer restore()
+
+	t.Run("Create success", func(t *testing.T) {
+		gomock.InOrder(
+			mockSDK.EXPECT().Get(ipsecEPGwID, ipsecEPSvcID, ipsecEPID).Return(nsxModel.IPSecVpnLocalEndpoint{}, vapiErrors.NotFound{}),
+			mockSDK.EXPECT().Patch(ipsecEPGwID, ipsecEPSvcID, ipsecEPID, gomock.Any()).Return(nil),
+			mockSDK.EXPECT().Get(ipsecEPGwID, ipsecEPSvcID, ipsecEPID).Return(ipsecEPAPIResponse(), nil),
+		)
+
+		res := resourceNsxtPolicyIPSecVpnLocalEndpoint()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalIPSecEPData())
+
+		err := resourceNsxtPolicyIPSecVpnLocalEndpointCreate(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, ipsecEPID, d.Id())
+	})
+}
+
+func TestMockResourceNsxtPolicyIPSecVpnLocalEndpointRead(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupIPSecEPMock(t, ctrl)
+	defer restore()
+
+	t.Run("Read success", func(t *testing.T) {
+		mockSDK.EXPECT().Get(ipsecEPGwID, ipsecEPSvcID, ipsecEPID).Return(ipsecEPAPIResponse(), nil)
+
+		res := resourceNsxtPolicyIPSecVpnLocalEndpoint()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalIPSecEPData())
+		d.SetId(ipsecEPID)
+
+		err := resourceNsxtPolicyIPSecVpnLocalEndpointRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, ipsecEPDisplayName, d.Get("display_name"))
+	})
+
+	t.Run("Read API error is propagated", func(t *testing.T) {
+		mockSDK.EXPECT().Get(ipsecEPGwID, ipsecEPSvcID, ipsecEPID).Return(nsxModel.IPSecVpnLocalEndpoint{}, vapiErrors.InternalServerError{})
+
+		res := resourceNsxtPolicyIPSecVpnLocalEndpoint()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalIPSecEPData())
+		d.SetId(ipsecEPID)
+
+		err := resourceNsxtPolicyIPSecVpnLocalEndpointRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+
+	t.Run("Read fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyIPSecVpnLocalEndpoint()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalIPSecEPData())
+
+		err := resourceNsxtPolicyIPSecVpnLocalEndpointRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyIPSecVpnLocalEndpointUpdate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupIPSecEPMock(t, ctrl)
+	defer restore()
+
+	t.Run("Update success", func(t *testing.T) {
+		gomock.InOrder(
+			mockSDK.EXPECT().Patch(ipsecEPGwID, ipsecEPSvcID, ipsecEPID, gomock.Any()).Return(nil),
+			mockSDK.EXPECT().Get(ipsecEPGwID, ipsecEPSvcID, ipsecEPID).Return(ipsecEPAPIResponse(), nil),
+		)
+
+		res := resourceNsxtPolicyIPSecVpnLocalEndpoint()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalIPSecEPData())
+		d.SetId(ipsecEPID)
+
+		err := resourceNsxtPolicyIPSecVpnLocalEndpointUpdate(d, newGoMockProviderClient())
+		require.NoError(t, err)
+	})
+
+	t.Run("Update fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyIPSecVpnLocalEndpoint()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalIPSecEPData())
+
+		err := resourceNsxtPolicyIPSecVpnLocalEndpointUpdate(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyIPSecVpnLocalEndpointDelete(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupIPSecEPMock(t, ctrl)
+	defer restore()
+
+	t.Run("Delete success", func(t *testing.T) {
+		mockSDK.EXPECT().Delete(ipsecEPGwID, ipsecEPSvcID, ipsecEPID).Return(nil)
+
+		res := resourceNsxtPolicyIPSecVpnLocalEndpoint()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalIPSecEPData())
+		d.SetId(ipsecEPID)
+
+		err := resourceNsxtPolicyIPSecVpnLocalEndpointDelete(d, newGoMockProviderClient())
+		require.NoError(t, err)
+	})
+
+	t.Run("Delete fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyIPSecVpnLocalEndpoint()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalIPSecEPData())
+
+		err := resourceNsxtPolicyIPSecVpnLocalEndpointDelete(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}

--- a/nsxt/utgomock_resource_nsxt_policy_ipsec_vpn_service_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_ipsec_vpn_service_test.go
@@ -1,0 +1,200 @@
+//go:build unittest
+
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package nsxt
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	vapiErrors "github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
+	vapiProtocolClient "github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
+	nsxModel "github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+
+	ipsecvpnapi "github.com/vmware/terraform-provider-nsxt/api/infra/tier_1s/ipsec_vpn_services"
+	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
+	t1Mocks "github.com/vmware/terraform-provider-nsxt/mocks/infra/tier_1s"
+)
+
+var (
+	ipsecSvcID          = "ipsec-svc-1"
+	ipsecSvcDisplayName = "Test IPSec VPN Service"
+	ipsecSvcDescription = "Test ipsec vpn service"
+	ipsecSvcRevision    = int64(1)
+	ipsecSvcGwPath      = "/infra/tier-1s/t1-gw-1"
+	ipsecSvcGwID        = "t1-gw-1"
+	ipsecSvcPath        = "/infra/tier-1s/t1-gw-1/ipsec-vpn-services/ipsec-svc-1"
+)
+
+func ipsecSvcAPIResponse() nsxModel.IPSecVpnService {
+	enabled := true
+	haSync := true
+	logLevel := nsxModel.IPSecVpnService_IKE_LOG_LEVEL_INFO
+	return nsxModel.IPSecVpnService{
+		Id:          &ipsecSvcID,
+		DisplayName: &ipsecSvcDisplayName,
+		Description: &ipsecSvcDescription,
+		Revision:    &ipsecSvcRevision,
+		Path:        &ipsecSvcPath,
+		Enabled:     &enabled,
+		HaSync:      &haSync,
+		IkeLogLevel: &logLevel,
+	}
+}
+
+func minimalIPSecSvcData() map[string]interface{} {
+	return map[string]interface{}{
+		"display_name":  ipsecSvcDisplayName,
+		"description":   ipsecSvcDescription,
+		"nsx_id":        ipsecSvcID,
+		"gateway_path":  ipsecSvcGwPath,
+		"enabled":       true,
+		"ha_sync":       true,
+		"ike_log_level": nsxModel.IPSecVpnService_IKE_LOG_LEVEL_INFO,
+	}
+}
+
+func setupIPSecSvcMock(t *testing.T, ctrl *gomock.Controller) (*t1Mocks.MockIpsecVpnServicesClient, func()) {
+	mockSDK := t1Mocks.NewMockIpsecVpnServicesClient(ctrl)
+	mockWrapper := &ipsecvpnapi.IPSecVpnServiceClientContext{
+		Client:     mockSDK,
+		ClientType: utl.Local,
+	}
+	original := cliTier1IpsecVpnServicesClient
+	cliTier1IpsecVpnServicesClient = func(_ utl.SessionContext, _ vapiProtocolClient.Connector) *ipsecvpnapi.IPSecVpnServiceClientContext {
+		return mockWrapper
+	}
+	return mockSDK, func() { cliTier1IpsecVpnServicesClient = original }
+}
+
+func TestMockResourceNsxtPolicyIPSecVpnServiceCreate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupIPSecSvcMock(t, ctrl)
+	defer restore()
+
+	t.Run("Create success", func(t *testing.T) {
+		gomock.InOrder(
+			mockSDK.EXPECT().Get(ipsecSvcGwID, ipsecSvcID).Return(nsxModel.IPSecVpnService{}, vapiErrors.NotFound{}),
+			mockSDK.EXPECT().Patch(ipsecSvcGwID, ipsecSvcID, gomock.Any()).Return(nil),
+			mockSDK.EXPECT().Get(ipsecSvcGwID, ipsecSvcID).Return(ipsecSvcAPIResponse(), nil),
+		)
+
+		res := resourceNsxtPolicyIPSecVpnService()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalIPSecSvcData())
+
+		err := resourceNsxtPolicyIPSecVpnServiceCreate(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, ipsecSvcID, d.Id())
+	})
+
+	t.Run("Create fails when already exists", func(t *testing.T) {
+		mockSDK.EXPECT().Get(ipsecSvcGwID, ipsecSvcID).Return(ipsecSvcAPIResponse(), nil)
+
+		res := resourceNsxtPolicyIPSecVpnService()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalIPSecSvcData())
+
+		err := resourceNsxtPolicyIPSecVpnServiceCreate(d, newGoMockProviderClient())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "already exists")
+	})
+}
+
+func TestMockResourceNsxtPolicyIPSecVpnServiceRead(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupIPSecSvcMock(t, ctrl)
+	defer restore()
+
+	t.Run("Read success", func(t *testing.T) {
+		mockSDK.EXPECT().Get(ipsecSvcGwID, ipsecSvcID).Return(ipsecSvcAPIResponse(), nil)
+
+		res := resourceNsxtPolicyIPSecVpnService()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalIPSecSvcData())
+		d.SetId(ipsecSvcID)
+
+		err := resourceNsxtPolicyIPSecVpnServiceRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, ipsecSvcDisplayName, d.Get("display_name"))
+	})
+
+	t.Run("Read API error is propagated", func(t *testing.T) {
+		mockSDK.EXPECT().Get(ipsecSvcGwID, ipsecSvcID).Return(nsxModel.IPSecVpnService{}, vapiErrors.InternalServerError{})
+
+		res := resourceNsxtPolicyIPSecVpnService()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalIPSecSvcData())
+		d.SetId(ipsecSvcID)
+
+		err := resourceNsxtPolicyIPSecVpnServiceRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+
+	t.Run("Read fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyIPSecVpnService()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalIPSecSvcData())
+
+		err := resourceNsxtPolicyIPSecVpnServiceRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyIPSecVpnServiceUpdate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupIPSecSvcMock(t, ctrl)
+	defer restore()
+
+	t.Run("Update success", func(t *testing.T) {
+		gomock.InOrder(
+			mockSDK.EXPECT().Update(ipsecSvcGwID, ipsecSvcID, gomock.Any()).Return(ipsecSvcAPIResponse(), nil),
+			mockSDK.EXPECT().Get(ipsecSvcGwID, ipsecSvcID).Return(ipsecSvcAPIResponse(), nil),
+		)
+
+		res := resourceNsxtPolicyIPSecVpnService()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalIPSecSvcData())
+		d.SetId(ipsecSvcID)
+
+		err := resourceNsxtPolicyIPSecVpnServiceUpdate(d, newGoMockProviderClient())
+		require.NoError(t, err)
+	})
+
+	t.Run("Update fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyIPSecVpnService()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalIPSecSvcData())
+
+		err := resourceNsxtPolicyIPSecVpnServiceUpdate(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyIPSecVpnServiceDelete(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupIPSecSvcMock(t, ctrl)
+	defer restore()
+
+	t.Run("Delete success", func(t *testing.T) {
+		mockSDK.EXPECT().Delete(ipsecSvcGwID, ipsecSvcID).Return(nil)
+
+		res := resourceNsxtPolicyIPSecVpnService()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalIPSecSvcData())
+		d.SetId(ipsecSvcID)
+
+		err := resourceNsxtPolicyIPSecVpnServiceDelete(d, newGoMockProviderClient())
+		require.NoError(t, err)
+	})
+
+	t.Run("Delete fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyIPSecVpnService()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalIPSecSvcData())
+
+		err := resourceNsxtPolicyIPSecVpnServiceDelete(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}

--- a/nsxt/utgomock_resource_nsxt_policy_ipsec_vpn_session_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_ipsec_vpn_session_test.go
@@ -1,0 +1,125 @@
+//go:build unittest
+
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package nsxt
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	vapiErrors "github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
+	vapiProtocolClient "github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
+	nsxModel "github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+
+	ipsecvpnapi "github.com/vmware/terraform-provider-nsxt/api/infra/tier_1s/ipsec_vpn_services"
+	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
+	t1IpsecMocks "github.com/vmware/terraform-provider-nsxt/mocks/infra/tier_1s/ipsec_vpn_services"
+)
+
+var (
+	ipsecSessionID          = "ipsec-session-1"
+	ipsecSessionServicePath = "/infra/tier-1s/t1-gw-1/ipsec-vpn-services/svc-1"
+	ipsecSessionGwID        = "t1-gw-1"
+	ipsecSessionSvcID       = "svc-1"
+)
+
+func minimalIPSecSessionData() map[string]interface{} {
+	return map[string]interface{}{
+		"display_name":               "Test IPSec Session",
+		"description":                "Test ipsec vpn session",
+		"nsx_id":                     ipsecSessionID,
+		"service_path":               ipsecSessionServicePath,
+		"vpn_type":                   routeBasedIPSecVpnSession,
+		"peer_id":                    "10.20.30.40",
+		"peer_address":               "10.20.30.40",
+		"ip_addresses":               []interface{}{"192.168.10.1"},
+		"prefix_length":              24,
+		"enabled":                    true,
+		"compliance_suite":           nsxModel.IPSecVpnSession_COMPLIANCE_SUITE_NONE,
+		"authentication_mode":        nsxModel.IPSecVpnSession_AUTHENTICATION_MODE_PSK,
+		"connection_initiation_mode": nsxModel.IPSecVpnSession_CONNECTION_INITIATION_MODE_INITIATOR,
+	}
+}
+
+func setupIPSecSessionMock(t *testing.T, ctrl *gomock.Controller) (*t1IpsecMocks.MockSessionsClient, func()) {
+	mockSDK := t1IpsecMocks.NewMockSessionsClient(ctrl)
+	mockWrapper := &ipsecvpnapi.IpsecVpnSessionClientContext{
+		Client:     mockSDK,
+		ClientType: utl.Local,
+	}
+	original := cliTier1IpsecVpnSessionsClient
+	cliTier1IpsecVpnSessionsClient = func(_ utl.SessionContext, _ vapiProtocolClient.Connector) *ipsecvpnapi.IpsecVpnSessionClientContext {
+		return mockWrapper
+	}
+	return mockSDK, func() { cliTier1IpsecVpnSessionsClient = original }
+}
+
+func TestMockResourceNsxtPolicyIPSecVpnSessionRead(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupIPSecSessionMock(t, ctrl)
+	defer restore()
+
+	t.Run("Read not found clears ID", func(t *testing.T) {
+		mockSDK.EXPECT().Get(ipsecSessionGwID, ipsecSessionSvcID, ipsecSessionID).Return(nil, vapiErrors.NotFound{})
+
+		res := resourceNsxtPolicyIPSecVpnSession()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalIPSecSessionData())
+		d.SetId(ipsecSessionID)
+
+		err := resourceNsxtPolicyIPSecVpnSessionRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, "", d.Id())
+	})
+
+	t.Run("Read API error is propagated", func(t *testing.T) {
+		mockSDK.EXPECT().Get(ipsecSessionGwID, ipsecSessionSvcID, ipsecSessionID).Return(nil, vapiErrors.InternalServerError{})
+
+		res := resourceNsxtPolicyIPSecVpnSession()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalIPSecSessionData())
+		d.SetId(ipsecSessionID)
+
+		err := resourceNsxtPolicyIPSecVpnSessionRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+
+	t.Run("Read fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyIPSecVpnSession()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalIPSecSessionData())
+
+		err := resourceNsxtPolicyIPSecVpnSessionRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyIPSecVpnSessionDelete(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupIPSecSessionMock(t, ctrl)
+	defer restore()
+
+	t.Run("Delete success", func(t *testing.T) {
+		mockSDK.EXPECT().Delete(ipsecSessionGwID, ipsecSessionSvcID, ipsecSessionID).Return(nil)
+
+		res := resourceNsxtPolicyIPSecVpnSession()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalIPSecSessionData())
+		d.SetId(ipsecSessionID)
+
+		err := resourceNsxtPolicyIPSecVpnSessionDelete(d, newGoMockProviderClient())
+		require.NoError(t, err)
+	})
+
+	t.Run("Delete fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyIPSecVpnSession()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalIPSecSessionData())
+
+		err := resourceNsxtPolicyIPSecVpnSessionDelete(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}

--- a/nsxt/utgomock_resource_nsxt_policy_ipsec_vpn_tunnel_profile_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_ipsec_vpn_tunnel_profile_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_l2_vpn_service_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_l2_vpn_service_test.go
@@ -1,0 +1,194 @@
+//go:build unittest
+
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package nsxt
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	vapiErrors "github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
+	vapiProtocolClient "github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
+	nsxModel "github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+
+	t1sapi "github.com/vmware/terraform-provider-nsxt/api/infra/tier_1s"
+	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
+	t1Mocks "github.com/vmware/terraform-provider-nsxt/mocks/infra/tier_1s"
+)
+
+var (
+	l2SvcID          = "l2-svc-1"
+	l2SvcDisplayName = "Test L2 VPN Service"
+	l2SvcDescription = "Test l2 vpn service"
+	l2SvcRevision    = int64(1)
+	l2SvcGwPath      = "/infra/tier-1s/t1-gw-1"
+	l2SvcGwID        = "t1-gw-1"
+	l2SvcPath        = "/infra/tier-1s/t1-gw-1/l2vpn-services/l2-svc-1"
+)
+
+func l2SvcAPIResponse() nsxModel.L2VPNService {
+	mode := nsxModel.L2VPNService_MODE_SERVER
+	return nsxModel.L2VPNService{
+		Id:          &l2SvcID,
+		DisplayName: &l2SvcDisplayName,
+		Description: &l2SvcDescription,
+		Revision:    &l2SvcRevision,
+		Path:        &l2SvcPath,
+		Mode:        &mode,
+	}
+}
+
+func minimalL2SvcData() map[string]interface{} {
+	return map[string]interface{}{
+		"display_name": l2SvcDisplayName,
+		"description":  l2SvcDescription,
+		"nsx_id":       l2SvcID,
+		"gateway_path": l2SvcGwPath,
+		"mode":         nsxModel.L2VPNService_MODE_SERVER,
+	}
+}
+
+func setupL2SvcMock(t *testing.T, ctrl *gomock.Controller) (*t1Mocks.MockL2vpnServicesClient, func()) {
+	mockSDK := t1Mocks.NewMockL2vpnServicesClient(ctrl)
+	mockWrapper := &t1sapi.L2VPNServiceClientContext{
+		Client:     mockSDK,
+		ClientType: utl.Local,
+	}
+	original := cliT1L2vpnServicesClient
+	cliT1L2vpnServicesClient = func(_ utl.SessionContext, _ vapiProtocolClient.Connector) *t1sapi.L2VPNServiceClientContext {
+		return mockWrapper
+	}
+	return mockSDK, func() { cliT1L2vpnServicesClient = original }
+}
+
+func TestMockResourceNsxtPolicyL2VpnServiceCreate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupL2SvcMock(t, ctrl)
+	defer restore()
+
+	t.Run("Create success", func(t *testing.T) {
+		gomock.InOrder(
+			mockSDK.EXPECT().Get(l2SvcGwID, l2SvcID).Return(nsxModel.L2VPNService{}, vapiErrors.NotFound{}),
+			mockSDK.EXPECT().Patch(l2SvcGwID, l2SvcID, gomock.Any()).Return(nil),
+			mockSDK.EXPECT().Get(l2SvcGwID, l2SvcID).Return(l2SvcAPIResponse(), nil),
+		)
+
+		res := resourceNsxtPolicyL2VpnService()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalL2SvcData())
+
+		err := resourceNsxtPolicyL2VpnServiceCreate(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, l2SvcID, d.Id())
+	})
+
+	t.Run("Create fails when already exists", func(t *testing.T) {
+		mockSDK.EXPECT().Get(l2SvcGwID, l2SvcID).Return(l2SvcAPIResponse(), nil)
+
+		res := resourceNsxtPolicyL2VpnService()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalL2SvcData())
+
+		err := resourceNsxtPolicyL2VpnServiceCreate(d, newGoMockProviderClient())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "already exists")
+	})
+}
+
+func TestMockResourceNsxtPolicyL2VpnServiceRead(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupL2SvcMock(t, ctrl)
+	defer restore()
+
+	t.Run("Read success", func(t *testing.T) {
+		mockSDK.EXPECT().Get(l2SvcGwID, l2SvcID).Return(l2SvcAPIResponse(), nil)
+
+		res := resourceNsxtPolicyL2VpnService()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalL2SvcData())
+		d.SetId(l2SvcID)
+
+		err := resourceNsxtPolicyL2VpnServiceRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, l2SvcDisplayName, d.Get("display_name"))
+	})
+
+	t.Run("Read API error is propagated", func(t *testing.T) {
+		mockSDK.EXPECT().Get(l2SvcGwID, l2SvcID).Return(nsxModel.L2VPNService{}, vapiErrors.InternalServerError{})
+
+		res := resourceNsxtPolicyL2VpnService()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalL2SvcData())
+		d.SetId(l2SvcID)
+
+		err := resourceNsxtPolicyL2VpnServiceRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+
+	t.Run("Read fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyL2VpnService()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalL2SvcData())
+
+		err := resourceNsxtPolicyL2VpnServiceRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyL2VpnServiceUpdate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupL2SvcMock(t, ctrl)
+	defer restore()
+
+	t.Run("Update success", func(t *testing.T) {
+		gomock.InOrder(
+			mockSDK.EXPECT().Patch(l2SvcGwID, l2SvcID, gomock.Any()).Return(nil),
+			mockSDK.EXPECT().Get(l2SvcGwID, l2SvcID).Return(l2SvcAPIResponse(), nil),
+		)
+
+		res := resourceNsxtPolicyL2VpnService()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalL2SvcData())
+		d.SetId(l2SvcID)
+
+		err := resourceNsxtPolicyL2VpnServiceUpdate(d, newGoMockProviderClient())
+		require.NoError(t, err)
+	})
+
+	t.Run("Update fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyL2VpnService()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalL2SvcData())
+
+		err := resourceNsxtPolicyL2VpnServiceUpdate(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyL2VpnServiceDelete(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupL2SvcMock(t, ctrl)
+	defer restore()
+
+	t.Run("Delete success", func(t *testing.T) {
+		mockSDK.EXPECT().Delete(l2SvcGwID, l2SvcID).Return(nil)
+
+		res := resourceNsxtPolicyL2VpnService()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalL2SvcData())
+		d.SetId(l2SvcID)
+
+		err := resourceNsxtPolicyL2VpnServiceDelete(d, newGoMockProviderClient())
+		require.NoError(t, err)
+	})
+
+	t.Run("Delete fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyL2VpnService()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalL2SvcData())
+
+		err := resourceNsxtPolicyL2VpnServiceDelete(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}

--- a/nsxt/utgomock_resource_nsxt_policy_l2_vpn_session_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_l2_vpn_session_test.go
@@ -1,0 +1,190 @@
+//go:build unittest
+
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package nsxt
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	vapiErrors "github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
+	vapiProtocolClient "github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
+	nsxModel "github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+
+	l2vpnapi "github.com/vmware/terraform-provider-nsxt/api/infra/tier_1s/l2vpn_services"
+	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
+	l2vpnMocks "github.com/vmware/terraform-provider-nsxt/mocks/infra/tier_1s/l2vpn_services"
+)
+
+var (
+	l2SessionID          = "l2-session-1"
+	l2SessionDisplayName = "Test L2 VPN Session"
+	l2SessionDescription = "Test l2 vpn session"
+	l2SessionRevision    = int64(1)
+	l2SessionServicePath = "/infra/tier-1s/t1-gw-1/l2vpn-services/l2-svc-1"
+	l2SessionGwID        = "t1-gw-1"
+	l2SessionSvcID       = "l2-svc-1"
+)
+
+func l2SessionAPIResponse() nsxModel.L2VPNSession {
+	return nsxModel.L2VPNSession{
+		Id:          &l2SessionID,
+		DisplayName: &l2SessionDisplayName,
+		Description: &l2SessionDescription,
+		Revision:    &l2SessionRevision,
+	}
+}
+
+func minimalL2SessionData() map[string]interface{} {
+	return map[string]interface{}{
+		"display_name": l2SessionDisplayName,
+		"description":  l2SessionDescription,
+		"nsx_id":       l2SessionID,
+		"service_path": l2SessionServicePath,
+	}
+}
+
+func setupL2SessionMock(t *testing.T, ctrl *gomock.Controller) (*l2vpnMocks.MockSessionsClient, func()) {
+	mockSDK := l2vpnMocks.NewMockSessionsClient(ctrl)
+	mockWrapper := &l2vpnapi.L2VPNSessionClientContext{
+		Client:     mockSDK,
+		ClientType: utl.Local,
+	}
+	original := cliT1L2vpnSessionsClient
+	cliT1L2vpnSessionsClient = func(_ utl.SessionContext, _ vapiProtocolClient.Connector) *l2vpnapi.L2VPNSessionClientContext {
+		return mockWrapper
+	}
+	return mockSDK, func() { cliT1L2vpnSessionsClient = original }
+}
+
+func TestMockResourceNsxtPolicyL2VPNSessionCreate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupL2SessionMock(t, ctrl)
+	defer restore()
+
+	t.Run("Create success", func(t *testing.T) {
+		gomock.InOrder(
+			mockSDK.EXPECT().Get(l2SessionGwID, l2SessionSvcID, l2SessionID).Return(nsxModel.L2VPNSession{}, vapiErrors.NotFound{}),
+			mockSDK.EXPECT().Patch(l2SessionGwID, l2SessionSvcID, l2SessionID, gomock.Any()).Return(nil),
+			mockSDK.EXPECT().Get(l2SessionGwID, l2SessionSvcID, l2SessionID).Return(l2SessionAPIResponse(), nil),
+		)
+
+		res := resourceNsxtPolicyL2VPNSession()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalL2SessionData())
+
+		err := resourceNsxtPolicyL2VPNSessionCreate(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, l2SessionID, d.Id())
+	})
+
+	t.Run("Create fails when already exists", func(t *testing.T) {
+		mockSDK.EXPECT().Get(l2SessionGwID, l2SessionSvcID, l2SessionID).Return(l2SessionAPIResponse(), nil)
+
+		res := resourceNsxtPolicyL2VPNSession()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalL2SessionData())
+
+		err := resourceNsxtPolicyL2VPNSessionCreate(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyL2VPNSessionRead(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupL2SessionMock(t, ctrl)
+	defer restore()
+
+	t.Run("Read success", func(t *testing.T) {
+		mockSDK.EXPECT().Get(l2SessionGwID, l2SessionSvcID, l2SessionID).Return(l2SessionAPIResponse(), nil)
+
+		res := resourceNsxtPolicyL2VPNSession()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalL2SessionData())
+		d.SetId(l2SessionID)
+
+		err := resourceNsxtPolicyL2VPNSessionRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, l2SessionDisplayName, d.Get("display_name"))
+	})
+
+	t.Run("Read not found clears ID", func(t *testing.T) {
+		mockSDK.EXPECT().Get(l2SessionGwID, l2SessionSvcID, l2SessionID).Return(nsxModel.L2VPNSession{}, vapiErrors.NotFound{})
+
+		res := resourceNsxtPolicyL2VPNSession()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalL2SessionData())
+		d.SetId(l2SessionID)
+
+		err := resourceNsxtPolicyL2VPNSessionRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, "", d.Id())
+	})
+
+	t.Run("Read fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyL2VPNSession()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalL2SessionData())
+
+		err := resourceNsxtPolicyL2VPNSessionRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyL2VPNSessionUpdate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupL2SessionMock(t, ctrl)
+	defer restore()
+
+	t.Run("Update success", func(t *testing.T) {
+		gomock.InOrder(
+			mockSDK.EXPECT().Patch(l2SessionGwID, l2SessionSvcID, l2SessionID, gomock.Any()).Return(nil),
+			mockSDK.EXPECT().Get(l2SessionGwID, l2SessionSvcID, l2SessionID).Return(l2SessionAPIResponse(), nil),
+		)
+
+		res := resourceNsxtPolicyL2VPNSession()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalL2SessionData())
+		d.SetId(l2SessionID)
+
+		err := resourceNsxtPolicyL2VPNSessionUpdate(d, newGoMockProviderClient())
+		require.NoError(t, err)
+	})
+
+	t.Run("Update fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyL2VPNSession()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalL2SessionData())
+
+		err := resourceNsxtPolicyL2VPNSessionUpdate(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyL2VPNSessionDelete(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupL2SessionMock(t, ctrl)
+	defer restore()
+
+	t.Run("Delete success", func(t *testing.T) {
+		mockSDK.EXPECT().Delete(l2SessionGwID, l2SessionSvcID, l2SessionID).Return(nil)
+
+		res := resourceNsxtPolicyL2VPNSession()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalL2SessionData())
+		d.SetId(l2SessionID)
+
+		err := resourceNsxtPolicyL2VPNSessionDelete(d, newGoMockProviderClient())
+		require.NoError(t, err)
+	})
+
+	t.Run("Delete fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyL2VPNSession()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalL2SessionData())
+
+		err := resourceNsxtPolicyL2VPNSessionDelete(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}

--- a/nsxt/utgomock_resource_nsxt_policy_l7_access_profile_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_l7_access_profile_test.go
@@ -1,0 +1,128 @@
+//go:build unittest
+
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package nsxt
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	vapiErrors "github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
+	vapiProtocolClient "github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
+	nsxModel "github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+
+	infraapi "github.com/vmware/terraform-provider-nsxt/api/infra"
+	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
+	infraMocks "github.com/vmware/terraform-provider-nsxt/mocks/infra"
+)
+
+var (
+	l7ProfileID          = "l7-profile-1"
+	l7ProfileDisplayName = "Test L7 Access Profile"
+	l7ProfileDescription = "Test l7 access profile"
+	l7ProfileRevision    = int64(1)
+)
+
+func l7ProfileAPIResponse() nsxModel.L7AccessProfile {
+	defaultAction := nsxModel.L7AccessProfile_DEFAULT_ACTION_ALLOW
+	return nsxModel.L7AccessProfile{
+		Id:            &l7ProfileID,
+		DisplayName:   &l7ProfileDisplayName,
+		Description:   &l7ProfileDescription,
+		Revision:      &l7ProfileRevision,
+		DefaultAction: &defaultAction,
+	}
+}
+
+func minimalL7ProfileData() map[string]interface{} {
+	return map[string]interface{}{
+		"display_name":   l7ProfileDisplayName,
+		"description":    l7ProfileDescription,
+		"nsx_id":         l7ProfileID,
+		"default_action": nsxModel.L7AccessProfile_DEFAULT_ACTION_ALLOW,
+	}
+}
+
+func setupL7ProfileMock(t *testing.T, ctrl *gomock.Controller) (*infraMocks.MockL7AccessProfilesClient, func()) {
+	mockSDK := infraMocks.NewMockL7AccessProfilesClient(ctrl)
+	mockWrapper := &infraapi.L7AccessProfileClientContext{
+		Client:     mockSDK,
+		ClientType: utl.Local,
+	}
+	original := cliL7AccessProfilesClient
+	cliL7AccessProfilesClient = func(_ utl.SessionContext, _ vapiProtocolClient.Connector) *infraapi.L7AccessProfileClientContext {
+		return mockWrapper
+	}
+	return mockSDK, func() { cliL7AccessProfilesClient = original }
+}
+
+func TestMockResourceNsxtPolicyL7AccessProfileRead(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupL7ProfileMock(t, ctrl)
+	defer restore()
+
+	t.Run("Read success", func(t *testing.T) {
+		mockSDK.EXPECT().Get(l7ProfileID).Return(l7ProfileAPIResponse(), nil)
+
+		res := resourceNsxtPolicyL7AccessProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalL7ProfileData())
+		d.SetId(l7ProfileID)
+
+		err := resourceNsxtPolicyL7AccessProfileRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, l7ProfileDisplayName, d.Get("display_name"))
+	})
+
+	t.Run("Read not found clears ID", func(t *testing.T) {
+		mockSDK.EXPECT().Get(l7ProfileID).Return(nsxModel.L7AccessProfile{}, vapiErrors.NotFound{})
+
+		res := resourceNsxtPolicyL7AccessProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalL7ProfileData())
+		d.SetId(l7ProfileID)
+
+		err := resourceNsxtPolicyL7AccessProfileRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, "", d.Id())
+	})
+
+	t.Run("Read fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyL7AccessProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalL7ProfileData())
+
+		err := resourceNsxtPolicyL7AccessProfileRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyL7AccessProfileDelete(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupL7ProfileMock(t, ctrl)
+	defer restore()
+
+	t.Run("Delete success", func(t *testing.T) {
+		mockSDK.EXPECT().Delete(l7ProfileID, gomock.Any()).Return(nil)
+
+		res := resourceNsxtPolicyL7AccessProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalL7ProfileData())
+		d.SetId(l7ProfileID)
+
+		err := resourceNsxtPolicyL7AccessProfileDelete(d, newGoMockProviderClient())
+		require.NoError(t, err)
+	})
+
+	t.Run("Delete fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyL7AccessProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalL7ProfileData())
+
+		err := resourceNsxtPolicyL7AccessProfileDelete(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}

--- a/nsxt/utgomock_resource_nsxt_policy_lb_client_ssl_profile_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_lb_client_ssl_profile_test.go
@@ -1,0 +1,186 @@
+//go:build unittest
+
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package nsxt
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	vapiErrors "github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
+	vapiProtocolClient "github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
+	nsxModel "github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+
+	infraapi "github.com/vmware/terraform-provider-nsxt/api/infra"
+	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
+	infraMocks "github.com/vmware/terraform-provider-nsxt/mocks/infra"
+)
+
+var (
+	lbClientSslID          = "lb-client-ssl-1"
+	lbClientSslDisplayName = "Test LB Client SSL Profile"
+	lbClientSslDescription = "Test lb client ssl profile"
+	lbClientSslRevision    = int64(1)
+)
+
+func lbClientSslAPIResponse() nsxModel.LBClientSslProfile {
+	return nsxModel.LBClientSslProfile{
+		Id:          &lbClientSslID,
+		DisplayName: &lbClientSslDisplayName,
+		Description: &lbClientSslDescription,
+		Revision:    &lbClientSslRevision,
+	}
+}
+
+func minimalLBClientSslData() map[string]interface{} {
+	return map[string]interface{}{
+		"display_name": lbClientSslDisplayName,
+		"description":  lbClientSslDescription,
+		"nsx_id":       lbClientSslID,
+	}
+}
+
+func setupLBClientSslMock(t *testing.T, ctrl *gomock.Controller) (*infraMocks.MockLbClientSslProfilesClient, func()) {
+	mockSDK := infraMocks.NewMockLbClientSslProfilesClient(ctrl)
+	mockWrapper := &infraapi.LBClientSslProfileClientContext{
+		Client:     mockSDK,
+		ClientType: utl.Local,
+	}
+	original := cliLbClientSslProfilesClient
+	cliLbClientSslProfilesClient = func(_ utl.SessionContext, _ vapiProtocolClient.Connector) *infraapi.LBClientSslProfileClientContext {
+		return mockWrapper
+	}
+	return mockSDK, func() { cliLbClientSslProfilesClient = original }
+}
+
+func TestMockResourceNsxtPolicyLBClientSslProfileCreate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupLBClientSslMock(t, ctrl)
+	defer restore()
+
+	t.Run("Create success", func(t *testing.T) {
+		gomock.InOrder(
+			mockSDK.EXPECT().Get(lbClientSslID).Return(nsxModel.LBClientSslProfile{}, vapiErrors.NotFound{}),
+			mockSDK.EXPECT().Patch(lbClientSslID, gomock.Any()).Return(nil),
+			mockSDK.EXPECT().Get(lbClientSslID).Return(lbClientSslAPIResponse(), nil),
+		)
+
+		res := resourceNsxtPolicyLBClientSslProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBClientSslData())
+
+		err := resourceNsxtPolicyLBClientSslProfileCreate(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, lbClientSslID, d.Id())
+	})
+
+	t.Run("Create fails when already exists", func(t *testing.T) {
+		mockSDK.EXPECT().Get(lbClientSslID).Return(lbClientSslAPIResponse(), nil)
+
+		res := resourceNsxtPolicyLBClientSslProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBClientSslData())
+
+		err := resourceNsxtPolicyLBClientSslProfileCreate(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyLBClientSslProfileRead(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupLBClientSslMock(t, ctrl)
+	defer restore()
+
+	t.Run("Read success", func(t *testing.T) {
+		mockSDK.EXPECT().Get(lbClientSslID).Return(lbClientSslAPIResponse(), nil)
+
+		res := resourceNsxtPolicyLBClientSslProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBClientSslData())
+		d.SetId(lbClientSslID)
+
+		err := resourceNsxtPolicyLBClientSslProfileRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, lbClientSslDisplayName, d.Get("display_name"))
+	})
+
+	t.Run("Read not found clears ID", func(t *testing.T) {
+		mockSDK.EXPECT().Get(lbClientSslID).Return(nsxModel.LBClientSslProfile{}, vapiErrors.NotFound{})
+
+		res := resourceNsxtPolicyLBClientSslProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBClientSslData())
+		d.SetId(lbClientSslID)
+
+		err := resourceNsxtPolicyLBClientSslProfileRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, "", d.Id())
+	})
+
+	t.Run("Read fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyLBClientSslProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBClientSslData())
+
+		err := resourceNsxtPolicyLBClientSslProfileRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyLBClientSslProfileUpdate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupLBClientSslMock(t, ctrl)
+	defer restore()
+
+	t.Run("Update success", func(t *testing.T) {
+		gomock.InOrder(
+			mockSDK.EXPECT().Patch(lbClientSslID, gomock.Any()).Return(nil),
+			mockSDK.EXPECT().Get(lbClientSslID).Return(lbClientSslAPIResponse(), nil),
+		)
+
+		res := resourceNsxtPolicyLBClientSslProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBClientSslData())
+		d.SetId(lbClientSslID)
+
+		err := resourceNsxtPolicyLBClientSslProfileUpdate(d, newGoMockProviderClient())
+		require.NoError(t, err)
+	})
+
+	t.Run("Update fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyLBClientSslProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBClientSslData())
+
+		err := resourceNsxtPolicyLBClientSslProfileUpdate(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyLBClientSslProfileDelete(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupLBClientSslMock(t, ctrl)
+	defer restore()
+
+	t.Run("Delete success", func(t *testing.T) {
+		mockSDK.EXPECT().Delete(lbClientSslID, gomock.Any()).Return(nil)
+
+		res := resourceNsxtPolicyLBClientSslProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBClientSslData())
+		d.SetId(lbClientSslID)
+
+		err := resourceNsxtPolicyLBClientSslProfileDelete(d, newGoMockProviderClient())
+		require.NoError(t, err)
+	})
+
+	t.Run("Delete fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyLBClientSslProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBClientSslData())
+
+		err := resourceNsxtPolicyLBClientSslProfileDelete(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}

--- a/nsxt/utgomock_resource_nsxt_policy_lb_cookie_persistence_profile_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_lb_cookie_persistence_profile_test.go
@@ -1,0 +1,144 @@
+//go:build unittest
+
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package nsxt
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	vapiErrors "github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
+	vapiProtocolClient "github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
+
+	infraapi "github.com/vmware/terraform-provider-nsxt/api/infra"
+	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
+	infraMocks "github.com/vmware/terraform-provider-nsxt/mocks/infra"
+)
+
+var (
+	lbCookieID          = "lb-cookie-1"
+	lbCookieDisplayName = "Test LB Cookie Persistence Profile"
+)
+
+func minimalLBCookieData() map[string]interface{} {
+	return map[string]interface{}{
+		"display_name": lbCookieDisplayName,
+		"nsx_id":       lbCookieID,
+	}
+}
+
+func setupLBPersistenceProfileMock(t *testing.T, ctrl *gomock.Controller) (*infraMocks.MockLbPersistenceProfilesClient, func()) {
+	mockSDK := infraMocks.NewMockLbPersistenceProfilesClient(ctrl)
+	mockWrapper := &infraapi.LBPersistenceProfileClientContext{
+		Client:     mockSDK,
+		ClientType: utl.Local,
+	}
+	original := cliLbPersistenceProfilesClient
+	cliLbPersistenceProfilesClient = func(_ utl.SessionContext, _ vapiProtocolClient.Connector) *infraapi.LBPersistenceProfileClientContext {
+		return mockWrapper
+	}
+	return mockSDK, func() { cliLbPersistenceProfilesClient = original }
+}
+
+func TestMockResourceNsxtPolicyLBCookiePersistenceProfileCreate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupLBPersistenceProfileMock(t, ctrl)
+	defer restore()
+
+	t.Run("Create fails when already exists", func(t *testing.T) {
+		mockSDK.EXPECT().Get(lbCookieID).Return(nil, nil)
+
+		res := resourceNsxtPolicyLBCookiePersistenceProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBCookieData())
+
+		err := resourceNsxtPolicyLBCookiePersistenceProfileCreate(d, newGoMockProviderClient())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "already exists")
+	})
+}
+
+func TestMockResourceNsxtPolicyLBCookiePersistenceProfileRead(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupLBPersistenceProfileMock(t, ctrl)
+	defer restore()
+
+	t.Run("Read not found clears ID", func(t *testing.T) {
+		mockSDK.EXPECT().Get(lbCookieID).Return(nil, vapiErrors.NotFound{})
+
+		res := resourceNsxtPolicyLBCookiePersistenceProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBCookieData())
+		d.SetId(lbCookieID)
+
+		err := resourceNsxtPolicyLBCookiePersistenceProfileRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, "", d.Id())
+	})
+
+	t.Run("Read API error is propagated", func(t *testing.T) {
+		mockSDK.EXPECT().Get(lbCookieID).Return(nil, vapiErrors.InternalServerError{})
+
+		res := resourceNsxtPolicyLBCookiePersistenceProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBCookieData())
+		d.SetId(lbCookieID)
+
+		err := resourceNsxtPolicyLBCookiePersistenceProfileRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+
+	t.Run("Read fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyLBCookiePersistenceProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBCookieData())
+
+		err := resourceNsxtPolicyLBCookiePersistenceProfileRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyLBCookiePersistenceProfileUpdate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	_, restore := setupLBPersistenceProfileMock(t, ctrl)
+	defer restore()
+
+	t.Run("Update fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyLBCookiePersistenceProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBCookieData())
+
+		err := resourceNsxtPolicyLBCookiePersistenceProfileUpdate(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyLBCookiePersistenceProfileDelete(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupLBPersistenceProfileMock(t, ctrl)
+	defer restore()
+
+	t.Run("Delete success", func(t *testing.T) {
+		mockSDK.EXPECT().Delete(lbCookieID, gomock.Any()).Return(nil)
+
+		res := resourceNsxtPolicyLBCookiePersistenceProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBCookieData())
+		d.SetId(lbCookieID)
+
+		err := resourceNsxtPolicyLBPersistenceProfileDelete(d, newGoMockProviderClient())
+		require.NoError(t, err)
+	})
+
+	t.Run("Delete fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyLBCookiePersistenceProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBCookieData())
+
+		err := resourceNsxtPolicyLBPersistenceProfileDelete(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}

--- a/nsxt/utgomock_resource_nsxt_policy_lb_fast_tcp_application_profile_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_lb_fast_tcp_application_profile_test.go
@@ -1,0 +1,145 @@
+//go:build unittest
+
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package nsxt
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	vapiErrors "github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
+	vapiProtocolClient "github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
+
+	infraapi "github.com/vmware/terraform-provider-nsxt/api/infra"
+	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
+	infraMocks "github.com/vmware/terraform-provider-nsxt/mocks/infra"
+)
+
+var (
+	lbFastTcpID          = "lb-fast-tcp-1"
+	lbFastTcpDisplayName = "Test LB Fast TCP Profile"
+)
+
+func minimalLBFastTcpData() map[string]interface{} {
+	return map[string]interface{}{
+		"display_name": lbFastTcpDisplayName,
+		"nsx_id":       lbFastTcpID,
+	}
+}
+
+func setupLBAppProfileMock(t *testing.T, ctrl *gomock.Controller) (*infraMocks.MockLbAppProfilesClient, func()) {
+	mockSDK := infraMocks.NewMockLbAppProfilesClient(ctrl)
+	mockWrapper := &infraapi.LBAppProfileClientContext{
+		Client:     mockSDK,
+		ClientType: utl.Local,
+	}
+	original := cliLbAppProfilesClient
+	cliLbAppProfilesClient = func(_ utl.SessionContext, _ vapiProtocolClient.Connector) *infraapi.LBAppProfileClientContext {
+		return mockWrapper
+	}
+	return mockSDK, func() { cliLbAppProfilesClient = original }
+}
+
+func TestMockResourceNsxtPolicyLBFastTcpApplicationProfileCreate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupLBAppProfileMock(t, ctrl)
+	defer restore()
+
+	t.Run("Create fails when already exists", func(t *testing.T) {
+		// Return nil error but non-nil struct to indicate object exists
+		mockSDK.EXPECT().Get(lbFastTcpID).Return(nil, nil)
+
+		res := resourceNsxtPolicyLBFastTcpApplicationProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBFastTcpData())
+
+		err := resourceNsxtPolicyLBTcpApplicationProfileCreate(d, newGoMockProviderClient())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "already exists")
+	})
+}
+
+func TestMockResourceNsxtPolicyLBFastTcpApplicationProfileRead(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupLBAppProfileMock(t, ctrl)
+	defer restore()
+
+	t.Run("Read not found clears ID", func(t *testing.T) {
+		mockSDK.EXPECT().Get(lbFastTcpID).Return(nil, vapiErrors.NotFound{})
+
+		res := resourceNsxtPolicyLBFastTcpApplicationProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBFastTcpData())
+		d.SetId(lbFastTcpID)
+
+		err := resourceNsxtPolicyLBTcpApplicationProfileRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, "", d.Id())
+	})
+
+	t.Run("Read API error is propagated", func(t *testing.T) {
+		mockSDK.EXPECT().Get(lbFastTcpID).Return(nil, vapiErrors.InternalServerError{})
+
+		res := resourceNsxtPolicyLBFastTcpApplicationProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBFastTcpData())
+		d.SetId(lbFastTcpID)
+
+		err := resourceNsxtPolicyLBTcpApplicationProfileRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+
+	t.Run("Read fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyLBFastTcpApplicationProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBFastTcpData())
+
+		err := resourceNsxtPolicyLBTcpApplicationProfileRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyLBFastTcpApplicationProfileUpdate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	_, restore := setupLBAppProfileMock(t, ctrl)
+	defer restore()
+
+	t.Run("Update fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyLBFastTcpApplicationProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBFastTcpData())
+
+		err := resourceNsxtPolicyLBTcpApplicationProfileUpdate(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyLBFastTcpApplicationProfileDelete(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupLBAppProfileMock(t, ctrl)
+	defer restore()
+
+	t.Run("Delete success", func(t *testing.T) {
+		mockSDK.EXPECT().Delete(lbFastTcpID, gomock.Any()).Return(nil)
+
+		res := resourceNsxtPolicyLBFastTcpApplicationProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBFastTcpData())
+		d.SetId(lbFastTcpID)
+
+		err := resourceNsxtPolicyLBTcpApplicationProfileDelete(d, newGoMockProviderClient())
+		require.NoError(t, err)
+	})
+
+	t.Run("Delete fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyLBFastTcpApplicationProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBFastTcpData())
+
+		err := resourceNsxtPolicyLBTcpApplicationProfileDelete(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}

--- a/nsxt/utgomock_resource_nsxt_policy_lb_fast_udp_application_profile_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_lb_fast_udp_application_profile_test.go
@@ -1,0 +1,126 @@
+//go:build unittest
+
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package nsxt
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	vapiErrors "github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
+)
+
+var (
+	lbFastUdpID          = "lb-fast-udp-1"
+	lbFastUdpDisplayName = "Test LB Fast UDP Profile"
+)
+
+func minimalLBFastUdpData() map[string]interface{} {
+	return map[string]interface{}{
+		"display_name": lbFastUdpDisplayName,
+		"nsx_id":       lbFastUdpID,
+	}
+}
+
+func TestMockResourceNsxtPolicyLBFastUdpApplicationProfileCreate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupLBAppProfileMock(t, ctrl)
+	defer restore()
+
+	t.Run("Create fails when already exists", func(t *testing.T) {
+		mockSDK.EXPECT().Get(lbFastUdpID).Return(nil, nil)
+
+		res := resourceNsxtPolicyLBFastUdpApplicationProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBFastUdpData())
+
+		err := resourceNsxtPolicyLBUdpApplicationProfileCreate(d, newGoMockProviderClient())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "already exists")
+	})
+}
+
+func TestMockResourceNsxtPolicyLBFastUdpApplicationProfileRead(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupLBAppProfileMock(t, ctrl)
+	defer restore()
+
+	t.Run("Read not found clears ID", func(t *testing.T) {
+		mockSDK.EXPECT().Get(lbFastUdpID).Return(nil, vapiErrors.NotFound{})
+
+		res := resourceNsxtPolicyLBFastUdpApplicationProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBFastUdpData())
+		d.SetId(lbFastUdpID)
+
+		err := resourceNsxtPolicyLBUdpApplicationProfileRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, "", d.Id())
+	})
+
+	t.Run("Read API error is propagated", func(t *testing.T) {
+		mockSDK.EXPECT().Get(lbFastUdpID).Return(nil, vapiErrors.InternalServerError{})
+
+		res := resourceNsxtPolicyLBFastUdpApplicationProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBFastUdpData())
+		d.SetId(lbFastUdpID)
+
+		err := resourceNsxtPolicyLBUdpApplicationProfileRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+
+	t.Run("Read fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyLBFastUdpApplicationProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBFastUdpData())
+
+		err := resourceNsxtPolicyLBUdpApplicationProfileRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyLBFastUdpApplicationProfileUpdate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	_, restore := setupLBAppProfileMock(t, ctrl)
+	defer restore()
+
+	t.Run("Update fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyLBFastUdpApplicationProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBFastUdpData())
+
+		err := resourceNsxtPolicyLBUdpApplicationProfileUpdate(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyLBFastUdpApplicationProfileDelete(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupLBAppProfileMock(t, ctrl)
+	defer restore()
+
+	t.Run("Delete success", func(t *testing.T) {
+		mockSDK.EXPECT().Delete(lbFastUdpID, gomock.Any()).Return(nil)
+
+		res := resourceNsxtPolicyLBFastUdpApplicationProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBFastUdpData())
+		d.SetId(lbFastUdpID)
+
+		err := resourceNsxtPolicyLBUdpApplicationProfileDelete(d, newGoMockProviderClient())
+		require.NoError(t, err)
+	})
+
+	t.Run("Delete fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyLBFastUdpApplicationProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBFastUdpData())
+
+		err := resourceNsxtPolicyLBUdpApplicationProfileDelete(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}

--- a/nsxt/utgomock_resource_nsxt_policy_lb_generic_persistence_profile_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_lb_generic_persistence_profile_test.go
@@ -1,0 +1,126 @@
+//go:build unittest
+
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package nsxt
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	vapiErrors "github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
+)
+
+var (
+	lbGenericPersistID          = "lb-generic-persist-1"
+	lbGenericPersistDisplayName = "Test LB Generic Persistence Profile"
+)
+
+func minimalLBGenericPersistData() map[string]interface{} {
+	return map[string]interface{}{
+		"display_name": lbGenericPersistDisplayName,
+		"nsx_id":       lbGenericPersistID,
+	}
+}
+
+func TestMockResourceNsxtPolicyLBGenericPersistenceProfileCreate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupLBPersistenceProfileMock(t, ctrl)
+	defer restore()
+
+	t.Run("Create fails when already exists", func(t *testing.T) {
+		mockSDK.EXPECT().Get(lbGenericPersistID).Return(nil, nil)
+
+		res := resourceNsxtPolicyLBGenericPersistenceProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBGenericPersistData())
+
+		err := resourceNsxtPolicyLBGenericPersistenceProfileCreate(d, newGoMockProviderClient())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "already exists")
+	})
+}
+
+func TestMockResourceNsxtPolicyLBGenericPersistenceProfileRead(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupLBPersistenceProfileMock(t, ctrl)
+	defer restore()
+
+	t.Run("Read not found clears ID", func(t *testing.T) {
+		mockSDK.EXPECT().Get(lbGenericPersistID).Return(nil, vapiErrors.NotFound{})
+
+		res := resourceNsxtPolicyLBGenericPersistenceProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBGenericPersistData())
+		d.SetId(lbGenericPersistID)
+
+		err := resourceNsxtPolicyLBGenericPersistenceProfileRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, "", d.Id())
+	})
+
+	t.Run("Read API error is propagated", func(t *testing.T) {
+		mockSDK.EXPECT().Get(lbGenericPersistID).Return(nil, vapiErrors.InternalServerError{})
+
+		res := resourceNsxtPolicyLBGenericPersistenceProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBGenericPersistData())
+		d.SetId(lbGenericPersistID)
+
+		err := resourceNsxtPolicyLBGenericPersistenceProfileRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+
+	t.Run("Read fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyLBGenericPersistenceProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBGenericPersistData())
+
+		err := resourceNsxtPolicyLBGenericPersistenceProfileRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyLBGenericPersistenceProfileUpdate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	_, restore := setupLBPersistenceProfileMock(t, ctrl)
+	defer restore()
+
+	t.Run("Update fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyLBGenericPersistenceProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBGenericPersistData())
+
+		err := resourceNsxtPolicyLBGenericPersistenceProfileUpdate(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyLBGenericPersistenceProfileDelete(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupLBPersistenceProfileMock(t, ctrl)
+	defer restore()
+
+	t.Run("Delete success", func(t *testing.T) {
+		mockSDK.EXPECT().Delete(lbGenericPersistID, gomock.Any()).Return(nil)
+
+		res := resourceNsxtPolicyLBGenericPersistenceProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBGenericPersistData())
+		d.SetId(lbGenericPersistID)
+
+		err := resourceNsxtPolicyLBGenericPersistenceProfileDelete(d, newGoMockProviderClient())
+		require.NoError(t, err)
+	})
+
+	t.Run("Delete fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyLBGenericPersistenceProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBGenericPersistData())
+
+		err := resourceNsxtPolicyLBGenericPersistenceProfileDelete(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}

--- a/nsxt/utgomock_resource_nsxt_policy_lb_http_application_profile_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_lb_http_application_profile_test.go
@@ -1,0 +1,126 @@
+//go:build unittest
+
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package nsxt
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	vapiErrors "github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
+)
+
+var (
+	lbHttpAppID          = "lb-http-app-1"
+	lbHttpAppDisplayName = "Test LB HTTP App Profile"
+)
+
+func minimalLBHttpAppData() map[string]interface{} {
+	return map[string]interface{}{
+		"display_name": lbHttpAppDisplayName,
+		"nsx_id":       lbHttpAppID,
+	}
+}
+
+func TestMockResourceNsxtPolicyLBHttpApplicationProfileCreate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupLBAppProfileMock(t, ctrl)
+	defer restore()
+
+	t.Run("Create fails when already exists", func(t *testing.T) {
+		mockSDK.EXPECT().Get(lbHttpAppID).Return(nil, nil)
+
+		res := resourceNsxtPolicyLBHttpApplicationProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBHttpAppData())
+
+		err := resourceNsxtPolicyLBHttpApplicationProfileCreate(d, newGoMockProviderClient())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "already exists")
+	})
+}
+
+func TestMockResourceNsxtPolicyLBHttpApplicationProfileRead(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupLBAppProfileMock(t, ctrl)
+	defer restore()
+
+	t.Run("Read not found clears ID", func(t *testing.T) {
+		mockSDK.EXPECT().Get(lbHttpAppID).Return(nil, vapiErrors.NotFound{})
+
+		res := resourceNsxtPolicyLBHttpApplicationProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBHttpAppData())
+		d.SetId(lbHttpAppID)
+
+		err := resourceNsxtPolicyLBHttpApplicationProfileRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, "", d.Id())
+	})
+
+	t.Run("Read API error is propagated", func(t *testing.T) {
+		mockSDK.EXPECT().Get(lbHttpAppID).Return(nil, vapiErrors.InternalServerError{})
+
+		res := resourceNsxtPolicyLBHttpApplicationProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBHttpAppData())
+		d.SetId(lbHttpAppID)
+
+		err := resourceNsxtPolicyLBHttpApplicationProfileRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+
+	t.Run("Read fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyLBHttpApplicationProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBHttpAppData())
+
+		err := resourceNsxtPolicyLBHttpApplicationProfileRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyLBHttpApplicationProfileUpdate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	_, restore := setupLBAppProfileMock(t, ctrl)
+	defer restore()
+
+	t.Run("Update fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyLBHttpApplicationProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBHttpAppData())
+
+		err := resourceNsxtPolicyLBHttpApplicationProfileUpdate(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyLBHttpApplicationProfileDelete(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupLBAppProfileMock(t, ctrl)
+	defer restore()
+
+	t.Run("Delete success", func(t *testing.T) {
+		mockSDK.EXPECT().Delete(lbHttpAppID, gomock.Any()).Return(nil)
+
+		res := resourceNsxtPolicyLBHttpApplicationProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBHttpAppData())
+		d.SetId(lbHttpAppID)
+
+		err := resourceNsxtPolicyLBHttpApplicationProfileDelete(d, newGoMockProviderClient())
+		require.NoError(t, err)
+	})
+
+	t.Run("Delete fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyLBHttpApplicationProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBHttpAppData())
+
+		err := resourceNsxtPolicyLBHttpApplicationProfileDelete(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}

--- a/nsxt/utgomock_resource_nsxt_policy_lb_http_monitor_profile_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_lb_http_monitor_profile_test.go
@@ -1,0 +1,144 @@
+//go:build unittest
+
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package nsxt
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	vapiErrors "github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
+	vapiProtocolClient "github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
+
+	infraapi "github.com/vmware/terraform-provider-nsxt/api/infra"
+	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
+	infraMocks "github.com/vmware/terraform-provider-nsxt/mocks/infra"
+)
+
+var (
+	lbHttpMonitorID          = "lb-http-monitor-1"
+	lbHttpMonitorDisplayName = "Test LB HTTP Monitor Profile"
+)
+
+func minimalLBHttpMonitorData() map[string]interface{} {
+	return map[string]interface{}{
+		"display_name": lbHttpMonitorDisplayName,
+		"nsx_id":       lbHttpMonitorID,
+	}
+}
+
+func setupLBMonitorProfileMock(t *testing.T, ctrl *gomock.Controller) (*infraMocks.MockLbMonitorProfilesClient, func()) {
+	mockSDK := infraMocks.NewMockLbMonitorProfilesClient(ctrl)
+	mockWrapper := &infraapi.LBMonitorProfileClientContext{
+		Client:     mockSDK,
+		ClientType: utl.Local,
+	}
+	original := cliLbMonitorProfilesClient
+	cliLbMonitorProfilesClient = func(_ utl.SessionContext, _ vapiProtocolClient.Connector) *infraapi.LBMonitorProfileClientContext {
+		return mockWrapper
+	}
+	return mockSDK, func() { cliLbMonitorProfilesClient = original }
+}
+
+func TestMockResourceNsxtPolicyLBHttpMonitorProfileCreate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupLBMonitorProfileMock(t, ctrl)
+	defer restore()
+
+	t.Run("Create fails when already exists", func(t *testing.T) {
+		mockSDK.EXPECT().Get(lbHttpMonitorID).Return(nil, nil)
+
+		res := resourceNsxtPolicyLBHttpMonitorProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBHttpMonitorData())
+
+		err := resourceNsxtPolicyLBHttpMonitorProfileCreate(d, newGoMockProviderClient())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "already exists")
+	})
+}
+
+func TestMockResourceNsxtPolicyLBHttpMonitorProfileRead(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupLBMonitorProfileMock(t, ctrl)
+	defer restore()
+
+	t.Run("Read not found clears ID", func(t *testing.T) {
+		mockSDK.EXPECT().Get(lbHttpMonitorID).Return(nil, vapiErrors.NotFound{})
+
+		res := resourceNsxtPolicyLBHttpMonitorProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBHttpMonitorData())
+		d.SetId(lbHttpMonitorID)
+
+		err := resourceNsxtPolicyLBHttpMonitorProfileRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, "", d.Id())
+	})
+
+	t.Run("Read API error is propagated", func(t *testing.T) {
+		mockSDK.EXPECT().Get(lbHttpMonitorID).Return(nil, vapiErrors.InternalServerError{})
+
+		res := resourceNsxtPolicyLBHttpMonitorProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBHttpMonitorData())
+		d.SetId(lbHttpMonitorID)
+
+		err := resourceNsxtPolicyLBHttpMonitorProfileRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+
+	t.Run("Read fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyLBHttpMonitorProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBHttpMonitorData())
+
+		err := resourceNsxtPolicyLBHttpMonitorProfileRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyLBHttpMonitorProfileUpdate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	_, restore := setupLBMonitorProfileMock(t, ctrl)
+	defer restore()
+
+	t.Run("Update fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyLBHttpMonitorProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBHttpMonitorData())
+
+		err := resourceNsxtPolicyLBHttpMonitorProfileUpdate(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyLBHttpMonitorProfileDelete(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupLBMonitorProfileMock(t, ctrl)
+	defer restore()
+
+	t.Run("Delete success", func(t *testing.T) {
+		mockSDK.EXPECT().Delete(lbHttpMonitorID, gomock.Any()).Return(nil)
+
+		res := resourceNsxtPolicyLBHttpMonitorProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBHttpMonitorData())
+		d.SetId(lbHttpMonitorID)
+
+		err := resourceNsxtPolicyLBHttpMonitorProfileDelete(d, newGoMockProviderClient())
+		require.NoError(t, err)
+	})
+
+	t.Run("Delete fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyLBHttpMonitorProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBHttpMonitorData())
+
+		err := resourceNsxtPolicyLBHttpMonitorProfileDelete(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}

--- a/nsxt/utgomock_resource_nsxt_policy_lb_https_monitor_profile_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_lb_https_monitor_profile_test.go
@@ -1,0 +1,115 @@
+//go:build unittest
+
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package nsxt
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	vapiErrors "github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
+)
+
+var (
+	lbHttpsMonitorID          = "lb-https-monitor-1"
+	lbHttpsMonitorDisplayName = "Test LB HTTPS Monitor Profile"
+)
+
+func minimalLBHttpsMonitorData() map[string]interface{} {
+	return map[string]interface{}{
+		"display_name": lbHttpsMonitorDisplayName,
+		"nsx_id":       lbHttpsMonitorID,
+	}
+}
+
+func TestMockResourceNsxtPolicyLBHttpsMonitorProfileCreate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupLBMonitorProfileMock(t, ctrl)
+	defer restore()
+
+	t.Run("Create fails when already exists", func(t *testing.T) {
+		mockSDK.EXPECT().Get(lbHttpsMonitorID).Return(nil, nil)
+
+		res := resourceNsxtPolicyLBHttpsMonitorProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBHttpsMonitorData())
+
+		err := resourceNsxtPolicyLBHttpsMonitorProfileCreate(d, newGoMockProviderClient())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "already exists")
+	})
+}
+
+func TestMockResourceNsxtPolicyLBHttpsMonitorProfileRead(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupLBMonitorProfileMock(t, ctrl)
+	defer restore()
+
+	t.Run("Read not found clears ID", func(t *testing.T) {
+		mockSDK.EXPECT().Get(lbHttpsMonitorID).Return(nil, vapiErrors.NotFound{})
+
+		res := resourceNsxtPolicyLBHttpsMonitorProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBHttpsMonitorData())
+		d.SetId(lbHttpsMonitorID)
+
+		err := resourceNsxtPolicyLBHttpsMonitorProfileRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, "", d.Id())
+	})
+
+	t.Run("Read fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyLBHttpsMonitorProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBHttpsMonitorData())
+
+		err := resourceNsxtPolicyLBHttpsMonitorProfileRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyLBHttpsMonitorProfileUpdate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	_, restore := setupLBMonitorProfileMock(t, ctrl)
+	defer restore()
+
+	t.Run("Update fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyLBHttpsMonitorProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBHttpsMonitorData())
+
+		err := resourceNsxtPolicyLBHttpsMonitorProfileUpdate(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyLBHttpsMonitorProfileDelete(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupLBMonitorProfileMock(t, ctrl)
+	defer restore()
+
+	t.Run("Delete success", func(t *testing.T) {
+		mockSDK.EXPECT().Delete(lbHttpsMonitorID, gomock.Any()).Return(nil)
+
+		res := resourceNsxtPolicyLBHttpsMonitorProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBHttpsMonitorData())
+		d.SetId(lbHttpsMonitorID)
+
+		err := resourceNsxtPolicyLBHttpsMonitorProfileDelete(d, newGoMockProviderClient())
+		require.NoError(t, err)
+	})
+
+	t.Run("Delete fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyLBHttpsMonitorProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBHttpsMonitorData())
+
+		err := resourceNsxtPolicyLBHttpsMonitorProfileDelete(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}

--- a/nsxt/utgomock_resource_nsxt_policy_lb_icmp_monitor_profile_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_lb_icmp_monitor_profile_test.go
@@ -1,0 +1,115 @@
+//go:build unittest
+
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package nsxt
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	vapiErrors "github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
+)
+
+var (
+	lbIcmpMonitorID          = "lb-icmp-monitor-1"
+	lbIcmpMonitorDisplayName = "Test LB ICMP Monitor Profile"
+)
+
+func minimalLBIcmpMonitorData() map[string]interface{} {
+	return map[string]interface{}{
+		"display_name": lbIcmpMonitorDisplayName,
+		"nsx_id":       lbIcmpMonitorID,
+	}
+}
+
+func TestMockResourceNsxtPolicyLBIcmpMonitorProfileCreate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupLBMonitorProfileMock(t, ctrl)
+	defer restore()
+
+	t.Run("Create fails when already exists", func(t *testing.T) {
+		mockSDK.EXPECT().Get(lbIcmpMonitorID).Return(nil, nil)
+
+		res := resourceNsxtPolicyLBIcmpMonitorProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBIcmpMonitorData())
+
+		err := resourceNsxtPolicyLBIcmpMonitorProfileCreate(d, newGoMockProviderClient())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "already exists")
+	})
+}
+
+func TestMockResourceNsxtPolicyLBIcmpMonitorProfileRead(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupLBMonitorProfileMock(t, ctrl)
+	defer restore()
+
+	t.Run("Read not found clears ID", func(t *testing.T) {
+		mockSDK.EXPECT().Get(lbIcmpMonitorID).Return(nil, vapiErrors.NotFound{})
+
+		res := resourceNsxtPolicyLBIcmpMonitorProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBIcmpMonitorData())
+		d.SetId(lbIcmpMonitorID)
+
+		err := resourceNsxtPolicyLBIcmpMonitorProfileRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, "", d.Id())
+	})
+
+	t.Run("Read fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyLBIcmpMonitorProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBIcmpMonitorData())
+
+		err := resourceNsxtPolicyLBIcmpMonitorProfileRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyLBIcmpMonitorProfileUpdate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	_, restore := setupLBMonitorProfileMock(t, ctrl)
+	defer restore()
+
+	t.Run("Update fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyLBIcmpMonitorProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBIcmpMonitorData())
+
+		err := resourceNsxtPolicyLBIcmpMonitorProfileUpdate(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyLBIcmpMonitorProfileDelete(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupLBMonitorProfileMock(t, ctrl)
+	defer restore()
+
+	t.Run("Delete success", func(t *testing.T) {
+		mockSDK.EXPECT().Delete(lbIcmpMonitorID, gomock.Any()).Return(nil)
+
+		res := resourceNsxtPolicyLBIcmpMonitorProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBIcmpMonitorData())
+		d.SetId(lbIcmpMonitorID)
+
+		err := resourceNsxtPolicyLBIcmpMonitorProfileDelete(d, newGoMockProviderClient())
+		require.NoError(t, err)
+	})
+
+	t.Run("Delete fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyLBIcmpMonitorProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBIcmpMonitorData())
+
+		err := resourceNsxtPolicyLBIcmpMonitorProfileDelete(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}

--- a/nsxt/utgomock_resource_nsxt_policy_lb_passive_monitor_profile_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_lb_passive_monitor_profile_test.go
@@ -1,0 +1,115 @@
+//go:build unittest
+
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package nsxt
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	vapiErrors "github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
+)
+
+var (
+	lbPassiveMonitorID          = "lb-passive-monitor-1"            //nolint:gosec
+	lbPassiveMonitorDisplayName = "Test LB Passive Monitor Profile" //nolint:gosec
+)
+
+func minimalLBPassiveMonitorData() map[string]interface{} {
+	return map[string]interface{}{
+		"display_name": lbPassiveMonitorDisplayName,
+		"nsx_id":       lbPassiveMonitorID,
+	}
+}
+
+func TestMockResourceNsxtPolicyLBPassiveMonitorProfileCreate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupLBMonitorProfileMock(t, ctrl)
+	defer restore()
+
+	t.Run("Create fails when already exists", func(t *testing.T) {
+		mockSDK.EXPECT().Get(lbPassiveMonitorID).Return(nil, nil)
+
+		res := resourceNsxtPolicyLBPassiveMonitorProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBPassiveMonitorData())
+
+		err := resourceNsxtPolicyLBPassiveMonitorProfileCreate(d, newGoMockProviderClient())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "already exists")
+	})
+}
+
+func TestMockResourceNsxtPolicyLBPassiveMonitorProfileRead(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupLBMonitorProfileMock(t, ctrl)
+	defer restore()
+
+	t.Run("Read not found clears ID", func(t *testing.T) {
+		mockSDK.EXPECT().Get(lbPassiveMonitorID).Return(nil, vapiErrors.NotFound{})
+
+		res := resourceNsxtPolicyLBPassiveMonitorProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBPassiveMonitorData())
+		d.SetId(lbPassiveMonitorID)
+
+		err := resourceNsxtPolicyLBPassiveMonitorProfileRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, "", d.Id())
+	})
+
+	t.Run("Read fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyLBPassiveMonitorProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBPassiveMonitorData())
+
+		err := resourceNsxtPolicyLBPassiveMonitorProfileRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyLBPassiveMonitorProfileUpdate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	_, restore := setupLBMonitorProfileMock(t, ctrl)
+	defer restore()
+
+	t.Run("Update fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyLBPassiveMonitorProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBPassiveMonitorData())
+
+		err := resourceNsxtPolicyLBPassiveMonitorProfileUpdate(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyLBPassiveMonitorProfileDelete(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupLBMonitorProfileMock(t, ctrl)
+	defer restore()
+
+	t.Run("Delete success", func(t *testing.T) {
+		mockSDK.EXPECT().Delete(lbPassiveMonitorID, gomock.Any()).Return(nil)
+
+		res := resourceNsxtPolicyLBPassiveMonitorProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBPassiveMonitorData())
+		d.SetId(lbPassiveMonitorID)
+
+		err := resourceNsxtPolicyLBPassiveMonitorProfileDelete(d, newGoMockProviderClient())
+		require.NoError(t, err)
+	})
+
+	t.Run("Delete fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyLBPassiveMonitorProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBPassiveMonitorData())
+
+		err := resourceNsxtPolicyLBPassiveMonitorProfileDelete(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}

--- a/nsxt/utgomock_resource_nsxt_policy_lb_pool_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_lb_pool_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_lb_server_ssl_profile_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_lb_server_ssl_profile_test.go
@@ -1,0 +1,186 @@
+//go:build unittest
+
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package nsxt
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	vapiErrors "github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
+	vapiProtocolClient "github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
+	nsxModel "github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+
+	infraapi "github.com/vmware/terraform-provider-nsxt/api/infra"
+	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
+	infraMocks "github.com/vmware/terraform-provider-nsxt/mocks/infra"
+)
+
+var (
+	lbServerSslID          = "lb-server-ssl-1"
+	lbServerSslDisplayName = "Test LB Server SSL Profile"
+	lbServerSslDescription = "Test lb server ssl profile"
+	lbServerSslRevision    = int64(1)
+)
+
+func lbServerSslAPIResponse() nsxModel.LBServerSslProfile {
+	return nsxModel.LBServerSslProfile{
+		Id:          &lbServerSslID,
+		DisplayName: &lbServerSslDisplayName,
+		Description: &lbServerSslDescription,
+		Revision:    &lbServerSslRevision,
+	}
+}
+
+func minimalLBServerSslData() map[string]interface{} {
+	return map[string]interface{}{
+		"display_name": lbServerSslDisplayName,
+		"description":  lbServerSslDescription,
+		"nsx_id":       lbServerSslID,
+	}
+}
+
+func setupLBServerSslMock(t *testing.T, ctrl *gomock.Controller) (*infraMocks.MockLbServerSslProfilesClient, func()) {
+	mockSDK := infraMocks.NewMockLbServerSslProfilesClient(ctrl)
+	mockWrapper := &infraapi.LBServerSslProfileClientContext{
+		Client:     mockSDK,
+		ClientType: utl.Local,
+	}
+	original := cliLbServerSslProfilesClient
+	cliLbServerSslProfilesClient = func(_ utl.SessionContext, _ vapiProtocolClient.Connector) *infraapi.LBServerSslProfileClientContext {
+		return mockWrapper
+	}
+	return mockSDK, func() { cliLbServerSslProfilesClient = original }
+}
+
+func TestMockResourceNsxtPolicyLBServerSslProfileCreate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupLBServerSslMock(t, ctrl)
+	defer restore()
+
+	t.Run("Create success", func(t *testing.T) {
+		gomock.InOrder(
+			mockSDK.EXPECT().Get(lbServerSslID).Return(nsxModel.LBServerSslProfile{}, vapiErrors.NotFound{}),
+			mockSDK.EXPECT().Patch(lbServerSslID, gomock.Any()).Return(nil),
+			mockSDK.EXPECT().Get(lbServerSslID).Return(lbServerSslAPIResponse(), nil),
+		)
+
+		res := resourceNsxtPolicyLBServerSslProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBServerSslData())
+
+		err := resourceNsxtPolicyLBServerSslProfileCreate(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, lbServerSslID, d.Id())
+	})
+
+	t.Run("Create fails when already exists", func(t *testing.T) {
+		mockSDK.EXPECT().Get(lbServerSslID).Return(lbServerSslAPIResponse(), nil)
+
+		res := resourceNsxtPolicyLBServerSslProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBServerSslData())
+
+		err := resourceNsxtPolicyLBServerSslProfileCreate(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyLBServerSslProfileRead(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupLBServerSslMock(t, ctrl)
+	defer restore()
+
+	t.Run("Read success", func(t *testing.T) {
+		mockSDK.EXPECT().Get(lbServerSslID).Return(lbServerSslAPIResponse(), nil)
+
+		res := resourceNsxtPolicyLBServerSslProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBServerSslData())
+		d.SetId(lbServerSslID)
+
+		err := resourceNsxtPolicyLBServerSslProfileRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, lbServerSslDisplayName, d.Get("display_name"))
+	})
+
+	t.Run("Read not found clears ID", func(t *testing.T) {
+		mockSDK.EXPECT().Get(lbServerSslID).Return(nsxModel.LBServerSslProfile{}, vapiErrors.NotFound{})
+
+		res := resourceNsxtPolicyLBServerSslProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBServerSslData())
+		d.SetId(lbServerSslID)
+
+		err := resourceNsxtPolicyLBServerSslProfileRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, "", d.Id())
+	})
+
+	t.Run("Read fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyLBServerSslProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBServerSslData())
+
+		err := resourceNsxtPolicyLBServerSslProfileRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyLBServerSslProfileUpdate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupLBServerSslMock(t, ctrl)
+	defer restore()
+
+	t.Run("Update success", func(t *testing.T) {
+		gomock.InOrder(
+			mockSDK.EXPECT().Update(lbServerSslID, gomock.Any()).Return(lbServerSslAPIResponse(), nil),
+			mockSDK.EXPECT().Get(lbServerSslID).Return(lbServerSslAPIResponse(), nil),
+		)
+
+		res := resourceNsxtPolicyLBServerSslProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBServerSslData())
+		d.SetId(lbServerSslID)
+
+		err := resourceNsxtPolicyLBServerSslProfileUpdate(d, newGoMockProviderClient())
+		require.NoError(t, err)
+	})
+
+	t.Run("Update fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyLBServerSslProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBServerSslData())
+
+		err := resourceNsxtPolicyLBServerSslProfileUpdate(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyLBServerSslProfileDelete(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupLBServerSslMock(t, ctrl)
+	defer restore()
+
+	t.Run("Delete success", func(t *testing.T) {
+		mockSDK.EXPECT().Delete(lbServerSslID, gomock.Any()).Return(nil)
+
+		res := resourceNsxtPolicyLBServerSslProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBServerSslData())
+		d.SetId(lbServerSslID)
+
+		err := resourceNsxtPolicyLBServerSslProfileDelete(d, newGoMockProviderClient())
+		require.NoError(t, err)
+	})
+
+	t.Run("Delete fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyLBServerSslProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBServerSslData())
+
+		err := resourceNsxtPolicyLBServerSslProfileDelete(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}

--- a/nsxt/utgomock_resource_nsxt_policy_lb_service_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_lb_service_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_lb_source_ip_persistence_profile_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_lb_source_ip_persistence_profile_test.go
@@ -1,0 +1,126 @@
+//go:build unittest
+
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package nsxt
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	vapiErrors "github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
+)
+
+var (
+	lbSourceIpID          = "lb-source-ip-1"
+	lbSourceIpDisplayName = "Test LB Source IP Persistence Profile"
+)
+
+func minimalLBSourceIpData() map[string]interface{} {
+	return map[string]interface{}{
+		"display_name": lbSourceIpDisplayName,
+		"nsx_id":       lbSourceIpID,
+	}
+}
+
+func TestMockResourceNsxtPolicyLBSourceIpPersistenceProfileCreate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupLBPersistenceProfileMock(t, ctrl)
+	defer restore()
+
+	t.Run("Create fails when already exists", func(t *testing.T) {
+		mockSDK.EXPECT().Get(lbSourceIpID).Return(nil, nil)
+
+		res := resourceNsxtPolicyLBSourceIpPersistenceProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBSourceIpData())
+
+		err := resourceNsxtPolicyLBSourceIpPersistenceProfileCreate(d, newGoMockProviderClient())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "already exists")
+	})
+}
+
+func TestMockResourceNsxtPolicyLBSourceIpPersistenceProfileRead(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupLBPersistenceProfileMock(t, ctrl)
+	defer restore()
+
+	t.Run("Read not found clears ID", func(t *testing.T) {
+		mockSDK.EXPECT().Get(lbSourceIpID).Return(nil, vapiErrors.NotFound{})
+
+		res := resourceNsxtPolicyLBSourceIpPersistenceProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBSourceIpData())
+		d.SetId(lbSourceIpID)
+
+		err := resourceNsxtPolicyLBSourceIpPersistenceProfileRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, "", d.Id())
+	})
+
+	t.Run("Read API error is propagated", func(t *testing.T) {
+		mockSDK.EXPECT().Get(lbSourceIpID).Return(nil, vapiErrors.InternalServerError{})
+
+		res := resourceNsxtPolicyLBSourceIpPersistenceProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBSourceIpData())
+		d.SetId(lbSourceIpID)
+
+		err := resourceNsxtPolicyLBSourceIpPersistenceProfileRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+
+	t.Run("Read fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyLBSourceIpPersistenceProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBSourceIpData())
+
+		err := resourceNsxtPolicyLBSourceIpPersistenceProfileRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyLBSourceIpPersistenceProfileUpdate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	_, restore := setupLBPersistenceProfileMock(t, ctrl)
+	defer restore()
+
+	t.Run("Update fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyLBSourceIpPersistenceProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBSourceIpData())
+
+		err := resourceNsxtPolicyLBSourceIpPersistenceProfileUpdate(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyLBSourceIpPersistenceProfileDelete(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupLBPersistenceProfileMock(t, ctrl)
+	defer restore()
+
+	t.Run("Delete success", func(t *testing.T) {
+		mockSDK.EXPECT().Delete(lbSourceIpID, gomock.Any()).Return(nil)
+
+		res := resourceNsxtPolicyLBSourceIpPersistenceProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBSourceIpData())
+		d.SetId(lbSourceIpID)
+
+		err := resourceNsxtPolicyLBSourceIpPersistenceProfileDelete(d, newGoMockProviderClient())
+		require.NoError(t, err)
+	})
+
+	t.Run("Delete fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyLBSourceIpPersistenceProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBSourceIpData())
+
+		err := resourceNsxtPolicyLBSourceIpPersistenceProfileDelete(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}

--- a/nsxt/utgomock_resource_nsxt_policy_lb_tcp_monitor_profile_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_lb_tcp_monitor_profile_test.go
@@ -1,0 +1,115 @@
+//go:build unittest
+
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package nsxt
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	vapiErrors "github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
+)
+
+var (
+	lbTcpMonitorID          = "lb-tcp-monitor-1"
+	lbTcpMonitorDisplayName = "Test LB TCP Monitor Profile"
+)
+
+func minimalLBTcpMonitorData() map[string]interface{} {
+	return map[string]interface{}{
+		"display_name": lbTcpMonitorDisplayName,
+		"nsx_id":       lbTcpMonitorID,
+	}
+}
+
+func TestMockResourceNsxtPolicyLBTcpMonitorProfileCreate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupLBMonitorProfileMock(t, ctrl)
+	defer restore()
+
+	t.Run("Create fails when already exists", func(t *testing.T) {
+		mockSDK.EXPECT().Get(lbTcpMonitorID).Return(nil, nil)
+
+		res := resourceNsxtPolicyLBTcpMonitorProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBTcpMonitorData())
+
+		err := resourceNsxtPolicyLBTcpMonitorProfileCreate(d, newGoMockProviderClient())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "already exists")
+	})
+}
+
+func TestMockResourceNsxtPolicyLBTcpMonitorProfileRead(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupLBMonitorProfileMock(t, ctrl)
+	defer restore()
+
+	t.Run("Read not found clears ID", func(t *testing.T) {
+		mockSDK.EXPECT().Get(lbTcpMonitorID).Return(nil, vapiErrors.NotFound{})
+
+		res := resourceNsxtPolicyLBTcpMonitorProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBTcpMonitorData())
+		d.SetId(lbTcpMonitorID)
+
+		err := resourceNsxtPolicyLBTcpMonitorProfileRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, "", d.Id())
+	})
+
+	t.Run("Read fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyLBTcpMonitorProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBTcpMonitorData())
+
+		err := resourceNsxtPolicyLBTcpMonitorProfileRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyLBTcpMonitorProfileUpdate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	_, restore := setupLBMonitorProfileMock(t, ctrl)
+	defer restore()
+
+	t.Run("Update fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyLBTcpMonitorProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBTcpMonitorData())
+
+		err := resourceNsxtPolicyLBTcpMonitorProfileUpdate(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyLBTcpMonitorProfileDelete(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupLBMonitorProfileMock(t, ctrl)
+	defer restore()
+
+	t.Run("Delete success", func(t *testing.T) {
+		mockSDK.EXPECT().Delete(lbTcpMonitorID, gomock.Any()).Return(nil)
+
+		res := resourceNsxtPolicyLBTcpMonitorProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBTcpMonitorData())
+		d.SetId(lbTcpMonitorID)
+
+		err := resourceNsxtPolicyLBTcpMonitorProfileDelete(d, newGoMockProviderClient())
+		require.NoError(t, err)
+	})
+
+	t.Run("Delete fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyLBTcpMonitorProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBTcpMonitorData())
+
+		err := resourceNsxtPolicyLBTcpMonitorProfileDelete(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}

--- a/nsxt/utgomock_resource_nsxt_policy_lb_udp_monitor_profile_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_lb_udp_monitor_profile_test.go
@@ -1,0 +1,115 @@
+//go:build unittest
+
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package nsxt
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	vapiErrors "github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
+)
+
+var (
+	lbUdpMonitorID          = "lb-udp-monitor-1"
+	lbUdpMonitorDisplayName = "Test LB UDP Monitor Profile"
+)
+
+func minimalLBUdpMonitorData() map[string]interface{} {
+	return map[string]interface{}{
+		"display_name": lbUdpMonitorDisplayName,
+		"nsx_id":       lbUdpMonitorID,
+	}
+}
+
+func TestMockResourceNsxtPolicyLBUdpMonitorProfileCreate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupLBMonitorProfileMock(t, ctrl)
+	defer restore()
+
+	t.Run("Create fails when already exists", func(t *testing.T) {
+		mockSDK.EXPECT().Get(lbUdpMonitorID).Return(nil, nil)
+
+		res := resourceNsxtPolicyLBUdpMonitorProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBUdpMonitorData())
+
+		err := resourceNsxtPolicyLBUdpMonitorProfileCreate(d, newGoMockProviderClient())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "already exists")
+	})
+}
+
+func TestMockResourceNsxtPolicyLBUdpMonitorProfileRead(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupLBMonitorProfileMock(t, ctrl)
+	defer restore()
+
+	t.Run("Read not found clears ID", func(t *testing.T) {
+		mockSDK.EXPECT().Get(lbUdpMonitorID).Return(nil, vapiErrors.NotFound{})
+
+		res := resourceNsxtPolicyLBUdpMonitorProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBUdpMonitorData())
+		d.SetId(lbUdpMonitorID)
+
+		err := resourceNsxtPolicyLBUdpMonitorProfileRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, "", d.Id())
+	})
+
+	t.Run("Read fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyLBUdpMonitorProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBUdpMonitorData())
+
+		err := resourceNsxtPolicyLBUdpMonitorProfileRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyLBUdpMonitorProfileUpdate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	_, restore := setupLBMonitorProfileMock(t, ctrl)
+	defer restore()
+
+	t.Run("Update fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyLBUdpMonitorProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBUdpMonitorData())
+
+		err := resourceNsxtPolicyLBUdpMonitorProfileUpdate(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyLBUdpMonitorProfileDelete(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupLBMonitorProfileMock(t, ctrl)
+	defer restore()
+
+	t.Run("Delete success", func(t *testing.T) {
+		mockSDK.EXPECT().Delete(lbUdpMonitorID, gomock.Any()).Return(nil)
+
+		res := resourceNsxtPolicyLBUdpMonitorProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBUdpMonitorData())
+		d.SetId(lbUdpMonitorID)
+
+		err := resourceNsxtPolicyLBUdpMonitorProfileDelete(d, newGoMockProviderClient())
+		require.NoError(t, err)
+	})
+
+	t.Run("Delete fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyLBUdpMonitorProfile()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBUdpMonitorData())
+
+		err := resourceNsxtPolicyLBUdpMonitorProfileDelete(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}

--- a/nsxt/utgomock_resource_nsxt_policy_lb_virtual_server_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_lb_virtual_server_test.go
@@ -1,0 +1,192 @@
+//go:build unittest
+
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package nsxt
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	vapiErrors "github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
+	vapiProtocolClient "github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
+	nsxModel "github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+
+	infraapi "github.com/vmware/terraform-provider-nsxt/api/infra"
+	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
+	infraMocks "github.com/vmware/terraform-provider-nsxt/mocks/infra"
+)
+
+var (
+	lbVsID          = "lb-vs-1"
+	lbVsDisplayName = "Test LB Virtual Server"
+	lbVsDescription = "Test lb virtual server"
+	lbVsRevision    = int64(1)
+	lbVsIPAddr      = "10.0.0.1"
+)
+
+func lbVsAPIResponse() nsxModel.LBVirtualServer {
+	return nsxModel.LBVirtualServer{
+		Id:          &lbVsID,
+		DisplayName: &lbVsDisplayName,
+		Description: &lbVsDescription,
+		Revision:    &lbVsRevision,
+		IpAddress:   &lbVsIPAddr,
+	}
+}
+
+func minimalLBVsData() map[string]interface{} {
+	return map[string]interface{}{
+		"display_name": lbVsDisplayName,
+		"description":  lbVsDescription,
+		"nsx_id":       lbVsID,
+		"ip_address":   lbVsIPAddr,
+		"ports":        []interface{}{"80"},
+	}
+}
+
+func setupLBVsMock(t *testing.T, ctrl *gomock.Controller) (*infraMocks.MockLbVirtualServersClient, func()) {
+	mockSDK := infraMocks.NewMockLbVirtualServersClient(ctrl)
+	mockWrapper := &infraapi.LBVirtualServerClientContext{
+		Client:     mockSDK,
+		ClientType: utl.Local,
+	}
+	original := cliLbVirtualServersClient
+	cliLbVirtualServersClient = func(_ utl.SessionContext, _ vapiProtocolClient.Connector) *infraapi.LBVirtualServerClientContext {
+		return mockWrapper
+	}
+	return mockSDK, func() { cliLbVirtualServersClient = original }
+}
+
+func TestMockResourceNsxtPolicyLBVirtualServerCreate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupLBVsMock(t, ctrl)
+	defer restore()
+
+	t.Run("Create success", func(t *testing.T) {
+		gomock.InOrder(
+			mockSDK.EXPECT().Get(lbVsID).Return(nsxModel.LBVirtualServer{}, vapiErrors.NotFound{}),
+			mockSDK.EXPECT().Patch(lbVsID, gomock.Any()).Return(nil),
+			mockSDK.EXPECT().Get(lbVsID).Return(lbVsAPIResponse(), nil),
+		)
+
+		res := resourceNsxtPolicyLBVirtualServer()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBVsData())
+
+		err := resourceNsxtPolicyLBVirtualServerCreate(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, lbVsID, d.Id())
+	})
+
+	t.Run("Create fails when already exists", func(t *testing.T) {
+		mockSDK.EXPECT().Get(lbVsID).Return(lbVsAPIResponse(), nil)
+
+		res := resourceNsxtPolicyLBVirtualServer()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBVsData())
+
+		err := resourceNsxtPolicyLBVirtualServerCreate(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyLBVirtualServerRead(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupLBVsMock(t, ctrl)
+	defer restore()
+
+	t.Run("Read success", func(t *testing.T) {
+		mockSDK.EXPECT().Get(lbVsID).Return(lbVsAPIResponse(), nil)
+
+		res := resourceNsxtPolicyLBVirtualServer()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBVsData())
+		d.SetId(lbVsID)
+
+		err := resourceNsxtPolicyLBVirtualServerRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, lbVsDisplayName, d.Get("display_name"))
+	})
+
+	t.Run("Read not found clears ID", func(t *testing.T) {
+		mockSDK.EXPECT().Get(lbVsID).Return(nsxModel.LBVirtualServer{}, vapiErrors.NotFound{})
+
+		res := resourceNsxtPolicyLBVirtualServer()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBVsData())
+		d.SetId(lbVsID)
+
+		err := resourceNsxtPolicyLBVirtualServerRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, "", d.Id())
+	})
+
+	t.Run("Read fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyLBVirtualServer()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBVsData())
+
+		err := resourceNsxtPolicyLBVirtualServerRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyLBVirtualServerUpdate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupLBVsMock(t, ctrl)
+	defer restore()
+
+	t.Run("Update success", func(t *testing.T) {
+		// Update: Get (for rule check when no rule change), Patch, then Get (read after update)
+		gomock.InOrder(
+			mockSDK.EXPECT().Get(lbVsID).Return(lbVsAPIResponse(), nil),
+			mockSDK.EXPECT().Patch(lbVsID, gomock.Any()).Return(nil),
+			mockSDK.EXPECT().Get(lbVsID).Return(lbVsAPIResponse(), nil),
+		)
+
+		res := resourceNsxtPolicyLBVirtualServer()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBVsData())
+		d.SetId(lbVsID)
+
+		err := resourceNsxtPolicyLBVirtualServerUpdate(d, newGoMockProviderClient())
+		require.NoError(t, err)
+	})
+
+	t.Run("Update fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyLBVirtualServer()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBVsData())
+
+		err := resourceNsxtPolicyLBVirtualServerUpdate(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyLBVirtualServerDelete(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupLBVsMock(t, ctrl)
+	defer restore()
+
+	t.Run("Delete success", func(t *testing.T) {
+		mockSDK.EXPECT().Delete(lbVsID, gomock.Any()).Return(nil)
+
+		res := resourceNsxtPolicyLBVirtualServer()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBVsData())
+		d.SetId(lbVsID)
+
+		err := resourceNsxtPolicyLBVirtualServerDelete(d, newGoMockProviderClient())
+		require.NoError(t, err)
+	})
+
+	t.Run("Delete fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyLBVirtualServer()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBVsData())
+
+		err := resourceNsxtPolicyLBVirtualServerDelete(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}

--- a/nsxt/utgomock_resource_nsxt_policy_ldap_identity_source_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_ldap_identity_source_test.go
@@ -1,0 +1,54 @@
+//go:build unittest
+
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package nsxt
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/require"
+)
+
+func minimalLDAPData() map[string]interface{} {
+	return map[string]interface{}{
+		"nsx_id":      "ldap-src-1",
+		"description": "Test LDAP Source",
+		"type":        activeDirectoryType,
+		"domain_name": "corp.example.com",
+		"base_dn":     "dc=corp,dc=example,dc=com",
+	}
+}
+
+func TestMockResourceNsxtPolicyLdapIdentitySourceRead(t *testing.T) {
+	t.Run("Read fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyLdapIdentitySource()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLDAPData())
+
+		err := resourceNsxtPolicyLdapIdentitySourceRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyLdapIdentitySourceUpdate(t *testing.T) {
+	t.Run("Update fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyLdapIdentitySource()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLDAPData())
+
+		err := resourceNsxtPolicyLdapIdentitySourceUpdate(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyLdapIdentitySourceDelete(t *testing.T) {
+	t.Run("Delete fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyLdapIdentitySource()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLDAPData())
+
+		err := resourceNsxtPolicyLdapIdentitySourceDelete(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}

--- a/nsxt/utgomock_resource_nsxt_policy_mac_discovery_profile_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_mac_discovery_profile_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_metadata_proxy_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_metadata_proxy_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_nat_rule_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_nat_rule_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_network_span_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_network_span_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_ospf_area_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_ospf_area_test.go
@@ -1,0 +1,186 @@
+//go:build unittest
+
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package nsxt
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	vapiErrors "github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
+	vapiProtocolClient "github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
+	nsxModel "github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+
+	ospfapi "github.com/vmware/terraform-provider-nsxt/api/infra/tier_0s/locale_services/ospf"
+	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
+	ospfMocks "github.com/vmware/terraform-provider-nsxt/mocks/infra/tier_0s/locale_services/ospf"
+)
+
+var (
+	ospfAreaID          = "ospf-area-1"
+	ospfAreaDisplayName = "Test OSPF Area"
+	ospfAreaDescription = "Test ospf area"
+	ospfAreaRevision    = int64(1)
+	ospfAreaOspfPath    = "/infra/tier-0s/t0-gw-1/locale-services/ls-1/ospf"
+	ospfAreaGwID        = "t0-gw-1"
+	ospfAreaLsID        = "ls-1"
+	ospfAreaID2         = "10"
+)
+
+func ospfAreaAPIResponse() nsxModel.OspfAreaConfig {
+	areaType := nsxModel.OspfAreaConfig_AREA_TYPE_NSSA
+	return nsxModel.OspfAreaConfig{
+		Id:          &ospfAreaID,
+		DisplayName: &ospfAreaDisplayName,
+		Description: &ospfAreaDescription,
+		Revision:    &ospfAreaRevision,
+		AreaType:    &areaType,
+		AreaId:      &ospfAreaID2,
+	}
+}
+
+func minimalOSPFAreaData() map[string]interface{} {
+	return map[string]interface{}{
+		"display_name": ospfAreaDisplayName,
+		"description":  ospfAreaDescription,
+		"nsx_id":       ospfAreaID,
+		"ospf_path":    ospfAreaOspfPath,
+		"area_id":      ospfAreaID2,
+		"area_type":    nsxModel.OspfAreaConfig_AREA_TYPE_NSSA,
+		"auth_mode":    nsxModel.OspfAuthenticationConfig_MODE_NONE,
+	}
+}
+
+func setupOSPFAreaMock(t *testing.T, ctrl *gomock.Controller) (*ospfMocks.MockAreasClient, func()) {
+	mockSDK := ospfMocks.NewMockAreasClient(ctrl)
+	mockWrapper := &ospfapi.OspfAreaConfigClientContext{
+		Client:     mockSDK,
+		ClientType: utl.Local,
+	}
+	original := cliOspfAreasClient
+	cliOspfAreasClient = func(_ utl.SessionContext, _ vapiProtocolClient.Connector) *ospfapi.OspfAreaConfigClientContext {
+		return mockWrapper
+	}
+	return mockSDK, func() { cliOspfAreasClient = original }
+}
+
+func TestMockResourceNsxtPolicyOspfAreaCreate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupOSPFAreaMock(t, ctrl)
+	defer restore()
+
+	t.Run("Create success", func(t *testing.T) {
+		gomock.InOrder(
+			mockSDK.EXPECT().Patch(ospfAreaGwID, ospfAreaLsID, ospfAreaID, gomock.Any()).Return(ospfAreaAPIResponse(), nil),
+			mockSDK.EXPECT().Get(ospfAreaGwID, ospfAreaLsID, ospfAreaID).Return(ospfAreaAPIResponse(), nil),
+		)
+
+		res := resourceNsxtPolicyOspfArea()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalOSPFAreaData())
+
+		err := resourceNsxtPolicyOspfAreaCreate(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, ospfAreaID, d.Id())
+	})
+}
+
+func TestMockResourceNsxtPolicyOspfAreaRead(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupOSPFAreaMock(t, ctrl)
+	defer restore()
+
+	t.Run("Read success", func(t *testing.T) {
+		mockSDK.EXPECT().Get(ospfAreaGwID, ospfAreaLsID, ospfAreaID).Return(ospfAreaAPIResponse(), nil)
+
+		res := resourceNsxtPolicyOspfArea()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalOSPFAreaData())
+		d.SetId(ospfAreaID)
+
+		err := resourceNsxtPolicyOspfAreaRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, ospfAreaDisplayName, d.Get("display_name"))
+	})
+
+	t.Run("Read not found clears ID", func(t *testing.T) {
+		mockSDK.EXPECT().Get(ospfAreaGwID, ospfAreaLsID, ospfAreaID).Return(nsxModel.OspfAreaConfig{}, vapiErrors.NotFound{})
+
+		res := resourceNsxtPolicyOspfArea()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalOSPFAreaData())
+		d.SetId(ospfAreaID)
+
+		err := resourceNsxtPolicyOspfAreaRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, "", d.Id())
+	})
+
+	t.Run("Read fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyOspfArea()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalOSPFAreaData())
+
+		err := resourceNsxtPolicyOspfAreaRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyOspfAreaUpdate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupOSPFAreaMock(t, ctrl)
+	defer restore()
+
+	t.Run("Update success", func(t *testing.T) {
+		gomock.InOrder(
+			mockSDK.EXPECT().Patch(ospfAreaGwID, ospfAreaLsID, ospfAreaID, gomock.Any()).Return(ospfAreaAPIResponse(), nil),
+			mockSDK.EXPECT().Get(ospfAreaGwID, ospfAreaLsID, ospfAreaID).Return(ospfAreaAPIResponse(), nil),
+		)
+
+		res := resourceNsxtPolicyOspfArea()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalOSPFAreaData())
+		d.SetId(ospfAreaID)
+
+		err := resourceNsxtPolicyOspfAreaUpdate(d, newGoMockProviderClient())
+		require.NoError(t, err)
+	})
+
+	t.Run("Update fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyOspfArea()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalOSPFAreaData())
+
+		err := resourceNsxtPolicyOspfAreaUpdate(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyOspfAreaDelete(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupOSPFAreaMock(t, ctrl)
+	defer restore()
+
+	t.Run("Delete success", func(t *testing.T) {
+		mockSDK.EXPECT().Delete(ospfAreaGwID, ospfAreaLsID, ospfAreaID).Return(nil)
+
+		res := resourceNsxtPolicyOspfArea()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalOSPFAreaData())
+		d.SetId(ospfAreaID)
+
+		err := resourceNsxtPolicyOspfAreaDelete(d, newGoMockProviderClient())
+		require.NoError(t, err)
+	})
+
+	t.Run("Delete fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyOspfArea()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalOSPFAreaData())
+
+		err := resourceNsxtPolicyOspfAreaDelete(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}

--- a/nsxt/utgomock_resource_nsxt_policy_ospf_config_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_ospf_config_test.go
@@ -1,0 +1,128 @@
+//go:build unittest
+
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package nsxt
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	vapiErrors "github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
+	vapiProtocolClient "github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
+	nsxModel "github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+
+	ospfConfigapi "github.com/vmware/terraform-provider-nsxt/api/infra/tier_0s/locale_services"
+	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
+	lsMocks "github.com/vmware/terraform-provider-nsxt/mocks/infra/tier_0s/locale_services"
+)
+
+var (
+	ospfCfgGwPath   = "/infra/tier-0s/t0-gw-1"
+	ospfCfgGwID     = "t0-gw-1"
+	ospfCfgLsID     = "ls-1"
+	ospfCfgRevision = int64(1)
+)
+
+func ospfConfigAPIResponse() nsxModel.OspfRoutingConfig {
+	enabled := true
+	return nsxModel.OspfRoutingConfig{
+		DisplayName: nil,
+		Revision:    &ospfCfgRevision,
+		Enabled:     &enabled,
+	}
+}
+
+func minimalOSPFConfigData() map[string]interface{} {
+	return map[string]interface{}{
+		"gateway_path":          ospfCfgGwPath,
+		"enabled":               true,
+		"ecmp":                  true,
+		"default_originate":     false,
+		"graceful_restart_mode": nsxModel.OspfRoutingConfig_GRACEFUL_RESTART_MODE_HELPER_ONLY,
+	}
+}
+
+func setupOSPFConfigMock(t *testing.T, ctrl *gomock.Controller) (*lsMocks.MockOspfClient, func()) {
+	mockSDK := lsMocks.NewMockOspfClient(ctrl)
+	mockWrapper := &ospfConfigapi.OspfRoutingConfigClientContext{
+		Client:     mockSDK,
+		ClientType: utl.Local,
+	}
+	original := cliOspfClient
+	cliOspfClient = func(_ utl.SessionContext, _ vapiProtocolClient.Connector) *ospfConfigapi.OspfRoutingConfigClientContext {
+		return mockWrapper
+	}
+	return mockSDK, func() { cliOspfClient = original }
+}
+
+func TestMockResourceNsxtPolicyOspfConfigRead(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupOSPFConfigMock(t, ctrl)
+	defer restore()
+
+	t.Run("Read success", func(t *testing.T) {
+		mockSDK.EXPECT().Get(ospfCfgGwID, ospfCfgLsID).Return(ospfConfigAPIResponse(), nil)
+
+		res := resourceNsxtPolicyOspfConfig()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalOSPFConfigData())
+		d.SetId("ospf-cfg-1")
+		d.Set("locale_service_id", ospfCfgLsID)
+
+		err := resourceNsxtPolicyOspfConfigRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, true, d.Get("enabled"))
+	})
+
+	t.Run("Read API error is propagated", func(t *testing.T) {
+		mockSDK.EXPECT().Get(ospfCfgGwID, ospfCfgLsID).Return(nsxModel.OspfRoutingConfig{}, vapiErrors.InternalServerError{})
+
+		res := resourceNsxtPolicyOspfConfig()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalOSPFConfigData())
+		d.SetId("ospf-cfg-1")
+		d.Set("locale_service_id", ospfCfgLsID)
+
+		err := resourceNsxtPolicyOspfConfigRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyOspfConfigUpdate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupOSPFConfigMock(t, ctrl)
+	defer restore()
+
+	t.Run("Update success", func(t *testing.T) {
+		gomock.InOrder(
+			mockSDK.EXPECT().Patch(ospfCfgGwID, ospfCfgLsID, gomock.Any()).Return(ospfConfigAPIResponse(), nil),
+			mockSDK.EXPECT().Get(ospfCfgGwID, ospfCfgLsID).Return(ospfConfigAPIResponse(), nil),
+		)
+
+		res := resourceNsxtPolicyOspfConfig()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalOSPFConfigData())
+		d.SetId("ospf-cfg-1")
+		d.Set("gateway_id", ospfCfgGwID)
+		d.Set("locale_service_id", ospfCfgLsID)
+
+		err := resourceNsxtPolicyOspfConfigUpdate(d, newGoMockProviderClient())
+		require.NoError(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyOspfConfigDelete(t *testing.T) {
+	t.Run("Delete is a no-op", func(t *testing.T) {
+		res := resourceNsxtPolicyOspfConfig()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalOSPFConfigData())
+		d.SetId("ospf-cfg-1")
+
+		err := resourceNsxtPolicyOspfConfigDelete(d, newGoMockProviderClient())
+		require.NoError(t, err)
+	})
+}

--- a/nsxt/utgomock_resource_nsxt_policy_parent_gateway_policy_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_parent_gateway_policy_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_parent_intrusion_service_gateway_policy_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_parent_intrusion_service_gateway_policy_test.go
@@ -1,0 +1,224 @@
+//go:build unittest
+
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package nsxt
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	vapiErrors "github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
+	vapiProtocolClient "github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
+	nsxModel "github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+
+	apipkg "github.com/vmware/terraform-provider-nsxt/api"
+	apidomains "github.com/vmware/terraform-provider-nsxt/api/infra/domains"
+	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
+	inframocks "github.com/vmware/terraform-provider-nsxt/mocks/infra"
+	domainmocks "github.com/vmware/terraform-provider-nsxt/mocks/infra/domains"
+)
+
+var (
+	parentIdsGwPolicyID          = "parent-ids-gw-policy-id"
+	parentIdsGwPolicyDisplayName = "test-parent-ids-gw-policy"
+	parentIdsGwPolicyDescription = "Test Parent IDS Gateway Policy"
+	parentIdsGwPolicyRevision    = int64(1)
+	parentIdsGwPolicyDomain      = "default"
+	parentIdsGwPolicyPath        = "/infra/domains/default/ids-gateway-policies/parent-ids-gw-policy-id"
+	parentIdsGwPolicyCategory    = "LocalGatewayRules"
+)
+
+func parentIdsGwPolicyAPIResponse() nsxModel.IdsGatewayPolicy {
+	resourceType := "IdsGatewayPolicy"
+	seq := int64(0)
+	stateful := true
+	locked := false
+	comments := ""
+	return nsxModel.IdsGatewayPolicy{
+		Id:             &parentIdsGwPolicyID,
+		DisplayName:    &parentIdsGwPolicyDisplayName,
+		Description:    &parentIdsGwPolicyDescription,
+		Revision:       &parentIdsGwPolicyRevision,
+		Path:           &parentIdsGwPolicyPath,
+		Category:       &parentIdsGwPolicyCategory,
+		ResourceType:   &resourceType,
+		SequenceNumber: &seq,
+		Stateful:       &stateful,
+		Locked:         &locked,
+		Comments:       &comments,
+	}
+}
+
+func minimalParentIdsGwPolicyData() map[string]interface{} {
+	return map[string]interface{}{
+		"display_name":    parentIdsGwPolicyDisplayName,
+		"description":     parentIdsGwPolicyDescription,
+		"nsx_id":          parentIdsGwPolicyID,
+		"domain":          parentIdsGwPolicyDomain,
+		"locked":          false,
+		"stateful":        true,
+		"sequence_number": 0,
+		"category":        parentIdsGwPolicyCategory,
+	}
+}
+
+func setupParentIdsGwPolicyMock(t *testing.T, ctrl *gomock.Controller) (*domainmocks.MockIntrusionServiceGatewayPoliciesClient, *inframocks.MockInfraClient, func()) {
+	t.Helper()
+	mockSDK := domainmocks.NewMockIntrusionServiceGatewayPoliciesClient(ctrl)
+	mockWrapper := &apidomains.IntrusionServiceGatewayPolicyClientContext{
+		Client:     mockSDK,
+		ClientType: utl.Local,
+	}
+
+	original := cliIntrusionServiceGatewayPoliciesClient
+	cliIntrusionServiceGatewayPoliciesClient = func(_ utl.SessionContext, _ vapiProtocolClient.Connector) *apidomains.IntrusionServiceGatewayPolicyClientContext {
+		return mockWrapper
+	}
+
+	mockInfraSDK := inframocks.NewMockInfraClient(ctrl)
+	originalInfra := cliInfraClient
+	cliInfraClient = func(_ utl.SessionContext, _ vapiProtocolClient.Connector) *apipkg.InfraClientContext {
+		return &apipkg.InfraClientContext{Client: mockInfraSDK, ClientType: utl.Local}
+	}
+
+	return mockSDK, mockInfraSDK, func() {
+		cliIntrusionServiceGatewayPoliciesClient = original
+		cliInfraClient = originalInfra
+	}
+}
+
+func TestMockResourceNsxtPolicyParentIntrusionServiceGatewayPolicyCreate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, mockInfra, restore := setupParentIdsGwPolicyMock(t, ctrl)
+	defer restore()
+
+	t.Run("Create success", func(t *testing.T) {
+		notFoundErr := vapiErrors.NotFound{}
+		gomock.InOrder(
+			mockSDK.EXPECT().Get(parentIdsGwPolicyDomain, parentIdsGwPolicyID).Return(nsxModel.IdsGatewayPolicy{}, notFoundErr),
+			mockInfra.EXPECT().Patch(gomock.Any(), gomock.Any()).Return(nil),
+			mockSDK.EXPECT().Get(parentIdsGwPolicyDomain, parentIdsGwPolicyID).Return(parentIdsGwPolicyAPIResponse(), nil),
+		)
+
+		res := resourceNsxtPolicyParentIntrusionServiceGatewayPolicy()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalParentIdsGwPolicyData())
+
+		err := resourceNsxtPolicyParentIntrusionServiceGatewayPolicyCreate(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, parentIdsGwPolicyID, d.Id())
+		assert.Equal(t, parentIdsGwPolicyDisplayName, d.Get("display_name"))
+	})
+
+	t.Run("Create fails when already exists", func(t *testing.T) {
+		mockSDK.EXPECT().Get(parentIdsGwPolicyDomain, parentIdsGwPolicyID).Return(parentIdsGwPolicyAPIResponse(), nil)
+
+		res := resourceNsxtPolicyParentIntrusionServiceGatewayPolicy()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalParentIdsGwPolicyData())
+
+		err := resourceNsxtPolicyParentIntrusionServiceGatewayPolicyCreate(d, newGoMockProviderClient())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "already exists")
+	})
+}
+
+func TestMockResourceNsxtPolicyParentIntrusionServiceGatewayPolicyRead(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, _, restore := setupParentIdsGwPolicyMock(t, ctrl)
+	defer restore()
+
+	t.Run("Read success", func(t *testing.T) {
+		mockSDK.EXPECT().Get(parentIdsGwPolicyDomain, parentIdsGwPolicyID).Return(parentIdsGwPolicyAPIResponse(), nil)
+
+		res := resourceNsxtPolicyParentIntrusionServiceGatewayPolicy()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalParentIdsGwPolicyData())
+		d.SetId(parentIdsGwPolicyID)
+
+		err := resourceNsxtPolicyParentIntrusionServiceGatewayPolicyRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, parentIdsGwPolicyDisplayName, d.Get("display_name"))
+		assert.Equal(t, parentIdsGwPolicyDescription, d.Get("description"))
+	})
+
+	t.Run("Read not found clears ID", func(t *testing.T) {
+		mockSDK.EXPECT().Get(parentIdsGwPolicyDomain, parentIdsGwPolicyID).Return(nsxModel.IdsGatewayPolicy{}, vapiErrors.NotFound{})
+
+		res := resourceNsxtPolicyParentIntrusionServiceGatewayPolicy()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalParentIdsGwPolicyData())
+		d.SetId(parentIdsGwPolicyID)
+
+		err := resourceNsxtPolicyParentIntrusionServiceGatewayPolicyRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Empty(t, d.Id())
+	})
+
+	t.Run("Read fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyParentIntrusionServiceGatewayPolicy()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalParentIdsGwPolicyData())
+
+		err := resourceNsxtPolicyParentIntrusionServiceGatewayPolicyRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyParentIntrusionServiceGatewayPolicyUpdate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, mockInfra, restore := setupParentIdsGwPolicyMock(t, ctrl)
+	defer restore()
+
+	t.Run("Update success", func(t *testing.T) {
+		gomock.InOrder(
+			mockInfra.EXPECT().Patch(gomock.Any(), gomock.Any()).Return(nil),
+			mockSDK.EXPECT().Get(parentIdsGwPolicyDomain, parentIdsGwPolicyID).Return(parentIdsGwPolicyAPIResponse(), nil),
+		)
+
+		res := resourceNsxtPolicyParentIntrusionServiceGatewayPolicy()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalParentIdsGwPolicyData())
+		d.SetId(parentIdsGwPolicyID)
+
+		err := resourceNsxtPolicyParentIntrusionServiceGatewayPolicyUpdate(d, newGoMockProviderClient())
+		require.NoError(t, err)
+	})
+
+	t.Run("Update fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyParentIntrusionServiceGatewayPolicy()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalParentIdsGwPolicyData())
+
+		err := resourceNsxtPolicyParentIntrusionServiceGatewayPolicyUpdate(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyParentIntrusionServiceGatewayPolicyDelete(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, _, restore := setupParentIdsGwPolicyMock(t, ctrl)
+	defer restore()
+
+	t.Run("Delete success", func(t *testing.T) {
+		mockSDK.EXPECT().Delete(parentIdsGwPolicyDomain, parentIdsGwPolicyID).Return(nil)
+
+		res := resourceNsxtPolicyParentIntrusionServiceGatewayPolicy()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalParentIdsGwPolicyData())
+		d.SetId(parentIdsGwPolicyID)
+
+		err := resourceNsxtPolicyIntrusionServiceGatewayPolicyDelete(d, newGoMockProviderClient())
+		require.NoError(t, err)
+	})
+
+	t.Run("Delete fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyParentIntrusionServiceGatewayPolicy()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalParentIdsGwPolicyData())
+
+		err := resourceNsxtPolicyIntrusionServiceGatewayPolicyDelete(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}

--- a/nsxt/utgomock_resource_nsxt_policy_parent_security_policy_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_parent_security_policy_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_predefined_gateway_policy_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_predefined_gateway_policy_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_predefined_security_policy_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_predefined_security_policy_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_project_ip_address_allocation_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_project_ip_address_allocation_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_project_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_project_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_qos_profile_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_qos_profile_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_role_binding_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_role_binding_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_role_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_role_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_security_policy_container_cluster_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_security_policy_container_cluster_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_security_policy_rule_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_security_policy_rule_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_security_policy_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_security_policy_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_segment_port_profile_bindings_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_segment_port_profile_bindings_test.go
@@ -1,0 +1,63 @@
+//go:build unittest
+
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package nsxt
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/require"
+)
+
+func minimalSegmentPortProfileBindingsData() map[string]interface{} {
+	return map[string]interface{}{
+		"segment_port_path": "invalid-port-path",
+	}
+}
+
+func TestMockResourceNsxtPolicySegmentPortProfileBindingsCreate(t *testing.T) {
+	t.Run("Create fails with invalid segment_port_path", func(t *testing.T) {
+		res := resourceNsxtPolicySegmentPortProfileBindings()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalSegmentPortProfileBindingsData())
+
+		err := resourceNsxtPolicySegmentPortProfileBindingsCreate(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicySegmentPortProfileBindingsRead(t *testing.T) {
+	t.Run("Read fails with invalid segment_port_path", func(t *testing.T) {
+		res := resourceNsxtPolicySegmentPortProfileBindings()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalSegmentPortProfileBindingsData())
+		d.SetId("port-1")
+
+		err := resourceNsxtPolicySegmentPortProfileBindingsRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicySegmentPortProfileBindingsUpdate(t *testing.T) {
+	t.Run("Update fails with invalid segment_port_path", func(t *testing.T) {
+		res := resourceNsxtPolicySegmentPortProfileBindings()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalSegmentPortProfileBindingsData())
+		d.SetId("port-1")
+
+		err := resourceNsxtPolicySegmentPortProfileBindingsUpdate(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicySegmentPortProfileBindingsDelete(t *testing.T) {
+	t.Run("Delete fails with invalid segment_port_path", func(t *testing.T) {
+		res := resourceNsxtPolicySegmentPortProfileBindings()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalSegmentPortProfileBindingsData())
+		d.SetId("port-1")
+
+		err := resourceNsxtPolicySegmentPortProfileBindingsDelete(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}

--- a/nsxt/utgomock_resource_nsxt_policy_segment_port_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_segment_port_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_segment_security_profile_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_segment_security_profile_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_segment_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_segment_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_service_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_service_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_share_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_share_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_shared_resource_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_shared_resource_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_site_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_site_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_spoof_guard_profile_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_spoof_guard_profile_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_static_route_bfd_peer_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_static_route_bfd_peer_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_static_route_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_static_route_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_tier0_gateway_gre_tunnel_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_tier0_gateway_gre_tunnel_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_tier0_gateway_ha_vip_config_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_tier0_gateway_ha_vip_config_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_tier0_gateway_interface_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_tier0_gateway_interface_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_tier0_gateway_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_tier0_gateway_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_tier0_inter_vrf_routing_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_tier0_inter_vrf_routing_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_tier1_gateway_interface_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_tier1_gateway_interface_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_tier1_gateway_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_tier1_gateway_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_transit_gateway_attachment_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_transit_gateway_attachment_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_transit_gateway_ipsec_vpn_local_endpoint_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_transit_gateway_ipsec_vpn_local_endpoint_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_transit_gateway_ipsec_vpn_service_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_transit_gateway_ipsec_vpn_service_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_transit_gateway_ipsec_vpn_session_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_transit_gateway_ipsec_vpn_session_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_transit_gateway_nat_rule_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_transit_gateway_nat_rule_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_transit_gateway_static_route_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_transit_gateway_static_route_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_transit_gateway_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_transit_gateway_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_transport_zone_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_transport_zone_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_uplink_host_switch_profile_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_uplink_host_switch_profile_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_vlan_segment_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_vlan_segment_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_vm_tags_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_vm_tags_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_vni_pool_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_vni_pool_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_policy_vtep_ha_host_switch_profile_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_vtep_ha_host_switch_profile_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_principal_identity_test.go
+++ b/nsxt/utgomock_resource_nsxt_principal_identity_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_proxy_config_test.go
+++ b/nsxt/utgomock_resource_nsxt_proxy_config_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_upgrade_precheck_acknowledge_test.go
+++ b/nsxt/utgomock_resource_nsxt_upgrade_precheck_acknowledge_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_upgrade_prepare_test.go
+++ b/nsxt/utgomock_resource_nsxt_upgrade_prepare_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_upgrade_run_test.go
+++ b/nsxt/utgomock_resource_nsxt_upgrade_run_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_vpc_attachment_test.go
+++ b/nsxt/utgomock_resource_nsxt_vpc_attachment_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_vpc_connectivity_profile_test.go
+++ b/nsxt/utgomock_resource_nsxt_vpc_connectivity_profile_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_vpc_dhcp_v4_static_binding_config_test.go
+++ b/nsxt/utgomock_resource_nsxt_vpc_dhcp_v4_static_binding_config_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_vpc_external_address_test.go
+++ b/nsxt/utgomock_resource_nsxt_vpc_external_address_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_vpc_gateway_policy_test.go
+++ b/nsxt/utgomock_resource_nsxt_vpc_gateway_policy_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_vpc_group_test.go
+++ b/nsxt/utgomock_resource_nsxt_vpc_group_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_vpc_ip_address_allocation_test.go
+++ b/nsxt/utgomock_resource_nsxt_vpc_ip_address_allocation_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_vpc_nat_rule_test.go
+++ b/nsxt/utgomock_resource_nsxt_vpc_nat_rule_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_vpc_security_policy_test.go
+++ b/nsxt/utgomock_resource_nsxt_vpc_security_policy_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_vpc_service_profile_test.go
+++ b/nsxt/utgomock_resource_nsxt_vpc_service_profile_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_vpc_static_routes_test.go
+++ b/nsxt/utgomock_resource_nsxt_vpc_static_routes_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_vpc_subnet_test.go
+++ b/nsxt/utgomock_resource_nsxt_vpc_subnet_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/utgomock_resource_nsxt_vpc_test.go
+++ b/nsxt/utgomock_resource_nsxt_vpc_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0

--- a/nsxt/validator_test.go
+++ b/nsxt/validator_test.go
@@ -1,3 +1,5 @@
+//go:build unittest
+
 // © Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0
@@ -8,7 +10,7 @@ import (
 	"testing"
 )
 
-func TestValidateCidrOrIPOrRange(t *testing.T) {
+func TestUnitNsxt_ValidateCidrOrIPOrRange(t *testing.T) {
 
 	cases := map[string]struct {
 		value  interface{}
@@ -66,7 +68,7 @@ func TestValidateCidrOrIPOrRange(t *testing.T) {
 	}
 }
 
-func TestValidateCidrOrIPOrRangeList(t *testing.T) {
+func TestUnitNsxt_ValidateCidrOrIPOrRangeList(t *testing.T) {
 
 	cases := map[string]struct {
 		value  interface{}
@@ -116,7 +118,7 @@ func TestValidateCidrOrIPOrRangeList(t *testing.T) {
 	}
 }
 
-func TestValidateSingleIP(t *testing.T) {
+func TestUnitNsxt_ValidateSingleIP(t *testing.T) {
 
 	cases := map[string]struct {
 		value  interface{}
@@ -144,7 +146,7 @@ func TestValidateSingleIP(t *testing.T) {
 		},
 		"badIP": {
 			value:  "192.278.3.1",
-			result: true,
+			result: false,
 		},
 	}
 

--- a/nsxt/validators_table_test.go
+++ b/nsxt/validators_table_test.go
@@ -1,0 +1,341 @@
+//go:build unittest
+
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package nsxt
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnitNsxt_validateASPlainOrDot(t *testing.T) {
+	cases := []struct {
+		name    string
+		value   interface{}
+		wantErr bool
+	}{
+		{"plain asn", "65001", false},
+		{"dot notation", "1.10", false},
+		{"too many dots", "1.2.3", true},
+		{"non numeric plain", "abc", true},
+		{"non numeric dot high", "1.abc", true},
+		{"wrong type", 42, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, es := validateASPlainOrDot(tc.value, "key")
+			if tc.wantErr {
+				assert.NotEmpty(t, es, "expected error for %#v", tc.value)
+			} else {
+				assert.Empty(t, es)
+			}
+		})
+	}
+}
+
+func TestUnitNsxt_validateASPath(t *testing.T) {
+	cases := []struct {
+		name    string
+		value   interface{}
+		wantErr bool
+	}{
+		{"single asn", "65001", false},
+		{"two asns", "65001 65002", false},
+		{"dot in path", "1.10 65002", false},
+		{"invalid token", "65001 bad", true},
+		{"wrong type", 1, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, es := validateASPath(tc.value, "key")
+			if tc.wantErr {
+				assert.NotEmpty(t, es)
+			} else {
+				assert.Empty(t, es)
+			}
+		})
+	}
+}
+
+func TestUnitNsxt_validatePolicyBGPCommunity(t *testing.T) {
+	cases := []struct {
+		name    string
+		value   interface{}
+		wantErr bool
+	}{
+		{"NO_EXPORT", "NO_EXPORT", false},
+		{"NO_ADVERTISE", "NO_ADVERTISE", false},
+		{"NO_EXPORT_SUBCONFED", "NO_EXPORT_SUBCONFED", false},
+		{"aa nn", "1:2", false},
+		{"aa bb nn", "1:2:3", false},
+		{"too few parts", "1", true},
+		{"too many parts", "1:2:3:4", true},
+		{"non numeric", "a:b", true},
+		{"wrong type", 99, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, es := validatePolicyBGPCommunity(tc.value, "key")
+			if tc.wantErr {
+				assert.NotEmpty(t, es)
+			} else {
+				assert.Empty(t, es)
+			}
+		})
+	}
+}
+
+func TestUnitNsxt_validateLdapOrLdapsURL(t *testing.T) {
+	v := validateLdapOrLdapsURL()
+	cases := []struct {
+		name    string
+		value   interface{}
+		wantErr bool
+	}{
+		{"ldap", "ldap://ldap.example.com:389", false},
+		{"ldaps", "ldaps://ldap.example.com:636", false},
+		{"http rejected", "http://x", true},
+		{"not a url", ":::not", true},
+		{"wrong type", 1, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, es := v(tc.value, "key")
+			if tc.wantErr {
+				assert.NotEmpty(t, es)
+			} else {
+				assert.Empty(t, es)
+			}
+		})
+	}
+}
+
+func TestUnitNsxt_validateNsxtProviderHostFormat(t *testing.T) {
+	v := validateNsxtProviderHostFormat()
+	cases := []struct {
+		name    string
+		value   interface{}
+		wantErr bool
+	}{
+		{"host only", "nsx.example.com", false},
+		{"https url", "https://nsx.example.com", false},
+		{"empty invalid", "", true},
+		{"wrong type", 1, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, es := v(tc.value, "key")
+			if tc.wantErr {
+				assert.NotEmpty(t, es)
+			} else {
+				assert.Empty(t, es)
+			}
+		})
+	}
+}
+
+func TestUnitNsxt_validatePortRangeAndSinglePort(t *testing.T) {
+	pr := validatePortRange()
+	sp := validateSinglePort()
+	cases := []struct {
+		name    string
+		v       func(interface{}, string) ([]string, []error)
+		value   interface{}
+		wantErr bool
+	}{
+		{"range ok", pr, "80-443", false},
+		{"single port ok", pr, "8080", false},
+		{"range invalid", pr, "99999-100000", true},
+		{"garbage", pr, "a-b", true},
+		{"single ok", sp, "443", false},
+		{"single bad", sp, "70000", true},
+		{"single wrong type", sp, struct{}{}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, es := tc.v(tc.value, "key")
+			if tc.wantErr {
+				assert.NotEmpty(t, es)
+			} else {
+				assert.Empty(t, es)
+			}
+		})
+	}
+}
+
+func TestUnitNsxt_validatePowerOf2(t *testing.T) {
+	v := validatePowerOf2(false, 64)
+	cases := []struct {
+		name    string
+		value   interface{}
+		wantErr bool
+	}{
+		{"power of 2", 8, false},
+		{"not pow2", 6, true},
+		{"wrong type", "8", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, es := v(tc.value, "key")
+			if tc.wantErr {
+				assert.NotEmpty(t, es)
+			} else {
+				assert.Empty(t, es)
+			}
+		})
+	}
+
+	t.Run("allow zero", func(t *testing.T) {
+		v0 := validatePowerOf2(true, 0)
+		_, es := v0(0, "k")
+		assert.Empty(t, es)
+	})
+}
+
+func TestUnitNsxt_validateASNPairAndIPorASNPair(t *testing.T) {
+	t.Run("ASN pair", func(t *testing.T) {
+		_, es := validateASNPair("65001:100", "k")
+		assert.Empty(t, es)
+		_, es = validateASNPair("bad", "k")
+		assert.NotEmpty(t, es)
+		_, es = validateASNPair(1, "k")
+		assert.NotEmpty(t, es)
+	})
+	t.Run("IP or ASN pair", func(t *testing.T) {
+		_, es := validateIPorASNPair("192.0.2.1:42", "k")
+		assert.Empty(t, es)
+		_, es = validateIPorASNPair("65001:100", "k")
+		assert.Empty(t, es)
+		_, es = validateIPorASNPair("nope", "k")
+		assert.NotEmpty(t, es)
+	})
+}
+
+func TestUnitNsxt_validateVLANIdAndRange(t *testing.T) {
+	t.Run("vlan id int", func(t *testing.T) {
+		_, es := validateVLANId(100, "k")
+		assert.Empty(t, es)
+		_, es = validateVLANId(5000, "k")
+		assert.NotEmpty(t, es)
+	})
+	t.Run("vlan id string", func(t *testing.T) {
+		_, es := validateVLANId("4095", "k")
+		assert.Empty(t, es)
+	})
+	t.Run("vlan range", func(t *testing.T) {
+		_, es := validateVLANIdOrRange("10-20", "k")
+		assert.Empty(t, es)
+		_, es = validateVLANIdOrRange("1-2-3", "k")
+		assert.NotEmpty(t, es)
+	})
+}
+
+func TestUnitNsxt_validateStringIntBetween(t *testing.T) {
+	v := validateStringIntBetween(1, 5)
+	cases := []struct {
+		val     string
+		wantErr bool
+	}{
+		{"3", false},
+		{"0", true},
+		{"6", true},
+		{"x", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.val, func(t *testing.T) {
+			_, es := v(tc.val, "k")
+			if tc.wantErr {
+				assert.NotEmpty(t, es)
+			} else {
+				assert.Empty(t, es)
+			}
+		})
+	}
+	_, es := v(1, "k")
+	require.NotEmpty(t, es)
+}
+
+func TestUnitNsxt_validateSingleIPOrHostName(t *testing.T) {
+	v := validateSingleIPOrHostName()
+	cases := []struct {
+		val     string
+		wantErr bool
+	}{
+		{"192.0.2.1", false},
+		{"host.example.com", false},
+		{"bad host!", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.val, func(t *testing.T) {
+			_, es := v(tc.val, "k")
+			if tc.wantErr {
+				assert.NotEmpty(t, es)
+			} else {
+				assert.Empty(t, es)
+			}
+		})
+	}
+}
+
+func TestUnitNsxt_validatePolicyPathAndIDAndProjectID(t *testing.T) {
+	vp := validatePolicyPath()
+	_, es := vp("/infra/domains/default/groups/g1", "k")
+	assert.Empty(t, es)
+	_, es = vp("not-a-path", "k")
+	assert.NotEmpty(t, es)
+
+	vid := validateID()
+	_, es = vid("ok-id", "k")
+	assert.Empty(t, es)
+	_, es = vid("bad/id", "k")
+	assert.NotEmpty(t, es)
+
+	vpdef := validateProjectID(true)
+	_, es = vpdef("default", "k")
+	assert.Empty(t, es)
+
+	vpno := validateProjectID(false)
+	_, es = vpno("default", "k")
+	assert.NotEmpty(t, es)
+}
+
+func TestUnitNsxt_validatePolicySourceDestinationGroups(t *testing.T) {
+	v := validatePolicySourceDestinationGroups()
+	cases := []struct {
+		val     string
+		wantErr bool
+	}{
+		{"/infra/domains/default/groups/g1", false},
+		{"192.0.2.0/24", false},
+		{"192.0.2.1-192.0.2.5", false},
+		{"not-valid", true},
+	}
+	for _, tc := range cases {
+		t.Run(strings.Trim(tc.val, "/"), func(t *testing.T) {
+			_, es := v(tc.val, "k")
+			if tc.wantErr {
+				assert.NotEmpty(t, es)
+			} else {
+				assert.Empty(t, es)
+			}
+		})
+	}
+}
+
+func TestUnitNsxt_validateCidrIPCidr(t *testing.T) {
+	vc := validateCidr()
+	_, es := vc("10.0.0.0/8", "k")
+	assert.Empty(t, es)
+	_, es = vc("not-cidr", "k")
+	assert.NotEmpty(t, es)
+
+	vipc := validateIPCidr()
+	_, es = vipc("10.0.0.1/32", "k")
+	assert.Empty(t, es)
+}


### PR DESCRIPTION
Also, reorganize GitHub actions, as previously UTs were failing on formatting checks before they execute.
Now this is running separately, in parallel.

Add UTs for utility funcs.
Also, measure coverage only under nsxt directory as api wrappers etc coverage is not relevant.

For resources:

nsxt_policy_ip_pool_block_subnet
nsxt_policy_ip_pool_static_subnet
nsxt_policy_ip_pool
nsxt_policy_ipsec_vpn_local_endpoint
nsxt_policy_ipsec_vpn_service
nsxt_policy_ipsec_vpn_session
nsxt_policy_l2_vpn_service
nsxt_policy_l2_vpn_session
nsxt_policy_l7_access_profile
nsxt_policy_lb_client_ssl_profile
nsxt_policy_lb_cookie_persistence_profile
nsxt_policy_lb_fast_tcp_application_profile
nsxt_policy_lb_fast_udp_application_profile
nsxt_policy_lb_generic_persistence_profile
nsxt_policy_lb_http_application_profile
nsxt_policy_lb_http_monitor_profile
nsxt_policy_lb_https_monitor_profile
nsxt_policy_lb_icmp_monitor_profile
nsxt_policy_lb_passive_monitor_profile
nsxt_policy_lb_server_ssl_profile
nsxt_policy_lb_source_ip_persistence_profile
nsxt_policy_lb_tcp_monitor_profile
nsxt_policy_lb_udp_monitor_profile
nsxt_policy_lb_virtual_server
nsxt_policy_ldap_identity_source
nsxt_policy_ospf_area
nsxt_policy_ospf_config
nsxt_policy_segment_port_profile_bindings
nsxt_policy_intrusion_service_gateway_policy_rule
nsxt_policy_intrusion_service_gateway_policy

Data sources:

nsxt_policy_lb_app_profile
nsxt_policy_lb_client_ssl_profile
nsxt_policy_lb_monitor
nsxt_policy_lb_persistence_profile
nsxt_policy_lb_server_ssl_profile
nsxt_policy_tags_test
nsxt_policy_transit_gateway_nat
nsxt_policy_vni_pool
nsxt_policy_intrusion_service_gateway_policy

Coverage before: 35.5%
Coverage after:  50.3%