### PR TITLE
Add acceptance tests for nsxt_edge_transport_node and nsxt_policy_edge_transport_node

### DIFF
--- a/nsxt/resource_nsxt_edge_transport_node_test.go
+++ b/nsxt/resource_nsxt_edge_transport_node_test.go
@@ -1,0 +1,256 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package nsxt
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func TestAccResourceNsxtEdgeTransportNode_basic(t *testing.T) {
+	testResourceName := "nsxt_edge_transport_node.test"
+	displayName := getAccTestResourceName()
+	updatedDescription := "Updated acceptance test edge transport node"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccEdgeTransportNodePreCheck(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtEdgeTransportNodeCheckDestroy(state, displayName)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtEdgeTransportNodeCreateTemplate(displayName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(testResourceName, "display_name", displayName),
+					resource.TestCheckResourceAttr(testResourceName, "description", "Acceptance test edge transport node"),
+					resource.TestCheckResourceAttrSet(testResourceName, "id"),
+				),
+			},
+			{
+				Config: testAccNsxtEdgeTransportNodeWithDataSourceTemplate(displayName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(
+						"data.nsxt_transport_node.test", "display_name",
+						testResourceName, "display_name",
+					),
+					resource.TestCheckResourceAttrSet("data.nsxt_transport_node.test", "id"),
+				),
+			},
+			{
+				Config: testAccNsxtEdgeTransportNodeUpdateTemplate(displayName, updatedDescription),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(testResourceName, "display_name", displayName),
+					resource.TestCheckResourceAttr(testResourceName, "description", updatedDescription),
+				),
+			},
+			{
+				ResourceName:      testResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"deployment_config.0.node_user_settings.0.cli_password",
+					"deployment_config.0.node_user_settings.0.root_password",
+					// ip_addresses is assigned by NSX after deployment and may not
+					// yet be populated in the initial apply state.
+					"ip_addresses",
+					// revision may be incremented by NSX between apply and import.
+					"revision",
+					// On a fresh import there is no prior state to restore policy
+					// paths from (etNodeNormalizeHostSwitchesInState requires them).
+					"standard_host_switch.0.uplink_profile",
+					"standard_host_switch.0.transport_zone_endpoint.0.transport_zone",
+				},
+			},
+		},
+	})
+}
+
+func TestAccResourceNsxtEdgeTransportNode_importBasic(t *testing.T) {
+	testResourceName := "nsxt_edge_transport_node.test"
+	displayName := getAccTestResourceName()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccEdgeTransportNodePreCheck(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtEdgeTransportNodeCheckDestroy(state, displayName)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtEdgeTransportNodeCreateTemplate(displayName),
+			},
+			{
+				ResourceName:      testResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"deployment_config.0.node_user_settings.0.cli_password",
+					"deployment_config.0.node_user_settings.0.root_password",
+					"ip_addresses",
+					"revision",
+					"standard_host_switch.0.uplink_profile",
+					"standard_host_switch.0.transport_zone_endpoint.0.transport_zone",
+				},
+			},
+		},
+	})
+}
+
+func testAccNsxtEdgeTransportNodeCheckDestroy(state *terraform.State, displayName string) error {
+	connector := getPolicyConnector(testAccProvider.Meta().(nsxtClients))
+	client := cliTransportNodesClient(connector)
+
+	for _, rs := range state.RootModule().Resources {
+		if rs.Type != "nsxt_edge_transport_node" {
+			continue
+		}
+
+		id := rs.Primary.ID
+		_, err := client.Get(id)
+		if err == nil {
+			return fmt.Errorf("edge transport node %s (%s) still exists", displayName, id)
+		}
+		if !isNotFoundError(err) {
+			return fmt.Errorf("unexpected error checking edge transport node %s: %v", id, err)
+		}
+	}
+	return nil
+}
+
+func testAccNsxtEdgeTransportNodeInfraTemplate() string {
+	return fmt.Sprintf(`
+data "nsxt_compute_manager" "test" {
+  display_name = "%s"
+}
+
+data "nsxt_compute_collection" "test" {
+  display_name = "%s"
+  origin_id    = data.nsxt_compute_manager.test.id
+}
+
+data "nsxt_policy_transport_zone" "test" {
+  display_name = "%s"
+}
+
+resource "nsxt_policy_uplink_host_switch_profile" "uplink" {
+  display_name = "test-edge-uplink"
+  teaming {
+    active {
+      uplink_name = "uplink1"
+      uplink_type = "PNIC"
+    }
+    policy = "FAILOVER_ORDER"
+  }
+}
+`, getComputeManagerName(), getComputeCollectionName(), getOverlayTransportZoneName())
+}
+
+func testAccNsxtEdgeTransportNodeCreateTemplate(displayName string) string {
+	return testAccNsxtEdgeTransportNodeInfraTemplate() + fmt.Sprintf(`
+resource "nsxt_edge_transport_node" "test" {
+  display_name = "%s"
+  description  = "Acceptance test edge transport node"
+
+  deployment_config {
+    form_factor = "SMALL"
+    node_user_settings {
+      cli_password  = "%s"
+      root_password = "%s"
+    }
+    vm_deployment_config {
+      vc_id                 = data.nsxt_compute_manager.test.id
+      compute_id            = data.nsxt_compute_collection.test.cm_local_id
+      storage_id            = "%s"
+      management_network_id = "%s"
+      data_network_ids      = ["%s"]
+    }
+  }
+
+  node_settings {
+    hostname = "%s"
+  }
+
+  standard_host_switch {
+    uplink_profile = nsxt_policy_uplink_host_switch_profile.uplink.path
+    ip_assignment {
+      assigned_by_dhcp = true
+    }
+    transport_zone_endpoint {
+      transport_zone = data.nsxt_policy_transport_zone.test.path
+    }
+    pnic {
+      device_name = "fp-eth0"
+      uplink_name = "uplink1"
+    }
+  }
+}
+
+data "nsxt_transport_node_realization" "test" {
+  id      = nsxt_edge_transport_node.test.id
+  timeout = 3600
+}
+`, displayName,
+		os.Getenv("NSXT_PASSWORD"), os.Getenv("NSXT_PASSWORD"),
+		getDatastoreID(), getMgtNetworkID(), getEdgeDataNetworkID(),
+		getEdgeHostname())
+}
+
+func testAccNsxtEdgeTransportNodeWithDataSourceTemplate(displayName string) string {
+	return testAccNsxtEdgeTransportNodeCreateTemplate(displayName) + `
+data "nsxt_transport_node" "test" {
+  display_name = nsxt_edge_transport_node.test.display_name
+}
+`
+}
+
+func testAccNsxtEdgeTransportNodeUpdateTemplate(displayName, description string) string {
+	return testAccNsxtEdgeTransportNodeInfraTemplate() + fmt.Sprintf(`
+resource "nsxt_edge_transport_node" "test" {
+  display_name = "%s"
+  description  = "%s"
+
+  deployment_config {
+    form_factor = "SMALL"
+    node_user_settings {
+      cli_password  = "%s"
+      root_password = "%s"
+    }
+    vm_deployment_config {
+      vc_id                 = data.nsxt_compute_manager.test.id
+      compute_id            = data.nsxt_compute_collection.test.cm_local_id
+      storage_id            = "%s"
+      management_network_id = "%s"
+      data_network_ids      = ["%s"]
+    }
+  }
+
+  node_settings {
+    hostname = "%s"
+  }
+
+  standard_host_switch {
+    uplink_profile = nsxt_policy_uplink_host_switch_profile.uplink.path
+    ip_assignment {
+      assigned_by_dhcp = true
+    }
+    transport_zone_endpoint {
+      transport_zone = data.nsxt_policy_transport_zone.test.path
+    }
+    pnic {
+      device_name = "fp-eth0"
+      uplink_name = "uplink1"
+    }
+  }
+}
+`, displayName, description,
+		os.Getenv("NSXT_PASSWORD"), os.Getenv("NSXT_PASSWORD"),
+		getDatastoreID(), getMgtNetworkID(), getEdgeDataNetworkID(),
+		getEdgeHostname())
+}

