### PR TITLE
Fix edge_transport_node issues

### DIFF
--- a/nsxt/policy_utils.go
+++ b/nsxt/policy_utils.go
@@ -561,6 +561,18 @@ func getPolicyIDFromPath(path string) string {
 	return tokens[len(tokens)-1]
 }
 
+// suppressPolicyPathOrID avoids perpetual drift when the API returns a bare
+// resource ID but configuration uses a policy path (or vice versa).
+func suppressPolicyPathOrID(_, oldVal, newVal string, _ *schema.ResourceData) bool {
+	if oldVal == newVal {
+		return true
+	}
+	if oldVal == "" || newVal == "" {
+		return false
+	}
+	return getPolicyIDFromPath(oldVal) == getPolicyIDFromPath(newVal)
+}
+
 func interfaceListToStringList(interfaces []interface{}) []string {
 	var strList []string
 	for _, elem := range interfaces {

--- a/nsxt/resource_nsxt_edge_transport_node.go
+++ b/nsxt/resource_nsxt_edge_transport_node.go
@@ -196,7 +196,8 @@ func getEdgeNodeDeploymentConfigSchema() *schema.Schema {
 							"audit_username": {
 								Type:        schema.TypeString,
 								Optional:    true,
-								Description: "CLI \"audit\" username",
+								Computed:    true,
+								Description: "CLI \"audit\" username; if omitted, set from NSX after read",
 							},
 							"cli_password": {
 								Type:        schema.TypeString,
@@ -462,16 +463,18 @@ func getStandardHostSwitchSchema(nodeType string) *schema.Schema {
 				},
 				"host_switch_profile": getHostSwitchProfileIDsSchema(),
 				"uplink_profile": {
-					Type:        schema.TypeString,
-					Description: "Host switch uplink profile",
-					Optional:    true,
-					Computed:    true,
+					Type:             schema.TypeString,
+					Description:      "Host switch uplink profile",
+					Optional:         true,
+					Computed:         true,
+					DiffSuppressFunc: suppressPolicyPathOrID,
 				},
 				"vtep_ha_profile": {
-					Type:        schema.TypeString,
-					Description: "Host switch high availability profile",
-					Optional:    true,
-					Computed:    true,
+					Type:             schema.TypeString,
+					Description:      "Host switch high availability profile",
+					Optional:         true,
+					Computed:         true,
+					DiffSuppressFunc: suppressPolicyPathOrID,
 				},
 				"ip_assignment":   getIPAssignmentSchema(false),
 				"ipv6_assignment": getIPv6AssignmentSchema(),
@@ -554,16 +557,18 @@ func getStandardHostSwitchSchema(nodeType string) *schema.Schema {
 									},
 									"host_switch_profile": getHostSwitchProfileIDsSchema(),
 									"uplink_profile": {
-										Type:        schema.TypeString,
-										Description: "Host switch uplink profile",
-										Optional:    true,
-										Computed:    true,
+										Type:             schema.TypeString,
+										Description:      "Host switch uplink profile",
+										Optional:         true,
+										Computed:         true,
+										DiffSuppressFunc: suppressPolicyPathOrID,
 									},
 									"vtep_ha_profile": {
-										Type:        schema.TypeString,
-										Description: "Host switch high availability profile",
-										Optional:    true,
-										Computed:    true,
+										Type:             schema.TypeString,
+										Description:      "Host switch high availability profile",
+										Optional:         true,
+										Computed:         true,
+										DiffSuppressFunc: suppressPolicyPathOrID,
 									},
 									"ip_assignment":   getIPAssignmentSchema(false),
 									"ipv6_assignment": getIPv6AssignmentSchema(),
@@ -612,10 +617,11 @@ func getTransportZoneEndpointSchema() *schema.Schema {
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"transport_zone": {
-					Type:         schema.TypeString,
-					Required:     true,
-					Description:  "Unique ID identifying the transport zone for this endpoint",
-					ValidateFunc: validation.StringIsNotWhiteSpace,
+					Type:             schema.TypeString,
+					Required:         true,
+					Description:      "Unique ID identifying the transport zone for this endpoint",
+					ValidateFunc:     validation.StringIsNotWhiteSpace,
+					DiffSuppressFunc: suppressPolicyPathOrID,
 				},
 				"transport_zone_profiles": {
 					Type:        schema.TypeList,
@@ -665,7 +671,8 @@ func getHostSwitchProfileIDsSchema() *schema.Schema {
 		Description: "Identifiers of host switch profiles to be associated with this host switch",
 		Optional:    true,
 		Elem: &schema.Schema{
-			Type: schema.TypeString,
+			Type:             schema.TypeString,
+			DiffSuppressFunc: suppressPolicyPathOrID,
 		},
 		Computed:   true,
 		Deprecated: "use specific profiles instead",
@@ -1009,7 +1016,7 @@ func getEdgeNodeDeploymentConfigFromSchema(cfg interface{}) (*mpmodel.EdgeNodeDe
 			for _, nusi := range c["node_user_settings"].([]interface{}) {
 				nus := nusi.(map[string]interface{})
 				auditPassword := nus["audit_password"].(string)
-				auditUsername := nus["audit_username"].(string)
+				auditUsername, _ := nus["audit_username"].(string)
 				cliPassword := nus["cli_password"].(string)
 				cliUsername := nus["cli_username"].(string)
 				rootPassword := nus["root_password"].(string)


### PR DESCRIPTION
Two different issues found in edge_transport_node:
* When a user specifies a policy path for the profiles or TZs, the value is accepted. Yet NSX returns the edge struct with IDs instead of the sent values. This PR replaces the submitted values with IDs.
* NSX returns audit_username when not specified. This should be computed.