### PR TITLE
Fix three bugs in nsxt_edge_transport_node_rtep resource (bug 3698901)

### DIFF
--- a/docs/resources/edge_transport_node_rtep.md
+++ b/docs/resources/edge_transport_node_rtep.md
@@ -21,7 +21,7 @@ resource "nsxt_edge_transport_node_rtep" "test_rtep" {
 
   host_switch_name = "someSwitch"
   ip_assignment {
-    assigned_by_dhcp = true
+    static_ip_pool = "ip-pool-uuid"
   }
   named_teaming_policy = "tp123"
   rtep_vlan            = 500
@@ -35,7 +35,6 @@ The following arguments are supported:
 * `edge_id` - (Required) Edge ID to associate with remote tunnel endpoint.
 * `host_switch_name` - (Required) The host switch name to be used for the remote tunnel endpoint.
 * `ip_assignment` - (Required) - Specification for IPs to be used with host switch virtual tunnel endpoints. Should contain exactly one of the below:
-    * `assigned_by_dhcp` - (Optional) Enables DHCP assignment.
     * `static_ip` - (Optional) IP assignment specification for Static IP List.
         * `ip_addresses` - (Required) List of IPs for transport node host switch virtual tunnel endpoints.
         * `subnet_mask` - (Required) Subnet mask.

--- a/nsxt/resource_nsxt_edge_transport_node.go
+++ b/nsxt/resource_nsxt_edge_transport_node.go
@@ -789,6 +789,15 @@ func getIPAssignmentSchema(required bool) *schema.Schema {
 	}
 }
 
