### PR TITLE
Ignore list order for nsxt_policy_project tier0_gateway_paths attribute

### DIFF
--- a/nsxt/policy_utils.go
+++ b/nsxt/policy_utils.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log"
 	"net/url"
+	"sort"
 	"strings"
 	"time"
 
@@ -579,6 +580,53 @@ func interfaceListToStringList(interfaces []interface{}) []string {
 		strList = append(strList, elem.(string))
 	}
 	return strList
+}
+
+// stringListsEqualIgnoreOrder reports whether two slices contain the same strings
+// with the same multiplicity. NSX may return tier-0 (and similar) path lists in
+// a canonical order that does not match the configuration order.
+func stringListsEqualIgnoreOrder(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	if len(a) == 0 {
+		return true
+	}
+	ac := append([]string(nil), a...)
+	bc := append([]string(nil), b...)
+	sort.Strings(ac)
+	sort.Strings(bc)
+	for i := range ac {
+		if ac[i] != bc[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// diffSuppressStringListOfPathsOrder returns a DiffSuppressFunc for a TypeList of
+// policy path strings when the remote API may reorder elements. The SDK invokes
+// the suppressor for each diff key (attr.0, attr.1, …); we compare the full lists.
+func diffSuppressStringListOfPathsOrder(attr string) schema.SchemaDiffSuppressFunc {
+	prefix := attr + "."
+	return func(k, old, new string, d *schema.ResourceData) bool {
+		if !strings.HasPrefix(k, prefix) {
+			return false
+		}
+		if strings.HasSuffix(k, ".#") {
+			return false
+		}
+		o, n := d.GetChange(attr)
+		oldList, _ := o.([]interface{})
+		newList, _ := n.([]interface{})
+		if oldList == nil {
+			oldList = []interface{}{}
+		}
+		if newList == nil {
+			newList = []interface{}{}
+		}
+		return stringListsEqualIgnoreOrder(interfaceListToStringList(oldList), interfaceListToStringList(newList))
+	}
 }
 
 func policyResourceNotSupportedError() error {

--- a/nsxt/policy_utils_test.go
+++ b/nsxt/policy_utils_test.go
@@ -166,6 +166,14 @@ func TestUnitNsxt_InterfaceListToStringList(t *testing.T) {
 	assert.Equal(t, []string{"a", "b"}, interfaceListToStringList([]interface{}{"a", "b"}))
 }
 
+func TestUnitNsxt_StringListsEqualIgnoreOrder(t *testing.T) {
+	assert.True(t, stringListsEqualIgnoreOrder(nil, nil))
+	assert.True(t, stringListsEqualIgnoreOrder([]string{}, []string{}))
+	assert.True(t, stringListsEqualIgnoreOrder([]string{"b", "a"}, []string{"a", "b"}))
+	assert.False(t, stringListsEqualIgnoreOrder([]string{"a"}, []string{"a", "b"}))
+	assert.False(t, stringListsEqualIgnoreOrder([]string{"a", "a"}, []string{"a", "b"}))
+}
+
 func TestUnitNsxt_IsValidResourceID(t *testing.T) {
 	assert.True(t, isValidResourceID("abc-123"))
 	assert.False(t, isValidResourceID(""))

--- a/nsxt/resource_nsxt_policy_project.go
+++ b/nsxt/resource_nsxt_policy_project.go
@@ -83,9 +83,10 @@ func resourceNsxtPolicyProject() *schema.Resource {
 			// List-level ValidateFunc is not supported for TypeList in SDK v2 (only primitives and TypeMap);
 			// duplicate-path checks run in CustomizeDiff via ValidateStringListNoDuplicateValues.
 			"tier0_gateway_paths": {
-				Type:     schema.TypeList,
-				Elem:     getElemPolicyPathSchema(),
-				Optional: true,
+				Type:             schema.TypeList,
+				Elem:             getElemPolicyPathSchema(),
+				Optional:         true,
+				DiffSuppressFunc: diffSuppressStringListOfPathsOrder("tier0_gateway_paths"),
 			},
 			"activate_default_dfw_rules": {
 				Type:     schema.TypeBool,


### PR DESCRIPTION
NSX may return the list elements in a different order than posted. While this order is redundant, and we could use a TypeSet here, changing this attribute now will break backward compatibility. Therefore we use CustomizeDiff instead.

Fixes: #1535 