### PR TITLE
Fix VM multitenancy and other VM testing issues

### DIFF
--- a/api/utl/api_util.go
+++ b/api/utl/api_util.go
@@ -31,6 +31,7 @@ type SessionContextSpec struct {
 	IsRequired          bool
 	IsComputed          bool
 	IsVpc               bool
+	IsVpcOptional       bool
 	AllowDefaultProject bool
 	FromGlobal          bool
 }

--- a/docs/resources/policy_vm_tags.md
+++ b/docs/resources/policy_vm_tags.md
@@ -92,13 +92,14 @@ An existing VM Tags collection can be [imported][docs-import] into this resource
 terraform import nsxt_policy_vm_tags.vm1_tags ID
 ```
 
-The above would import NSX Virtual Machine tags as a resource named `vm1_tags` with the NSX ID `ID`, where ID is external ID of the Virtual Machine.
+The above would import NSX Virtual Machine tags as a resource named `vm1_tags` with the NSX ID `ID`, where `ID` is the external ID of the Virtual Machine.
+
+For multitenancy, provide both the VM instance ID and the project ID separated by `::`:
 
 ```shell
-terraform import nsxt_policy_vm_tags.vm1_tags POLICY_PATH
+terraform import nsxt_policy_vm_tags.vm1_tags ID::PROJECT_ID
 ```
 
-The above would import NSX Virtual Machine tags as a resource named `vm1_tags` with policy path `POLICY_PATH`.
-Note: for multitenancy projects only the later form is usable.
+The above would import NSX Virtual Machine tags as a resource named `vm1_tags` with the VM external ID `ID` within project `PROJECT_ID`.
 
 Note that import of port tags is not supported.

--- a/docs/resources/policy_vm_tags.md
+++ b/docs/resources/policy_vm_tags.md
@@ -70,6 +70,34 @@ resource "nsxt_policy_vm_tags" "vm1_tags" {
 }
 ```
 
+## Example Usage - VPC
+
+```hcl
+data "nsxt_policy_project" "demoproj" {
+  display_name = "demoproj"
+}
+
+data "nsxt_vpc" "demovpc" {
+  display_name = "demovpc"
+  context {
+    project_id = data.nsxt_policy_project.demoproj.id
+  }
+}
+
+resource "nsxt_policy_vm_tags" "vm1_tags" {
+  context {
+    project_id = data.nsxt_policy_project.demoproj.id
+    vpc_id     = data.nsxt_vpc.demovpc.id
+  }
+  instance_id = vsphere_virtual_machine.vm1.id
+
+  tag {
+    scope = "color"
+    tag   = "blue"
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -78,6 +106,7 @@ The following arguments are supported:
 * `tag` - (Optional) A list of scope + tag pairs to associate with this Virtual Machine.
 * `context` - (Optional) The context which the object belongs to
     * `project_id` - (Required) The ID of the project which the object belongs to
+    * `vpc_id` - (Optional) The ID of the VPC which the object belongs to
 * `port` - (Optional) Option to tag segment port auto-created for the VM on specified segment.
     * `segment_path` - (Required) Segment where the port is to be tagged.
     * `tag` - (Optional) A list of scope + tag pairs to associate with this segment port.
@@ -101,5 +130,13 @@ terraform import nsxt_policy_vm_tags.vm1_tags ID::PROJECT_ID
 ```
 
 The above would import NSX Virtual Machine tags as a resource named `vm1_tags` with the VM external ID `ID` within project `PROJECT_ID`.
+
+For VPC, provide the VM instance ID, project ID, and VPC ID all separated by `::`:
+
+```shell
+terraform import nsxt_policy_vm_tags.vm1_tags ID::PROJECT_ID::VPC_ID
+```
+
+The above would import NSX Virtual Machine tags as a resource named `vm1_tags` with the VM external ID `ID` within VPC `VPC_ID` of project `PROJECT_ID`.
 
 Note that import of port tags is not supported.

