### PR TITLE
Fix index out of range panic for short segment paths

### DIFF
--- a/nsxt/segment_port_common.go
+++ b/nsxt/segment_port_common.go
@@ -412,7 +412,7 @@ func getSegmentPort(segmentPath, segmentPortId string, context utl.SessionContex
 
 func isT1Segment(segmentPath string) bool {
 	pathSplit := strings.Split(segmentPath, "/")
-	if len(pathSplit) >= 3 && pathSplit[len(pathSplit)-4] == "tier-1s" {
+	if len(pathSplit) >= 4 && pathSplit[len(pathSplit)-4] == "tier-1s" {
 		return true
 	}
 	return false
@@ -425,7 +425,7 @@ func getSegmentIdFromSegPath(segPortPath string) string {
 
 func getT1IdFromSegPath(segPortPath string) string {
 	pathSplit := strings.Split(segPortPath, "/")
-	if len(pathSplit) >= 3 && pathSplit[len(pathSplit)-4] == "tier-1s" {
+	if len(pathSplit) >= 4 && pathSplit[len(pathSplit)-4] == "tier-1s" {
 		return pathSplit[len(pathSplit)-3]
 	}
 	return ""

--- a/nsxt/utgomock_resource_nsxt_policy_segment_port_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_segment_port_test.go
@@ -196,6 +196,37 @@ func TestMockResourceNsxtPolicySegmentPortCreate(t *testing.T) {
 		assert.NotEmpty(t, d.Id())
 		assert.Equal(t, segPortDisplayName, d.Get("display_name"))
 	})
+
+	t.Run("Create succeeds with short segment path", func(t *testing.T) {
+		shortSegmentPath := "a/b/c"
+		shortSegmentID := "c"
+		mockInfraSDK.EXPECT().Patch(gomock.Any(), gomock.Any()).Return(nil)
+		mockPortsSDK.EXPECT().Get(shortSegmentID, gomock.Any()).Return(model.SegmentPort{
+			DisplayName: &segPortDisplayName,
+			Description: &segPortDescription,
+			Path:        &segPortPath,
+			Revision:    &segPortRevision,
+		}, nil)
+		mockDiscoverySDK.EXPECT().List(shortSegmentID, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(model.PortDiscoveryProfileBindingMapListResult{Results: []model.PortDiscoveryProfileBindingMap{}}, nil)
+		mockQosSDK.EXPECT().List(shortSegmentID, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(model.PortQosProfileBindingMapListResult{Results: []model.PortQosProfileBindingMap{}}, nil)
+		mockSecuritySDK.EXPECT().List(shortSegmentID, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(model.PortSecurityProfileBindingMapListResult{Results: []model.PortSecurityProfileBindingMap{}}, nil)
+
+		res := resourceNsxtPolicySegmentPort()
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+			"segment_path": shortSegmentPath,
+			"display_name": segPortDisplayName,
+		})
+
+		m := newGoMockProviderClient()
+		assert.NotPanics(t, func() {
+			err := resourceNsxtPolicySegmentPortCreate(d, m)
+			require.NoError(t, err)
+		})
+		assert.NotEmpty(t, d.Id())
+	})
 }
 
 func TestMockResourceNsxtPolicySegmentPortUpdate(t *testing.T) {
@@ -328,4 +359,77 @@ func TestMockResourceNsxtPolicySegmentPortDelete(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "Error obtaining Segment Port ID")
 	})
+}
+
+func TestMockIsT1Segment(t *testing.T) {
+	tests := []struct {
+		name        string
+		segmentPath string
+		expected    bool
+	}{
+		{
+			name:        "T1 segment path",
+			segmentPath: "/infra/tier-1s/t1-1/segments/seg-1",
+			expected:    true,
+		},
+		{
+			name:        "non-T1 infra segment path",
+			segmentPath: "/infra/segments/seg-1",
+			expected:    false,
+		},
+		{
+			name:        "short path with three tokens",
+			segmentPath: "a/b/c",
+			expected:    false,
+		},
+		{
+			name:        "short path with two tokens",
+			segmentPath: "a/b",
+			expected:    false,
+		},
+		{
+			name:        "empty string",
+			segmentPath: "",
+			expected:    false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isT1Segment(tt.segmentPath))
+		})
+	}
+}
+
+func TestMockGetT1IdFromSegPath(t *testing.T) {
+	tests := []struct {
+		name        string
+		segmentPath string
+		expectedID  string
+	}{
+		{
+			name:        "T1 segment path",
+			segmentPath: "/infra/tier-1s/t1-1/segments/seg-1",
+			expectedID:  "t1-1",
+		},
+		{
+			name:        "non-T1 segment path",
+			segmentPath: "/infra/segments/seg-1",
+			expectedID:  "",
+		},
+		{
+			name:        "short path with three tokens",
+			segmentPath: "a/b/c",
+			expectedID:  "",
+		},
+		{
+			name:        "empty string",
+			segmentPath: "",
+			expectedID:  "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expectedID, getT1IdFromSegPath(tt.segmentPath))
+		})
+	}
 }


### PR DESCRIPTION
isT1Segment() and getT1IdFromSegPath() accessed pathSplit[len-4] while only guarding with `len >= 3`. When segment_path contains exactly three tokens (e.g. "a/b/c"), len-4 evaluates to -1 and Go panics with "index out of range [-1]" instead of returning a graceful error.

Raise the minimum length guard to >= 4 in both functions so the index is always in bounds. A valid T1 segment path has the form /infra/tier-1s/{id}/segments/{id} (six tokens), so the existing happy-path behaviour is unchanged.