### PR TITLE
Skip empty bgp_route_leaking and static_route_advertisement blocks to prevent drift

### DIFF
--- a/nsxt/resource_nsxt_policy_tier0_inter_vrf_routing.go
+++ b/nsxt/resource_nsxt_policy_tier0_inter_vrf_routing.go
@@ -316,7 +316,9 @@ func resourceNsxtPolicyTier0InterVRFRoutingRead(d *schema.ResourceData, m interf
 
 		brlList = append(brlList, brlMap)
 	}
-	d.Set("bgp_route_leaking", brlList)
+	if brlList != nil {
+		d.Set("bgp_route_leaking", brlList)
+	}
 
 	var sraList []interface{}
 	if obj.StaticRouteAdvertisement != nil {
@@ -337,7 +339,9 @@ func resourceNsxtPolicyTier0InterVRFRoutingRead(d *schema.ResourceData, m interf
 
 		sraList = []interface{}{sra}
 	}
-	d.Set("static_route_advertisement", sraList)
+	if sraList != nil {
+		d.Set("static_route_advertisement", sraList)
+	}
 	d.Set("target_path", obj.TargetPath)
 
 	return nil


### PR DESCRIPTION
Skip empty bgp_route_leaking and static_route_advertisement blocks to prevent drift

When bgp_route_leaking {} or static_route_advertisement {} is specified
without any nested fields, the schema parser produced a model object with
zero-value pointers. The NSX API silently discards such objects, so the
subsequent Read returns an empty list / nil struct. On re-apply Terraform
sees config has one empty block while state has none, producing a perpetual
"+ bgp_route_leaking {}" or "+ static_route_advertisement {}" update.