--- a/nsxt/data_source_nsxt_policy_certificate_test.go
+++ b/nsxt/data_source_nsxt_policy_certificate_test.go
@@ -20,6 +20,7 @@ func TestAccDataSourceNsxtPolicyCertificate_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
+			testAccOnlyLocalManager(t)
 		},
 		Providers: testAccProviders,
 		CheckDestroy: func(*terraform.State) error {

--- a/nsxt/data_source_nsxt_policy_vm_test.go
+++ b/nsxt/data_source_nsxt_policy_vm_test.go
@@ -26,7 +26,6 @@ func TestAccDataSourceNsxtPolicyVM_multitenancy(t *testing.T) {
 		testAccPreCheck(t)
 		testAccOnlyMultitenancy(t)
 		testAccEnvDefined(t, "NSXT_TEST_MULTITENANCY_VM_ID")
-		testAccEnvDefined(t, "NSXT_TEST_MULTITENANCY_VM_NAME")
 	})
 }
 func testAccDataSourceNsxtPolicyVMBasic(t *testing.T, withContext bool, preCheck func()) {
@@ -78,7 +77,7 @@ data "nsxt_policy_vm" "test" {
 output "vm_vif_id" {
   value = data.nsxt_policy_vm.test.vif_ids[0]
 }
-`, context, getTestVMName())
+`, context, getTestVMName(withContext))
 }
 
 func testAccNsxtPolicyVMReadByIDTemplate(withContext bool) string {

--- a/nsxt/data_source_nsxt_policy_vms_test.go
+++ b/nsxt/data_source_nsxt_policy_vms_test.go
@@ -21,10 +21,10 @@ func TestAccDataSourceNsxtPolicyVMs_basic(t *testing.T) {
 }
 
 func TestAccDataSourceNsxtPolicyVMs_multitenancy(t *testing.T) {
-	testAccDataSourceNsxtPolicyVMsBasic(t, false, func() {
+	testAccDataSourceNsxtPolicyVMsBasic(t, true, func() {
 		testAccPreCheck(t)
 		testAccOnlyMultitenancy(t)
-		testAccEnvDefined(t, "NSXT_TEST_VM_NAME")
+		testAccEnvDefined(t, "NSXT_TEST_MULTITENANCY_VM_ID")
 	})
 }
 
@@ -120,7 +120,7 @@ resource "nsxt_policy_group" "check" {
 output "vm_vif_id" {
   value = data.nsxt_policy_vm.check.vif_ids[0]
 }
-`, context, valueType, context, getTestVMName(), context, getTestVMName())
+`, context, valueType, context, getTestVMName(withContext), context, getTestVMName(withContext))
 }
 
 func testAccNsxtPolicyVMsTemplateFilter() string {
@@ -146,5 +146,5 @@ output "vmout" {
   value = data.nsxt_policy_vms.test.items["%s"]
 }
 
-`, getTestVMName())
+`, getTestVMName(false))
 }

--- a/nsxt/policy_importers_unit_test.go
+++ b/nsxt/policy_importers_unit_test.go
@@ -63,7 +63,18 @@ func TestUnitNsxt_getPolicyPathOrIDResourceImporter(t *testing.T) {
 
 func TestUnitNsxt_resourceNsxtPolicyVMTagsImporter(t *testing.T) {
 	m := newGoMockProviderClient()
-	contextSchema := getContextSchema(false, false, false)
+	contextSchema := &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		ForceNew: true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"project_id": {Type: schema.TypeString, Required: true, ForceNew: true},
+				"vpc_id":     {Type: schema.TypeString, Optional: true, ForceNew: true},
+			},
+		},
+	}
 
 	t.Run("plain instance id", func(t *testing.T) {
 		d := schema.TestResourceDataRaw(t, map[string]*schema.Schema{
@@ -131,6 +142,43 @@ func TestUnitNsxt_resourceNsxtPolicyVMTagsImporter(t *testing.T) {
 
 		_, err := resourceNsxtPolicyVMTagsImporter(d, m)
 		require.Error(t, err)
+	})
+
+	t.Run("composite instance_id::project_id::vpc_id sets context", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, map[string]*schema.Schema{
+			"context": contextSchema,
+		}, map[string]interface{}{})
+		d.SetId("503b13f0-22c7-4d72-a16e-aa7e6c8f2da6::demoproj::demovpc")
+
+		rd, err := resourceNsxtPolicyVMTagsImporter(d, m)
+		require.NoError(t, err)
+		require.Len(t, rd, 1)
+		assert.Equal(t, "503b13f0-22c7-4d72-a16e-aa7e6c8f2da6", rd[0].Id())
+		projectID, vpcID, _ := getContextDataFromSchema(rd[0])
+		assert.Equal(t, "demoproj", projectID)
+		assert.Equal(t, "demovpc", vpcID)
+	})
+
+	t.Run("empty vpc_id in three-part composite", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, map[string]*schema.Schema{
+			"context": contextSchema,
+		}, map[string]interface{}{})
+		d.SetId("503b13f0-22c7-4d72-a16e-aa7e6c8f2da6::demoproj::")
+
+		_, err := resourceNsxtPolicyVMTagsImporter(d, m)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "non-empty")
+	})
+
+	t.Run("empty project_id in three-part composite", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, map[string]*schema.Schema{
+			"context": contextSchema,
+		}, map[string]interface{}{})
+		d.SetId("503b13f0-22c7-4d72-a16e-aa7e6c8f2da6::::demovpc")
+
+		_, err := resourceNsxtPolicyVMTagsImporter(d, m)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "non-empty")
 	})
 }
 

