### PR TITLE
Add Computed to advanced_config.connectivity to prevent drift on re-a…

### DIFF
--- a/nsxt/segment_common.go
+++ b/nsxt/segment_common.go
@@ -205,6 +205,7 @@ func getPolicySegmentAdvancedConfigurationSchema() *schema.Resource {
 				Type:         schema.TypeString,
 				Description:  "Connectivity configuration to manually connect (ON) or disconnect (OFF)",
 				Optional:     true,
+				Computed:     true,
 				ValidateFunc: validation.StringInSlice(connectivityValues, false),
 			},
 			"hybrid": {
@@ -1381,7 +1382,9 @@ func nsxtPolicySegmentRead(d *schema.ResourceData, m interface{}, isVlan bool, i
 		if len(poolPaths) > 0 {
 			advConfig["address_pool_path"] = poolPaths[0]
 		}
-		advConfig["connectivity"] = obj.AdvancedConfig.Connectivity
+		if obj.AdvancedConfig.Connectivity != nil {
+			advConfig["connectivity"] = *obj.AdvancedConfig.Connectivity
+		}
 		advConfig["hybrid"] = obj.AdvancedConfig.Hybrid
 		advConfig["local_egress"] = obj.AdvancedConfig.LocalEgress
 		advConfig["multicast"] = obj.AdvancedConfig.Multicast


### PR DESCRIPTION
Add Computed to advanced_config.connectivity to prevent drift on re-apply

nsxt_policy_segment advanced_config.connectivity was declared Optional without
Computed. NSX defaults the field to ON when omitted, so the Read function
wrote ON back to state, causing a perpetual plan diff on every subsequent apply.

Two changes in segment_common.go:
- Add Computed: true to the connectivity schema attribute so Terraform treats
  a server-assigned value as authoritative when the user omits the field.
- Guard the Read assignment with a nil check and dereference the pointer
  consistently with all other pointer fields in the same block.