### PR TITLE
Fix GRE tunnel update failing with NSX error 500127

### DIFF
--- a/nsxt/resource_nsxt_policy_tier0_gateway_gre_tunnel.go
+++ b/nsxt/resource_nsxt_policy_tier0_gateway_gre_tunnel.go
@@ -152,7 +152,7 @@ func resourceNsxtPolicyTier0GatewayGRETunnel() *schema.Resource {
 	}
 }
 
-func tier0GatewayGRETunnelFromSchema(d *schema.ResourceData) (*data.StructValue, error) {
+func tier0GatewayGRETunnelFromSchema(d *schema.ResourceData, revision *int64) (*data.StructValue, error) {
 	converter := bindings.NewTypeConverter()
 
 	displayName := d.Get("display_name").(string)
@@ -214,6 +214,7 @@ func tier0GatewayGRETunnelFromSchema(d *schema.ResourceData) (*data.StructValue,
 		TunnelAddress:      tunnelAddresses,
 		TunnelKeepalive:    &tunnelKeepalive,
 		ResourceType:       model.GreTunnel__TYPE_IDENTIFIER,
+		Revision:           revision,
 	}
 	dataValue, errs := converter.ConvertToVapi(greTunnel, model.GreTunnelBindingType())
 	if errs != nil {
@@ -262,7 +263,7 @@ func resourceNsxtPolicyTier0GatewayGRETunnelCreate(d *schema.ResourceData, m int
 	sessionContext := utl.SessionContext{ClientType: utl.Local}
 	client := cliTunnelsClient(sessionContext, connector)
 
-	obj, err := tier0GatewayGRETunnelFromSchema(d)
+	obj, err := tier0GatewayGRETunnelFromSchema(d, nil)
 	if err != nil {
 		return fmt.Errorf("unable to create the GRE Tunnel: %v", err)
 	}
@@ -359,7 +360,8 @@ func resourceNsxtPolicyTier0GatewayGRETunnelUpdate(d *schema.ResourceData, m int
 	sessionContext := utl.SessionContext{ClientType: utl.Local}
 	client := cliTunnelsClient(sessionContext, connector)
 
-	obj, err := tier0GatewayGRETunnelFromSchema(d)
+	rev := int64(d.Get("revision").(int))
+	obj, err := tier0GatewayGRETunnelFromSchema(d, &rev)
 	if err != nil {
 		return fmt.Errorf("failed to update GRE Tunnel: %v", err)
 	}

--- a/nsxt/utgomock_resource_nsxt_policy_tier0_gateway_gre_tunnel_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_tier0_gateway_gre_tunnel_test.go
@@ -206,3 +206,58 @@ func TestMockResourceNsxtPolicyTier0GatewayGRETunnelDelete(t *testing.T) {
 		require.NoError(t, err)
 	})
 }
+
+func structValueToGreTunnel(t *testing.T, d data.DataValue) nsxModel.GreTunnel {
+	t.Helper()
+	converter := bindings.NewTypeConverter()
+	out, errs := converter.ConvertToGolang(d, nsxModel.GreTunnelBindingType())
+	require.Nil(t, errs)
+	return out.(nsxModel.GreTunnel)
+}
+
+// TestMockResourceNsxtPolicyTier0GatewayGRETunnelFromSchema verifies the
+// _revision field handling in tier0GatewayGRETunnelFromSchema.
+// Regression guard for issue #1027: Update was omitting _revision, causing
+// NSX to reject the PATCH with error code 500127 ("cannot create object as
+// it already exists").
+func TestMockResourceNsxtPolicyTier0GatewayGRETunnelFromSchema(t *testing.T) {
+	res := resourceNsxtPolicyTier0GatewayGRETunnel()
+
+	t.Run("Create omits revision", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalGreTunnelData())
+
+		sv, err := tier0GatewayGRETunnelFromSchema(d, nil)
+		require.NoError(t, err)
+		require.NotNil(t, sv)
+
+		gt := structValueToGreTunnel(t, sv)
+		assert.Nil(t, gt.Revision, "Revision must be omitted on create to avoid NSX error 500127")
+		require.NotNil(t, gt.DisplayName)
+		assert.Equal(t, greTunnelDisplayName, *gt.DisplayName)
+	})
+
+	t.Run("Update includes revision", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalGreTunnelData())
+
+		rev := greTunnelRevision
+		sv, err := tier0GatewayGRETunnelFromSchema(d, &rev)
+		require.NoError(t, err)
+		require.NotNil(t, sv)
+
+		gt := structValueToGreTunnel(t, sv)
+		require.NotNil(t, gt.Revision, "Revision must be present on update path")
+		assert.Equal(t, greTunnelRevision, *gt.Revision)
+	})
+
+	t.Run("Update with zero revision", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalGreTunnelData())
+
+		rev := int64(0)
+		sv, err := tier0GatewayGRETunnelFromSchema(d, &rev)
+		require.NoError(t, err)
+
+		gt := structValueToGreTunnel(t, sv)
+		require.NotNil(t, gt.Revision)
+		assert.Equal(t, int64(0), *gt.Revision)
+	})
+}


### PR DESCRIPTION
The update PATCH omitted the _revision field, causing NSX Policy API to treat the request as a create operation. Since the object already existed, NSX rejected it with error code 500127 ("cannot create object as it already exists").

Pass the current revision to tier0GatewayGRETunnelFromSchema only on the Update path (nil on Create), so that:
  - Create: _revision absent from body; NSX creates the object
  - Update: _revision present with correct value; NSX updates it

Fixes #1027