--- a/nsxt/policy_importers_unit_test.go
+++ b/nsxt/policy_importers_unit_test.go
@@ -61,6 +61,79 @@ func TestUnitNsxt_getPolicyPathOrIDResourceImporter(t *testing.T) {
 	})
 }
 
+func TestUnitNsxt_resourceNsxtPolicyVMTagsImporter(t *testing.T) {
+	m := newGoMockProviderClient()
+	contextSchema := getContextSchema(false, false, false)
+
+	t.Run("plain instance id", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, map[string]*schema.Schema{
+			"context": contextSchema,
+		}, map[string]interface{}{})
+		d.SetId("503b13f0-22c7-4d72-a16e-aa7e6c8f2da6")
+
+		rd, err := resourceNsxtPolicyVMTagsImporter(d, m)
+		require.NoError(t, err)
+		require.Len(t, rd, 1)
+		assert.Equal(t, "503b13f0-22c7-4d72-a16e-aa7e6c8f2da6", rd[0].Id())
+	})
+
+	t.Run("composite instance_id::project_id sets context", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, map[string]*schema.Schema{
+			"context": contextSchema,
+		}, map[string]interface{}{})
+		d.SetId("503b13f0-22c7-4d72-a16e-aa7e6c8f2da6::demoproj")
+
+		rd, err := resourceNsxtPolicyVMTagsImporter(d, m)
+		require.NoError(t, err)
+		require.Len(t, rd, 1)
+		assert.Equal(t, "503b13f0-22c7-4d72-a16e-aa7e6c8f2da6", rd[0].Id())
+		projectID, _, _ := getContextDataFromSchema(rd[0])
+		assert.Equal(t, "demoproj", projectID)
+	})
+
+	t.Run("empty id", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, map[string]*schema.Schema{
+			"context": contextSchema,
+		}, map[string]interface{}{})
+		d.SetId("")
+
+		_, err := resourceNsxtPolicyVMTagsImporter(d, m)
+		require.Error(t, err)
+	})
+
+	t.Run("empty instance_id in composite", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, map[string]*schema.Schema{
+			"context": contextSchema,
+		}, map[string]interface{}{})
+		d.SetId("::demoproj")
+
+		_, err := resourceNsxtPolicyVMTagsImporter(d, m)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "non-empty")
+	})
+
+	t.Run("empty project_id in composite", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, map[string]*schema.Schema{
+			"context": contextSchema,
+		}, map[string]interface{}{})
+		d.SetId("503b13f0-22c7-4d72-a16e-aa7e6c8f2da6::")
+
+		_, err := resourceNsxtPolicyVMTagsImporter(d, m)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "non-empty")
+	})
+
+	t.Run("slash in id without separator is rejected", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, map[string]*schema.Schema{
+			"context": contextSchema,
+		}, map[string]interface{}{})
+		d.SetId("/infra/realized-state/virtual-machines/vm1")
+
+		_, err := resourceNsxtPolicyVMTagsImporter(d, m)
+		require.Error(t, err)
+	})
+}
+
 func TestUnitNsxt_getVpcPathResourceImporter(t *testing.T) {
 	m := newGoMockProviderClient()
 	imp := getVpcPathResourceImporter("/orgs/o/projects/p/vpcs/v/infra/example")

--- a/nsxt/resource_nsxt_policy_vm_tags.go
+++ b/nsxt/resource_nsxt_policy_vm_tags.go
@@ -43,11 +43,19 @@ func resourceNsxtPolicyVMTagsImporter(d *schema.ResourceData, m interface{}) ([]
 		return nil, ErrEmptyImportID
 	}
 
-	if idx := strings.Index(importID, vmTagsImportIDSeparator); idx >= 0 {
-		instanceID := importID[:idx]
-		projectID := importID[idx+len(vmTagsImportIDSeparator):]
+	parts := strings.SplitN(importID, vmTagsImportIDSeparator, 3)
+	switch len(parts) {
+	case 1:
+		// Plain instance ID — local manager (no project, no VPC).
+		if !isValidResourceID(parts[0]) {
+			return nil, fmt.Errorf("invalid import ID %q: use instance_id, instance_id%sproject_id, or instance_id%sproject_id%svpc_id",
+				importID, vmTagsImportIDSeparator, vmTagsImportIDSeparator, vmTagsImportIDSeparator)
+		}
+	case 2:
+		// instance_id::project_id — multitenancy / project scope.
+		instanceID, projectID := parts[0], parts[1]
 		if instanceID == "" || projectID == "" {
-			return nil, fmt.Errorf("invalid import ID %q: both instance_id and project_id must be non-empty when using %q separator", importID, vmTagsImportIDSeparator)
+			return nil, fmt.Errorf("invalid import ID %q: instance_id and project_id must both be non-empty", importID)
 		}
 		ctxMap := map[string]interface{}{
 			"project_id": projectID,
@@ -56,11 +64,20 @@ func resourceNsxtPolicyVMTagsImporter(d *schema.ResourceData, m interface{}) ([]
 			return nil, err
 		}
 		d.SetId(instanceID)
-		return []*schema.ResourceData{d}, nil
-	}
-
-	if !isValidResourceID(importID) {
-		return nil, fmt.Errorf("invalid import ID %q: use instance_id for non-multitenancy or instance_id%sproject_id for multitenancy", importID, vmTagsImportIDSeparator)
+	case 3:
+		// instance_id::project_id::vpc_id — VPC scope.
+		instanceID, projectID, vpcID := parts[0], parts[1], parts[2]
+		if instanceID == "" || projectID == "" || vpcID == "" {
+			return nil, fmt.Errorf("invalid import ID %q: instance_id, project_id and vpc_id must all be non-empty", importID)
+		}
+		ctxMap := map[string]interface{}{
+			"project_id": projectID,
+			"vpc_id":     vpcID,
+		}
+		if err := d.Set("context", []interface{}{ctxMap}); err != nil {
+			return nil, err
+		}
+		d.SetId(instanceID)
 	}
 	return []*schema.ResourceData{d}, nil
 }
@@ -93,7 +110,7 @@ func resourceNsxtPolicyVMTags() *schema.Resource {
 					},
 				},
 			},
