### PR TITLE
Fix incorrect data source in edge_transport_node_rtep example

### DIFF
--- a/docs/resources/edge_transport_node_rtep.md
+++ b/docs/resources/edge_transport_node_rtep.md
@@ -12,12 +12,12 @@ This resource is supported with NSX 4.1.0 onwards.
 ## Example Usage
 
 ```hcl
-data "nsxt_edge_transport_node" "test_node" {
+data "nsxt_transport_node" "test_node" {
   display_name = "edgenode1"
 }
 
 resource "nsxt_edge_transport_node_rtep" "test_rtep" {
-  edge_id = data.nsxt_edge_transport_node.test_node.id
+  edge_id = data.nsxt_transport_node.test_node.id
 
   host_switch_name = "someSwitch"
   ip_assignment {


### PR DESCRIPTION
Replace non-existent `nsxt_edge_transport_node` data source with the correct `nsxt_transport_node` in the Example Usage block, and update the corresponding `edge_id` reference.