### PR TITLE
Prevent security profile update state drift

### DIFF
--- a/nsxt/resource_nsxt_policy_segment_security_profile.go
+++ b/nsxt/resource_nsxt_policy_segment_security_profile.go
@@ -349,6 +349,10 @@ func resourceNsxtPolicySegmentSecurityProfileRead(d *schema.ResourceData, m inte
 	d.Set("nsx_id", id)
 	d.Set("path", obj.Path)
 	d.Set("revision", obj.Revision)
+	// bpdu_filter_allow is marked `skip: true` in metadata, so StructToSchema
+	// does not sync it. Set it manually from the API response so refresh keeps
+	// the state aligned with NSX (e.g., after a rejected update).
+	d.Set("bpdu_filter_allow", obj.BpduFilterAllow)
 
 	return nil
 }


### PR DESCRIPTION
The bpdu_filter_allow attribute is declared with `skip: true` in the metadata-driven schema, which excludes it from the automatic metadata.StructToSchema reflection used in the Read function. Read also did not call d.Set on this field manually, so the value present in the schema after Read was whatever was already in the ResourceData, not the value returned by the NSX API.

When an update is rejected by NSX (e.g., due to invalid uppercase hex digits in a MAC address), Terraform Plugin SDK v2 persists the planned values into state. On the next plan, refresh calls Read, which leaves bpdu_filter_allow untouched and the corrupted (rejected) values stay in state. Subsequent applies then report "No changes", masking the original rejection.

This commit explicitly sets bpdu_filter_allow from the NSX response in Read so refresh always reconciles the state with reality, even after a failed apply.