### PR TITLE
Address a bug with floodProtectionProfileBindingModelToSchema

### DIFF
--- a/nsxt/resource_nsxt_policy_distributed_flood_protection_profile_binding.go
+++ b/nsxt/resource_nsxt_policy_distributed_flood_protection_profile_binding.go
@@ -154,9 +154,17 @@ func resourceNsxtPolicyDistributedFloodProtectionProfileBindingRead(d *schema.Re
 		return handleReadError(d, "FloodProtectionProfileBinding", id, err)
 	}
 
-	floodProtectionProfileBindingModelToSchema(d, *binding.DisplayName, *binding.Description, id, *binding.Path, *binding.ProfilePath, *binding.SequenceNumber, binding.Tags, *binding.Revision)
+	floodProtectionProfileBindingModelToSchema(d, binding.DisplayName, binding.Description, id, binding.Path, binding.ProfilePath, int64PtrOrZero(binding.SequenceNumber), binding.Tags, binding.Revision)
 
 	return nil
+}
+
+func int64PtrOrZero(p *int64) *int64 {
+	if p != nil {
+		return p
+	}
+	z := int64(0)
+	return &z
 }
 
 func resourceNsxtPolicyDistributedFloodProtectionProfileBindingUpdate(d *schema.ResourceData, m interface{}) error {

--- a/nsxt/resource_nsxt_policy_gateway_flood_protection_profile_binding.go
+++ b/nsxt/resource_nsxt_policy_gateway_flood_protection_profile_binding.go
@@ -230,11 +230,12 @@ func resourceNsxtPolicyGatewayFloodProtectionProfileBindingRead(d *schema.Resour
 		return handleReadError(d, "GatewayFloodProtectionProfileBinding", id, err)
 	}
 
-	floodProtectionProfileBindingModelToSchema(d, *binding.DisplayName, *binding.Description, id, *binding.Path, *binding.ProfilePath, -1, binding.Tags, *binding.Revision)
+	floodProtectionProfileBindingModelToSchema(d, binding.DisplayName, binding.Description, id, binding.Path, binding.ProfilePath, nil, binding.Tags, binding.Revision)
 	return nil
 }
 
-func floodProtectionProfileBindingModelToSchema(d *schema.ResourceData, displayName, description, nsxID, path, profilePath string, seqNum int64, tags []model.Tag, revision int64) {
+// seqNum is set only for the distributed binding; pass nil for gateway (no sequence_number attribute).
+func floodProtectionProfileBindingModelToSchema(d *schema.ResourceData, displayName, description *string, nsxID string, path, profilePath *string, seqNum *int64, tags []model.Tag, revision *int64) {
 	d.Set("display_name", displayName)
 	d.Set("description", description)
 	setPolicyTagsInSchema(d, tags)
@@ -243,7 +244,7 @@ func floodProtectionProfileBindingModelToSchema(d *schema.ResourceData, displayN
 	d.Set("revision", revision)
 
 	d.Set("profile_path", profilePath)
-	if seqNum != -1 {
+	if seqNum != nil {
 		d.Set("sequence_number", seqNum)
 	}
 }

--- a/nsxt/utgomock_resource_nsxt_policy_distributed_flood_protection_profile_binding_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_distributed_flood_protection_profile_binding_test.go
@@ -154,6 +154,21 @@ func TestMockResourceNsxtPolicyDistributedFloodProtectionProfileBindingRead(t *t
 		assert.Equal(t, ffppbProfilePath, d.Get("profile_path"))
 	})
 
+	t.Run("Read_success_when_API_omits_optional_pointer_fields", func(t *testing.T) {
+		mockBindingSDK.EXPECT().Get(ffppbDomainID, ffppbGroupID, ffppbID).Return(model.PolicyFirewallFloodProtectionProfileBindingMap{}, nil)
+
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+			"group_path": ffppbGroupPath,
+		})
+		d.SetId(ffppbID)
+		m := newGoMockProviderClient()
+		err := resourceNsxtPolicyDistributedFloodProtectionProfileBindingRead(d, m)
+		require.NoError(t, err)
+		assert.Equal(t, "", d.Get("display_name"))
+		assert.Equal(t, "", d.Get("profile_path"))
+		assert.Equal(t, 0, d.Get("revision"))
+	})
+
 	t.Run("Read_fails_when_ID_is_empty", func(t *testing.T) {
 		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
 			"group_path": ffppbGroupPath,


### PR DESCRIPTION
When null values are returned from NSX, function causes a null pointer exception.