### PR TITLE
Revise handling of edge_transport_node node_settings for v4.2

### DIFF
--- a/nsxt/resource_nsxt_edge_transport_node.go
+++ b/nsxt/resource_nsxt_edge_transport_node.go
@@ -882,9 +882,12 @@ func getTransportNodeFromSchema(d *schema.ResourceData, m interface{}) (*mpmodel
 		return nil, fmt.Errorf("failed to create Transport Node: %v", err)
 	}
 
-	nodeSettings, err := getEdgeNodeSettingsFromSchema(d.Get("node_settings"))
-	if err != nil {
-		return nil, err
+	var nodeSettings *mpmodel.EdgeNodeSettings
+	if util.NsxVersionHigherOrEqual("9.0.0") || nodeID == "" {
+		nodeSettings, err = getEdgeNodeSettingsFromSchema(d.Get("node_settings"))
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	var nodeDeploymentInfo *data.StructValue


### PR DESCRIPTION
PR #2033 changed the behavior of node_settings object, which broke MP edge behavior for v4.2.x with imported nodes.

This addresses this issue.