### PR TITLE
Create self signed certificate to imporve acceptance test coverage

### DIFF
--- a/nsxt/data_source_nsxt_policy_certificate_test.go
+++ b/nsxt/data_source_nsxt_policy_certificate_test.go
@@ -9,20 +9,31 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestAccDataSourceNsxtPolicyCertificate_basic(t *testing.T) {
-	name := getTestCertificateName(false)
+	name := getAccTestResourceName()
 	testResourceName := "data.nsxt_policy_certificate.test"
+	var accTestTlsCertID string
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccEnvDefined(t, "NSXT_TEST_CERTIFICATE_NAME")
 		},
 		Providers: testAccProviders,
+		CheckDestroy: func(*terraform.State) error {
+			return testAccTlsCertificateDeleteGlobal(accTestTlsCertID)
+		},
 		Steps: []resource.TestStep{
 			{
+				PreConfig: func() {
+					id, err := testAccTlsCertificateSelfSignedCreateGlobal(name)
+					if err != nil {
+						t.Fatal(err)
+					}
+					accTestTlsCertID = id
+				},
 				Config: testAccNsxtPolicyCertificateReadTemplate(false, name),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(testResourceName, "display_name", name),
@@ -46,18 +57,30 @@ data "nsxt_policy_certificate" "test" {
 }
 
 func TestAccDataSourceContextBasedNsxtPolicyCertificate_basic(t *testing.T) {
-	name := getTestCertificateName(false)
+	name := getAccTestResourceName()
 	testResourceName := "data.nsxt_policy_certificate.test"
+	var accTestTlsCertID string
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccEnvDefined(t, "NSXT_TEST_LOCAL_DEV")
-			testAccEnvDefined(t, "NSXT_TEST_CERTIFICATE_NAME")
+			if testAccMultitenancyProjectID() == "" {
+				t.Skipf("This test requires NSXT_PROJECT_ID or NSXT_VPC_PROJECT_ID for project-scoped TLS certificate API")
+			}
 		},
 		Providers: testAccProviders,
+		CheckDestroy: func(*terraform.State) error {
+			return testAccTlsCertificateDeleteProject(accTestTlsCertID)
+		},
 		Steps: []resource.TestStep{
 			{
+				PreConfig: func() {
+					id, err := testAccTlsCertificateSelfSignedCreateProject(name)
+					if err != nil {
+						t.Fatal(err)
+					}
+					accTestTlsCertID = id
+				},
 				Config: testAccNsxtPolicyCertificateReadTemplate(true, name),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(testResourceName, "display_name", name),

--- a/nsxt/policy_tls_certificate_acc_test.go
+++ b/nsxt/policy_tls_certificate_acc_test.go
@@ -1,0 +1,101 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package nsxt
+
+import (
+	"fmt"
+	"os"
+
+	sdkinfra "github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+	projectinfra "github.com/vmware/vsphere-automation-sdk-go/services/nsxt/orgs/projects/infra"
+)
+
+func testAccTlsCsrWithDaysValidSpec(displayName string) model.TlsCsrWithDaysValid {
+	algo := model.TlsCsrWithDaysValid_ALGORITHM_RSA
+	keySize := int64(2048)
+	days := int64(365)
+	isCa := false
+	cn := displayName
+	return model.TlsCsrWithDaysValid{
+		DisplayName: &displayName,
+		Algorithm:   &algo,
+		KeySize:     &keySize,
+		DaysValid:   &days,
+		IsCa:        &isCa,
+		Subject: &model.Principal{
+			Attributes: []model.KeyValue{
+				{Key: ptr("CN"), Value: &cn},
+			},
+		},
+	}
+}
+
+func testAccTlsCertificateSelfSignedCreateGlobal(displayName string) (string, error) {
+	connector, err := testAccGetPolicyConnector()
+	if err != nil {
+		return "", err
+	}
+	cert, err := sdkinfra.NewCsrsClient(connector).Selfsign0(testAccTlsCsrWithDaysValidSpec(displayName))
+	if err != nil {
+		return "", err
+	}
+	if cert.Id == nil || *cert.Id == "" {
+		return "", fmt.Errorf("tls certificate Selfsign0 returned empty id")
+	}
+	return *cert.Id, nil
+}
+
+func testAccTlsCertificateSelfSignedCreateProject(displayName string) (string, error) {
+	projectID := testAccMultitenancyProjectID()
+	if projectID == "" {
+		return "", fmt.Errorf("project id is not set (NSXT_PROJECT_ID or NSXT_VPC_PROJECT_ID)")
+	}
+	connector, err := testAccGetPolicyConnector()
+	if err != nil {
+		return "", err
+	}
+	cert, err := projectinfra.NewCsrsClient(connector).Selfsign0(defaultOrgID, projectID, testAccTlsCsrWithDaysValidSpec(displayName))
+	if err != nil {
+		return "", err
+	}
+	if cert.Id == nil || *cert.Id == "" {
+		return "", fmt.Errorf("project tls certificate Selfsign0 returned empty id")
+	}
+	return *cert.Id, nil
+}
+
+func testAccMultitenancyProjectID() string {
+	if testAccIsVPC() {
+		return os.Getenv("NSXT_VPC_PROJECT_ID")
+	}
+	return os.Getenv("NSXT_PROJECT_ID")
+}
+
+func testAccTlsCertificateDeleteGlobal(certID string) error {
+	if certID == "" {
+		return nil
+	}
+	connector, err := testAccGetPolicyConnector()
+	if err != nil {
+		return err
+	}
+	return sdkinfra.NewCertificatesClient(connector).Delete(certID)
+}
+
+func testAccTlsCertificateDeleteProject(certID string) error {
+	if certID == "" {
+		return nil
+	}
+	projectID := testAccMultitenancyProjectID()
+	if projectID == "" {
+		return nil
+	}
+	connector, err := testAccGetPolicyConnector()
+	if err != nil {
+		return err
+	}
+	return projectinfra.NewCertificatesClient(connector).Delete(defaultOrgID, projectID, certID)
+}

--- a/nsxt/resource_nsxt_policy_ipsec_vpn_session_test.go
+++ b/nsxt/resource_nsxt_policy_ipsec_vpn_session_test.go
@@ -344,19 +344,30 @@ func TestAccResourceNsxtPolicyIPSecVpnSessionPolicyBased_tier1_multitenancy(t *t
 func TestAccResourceNsxtPolicyIPSecVpnSessionRouteBasedWithComplianceSuite(t *testing.T) {
 
 	testResourceName := testAccIPSecVpnSessionResourceName
+	certDisplayName := getAccTestResourceName()
+	var accTestIPSecTlsCertID string
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccOnlyLocalManager(t)
-			testAccEnvDefined(t, "NSXT_TEST_CERTIFICATE_NAME")
 		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNsxtPolicyIPSecVpnSessionCheckDestroy(state, accTestPolicyIPSecVpnSessionRouteBasedComlianceSuiteAttributes["display_name"])
+			if err := testAccNsxtPolicyIPSecVpnSessionCheckDestroy(state, accTestPolicyIPSecVpnSessionRouteBasedComlianceSuiteAttributes["display_name"]); err != nil {
+				return err
+			}
+			return testAccTlsCertificateDeleteGlobal(accTestIPSecTlsCertID)
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNsxtPolicyIPSecVpnSessionRouteBasedTemplateWithComplianceSuite(true),
+				PreConfig: func() {
+					id, err := testAccTlsCertificateSelfSignedCreateGlobal(certDisplayName)
+					if err != nil {
+						t.Fatal(err)
+					}
+					accTestIPSecTlsCertID = id
+				},
+				Config: testAccNsxtPolicyIPSecVpnSessionRouteBasedTemplateWithComplianceSuite(true, certDisplayName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNsxtPolicyIPSecVpnSessionExists(accTestPolicyIPSecVpnSessionRouteBasedComlianceSuiteAttributes["display_name"], testResourceName),
 					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestPolicyIPSecVpnSessionRouteBasedComlianceSuiteAttributes["display_name"]),
@@ -508,19 +519,30 @@ func TestAccResourceNsxtPolicyIPSecVpnSessionPolicyBased_basic(t *testing.T) {
 func TestAccResourceNsxtPolicyIPSecVpnSessionPolicyBasedWithComplianceSuite(t *testing.T) {
 
 	testResourceName := testAccIPSecVpnSessionResourceName
+	certDisplayName := getAccTestResourceName()
+	var accTestIPSecTlsCertID string
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccOnlyLocalManager(t)
-			testAccEnvDefined(t, "NSXT_TEST_CERTIFICATE_NAME")
 		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNsxtPolicyIPSecVpnSessionCheckDestroy(state, accTestPolicyIPSecVpnSessionPolicyBasedComlianceSuiteAttributes["display_name"])
+			if err := testAccNsxtPolicyIPSecVpnSessionCheckDestroy(state, accTestPolicyIPSecVpnSessionPolicyBasedComlianceSuiteAttributes["display_name"]); err != nil {
+				return err
+			}
+			return testAccTlsCertificateDeleteGlobal(accTestIPSecTlsCertID)
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNsxtPolicyIPSecVpnSessionPolicyBasedTemplateWithComplianceSuite(true),
+				PreConfig: func() {
+					id, err := testAccTlsCertificateSelfSignedCreateGlobal(certDisplayName)
+					if err != nil {
+						t.Fatal(err)
+					}
+					accTestIPSecTlsCertID = id
+				},
+				Config: testAccNsxtPolicyIPSecVpnSessionPolicyBasedTemplateWithComplianceSuite(true, certDisplayName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNsxtPolicyIPSecVpnSessionExists(accTestPolicyIPSecVpnSessionPolicyBasedComlianceSuiteAttributes["display_name"], testResourceName),
 					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestPolicyIPSecVpnSessionPolicyBasedComlianceSuiteAttributes["display_name"]),
@@ -763,8 +785,8 @@ func testAccNSXPolicyIPSecVpnSessionImporterGetID(s *terraform.State) (string, e
 	return fmt.Sprintf("%s/sessions/%s", servicePath, resourceID), nil
 }
 
-func testAccNsxtPolicyIPSecVpnSessionPreConditionTemplate(isT0 bool, useCert bool) string {
-	certName := getTestCertificateName(false)
+func testAccNsxtPolicyIPSecVpnSessionPreConditionTemplate(isT0 bool, useCert bool, certDisplayName string) string {
+	certName := certDisplayName
 	var localEndpointTemplate string
 	if useCert {
 		localEndpointTemplate = fmt.Sprintf(`
@@ -835,9 +857,9 @@ resource "nsxt_policy_ipsec_vpn_dpd_profile" "test" {
 }`, ipsecVpnResourceName, ipsecVpnResourceName, ipsecVpnResourceName)
 }
 
-func testAccNsxtPolicyIPSecVpnSessionTier1MultitenancyPreConditionTemplate(useCert bool) string {
+func testAccNsxtPolicyIPSecVpnSessionTier1MultitenancyPreConditionTemplate(useCert bool, certDisplayName string) string {
 	context := testAccNsxtPolicyMultitenancyContext()
-	certName := getTestCertificateName(false)
+	certName := certDisplayName
 	var localEndpointTemplate string
 	if useCert {
 		localEndpointTemplate = fmt.Sprintf(`
@@ -916,7 +938,7 @@ func testAccNsxtPolicyIPSecVpnSessionTier1MultitenancyTemplate(createFlow bool) 
 		attrMap = accTestPolicyIPSecVpnSessionRouteBasedUpdateAttributes
 	}
 	return testAccNsxtPolicyTier1WithEdgeClusterForVPNMultitenancy() +
-		testAccNsxtPolicyIPSecVpnSessionTier1MultitenancyPreConditionTemplate(false) +
+		testAccNsxtPolicyIPSecVpnSessionTier1MultitenancyPreConditionTemplate(false, "") +
 		fmt.Sprintf(`
 resource "nsxt_policy_ipsec_vpn_session" "test" {
 %s
@@ -957,7 +979,7 @@ func testAccNsxtPolicyIPSecVpnSessionPolicyBasedTier1MultitenancyTemplate(create
 		attrMap = accTestPolicyIPSecVpnSessionPolicyBasedUpdateAttributes
 	}
 	return testAccNsxtPolicyTier1WithEdgeClusterForVPNMultitenancy() +
-		testAccNsxtPolicyIPSecVpnSessionTier1MultitenancyPreConditionTemplate(false) +
+		testAccNsxtPolicyIPSecVpnSessionTier1MultitenancyPreConditionTemplate(false, "") +
 		fmt.Sprintf(`
 resource "nsxt_policy_ipsec_vpn_session" "test" {
 %s
@@ -996,7 +1018,7 @@ func testAccNsxtPolicyIPSecVpnSessionTier1MultitenancyMinimalistic() string {
 	context := testAccNsxtPolicyMultitenancyContext()
 	attrMap := accTestPolicyIPSecVpnSessionRouteBasedCreateAttributes
 	return testAccNsxtPolicyTier1WithEdgeClusterForVPNMultitenancy() +
-		testAccNsxtPolicyIPSecVpnSessionTier1MultitenancyPreConditionTemplate(false) +
+		testAccNsxtPolicyIPSecVpnSessionTier1MultitenancyPreConditionTemplate(false, "") +
 		fmt.Sprintf(`
 resource "nsxt_policy_ipsec_vpn_session" "test" {
 %s
@@ -1016,7 +1038,7 @@ resource "nsxt_policy_ipsec_vpn_session" "test" {
 func testAccNsxtPolicyIPSecVpnSessionRouteBasedMinimalistic() string {
 	attrMap := accTestPolicyIPSecVpnSessionRouteBasedCreateAttributes
 	return testAccNsxtPolicyTier0WithEdgeClusterForVPN() +
-		testAccNsxtPolicyIPSecVpnSessionPreConditionTemplate(true, false) +
+		testAccNsxtPolicyIPSecVpnSessionPreConditionTemplate(true, false, "") +
 		fmt.Sprintf(`
 resource "nsxt_policy_ipsec_vpn_session" "test" {
   display_name        = "%s"
@@ -1039,7 +1061,7 @@ func testAccNsxtPolicyIPSecVpnSessionRouteBasedTemplate(createFlow bool, isT0 bo
 	} else {
 		attrMap = accTestPolicyIPSecVpnSessionRouteBasedUpdateAttributes
 	}
-	return testAccNsxtPolicyGatewayTemplate(isT0) + testAccNsxtPolicyIPSecVpnSessionPreConditionTemplate(isT0, false) +
+	return testAccNsxtPolicyGatewayTemplate(isT0) + testAccNsxtPolicyIPSecVpnSessionPreConditionTemplate(isT0, false, "") +
 		fmt.Sprintf(`
 resource "nsxt_policy_ipsec_vpn_session" "test" {
   display_name               = "%s"
@@ -1076,7 +1098,7 @@ func testAccNsxtPolicyIPSecVpnSessionPolicyBasedTemplate(createFlow bool, isT0 b
 	} else {
 		attrMap = accTestPolicyIPSecVpnSessionPolicyBasedUpdateAttributes
 	}
-	return testAccNsxtPolicyGatewayTemplate(isT0) + testAccNsxtPolicyIPSecVpnSessionPreConditionTemplate(isT0, false) +
+	return testAccNsxtPolicyGatewayTemplate(isT0) + testAccNsxtPolicyIPSecVpnSessionPreConditionTemplate(isT0, false, "") +
 		fmt.Sprintf(`
 resource "nsxt_policy_ipsec_vpn_session" "test" {
   display_name               = "%s"
@@ -1109,9 +1131,9 @@ resource "nsxt_policy_ipsec_vpn_session" "test" {
 			attrMap["psk"], attrMap["connection_initiation_mode"], attrMap["sources"], attrMap["destinations"])
 }
 
-func testAccNsxtPolicyIPSecVpnSessionRouteBasedTemplateWithComplianceSuite(isT0 bool) string {
+func testAccNsxtPolicyIPSecVpnSessionRouteBasedTemplateWithComplianceSuite(isT0 bool, certDisplayName string) string {
 	attrMap := accTestPolicyIPSecVpnSessionRouteBasedComlianceSuiteAttributes
-	return testAccNsxtPolicyGatewayTemplate(isT0) + testAccNsxtPolicyIPSecVpnSessionPreConditionTemplate(isT0, true) +
+	return testAccNsxtPolicyGatewayTemplate(isT0) + testAccNsxtPolicyIPSecVpnSessionPreConditionTemplate(isT0, true, certDisplayName) +
 		fmt.Sprintf(`
 resource "nsxt_policy_ipsec_vpn_session" "test" {
   display_name               = "%s"
@@ -1138,9 +1160,9 @@ resource "nsxt_policy_ipsec_vpn_session" "test" {
 			attrMap["connection_initiation_mode"], attrMap["ip_addresses"], attrMap["prefix_length"])
 }
 
-func testAccNsxtPolicyIPSecVpnSessionPolicyBasedTemplateWithComplianceSuite(isT0 bool) string {
+func testAccNsxtPolicyIPSecVpnSessionPolicyBasedTemplateWithComplianceSuite(isT0 bool, certDisplayName string) string {
 	attrMap := accTestPolicyIPSecVpnSessionPolicyBasedComlianceSuiteAttributes
-	return testAccNsxtPolicyGatewayTemplate(isT0) + testAccNsxtPolicyIPSecVpnSessionPreConditionTemplate(isT0, true) +
+	return testAccNsxtPolicyGatewayTemplate(isT0) + testAccNsxtPolicyIPSecVpnSessionPreConditionTemplate(isT0, true, certDisplayName) +
 		fmt.Sprintf(`
 resource "nsxt_policy_ipsec_vpn_session" "test" {
   display_name               = "%s"
@@ -1178,7 +1200,7 @@ func testAccNsxtPolicyIPSecVpnSessionPolicyBasedIPv6Template(createFlow bool, is
 	} else {
 		attrMap = accTestPolicyIPSecVpnSessionPolicyBasedIPv6UpdateAttributes
 	}
-	return testAccNsxtPolicyGatewayTemplate(isT0) + testAccNsxtPolicyIPSecVpnSessionIPv6PreConditionTemplate(isT0, false) +
+	return testAccNsxtPolicyGatewayTemplate(isT0) + testAccNsxtPolicyIPSecVpnSessionIPv6PreConditionTemplate(isT0, false, "") +
 		fmt.Sprintf(`
 resource "nsxt_policy_ipsec_vpn_session" "test" {
 	display_name               = "%s"
@@ -1211,8 +1233,8 @@ resource "nsxt_policy_ipsec_vpn_session" "test" {
 			attrMap["psk"], attrMap["connection_initiation_mode"], attrMap["sources"], attrMap["destinations"])
 }
 
-func testAccNsxtPolicyIPSecVpnSessionIPv6PreConditionTemplate(isT0 bool, useCert bool) string {
-	certName := getTestCertificateName(false)
+func testAccNsxtPolicyIPSecVpnSessionIPv6PreConditionTemplate(isT0 bool, useCert bool, certDisplayName string) string {
+	certName := certDisplayName
 	var localEndpointTemplate string
 	if useCert {
 		localEndpointTemplate = fmt.Sprintf(`
@@ -1441,7 +1463,7 @@ func testAccNsxtPolicyIPSecVpnSessionRouteBasedIPv6Template(createFlow bool, isT
 	} else {
 		attrMap = accTestPolicyIPSecVpnSessionRouteBasedIPv6UpdateAttributes
 	}
-	return testAccNsxtPolicyGatewayTemplate(isT0) + testAccNsxtPolicyIPSecVpnSessionIPv6PreConditionTemplate(isT0, false) +
+	return testAccNsxtPolicyGatewayTemplate(isT0) + testAccNsxtPolicyIPSecVpnSessionIPv6PreConditionTemplate(isT0, false, "") +
 		fmt.Sprintf(`
 resource "nsxt_policy_ipsec_vpn_session" "test" {
 	display_name               = "%s"
@@ -1473,7 +1495,7 @@ resource "nsxt_policy_ipsec_vpn_session" "test" {
 func testAccNsxtPolicyIPSecVpnSessionRouteBasedIPv6Minimalistic() string {
 	attrMap := accTestPolicyIPSecVpnSessionRouteBasedIPv6CreateAttributes
 	return testAccNsxtPolicyTier0WithEdgeClusterForVPN() +
-		testAccNsxtPolicyIPSecVpnSessionIPv6PreConditionTemplate(true, false) +
+		testAccNsxtPolicyIPSecVpnSessionIPv6PreConditionTemplate(true, false, "") +
 		fmt.Sprintf(`
 resource "nsxt_policy_ipsec_vpn_session" "test" {
 	display_name        = "%s"

--- a/nsxt/resource_nsxt_policy_lb_virtual_server_test.go
+++ b/nsxt/resource_nsxt_policy_lb_virtual_server_test.go
@@ -129,20 +129,31 @@ func TestAccResourceNsxtPolicyLBVirtualServer_basic(t *testing.T) {
 // TODO: add CRLs and other certificates
 func TestAccResourceNsxtPolicyLBVirtualServer_withSSL(t *testing.T) {
 	testResourceName := "nsxt_policy_lb_virtual_server.test"
+	certDisplayName := getAccTestResourceName()
+	var accTestLbTlsCertID string
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccOnlyLocalManager(t)
 			testAccPreCheck(t)
-			testAccEnvDefined(t, "NSXT_TEST_CERTIFICATE_NAME")
 		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNsxtPolicyLBVirtualServerCheckDestroy(state, accTestPolicyLBVirtualServerCreateAttributes["display_name"])
+			if err := testAccNsxtPolicyLBVirtualServerCheckDestroy(state, accTestPolicyLBVirtualServerCreateAttributes["display_name"]); err != nil {
+				return err
+			}
+			return testAccTlsCertificateDeleteGlobal(accTestLbTlsCertID)
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNsxtPolicyLBVirtualServerSSLTemplate(true),
+				PreConfig: func() {
+					id, err := testAccTlsCertificateSelfSignedCreateGlobal(certDisplayName)
+					if err != nil {
+						t.Fatal(err)
+					}
+					accTestLbTlsCertID = id
+				},
+				Config: testAccNsxtPolicyLBVirtualServerSSLTemplate(true, certDisplayName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNsxtPolicyLBVirtualServerExists(testResourceName),
 					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestPolicyLBVirtualServerCreateAttributes["display_name"]),
@@ -161,7 +172,7 @@ func TestAccResourceNsxtPolicyLBVirtualServer_withSSL(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNsxtPolicyLBVirtualServerSSLTemplate(false),
+				Config: testAccNsxtPolicyLBVirtualServerSSLTemplate(false, certDisplayName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNsxtPolicyLBVirtualServerExists(testResourceName),
 					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestPolicyLBVirtualServerUpdateAttributes["display_name"]),
@@ -841,7 +852,7 @@ data "nsxt_policy_realization_info" "realization_info" {
 }`, accTestPolicyLBVirtualServerUpdateAttributes["display_name"], attrMap["ip_address"], accTestPolicyLBVirtualServerUpdateAttributes["ports"])
 }
 
-func testAccNsxtPolicyLBVirtualServerSSLTemplate(createFlow bool) string {
+func testAccNsxtPolicyLBVirtualServerSSLTemplate(createFlow bool, certDisplayName string) string {
 	var attrMap map[string]string
 	if createFlow {
 		attrMap = accTestPolicyLBVirtualServerCreateAttributes
@@ -882,7 +893,7 @@ resource "nsxt_policy_lb_virtual_server" "test" {
     certificate_chain_depth = %s
     ssl_profile_path        = data.nsxt_policy_lb_server_ssl_profile.default.path
   }
-}`, getTestCertificateName(false), attrMap["display_name"], attrMap["ip_address"], attrMap["ports"], attrMap["certificate_chain_depth"], attrMap["certificate_chain_depth"])
+}`, certDisplayName, attrMap["display_name"], attrMap["ip_address"], attrMap["ports"], attrMap["certificate_chain_depth"], attrMap["certificate_chain_depth"])
 }
 
 func testAccNsxtPolicyLBVirtualServerWithAccessList(createFlow bool) string {

--- a/nsxt/utils_test.go
+++ b/nsxt/utils_test.go
@@ -167,13 +167,6 @@ func getTestAnotherSiteName() string {
 	return os.Getenv("NSXT_TEST_ANOTHER_SITE_NAME")
 }
 
-func getTestCertificateName(isClient bool) string {
-	if isClient {
-		return os.Getenv("NSXT_TEST_CLIENT_CERTIFICATE_NAME")
-	}
-	return os.Getenv("NSXT_TEST_CERTIFICATE_NAME")
-}
-
 func getTestLdapUser() string {
 	return os.Getenv("NSXT_TEST_LDAP_USER")
 }


### PR DESCRIPTION
Instead of dependency on a pre-existing certificate which is referenced by the acceptance test, create a certificate within the test scope.