-			"context": getContextSchema(false, false, false),
+			"context": getContextSchemaWithSpec(utl.SessionContextSpec{IsVpc: true, IsVpcOptional: true}),
 		},
 	}
 }

--- a/nsxt/resource_nsxt_policy_vm_tags.go
+++ b/nsxt/resource_nsxt_policy_vm_tags.go
@@ -24,6 +24,8 @@ import (
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 )
 
+const vmTagsImportIDSeparator = "::"
+
 var (
 	nsxtPolicyBiosUUIDKey     = "biosUuid"
 	nsxtPolicyInstanceUUIDKey = "instanceUuid"
@@ -35,7 +37,33 @@ var cliVirtualMachinesClient = realized_enforcement_points.NewVirtualMachinesCli
 var cliRealizedVirtualMachinesClient = realizedstate.NewVirtualMachinesClient
 var cliVirtualMachineTagsClient = realized_virtual_machines.NewTagsClient
 
-var vmTagsPathExample = getMultitenancyPathExample("/infra/realized-state/virtual-machines/[vm]")
+func resourceNsxtPolicyVMTagsImporter(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	importID := d.Id()
+	if isSpaceString(importID) {
+		return nil, ErrEmptyImportID
+	}
+
+	if idx := strings.Index(importID, vmTagsImportIDSeparator); idx >= 0 {
+		instanceID := importID[:idx]
+		projectID := importID[idx+len(vmTagsImportIDSeparator):]
+		if instanceID == "" || projectID == "" {
+			return nil, fmt.Errorf("invalid import ID %q: both instance_id and project_id must be non-empty when using %q separator", importID, vmTagsImportIDSeparator)
+		}
+		ctxMap := map[string]interface{}{
+			"project_id": projectID,
+		}
+		if err := d.Set("context", []interface{}{ctxMap}); err != nil {
+			return nil, err
+		}
+		d.SetId(instanceID)
+		return []*schema.ResourceData{d}, nil
+	}
+
+	if !isValidResourceID(importID) {
+		return nil, fmt.Errorf("invalid import ID %q: use instance_id for non-multitenancy or instance_id%sproject_id for multitenancy", importID, vmTagsImportIDSeparator)
+	}
+	return []*schema.ResourceData{d}, nil
+}
 
 func resourceNsxtPolicyVMTags() *schema.Resource {
 	return &schema.Resource{
@@ -44,7 +72,7 @@ func resourceNsxtPolicyVMTags() *schema.Resource {
 		Update: resourceNsxtPolicyVMTagsUpdate,
 		Delete: resourceNsxtPolicyVMTagsDelete,
 		Importer: &schema.ResourceImporter{
-			State: getPolicyPathOrIDResourceImporter(vmTagsPathExample),
+			State: resourceNsxtPolicyVMTagsImporter,
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_policy_vm_tags.go
+++ b/nsxt/resource_nsxt_policy_vm_tags.go
@@ -54,7 +54,7 @@ func resourceNsxtPolicyVMTagsImporter(d *schema.ResourceData, m interface{}) ([]
 	case 2:
 		// instance_id::project_id — multitenancy / project scope.
 		instanceID, projectID := parts[0], parts[1]
-		if instanceID == "" || projectID == "" {
+		if !isValidResourceID(instanceID) || projectID == "" {
 			return nil, fmt.Errorf("invalid import ID %q: instance_id and project_id must both be non-empty", importID)
 		}
 		ctxMap := map[string]interface{}{
@@ -67,7 +67,7 @@ func resourceNsxtPolicyVMTagsImporter(d *schema.ResourceData, m interface{}) ([]
 	case 3:
 		// instance_id::project_id::vpc_id — VPC scope.
 		instanceID, projectID, vpcID := parts[0], parts[1], parts[2]
-		if instanceID == "" || projectID == "" || vpcID == "" {
+		if !isValidResourceID(instanceID) || projectID == "" || vpcID == "" {
 			return nil, fmt.Errorf("invalid import ID %q: instance_id, project_id and vpc_id must all be non-empty", importID)
 		}
 		ctxMap := map[string]interface{}{

--- a/nsxt/resource_nsxt_policy_vm_tags_test.go
+++ b/nsxt/resource_nsxt_policy_vm_tags_test.go
@@ -68,7 +68,7 @@ func TestAccResourceNsxtPolicyVMTags_withPorts(t *testing.T) {
 			testAccOnlyLocalManager(t)
 			testAccPreCheck(t)
 			testAccEnvDefined(t, "NSXT_TEST_VM_ID")
-			testAccEnvDefined(t, "NSXT_TEST_VM_SEGMENT_ID")
+			testAccEnvDefined(t, "NSXT_TEST_VM_SEGMENT_NAME")
 		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
@@ -126,7 +126,7 @@ func TestAccResourceNsxtPolicyVMTags_import_basic(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyVMTags_import_basic_multitenancy(t *testing.T) {
-	vmID := getTestVMID(false)
+	vmID := getTestVMID(true)
 	testResourceName := "nsxt_policy_vm_tags.test"
 
 	resource.Test(t, resource.TestCase{
@@ -239,6 +239,10 @@ resource "nsxt_policy_vm_tags" "test" {
 
 func testAccNSXPolicyVMPortTagsCreateTemplate(instanceID string) string {
 	return fmt.Sprintf(`
+data "nsxt_policy_segment" "segment" {
+  display_name = "%s"
+}
+
 resource "nsxt_policy_vm_tags" "test" {
   instance_id = "%s"
 
@@ -248,22 +252,26 @@ resource "nsxt_policy_vm_tags" "test" {
   }
 
   port {
-    segment_path = "/infra/segments/%s"
+    segment_path = data.nsxt_policy_segment.segment.path
     tag {
       scope = "color"
       tag   = "green"
     }
   }
-}`, instanceID, getTestVMSegmentID())
+}`, getTestVMSegmentName(), instanceID)
 }
 
 func testAccNSXPolicyVMPortTagsUpdateTemplate(instanceID string) string {
 	return fmt.Sprintf(`
+data "nsxt_policy_segment" "segment" {
+  display_name = "%s"
+}
+
 resource "nsxt_policy_vm_tags" "test" {
   instance_id = "%s"
 
   port {
-    segment_path = "/infra/segments/%s"
+    segment_path = data.nsxt_policy_segment.segment.path
     tag {
       scope = "color"
       tag   = "green"
@@ -273,5 +281,5 @@ resource "nsxt_policy_vm_tags" "test" {
       tag   = "round"
     }
   }
-}`, instanceID, getTestVMSegmentID())
+}`, getTestVMSegmentName(), instanceID)
 }

--- a/nsxt/resource_nsxt_policy_vm_tags_test.go
+++ b/nsxt/resource_nsxt_policy_vm_tags_test.go
@@ -6,6 +6,7 @@ package nsxt
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -25,6 +26,70 @@ func TestAccResourceNsxtPolicyVMTags_multitenancy(t *testing.T) {
 		testAccPreCheck(t)
 		testAccOnlyMultitenancy(t)
 		testAccEnvDefined(t, "NSXT_TEST_MULTITENANCY_VM_ID")
+	})
+}
+
+func TestAccResourceNsxtPolicyVMTags_vpc(t *testing.T) {
+	vmID := os.Getenv("NSXT_TEST_VPC_VM_ID")
+	testResourceName := "nsxt_policy_vm_tags.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccOnlyVPC(t)
+			testAccEnvDefined(t, "NSXT_TEST_VPC_VM_ID")
+		},
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNSXPolicyVMTagsCheckDestroy(state)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNSXPolicyVMTagsCreateTemplate(vmID, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNSXPolicyVMTagsCheckExists(testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "instance_id", vmID),
+				),
+			},
+			{
+				Config: testAccNSXPolicyVMTagsUpdateTemplate(vmID, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNSXPolicyVMTagsCheckExists(testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "tag.#", "2"),
+					resource.TestCheckResourceAttr(testResourceName, "instance_id", vmID),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceNsxtPolicyVMTags_import_basic_vpc(t *testing.T) {
+	vmID := os.Getenv("NSXT_TEST_VPC_VM_ID")
+	testResourceName := "nsxt_policy_vm_tags.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccOnlyVPC(t)
+			testAccEnvDefined(t, "NSXT_TEST_VPC_VM_ID")
+		},
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNSXPolicyVMTagsCheckDestroy(state)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNSXPolicyVMTagsCreateTemplate(vmID, true),
+			},
+			{
+				ResourceName:            testResourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"instance_id"},
+				ImportStateIdFunc:       testAccNsxtPolicyVMTagsVPCImportIDFunc(testResourceName),
+			},
+		},
 	})
 }
 
@@ -171,6 +236,30 @@ func testAccNsxtPolicyVMTagsImportIDFunc(resourceName string) func(*terraform.St
 			return "", fmt.Errorf("NSX Policy VM Tags resource context.0.project_id not set in resources")
 		}
 		return instanceID + vmTagsImportIDSeparator + projectID, nil
+	}
+}
+
+// testAccNsxtPolicyVMTagsVPCImportIDFunc builds the composite
+// "<instance_id>::<project_id>::<vpc_id>" import identifier for VPC context.
+func testAccNsxtPolicyVMTagsVPCImportIDFunc(resourceName string) func(*terraform.State) (string, error) {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("NSX Policy VM Tags resource %s not found in resources", resourceName)
+		}
+		instanceID := rs.Primary.ID
+		if instanceID == "" {
+			return "", fmt.Errorf("NSX Policy VM Tags resource ID not set in resources")
+		}
+		projectID := rs.Primary.Attributes["context.0.project_id"]
+		if projectID == "" {
+			return "", fmt.Errorf("NSX Policy VM Tags resource context.0.project_id not set in resources")
+		}
+		vpcID := rs.Primary.Attributes["context.0.vpc_id"]
+		if vpcID == "" {
+			return "", fmt.Errorf("NSX Policy VM Tags resource context.0.vpc_id not set in resources")
+		}
+		return instanceID + vmTagsImportIDSeparator + projectID + vmTagsImportIDSeparator + vpcID, nil
 	}
 }
 

--- a/nsxt/resource_nsxt_policy_vm_tags_test.go
+++ b/nsxt/resource_nsxt_policy_vm_tags_test.go
@@ -148,10 +148,30 @@ func TestAccResourceNsxtPolicyVMTags_import_basic_multitenancy(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"instance_id"},
-				ImportStateIdFunc:       testAccResourceNsxtPolicyImportIDRetriever(testResourceName),
+				ImportStateIdFunc:       testAccNsxtPolicyVMTagsImportIDFunc(testResourceName),
 			},
 		},
 	})
+}
+
+// testAccNsxtPolicyVMTagsImportIDFunc builds the composite "<instance_id>::<project_id>" import
+// identifier for multitenancy, since nsxt_policy_vm_tags has no path attribute.
+func testAccNsxtPolicyVMTagsImportIDFunc(resourceName string) func(*terraform.State) (string, error) {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("NSX Policy VM Tags resource %s not found in resources", resourceName)
+		}
+		instanceID := rs.Primary.ID
+		if instanceID == "" {
+			return "", fmt.Errorf("NSX Policy VM Tags resource ID not set in resources")
+		}
+		projectID := rs.Primary.Attributes["context.0.project_id"]
+		if projectID == "" {
+			return "", fmt.Errorf("NSX Policy VM Tags resource context.0.project_id not set in resources")
+		}
+		return instanceID + vmTagsImportIDSeparator + projectID, nil
+	}
 }
 
 func testAccNSXPolicyVMTagsCheckExists(resourceName string) resource.TestCheckFunc {

--- a/nsxt/utils.go
+++ b/nsxt/utils.go
@@ -281,8 +281,8 @@ func getContextSchema(isRequired, isComputed, isVPC bool) *schema.Schema {
 
 func getContextSchemaWithSpec(spec api_util.SessionContextSpec) *schema.Schema {
 	ctxSchema := getContextSchemaExtended(spec.IsRequired, spec.IsComputed, spec.IsVpc, spec.AllowDefaultProject)
+	elem := ctxSchema.Elem.(*schema.Resource)
 	if spec.FromGlobal {
-		elem := ctxSchema.Elem.(*schema.Resource)
 		elem.Schema["from_global"] = &schema.Schema{
 			Type:        schema.TypeBool,
 			Description: "Search among global resource",
@@ -296,6 +296,12 @@ func getContextSchemaWithSpec(spec api_util.SessionContextSpec) *schema.Schema {
 			projectIdElem.Optional = true
 		}
 
+	}
+	if spec.IsVpcOptional {
+		if vpcElem, ok := elem.Schema["vpc_id"]; ok {
+			vpcElem.Required = false
+			vpcElem.Optional = true
+		}
 	}
 	return ctxSchema
 }

--- a/nsxt/utils_test.go
+++ b/nsxt/utils_test.go
@@ -151,11 +151,14 @@ func getTestVMID(isMultitenancy bool) string {
 	return os.Getenv("NSXT_TEST_VM_ID")
 }
 
-func getTestVMSegmentID() string {
-	return os.Getenv("NSXT_TEST_VM_SEGMENT_ID")
+func getTestVMSegmentName() string {
+	return os.Getenv("NSXT_TEST_VM_SEGMENT_NAME")
 }
 
-func getTestVMName() string {
+func getTestVMName(withContext bool) string {
+	if withContext {
+		return os.Getenv("NSXT_TEST_MULTITENANCY_VM_NAME")
+	}
 	return os.Getenv("NSXT_TEST_VM_NAME")
 }
 


### PR DESCRIPTION
Some test issues are due to usage of the wrong VM id in multitenancy environments.
Also, tests were looking up segment ids which weren't exposed.

For `nsxt_policy_vm_tags`, there are two issues which this handles which are beyond the testing scope:
* The code uses `path` to import a multitenancy VM tags resource. Yet, this resource has no path attribute. This has been replaced with instance_id::project_id import id.
* There's no coverage for the case of VPC VM. This has been added as well, with instance_id::project_id::vpc_id import id scheme. 