--- a/nsxt/resource_nsxt_policy_edge_transport_node.go
+++ b/nsxt/resource_nsxt_policy_edge_transport_node.go
@@ -353,6 +353,7 @@ func resourceNsxtPolicyEdgeTransportNode() *schema.Resource {
 				Description: "Appliance configuration",
 				MaxItems:    1,
 				Optional:    true,
+				Computed:    true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"allow_ssh_root_login": {

--- a/nsxt/resource_nsxt_policy_edge_transport_node_test.go
+++ b/nsxt/resource_nsxt_policy_edge_transport_node_test.go
@@ -1,0 +1,262 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package nsxt
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func TestAccResourceNsxtPolicyEdgeTransportNode_basic(t *testing.T) {
+	testResourceName := "nsxt_policy_edge_transport_node.test"
+	displayName := getAccTestResourceName()
+	updatedDescription := "Updated acceptance test policy edge transport node"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPolicyEdgeTransportNodePreCheck(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyEdgeTransportNodeCheckDestroy(state, displayName)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyEdgeTransportNodeCreateTemplate(displayName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(testResourceName, "display_name", displayName),
+					resource.TestCheckResourceAttr(testResourceName, "description", "Acceptance test policy edge transport node"),
+					resource.TestCheckResourceAttr(testResourceName, "form_factor", "SMALL"),
+					resource.TestCheckResourceAttrSet(testResourceName, "id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+				),
+			},
+			{
+				Config: testAccNsxtPolicyEdgeTransportNodeWithDataSourceTemplate(displayName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(
+						"data.nsxt_policy_edge_transport_node.test", "display_name",
+						testResourceName, "display_name",
+					),
+					resource.TestCheckResourceAttrSet("data.nsxt_policy_edge_transport_node.test", "id"),
+					resource.TestCheckResourceAttrSet("data.nsxt_policy_edge_transport_node.test", "unique_id"),
+				),
+			},
+			{
+				Config: testAccNsxtPolicyEdgeTransportNodeUpdateTemplate(displayName, updatedDescription),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(testResourceName, "display_name", displayName),
+					resource.TestCheckResourceAttr(testResourceName, "description", updatedDescription),
+				),
+			},
+			{
+				ResourceName:      testResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccResourceNsxtPolicyImportIDRetriever(testResourceName),
+				ImportStateVerifyIgnore: []string{
+					"credentials.0.cli_password",
+					"credentials.0.root_password",
+					// vm_deployment_config is not returned by the API after
+					// deployment completes.
+					"vm_deployment_config",
+					"revision",
+				},
+			},
+		},
+	})
+}
+
+func TestAccResourceNsxtPolicyEdgeTransportNode_importBasic(t *testing.T) {
+	testResourceName := "nsxt_policy_edge_transport_node.test"
+	displayName := getAccTestResourceName()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPolicyEdgeTransportNodePreCheck(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyEdgeTransportNodeCheckDestroy(state, displayName)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyEdgeTransportNodeCreateTemplate(displayName),
+			},
+			{
+				ResourceName:      testResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccResourceNsxtPolicyImportIDRetriever(testResourceName),
+				ImportStateVerifyIgnore: []string{
+					"credentials.0.cli_password",
+					"credentials.0.root_password",
+					"vm_deployment_config",
+					"revision",
+				},
+			},
+		},
+	})
+}
+
+func testAccNsxtPolicyEdgeTransportNodeCheckDestroy(state *terraform.State, displayName string) error {
+	connector := getPolicyConnector(testAccProvider.Meta().(nsxtClients))
+	sessionContext := utl.SessionContext{ClientType: utl.Local}
+	client := cliEdgeTransportNodesClient(sessionContext, connector)
+
+	for _, rs := range state.RootModule().Resources {
+		if rs.Type != "nsxt_policy_edge_transport_node" {
+			continue
+		}
+
+		tnPath := rs.Primary.Attributes["path"]
+		siteID, epID, id := getEdgeTransportNodeKeysFromPath(tnPath)
+		_, err := client.Get(siteID, epID, id)
+		if err == nil {
+			return fmt.Errorf("policy edge transport node %s (%s) still exists", displayName, id)
+		}
+		if !isNotFoundError(err) {
+			return fmt.Errorf("unexpected error checking policy edge transport node %s: %v", id, err)
+		}
+	}
+	return nil
+}
+
+func testAccNsxtPolicyEdgeTransportNodeInfraTemplate() string {
+	return fmt.Sprintf(`
+data "nsxt_compute_manager" "test" {
+  display_name = "%s"
+}
+
+data "nsxt_compute_collection" "test" {
+  display_name = "%s"
+  origin_id    = data.nsxt_compute_manager.test.id
+}
+
+data "nsxt_policy_transport_zone" "test" {
+  display_name = "%s"
+}
+
+resource "nsxt_policy_uplink_host_switch_profile" "uplink" {
+  display_name = "test-policy-edge-uplink"
+  teaming {
+    active {
+      uplink_name = "uplink1"
+      uplink_type = "PNIC"
+    }
+    policy = "FAILOVER_ORDER"
+  }
+}
+`, getComputeManagerName(), getComputeCollectionName(), getOverlayTransportZoneName())
+}
+
+func testAccNsxtPolicyEdgeTransportNodeCreateTemplate(displayName string) string {
+	return testAccNsxtPolicyEdgeTransportNodeInfraTemplate() + fmt.Sprintf(`
+resource "nsxt_policy_edge_transport_node" "test" {
+  display_name = "%s"
+  description  = "Acceptance test policy edge transport node"
+  form_factor  = "SMALL"
+  hostname     = "%s"
+
+  credentials {
+    cli_password  = "%s"
+    root_password = "%s"
+  }
+
+  management_interface {
+    network_id = "%s"
+    ip_assignment {
+      dhcp_v4 = true
+    }
+  }
+
+  switch {
+    overlay_transport_zone_path     = data.nsxt_policy_transport_zone.test.path
+    uplink_host_switch_profile_path = nsxt_policy_uplink_host_switch_profile.uplink.path
+    pnic {
+      device_name         = "fp-eth0"
+      uplink_name         = "uplink1"
+      datapath_network_id = "%s"
+    }
+    tunnel_endpoint {
+      ip_assignment {
+        dhcp_v4 = true
+      }
+    }
+  }
+
+  vm_deployment_config {
+    compute_manager_id = data.nsxt_compute_manager.test.id
+    compute_id         = data.nsxt_compute_collection.test.cm_local_id
+    storage_id         = "%s"
+  }
+}
+
+data "nsxt_policy_edge_transport_node_realization" "test" {
+  path    = nsxt_policy_edge_transport_node.test.path
+  timeout = 3600
+}
+`, displayName, getEdgeHostname(),
+		os.Getenv("NSXT_PASSWORD"), os.Getenv("NSXT_PASSWORD"),
+		getMgtNetworkID(), getEdgeDataNetworkID(),
+		getDatastoreID())
+}
+
+func testAccNsxtPolicyEdgeTransportNodeWithDataSourceTemplate(displayName string) string {
+	return testAccNsxtPolicyEdgeTransportNodeCreateTemplate(displayName) + `
+data "nsxt_policy_edge_transport_node" "test" {
+  display_name = nsxt_policy_edge_transport_node.test.display_name
+}
+`
+}
+
+func testAccNsxtPolicyEdgeTransportNodeUpdateTemplate(displayName, description string) string {
+	return testAccNsxtPolicyEdgeTransportNodeInfraTemplate() + fmt.Sprintf(`
+resource "nsxt_policy_edge_transport_node" "test" {
+  display_name = "%s"
+  description  = "%s"
+  form_factor  = "SMALL"
+  hostname     = "%s"
+
+  credentials {
+    cli_password  = "%s"
+    root_password = "%s"
+  }
+
+  management_interface {
+    network_id = "%s"
+    ip_assignment {
+      dhcp_v4 = true
+    }
+  }
+
+  switch {
+    overlay_transport_zone_path     = data.nsxt_policy_transport_zone.test.path
+    uplink_host_switch_profile_path = nsxt_policy_uplink_host_switch_profile.uplink.path
+    pnic {
+      device_name         = "fp-eth0"
+      uplink_name         = "uplink1"
+      datapath_network_id = "%s"
+    }
+    tunnel_endpoint {
+      ip_assignment {
+        dhcp_v4 = true
+      }
+    }
+  }
+
+  vm_deployment_config {
+    compute_manager_id = data.nsxt_compute_manager.test.id
+    compute_id         = data.nsxt_compute_collection.test.cm_local_id
+    storage_id         = "%s"
+  }
+}
+`, displayName, description, getEdgeHostname(),
+		os.Getenv("NSXT_PASSWORD"), os.Getenv("NSXT_PASSWORD"),
+		getMgtNetworkID(), getEdgeDataNetworkID(),
+		getDatastoreID())
+}

