### PR TITLE
Fix data source policy_project populating ipv6_blocks when API omits …

### DIFF
--- a/nsxt/data_source_nsxt_policy_project.go
+++ b/nsxt/data_source_nsxt_policy_project.go
@@ -144,7 +144,7 @@ func dataSourceNsxtPolicyProjectRead(d *schema.ResourceData, m interface{}) erro
 	d.Set("site_info", siteInfosList)
 	d.Set("tier0_gateway_paths", obj.Tier0s)
 	d.Set("external_ipv4_blocks", obj.ExternalIpv4Blocks)
-	if util.NsxVersionHigherOrEqual("9.2.0") {
+	if util.NsxVersionHigherOrEqual("9.2.0") && obj.Ipv6Blocks != nil {
 		d.Set("ipv6_blocks", obj.Ipv6Blocks)
 	}
 


### PR DESCRIPTION
…field

When NSX version >= 9.2.0 but a project has no IPv6 blocks configured, the API omits the ipv6_blocks field entirely. The previous code called d.Set("ipv6_blocks", nil) unconditionally, causing Terraform to write ipv6_blocks=[] into the tfstate. This broke the FVT test test_data_policy_project, which compared the tfstate against the direct API response and found a mismatch.

Fix: only set ipv6_blocks in state when obj.Ipv6Blocks is non-nil, i.e. when the API actually returned the field.