### PR TITLE
normalise transport_tunnels locale-service path in L2 VPN session Read

### DIFF
--- a/nsxt/resource_nsxt_policy_l2_vpn_session.go
+++ b/nsxt/resource_nsxt_policy_l2_vpn_session.go
@@ -61,9 +61,10 @@ func resourceNsxtPolicyL2VPNSession() *schema.Resource {
 				Default:     true,
 			},
 			"transport_tunnels": {
-				Type:        schema.TypeList,
-				Description: "List of transport tunnels(vpn sessions path) for redundancy",
-				Required:    true,
+				Type:             schema.TypeList,
+				Description:      "List of transport tunnels(vpn sessions path) for redundancy",
+				Required:         true,
+				DiffSuppressFunc: suppressL2VpnTransportTunnelsDiff,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
@@ -188,6 +189,42 @@ func resourceNsxtPolicyL2VPNSessionCreate(d *schema.ResourceData, m interface{})
 	return resourceNsxtPolicyL2VPNSessionRead(d, m)
 }
 
+// normalizeL2VpnTransportTunnelPath strips the optional `locale-services/<id>/`
+// segment from an IPsec VPN session policy path. NSX may expand a flat path
+//
+//	/infra/tier-0s/<gw>/ipsec-vpn-services/<svc>/sessions/<id>
+//
+// to the locale-service-scoped form:
+//
+//	/infra/tier-0s/<gw>/locale-services/default/ipsec-vpn-services/<svc>/sessions/<id>
+//
+// Both forms refer to the same session.
+func normalizeL2VpnTransportTunnelPath(path string) string {
+	const token = "/locale-services/"
+	idx := strings.Index(path, token)
+	if idx < 0 {
+		return path
+	}
+	rest := path[idx+len(token):]
+	slashIdx := strings.Index(rest, "/")
+	if slashIdx < 0 {
+		return path
+	}
+	return path[:idx] + rest[slashIdx:]
+}
+
+// suppressL2VpnTransportTunnelsDiff is a DiffSuppressFunc for the transport_tunnels
+// TypeList. It normalizes both the old and new element strings before comparing so
+// that perpetual drift is avoided when NSX returns the locale-service-scoped form of
+// an IPsec VPN session path while the user-supplied configuration contains the flat
+// form (or vice versa).
+func suppressL2VpnTransportTunnelsDiff(k, old, new string, _ *schema.ResourceData) bool {
+	if strings.HasSuffix(k, ".#") {
+		return old == new
+	}
+	return normalizeL2VpnTransportTunnelPath(old) == normalizeL2VpnTransportTunnelPath(new)
+}
+
 func parseL2VPNServicePolicyPath(path string) (bool, string, string, string, error) {
 	segs := strings.Split(path, "/")
 	// Path should be like /infra/tier-1s/aaa/locale-services/bbb/l2vpn-services/ccc
@@ -253,9 +290,7 @@ func resourceNsxtPolicyL2VPNSessionRead(d *schema.ResourceData, m interface{}) e
 	d.Set("revision", obj.Revision)
 	d.Set("enabled", obj.Enabled)
 
-	if len(obj.TransportTunnels) > 0 {
-		d.Set("transport_tunnels", obj.TransportTunnels)
-	}
+	d.Set("transport_tunnels", obj.TransportTunnels)
 	if util.NsxVersionHigherOrEqual("3.2.0") {
 		if obj.TcpMssClamping != nil {
 			direction := obj.TcpMssClamping.Direction

--- a/nsxt/utgomock_resource_nsxt_policy_l2_vpn_session_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_l2_vpn_session_test.go
@@ -188,3 +188,230 @@ func TestMockResourceNsxtPolicyL2VPNSessionDelete(t *testing.T) {
 		require.Error(t, err)
 	})
 }
+
+func TestMockNormalizeL2VpnTransportTunnelPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "flat T0 path returned unchanged",
+			input:    "/infra/tier-0s/t0/ipsec-vpn-services/svc1/sessions/sess1",
+			expected: "/infra/tier-0s/t0/ipsec-vpn-services/svc1/sessions/sess1",
+		},
+		{
+			name:     "locale-services default segment stripped from T0 path",
+			input:    "/infra/tier-0s/t0/locale-services/default/ipsec-vpn-services/svc1/sessions/sess1",
+			expected: "/infra/tier-0s/t0/ipsec-vpn-services/svc1/sessions/sess1",
+		},
+		{
+			name:     "non-default locale-service ID stripped",
+			input:    "/infra/tier-0s/t0/locale-services/ls-custom/ipsec-vpn-services/svc1/sessions/sess1",
+			expected: "/infra/tier-0s/t0/ipsec-vpn-services/svc1/sessions/sess1",
+		},
+		{
+			name:     "flat T1 path returned unchanged",
+			input:    "/infra/tier-1s/t1/ipsec-vpn-services/svc1/sessions/sess1",
+			expected: "/infra/tier-1s/t1/ipsec-vpn-services/svc1/sessions/sess1",
+		},
+		{
+			name:     "locale-services default segment stripped from T1 path",
+			input:    "/infra/tier-1s/t1/locale-services/default/ipsec-vpn-services/svc1/sessions/sess1",
+			expected: "/infra/tier-1s/t1/ipsec-vpn-services/svc1/sessions/sess1",
+		},
+		{
+			name:     "empty string returned unchanged",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "path ending at locale-services keyword without trailing slash unchanged",
+			input:    "/infra/tier-0s/t0/locale-services",
+			expected: "/infra/tier-0s/t0/locale-services",
+		},
+		{
+			name:     "path with locale-service ID but no further segment unchanged",
+			input:    "/infra/tier-0s/t0/locale-services/default",
+			expected: "/infra/tier-0s/t0/locale-services/default",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, normalizeL2VpnTransportTunnelPath(tt.input))
+		})
+	}
+}
+
+func TestMockSuppressL2VpnTransportTunnelsDiff(t *testing.T) {
+	flatPath := "/infra/tier-1s/t1/ipsec-vpn-services/svc1/sessions/sess1"
+	localeServicePath := "/infra/tier-1s/t1/locale-services/default/ipsec-vpn-services/svc1/sessions/sess1"
+	localeServicePathCustom := "/infra/tier-1s/t1/locale-services/custom/ipsec-vpn-services/svc1/sessions/sess1"
+	differentPath := "/infra/tier-1s/t1/ipsec-vpn-services/svc2/sessions/sess2"
+
+	tests := []struct {
+		name     string
+		k        string
+		old      string
+		new      string
+		expected bool
+	}{
+		{
+			name:     "count key is equal",
+			k:        "transport_tunnels.#",
+			old:      "1",
+			new:      "1",
+			expected: true,
+		},
+		{
+			name:     "count key differs",
+			k:        "transport_tunnels.#",
+			old:      "1",
+			new:      "2",
+			expected: false,
+		},
+		{
+			name:     "locale-service-scoped API path vs flat config path suppressed",
+			k:        "transport_tunnels.0",
+			old:      localeServicePath,
+			new:      flatPath,
+			expected: true,
+		},
+		{
+			name:     "non-default locale-service path vs flat config path suppressed",
+			k:        "transport_tunnels.0",
+			old:      localeServicePathCustom,
+			new:      flatPath,
+			expected: true,
+		},
+		{
+			name:     "flat path vs flat path is equal",
+			k:        "transport_tunnels.0",
+			old:      flatPath,
+			new:      flatPath,
+			expected: true,
+		},
+		{
+			name:     "genuinely different paths are not suppressed",
+			k:        "transport_tunnels.0",
+			old:      flatPath,
+			new:      differentPath,
+			expected: false,
+		},
+		{
+			name:     "empty old vs non-empty new is not suppressed",
+			k:        "transport_tunnels.0",
+			old:      "",
+			new:      flatPath,
+			expected: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := suppressL2VpnTransportTunnelsDiff(tt.k, tt.old, tt.new, nil)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestMockResourceNsxtPolicyL2VPNSessionReadTransportTunnels(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupL2SessionMock(t, ctrl)
+	defer restore()
+
+	flatPath := "/infra/tier-1s/" + l2SessionGwID + "/ipsec-vpn-services/svc1/sessions/sess1"
+	localeServicePath := "/infra/tier-1s/" + l2SessionGwID + "/locale-services/default/ipsec-vpn-services/svc1/sessions/sess1"
+
+	t.Run("Read stores locale-service-scoped API path in state unchanged", func(t *testing.T) {
+		resp := l2SessionAPIResponse()
+		resp.TransportTunnels = []string{localeServicePath}
+		mockSDK.EXPECT().Get(l2SessionGwID, l2SessionSvcID, l2SessionID).Return(resp, nil)
+
+		res := resourceNsxtPolicyL2VPNSession()
+		data := minimalL2SessionData()
+		data["transport_tunnels"] = []interface{}{flatPath}
+		d := schema.TestResourceDataRaw(t, res.Schema, data)
+		d.SetId(l2SessionID)
+
+		err := resourceNsxtPolicyL2VPNSessionRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+
+		tunnels := d.Get("transport_tunnels").([]interface{})
+		require.Len(t, tunnels, 1)
+		assert.Equal(t, localeServicePath, tunnels[0].(string), "Read must store the API-returned path verbatim; DiffSuppressFunc handles the comparison")
+	})
+
+	t.Run("Read stores flat API path in state unchanged", func(t *testing.T) {
+		resp := l2SessionAPIResponse()
+		resp.TransportTunnels = []string{flatPath}
+		mockSDK.EXPECT().Get(l2SessionGwID, l2SessionSvcID, l2SessionID).Return(resp, nil)
+
+		res := resourceNsxtPolicyL2VPNSession()
+		data := minimalL2SessionData()
+		data["transport_tunnels"] = []interface{}{flatPath}
+		d := schema.TestResourceDataRaw(t, res.Schema, data)
+		d.SetId(l2SessionID)
+
+		err := resourceNsxtPolicyL2VPNSessionRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+
+		tunnels := d.Get("transport_tunnels").([]interface{})
+		require.Len(t, tunnels, 1)
+		assert.Equal(t, flatPath, tunnels[0].(string))
+	})
+
+	t.Run("Read stores multiple API paths in state unchanged", func(t *testing.T) {
+		localeServicePath2 := "/infra/tier-1s/" + l2SessionGwID + "/locale-services/default/ipsec-vpn-services/svc2/sessions/sess2"
+		flatPath2 := "/infra/tier-1s/" + l2SessionGwID + "/ipsec-vpn-services/svc2/sessions/sess2"
+
+		resp := l2SessionAPIResponse()
+		resp.TransportTunnels = []string{localeServicePath, localeServicePath2}
+		mockSDK.EXPECT().Get(l2SessionGwID, l2SessionSvcID, l2SessionID).Return(resp, nil)
+
+		res := resourceNsxtPolicyL2VPNSession()
+		data := minimalL2SessionData()
+		data["transport_tunnels"] = []interface{}{flatPath, flatPath2}
+		d := schema.TestResourceDataRaw(t, res.Schema, data)
+		d.SetId(l2SessionID)
+
+		err := resourceNsxtPolicyL2VPNSessionRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+
+		tunnels := d.Get("transport_tunnels").([]interface{})
+		require.Len(t, tunnels, 2)
+		assert.Equal(t, localeServicePath, tunnels[0].(string))
+		assert.Equal(t, localeServicePath2, tunnels[1].(string))
+	})
+
+	t.Run("Read always resets transport_tunnels when API returns empty list", func(t *testing.T) {
+		resp := l2SessionAPIResponse()
+		resp.TransportTunnels = []string{}
+		mockSDK.EXPECT().Get(l2SessionGwID, l2SessionSvcID, l2SessionID).Return(resp, nil)
+
+		res := resourceNsxtPolicyL2VPNSession()
+		data := minimalL2SessionData()
+		data["transport_tunnels"] = []interface{}{flatPath}
+		d := schema.TestResourceDataRaw(t, res.Schema, data)
+		d.SetId(l2SessionID)
+
+		err := resourceNsxtPolicyL2VPNSessionRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+
+		tunnels := d.Get("transport_tunnels").([]interface{})
+		assert.Empty(t, tunnels, "stale transport_tunnels must be cleared when API returns empty list")
+	})
+
+	t.Run("Read API error is propagated", func(t *testing.T) {
+		mockSDK.EXPECT().Get(l2SessionGwID, l2SessionSvcID, l2SessionID).Return(nsxModel.L2VPNSession{}, vapiErrors.InternalServerError{})
+
+		res := resourceNsxtPolicyL2VPNSession()
+		data := minimalL2SessionData()
+		data["transport_tunnels"] = []interface{}{flatPath}
+		d := schema.TestResourceDataRaw(t, res.Schema, data)
+		d.SetId(l2SessionID)
+
+		err := resourceNsxtPolicyL2VPNSessionRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}


### PR DESCRIPTION
use DiffSuppressFunc for transport_tunnels locale-service path drift

NSX expands the flat IPsec VPN session path supplied in transport_tunnels
  /infra/tier-0s/<gw>/ipsec-vpn-services/<svc>/sessions/<id>
to the locale-service-scoped form on storage:
  /infra/tier-0s/<gw>/locale-services/default/ipsec-vpn-services/<svc>/sessions/<id>

The user's original config value is preserved verbatim in state; the
suppressor normalises both sides at plan time and returns true when
they refer to the same session. Read is simplified to a direct d.Set
that always fires, also fixing the stale-state bug when the API returns
an empty list.

Add TestMockSuppressL2VpnTransportTunnelsDiff (7 table cases) to cover
the new suppressor directly. Update
TestMockResourceNsxtPolicyL2VPNSessionReadTransportTunnels to assert
that Read stores the API-returned path verbatim.