--- a/nsxt/utils_test.go
+++ b/nsxt/utils_test.go
@@ -124,10 +124,26 @@ func getMgtNetworkID() string {
 	return os.Getenv("NSXT_TEST_MGT_NETWORK")
 }
 
+func getEdgeDataNetworkID() string {
+	id := os.Getenv("NSXT_TEST_PORTGROUP_ID")
+	if id == "" {
+		id = getMgtNetworkID()
+	}
+	return id
+}
+
 func getVNAHostname() string {
 	name := os.Getenv("NSXT_TEST_VNA_HOSTNAME")
 	if name == "" {
 		name = "vna-test.example.com"
+	}
+	return name
+}
+
+func getEdgeHostname() string {
+	name := os.Getenv("NSXT_TEST_EDGE_HOSTNAME")
+	if name == "" {
+		name = "test-edge.example.com"
 	}
 	return name
 }
@@ -295,6 +311,20 @@ func testAccTestFabric(t *testing.T) {
 	if !testAccIsFabric() {
 		t.Skipf("Fabric testing is not enabled")
 	}
+}
+
+func testAccEdgeTransportNodePreCheck(t *testing.T) {
+	testAccPreCheck(t)
+	testAccOnlyLocalManager(t)
+	testAccEnvDefined(t, "NSXT_TEST_COMPUTE_MANAGER")
+	testAccEnvDefined(t, "NSXT_TEST_COMPUTE_COLLECTION")
+	testAccEnvDefined(t, "NSXT_TEST_DATASTORE_ID")
+	testAccEnvDefined(t, "NSXT_TEST_MGT_NETWORK")
+}
+
+func testAccPolicyEdgeTransportNodePreCheck(t *testing.T) {
+	testAccEdgeTransportNodePreCheck(t)
+	testAccNSXVersion(t, "9.0.0")
 }
 
 func getTestVCUsername() string {


### PR DESCRIPTION
Tests cover LCM-deployed VM creation, realization validation, data source
lookup, description update, and import for both the MP and Policy API
edge transport node resources.

- Add getEdgeHostname() and testAccEdgeTransportNodePreCheck() to utils_test.go
- Add TestAccResourceNsxtEdgeTransportNode_basic and _importBasic
- Add TestAccResourceNsxtPolicyEdgeTransportNode_basic and _importBasic

Both tests use nsxt_transport_node_realization /
nsxt_policy_edge_transport_node_realization as a deployment gate, and
validate the corresponding read data sources in a subsequent step.
Passwords reuse NSXT_PASSWORD; the uplink profile is created inline.