+func getIPAssignmentSchemaForRTEP() *schema.Schema {
+	s := getIPAssignmentSchema(false)
+	r := s.Elem.(*schema.Resource)
+	delete(r.Schema, "assigned_by_dhcp")
+	delete(r.Schema, "no_ipv4")
+	delete(r.Schema, "static_ip_mac")
+	return s
+}
+
 func getIPv6AssignmentSchema() *schema.Schema {
 	return &schema.Schema{
 		Type:        schema.TypeList,

--- a/nsxt/resource_nsxt_edge_transport_node_rtep.go
+++ b/nsxt/resource_nsxt_edge_transport_node_rtep.go
@@ -34,7 +34,7 @@ func resourceNsxtEdgeTransportNodeRTEP() *schema.Resource {
 				Description: "The host switch name to be used for the remote tunnel endpoint",
 				Required:    true,
 			},
-			"ip_assignment": getIPAssignmentSchema(false),
+			"ip_assignment": getIPAssignmentSchemaForRTEP(),
 			"named_teaming_policy": {
 				Type:        schema.TypeString,
 				Description: "The named teaming policy to be used by the remote tunnel endpoint",
@@ -96,7 +96,7 @@ func resourceNsxtEdgeTransportNodeRTEPRead(d *schema.ResourceData, m interface{}
 	connector := getPolicyConnector(m)
 	client := cliTransportNodesClient(connector)
 
-	id := d.Get("edge_id").(string)
+	id := d.Id()
 
 	obj, err := client.Get(id)
 	if err != nil {
@@ -107,6 +107,7 @@ func resourceNsxtEdgeTransportNodeRTEPRead(d *schema.ResourceData, m interface{}
 		return errors.NotFound{}
 	}
 
+	d.Set("edge_id", id)
 	d.Set("host_switch_name", obj.RemoteTunnelEndpoint.HostSwitchName)
 	ipAssignment, err := setIPAssignmentInSchema(obj.RemoteTunnelEndpoint.IpAssignmentSpec)
 	if err != nil {
@@ -123,7 +124,7 @@ func resourceNsxtEdgeTransportNodeRTEPUpdate(d *schema.ResourceData, m interface
 	connector := getPolicyConnector(m)
 	client := cliTransportNodesClient(connector)
 
-	id := d.Get("edge_id").(string)
+	id := d.Id()
 
 	obj, err := client.Get(id)
 	if err != nil {
@@ -144,10 +145,12 @@ func resourceNsxtEdgeTransportNodeRTEPUpdate(d *schema.ResourceData, m interface
 	}
 
 	rtep := model.TransportNodeRemoteTunnelEndpointConfig{
-		HostSwitchName:     &hostSwitchName,
-		IpAssignmentSpec:   ipAssignment,
-		NamedTeamingPolicy: &namedTeamingPolicy,
-		RtepVlan:           &rtepVlan,
+		HostSwitchName:   &hostSwitchName,
+		IpAssignmentSpec: ipAssignment,
+		RtepVlan:         &rtepVlan,
+	}
+	if namedTeamingPolicy != "" {
+		rtep.NamedTeamingPolicy = &namedTeamingPolicy
 	}
 	obj.RemoteTunnelEndpoint = &rtep
 	_, err = client.Update(id, obj, nil, nil, nil, nil, nil, nil, nil)
@@ -162,7 +165,7 @@ func resourceNsxtEdgeTransportNodeRTEPDelete(d *schema.ResourceData, m interface
 	connector := getPolicyConnector(m)
 	client := cliTransportNodesClient(connector)
 
-	id := d.Get("edge_id").(string)
+	id := d.Id()
 
 	obj, err := client.Get(id)
 	if err != nil {

--- a/nsxt/utgomock_resource_nsxt_edge_transport_node_rtep_test.go
+++ b/nsxt/utgomock_resource_nsxt_edge_transport_node_rtep_test.go
@@ -27,16 +27,18 @@ var (
 	rtepHostSwitch    = "nvds-1"
 	rtepVlanID        = int64(100)
 	rtepTeamingPolicy = "named-teaming-1"
+	rtepIPPoolID      = "ip-pool-uuid-1"
 )
 
-// dhcpIpAssignmentStructValue builds the *data.StructValue for AssignedByDhcp
+// staticIPPoolAssignmentStructValue builds the *data.StructValue for StaticIpPoolSpec
 // so that RTEP Read tests can round-trip through setIPAssignmentInSchema.
-func dhcpIpAssignmentStructValue() *data.StructValue {
+func staticIPPoolAssignmentStructValue() *data.StructValue {
 	converter := bindings.NewTypeConverter()
-	dhcp := mpmodel.AssignedByDhcp{
-		ResourceType: mpmodel.IpAssignmentSpec_RESOURCE_TYPE_ASSIGNEDBYDHCP,
+	pool := mpmodel.StaticIpPoolSpec{
+		IpPoolId:     &rtepIPPoolID,
+		ResourceType: mpmodel.IpAssignmentSpec_RESOURCE_TYPE_STATICIPPOOLSPEC,
 	}
-	dataValue, errs := converter.ConvertToVapi(dhcp, mpmodel.AssignedByDhcpBindingType())
+	dataValue, errs := converter.ConvertToVapi(pool, mpmodel.StaticIpPoolSpecBindingType())
 	if errs != nil {
 		panic(errs[0])
 	}
@@ -51,7 +53,7 @@ func transportNodeWithRTEP() mpmodel.TransportNode {
 			HostSwitchName:     &rtepHostSwitch,
 			RtepVlan:           &rtepVlanID,
 			NamedTeamingPolicy: &rtepTeamingPolicy,
-			IpAssignmentSpec:   dhcpIpAssignmentStructValue(),
+			IpAssignmentSpec:   staticIPPoolAssignmentStructValue(),
 		},
 	}
 }
@@ -71,11 +73,8 @@ func minimalRTEPData() map[string]interface{} {
 		"rtep_vlan":        int(rtepVlanID),
 		"ip_assignment": []interface{}{
 			map[string]interface{}{
-				"assigned_by_dhcp": true,
-				"no_ipv4":          false,
-				"static_ip":        []interface{}{},
-				"static_ip_pool":   "",
-				"static_ip_mac":    []interface{}{},
+				"static_ip":      []interface{}{},
+				"static_ip_pool": rtepIPPoolID,
 			},
 		},
 	}
@@ -147,9 +146,11 @@ func TestMockResourceNsxtEdgeTransportNodeRTEPRead(t *testing.T) {
 		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
 			"edge_id": rtepEdgeID,
 		})
+		d.SetId(rtepEdgeID)
 
 		err := resourceNsxtEdgeTransportNodeRTEPRead(d, newGoMockProviderClient())
 		require.NoError(t, err)
+		assert.Equal(t, rtepEdgeID, d.Get("edge_id"))
 		assert.Equal(t, rtepHostSwitch, d.Get("host_switch_name"))
 		assert.Equal(t, int(rtepVlanID), d.Get("rtep_vlan"))
 	})
@@ -166,6 +167,7 @@ func TestMockResourceNsxtEdgeTransportNodeRTEPRead(t *testing.T) {
 		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
 			"edge_id": rtepEdgeID,
 		})
+		d.SetId(rtepEdgeID)
 
 		err := resourceNsxtEdgeTransportNodeRTEPRead(d, newGoMockProviderClient())
 		require.Error(t, err)
@@ -202,6 +204,7 @@ func TestMockResourceNsxtEdgeTransportNodeRTEPUpdate(t *testing.T) {
 
 		res := resourceNsxtEdgeTransportNodeRTEP()
 		d := schema.TestResourceDataRaw(t, res.Schema, minimalRTEPData())
+		d.SetId(rtepEdgeID)
 
 		err := resourceNsxtEdgeTransportNodeRTEPUpdate(d, newGoMockProviderClient())
 		require.Error(t, err)
@@ -240,6 +243,7 @@ func TestMockResourceNsxtEdgeTransportNodeRTEPDelete(t *testing.T) {
 		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
 			"edge_id": rtepEdgeID,
 		})
+		d.SetId(rtepEdgeID)
 
 		err := resourceNsxtEdgeTransportNodeRTEPDelete(d, newGoMockProviderClient())
 		require.NoError(t, err)
@@ -257,6 +261,7 @@ func TestMockResourceNsxtEdgeTransportNodeRTEPDelete(t *testing.T) {
 		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
 			"edge_id": rtepEdgeID,
 		})
+		d.SetId(rtepEdgeID)
 
 		err := resourceNsxtEdgeTransportNodeRTEPDelete(d, newGoMockProviderClient())
 		require.Error(t, err)


### PR DESCRIPTION
Issue 1 - Import by transport node UUID was broken: Read, Update and Delete all used d.Get("edge_id") to look up the edge, which is empty during terraform import (only d.Id() is populated at that point). Switch all three to d.Id(); add d.Set("edge_id", id) in Read so the attribute is written back to state after an import.

Issue 2 - Update sent an empty string pointer for NamedTeamingPolicy whenever the attribute was not set, causing NSX to reject the request with "uplink teaming policy name/s [] not specified". Apply the same non-empty guard that Create already had.

Issue 3 - DHCP and no_ipv4 IP assignment types are not supported by the NSX RTEP API (a DHCP request triggers a server-side NPE, code 99). Add getIPAssignmentSchemaForRTEP() which strips those unsupported fields from the shared schema, so an unsupported assignment type is rejected at terraform plan time instead of reaching the API. Update docs and unit tests accordingly.