### PR TITLE
VPC subnet property dns_server_preference should be computed

### DIFF
--- a/nsxt/resource_nsxt_vpc_subnet.go
+++ b/nsxt/resource_nsxt_vpc_subnet.go
@@ -298,6 +298,7 @@ var vpcSubnetSchema = map[string]*metadata.ExtendedSchema{
 						Schema: schema.Schema{
 							Type:         schema.TypeString,
 							ValidateFunc: validation.StringInSlice(dnsServerPreferenceValues, false),
+							Computed:     true,
 							Optional:     true,
 						},
 						Metadata: metadata.Metadata{


### PR DESCRIPTION
NSX assigns a value to this attribute wnd returns it when the API call doesn't specify it. Therefore this should be computed.