### PR TITLE
Add duplicate value validation to tier0_gateway_paths attribute of the project

### DIFF
--- a/nsxt/resource_nsxt_policy_project.go
+++ b/nsxt/resource_nsxt_policy_project.go
@@ -34,6 +34,13 @@ func resourceNsxtPolicyProject() *schema.Resource {
 		},
 
 		CustomizeDiff: func(ctx context.Context, d *schema.ResourceDiff, m interface{}) error {
+			if v, ok := d.GetOk("tier0_gateway_paths"); ok {
+				if list, ok := v.([]interface{}); ok && len(list) > 0 {
+					if err := ValidateStringListNoDuplicateValues(list, "tier0_gateway_paths"); err != nil {
+						return err
+					}
+				}
+			}
 			if util.NsxVersionHigherOrEqual("9.1.0") {
 				c := m.(nsxtClients)
 				raw := d.GetRawConfig()
@@ -73,6 +80,8 @@ func resourceNsxtPolicyProject() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+			// List-level ValidateFunc is not supported for TypeList in SDK v2 (only primitives and TypeMap);
+			// duplicate-path checks run in CustomizeDiff via ValidateStringListNoDuplicateValues.
 			"tier0_gateway_paths": {
 				Type:     schema.TypeList,
 				Elem:     getElemPolicyPathSchema(),

--- a/nsxt/validators.go
+++ b/nsxt/validators.go
@@ -569,3 +569,22 @@ func validateLdapOrLdapsURL() schema.SchemaValidateFunc {
 		return
 	}
 }
+
+// ValidateStringListNoDuplicateValues returns an error if the same string value appears more than once in list.
+//
+// Terraform Plugin SDK v2 does not invoke ValidateFunc/ValidateDiagFunc for TypeList (only for primitives and TypeMap);
+// use this helper from CustomizeDiff or other plan-time validation for list attributes.
+func ValidateStringListNoDuplicateValues(list []interface{}, attrName string) error {
+	seen := make(map[string]struct{}, len(list))
+	for i, item := range list {
+		s, ok := item.(string)
+		if !ok {
+			return fmt.Errorf("%s[%d]: expected string element", attrName, i)
+		}
+		if _, exists := seen[s]; exists {
+			return fmt.Errorf("%s must not contain duplicate values: %q appears more than once", attrName, s)
+		}
+		seen[s] = struct{}{}
+	}
+	return nil
+}

--- a/nsxt/validators_table_test.go
+++ b/nsxt/validators_table_test.go
@@ -372,3 +372,26 @@ func TestUnitNsxt_isT0Gw(t *testing.T) {
 	_, err = isT0Gw("/short")
 	require.Error(t, err)
 }
+
+func TestUnitNsxt_ValidateStringListNoDuplicateValues(t *testing.T) {
+	cases := []struct {
+		name    string
+		list    []interface{}
+		wantErr bool
+	}{
+		{"empty", []interface{}{}, false},
+		{"unique", []interface{}{"/a", "/b"}, false},
+		{"duplicate", []interface{}{"/a", "/a"}, true},
+		{"wrong type", []interface{}{42}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateStringListNoDuplicateValues(tc.list, "attr")
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Address a bug when duplicate values are added to the list of tier0_gateway_paths.