### PR TITLE
Fix intermittent project test failures due to concurrent display name…

### DIFF
--- a/nsxt/data_source_nsxt_policy_project_test.go
+++ b/nsxt/data_source_nsxt_policy_project_test.go
@@ -50,6 +50,17 @@ func TestAccDataSourceNsxtPolicyProject_basic(t *testing.T) {
 func TestAccDataSourceNsxtPolicyProject_920ipv6Blocks(t *testing.T) {
 	testDSName := "data.nsxt_policy_project.ds"
 	expected := map[string]string{"ipv6_block_count": "1"}
+	localShortID := getAccTestRandomString(6)
+	createAttrs := map[string]string{
+		"DisplayName": getAccTestResourceName(),
+		"Description": "terraform created",
+		"ShortId":     localShortID,
+	}
+	updateAttrs := map[string]string{
+		"DisplayName": getAccTestResourceName(),
+		"Description": "terraform updated",
+		"ShortId":     localShortID,
+	}
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -59,28 +70,28 @@ func TestAccDataSourceNsxtPolicyProject_920ipv6Blocks(t *testing.T) {
 		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNsxtPolicyProjectCheckDestroy(state, accTestPolicyProjectCreateAttributes["DisplayName"])
+			return testAccNsxtPolicyProjectCheckDestroy(state, createAttrs["DisplayName"])
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceNsxtPolicyProject920Config(),
+				Config: testAccDataSourceNsxtPolicyProject920Config(createAttrs, updateAttrs),
 				Check: resource.ComposeTestCheckFunc(
 					runChecksNsx920(testDSName, expected),
 					resource.TestCheckResourceAttrPair(testDSName, "ipv6_blocks.0", "nsxt_policy_ip_block.test_ipv6_block", "path"),
-					resource.TestCheckResourceAttr(testDSName, "display_name", accTestPolicyProjectCreateAttributes["DisplayName"]),
+					resource.TestCheckResourceAttr(testDSName, "display_name", createAttrs["DisplayName"]),
 				),
 			},
 		},
 	})
 }
 
-func testAccDataSourceNsxtPolicyProject920Config() string {
-	return testAccNsxtPolicyProjectTemplate920(true, true, true, true, true, false) + fmt.Sprintf(`
+func testAccDataSourceNsxtPolicyProject920Config(createAttrs, updateAttrs map[string]string) string {
+	return testAccNsxtPolicyProjectTemplate920(createAttrs, updateAttrs, true, true, true, true, true, false) + fmt.Sprintf(`
 data "nsxt_policy_project" "ds" {
   display_name = "%s"
   depends_on = [nsxt_policy_project.test]
 }
-`, accTestPolicyProjectCreateAttributes["DisplayName"])
+`, createAttrs["DisplayName"])
 }
 
 func testAccDataSourceNsxtPolicyProjectCreate(name string) error {

--- a/nsxt/resource_nsxt_policy_project_test.go
+++ b/nsxt/resource_nsxt_policy_project_test.go
@@ -365,6 +365,17 @@ func TestAccResourceNsxtPolicyProject_900defaultSecurityProfile(t *testing.T) {
 func TestAccResourceNsxtPolicyProject_910basic(t *testing.T) {
 	testResourceName := "nsxt_policy_project.test"
 	siteCount := getExpectedSiteInfoCount(t)
+	localShortID := getAccTestRandomString(6)
+	createAttrs := map[string]string{
+		"DisplayName": getAccTestResourceName(),
+		"Description": "terraform created",
+		"ShortId":     localShortID,
+	}
+	updateAttrs := map[string]string{
+		"DisplayName": getAccTestResourceName(),
+		"Description": "terraform updated",
+		"ShortId":     localShortID,
+	}
 	expectedValuesStep1 := map[string]string{
 		"t0_count":                   "1",
 		"ip_block_count":             "1",
@@ -392,14 +403,14 @@ func TestAccResourceNsxtPolicyProject_910basic(t *testing.T) {
 		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNsxtPolicyProjectCheckDestroy(state, accTestPolicyProjectUpdateAttributes["DisplayName"])
+			return testAccNsxtPolicyProjectCheckDestroy(state, updateAttrs["DisplayName"])
 		},
 		Steps: []resource.TestStep{
 			{
 				// Create: Set T0, Ext GW connection, Ext IPv4 Block, activate default DFW
-				Config: testAccNsxtPolicyProjectTemplate910(true, true, true, true),
+				Config: testAccNsxtPolicyProjectTemplate910(createAttrs, updateAttrs, true, true, true, true),
 				Check: resource.ComposeTestCheckFunc(
-					runChecksNsx410(testResourceName, accTestPolicyProjectCreateAttributes, expectedValuesStep1),
+					runChecksNsx410(testResourceName, createAttrs, expectedValuesStep1),
 					runChecksNsx411(testResourceName, expectedValuesStep1),
 					runChecksNsx420(testResourceName, expectedValuesStep1),
 					runChecksNsx900(testResourceName, expectedValuesStep1),
@@ -408,9 +419,9 @@ func TestAccResourceNsxtPolicyProject_910basic(t *testing.T) {
 			},
 			{
 				// Update: Set T0, Ext GW connection, No Ext IPv4 Block, disable default DFW
-				Config: testAccNsxtPolicyProjectTemplate910(false, true, false, false),
+				Config: testAccNsxtPolicyProjectTemplate910(createAttrs, updateAttrs, false, true, false, false),
 				Check: resource.ComposeTestCheckFunc(
-					runChecksNsx410(testResourceName, accTestPolicyProjectUpdateAttributes, expectedValuesStep2),
+					runChecksNsx410(testResourceName, updateAttrs, expectedValuesStep2),
 					runChecksNsx411(testResourceName, expectedValuesStep2),
 					runChecksNsx420(testResourceName, expectedValuesStep2),
 					runChecksNsx900(testResourceName, expectedValuesStep2),
@@ -424,6 +435,17 @@ func TestAccResourceNsxtPolicyProject_910basic(t *testing.T) {
 func TestAccResourceNsxtPolicyProject_920basic(t *testing.T) {
 	testResourceName := "nsxt_policy_project.test"
 	siteCount := getExpectedSiteInfoCount(t)
+	localShortID := getAccTestRandomString(6)
+	createAttrs := map[string]string{
+		"DisplayName": getAccTestResourceName(),
+		"Description": "terraform created",
+		"ShortId":     localShortID,
+	}
+	updateAttrs := map[string]string{
+		"DisplayName": getAccTestResourceName(),
+		"Description": "terraform updated",
+		"ShortId":     localShortID,
+	}
 	expectedValuesStep1 := map[string]string{
 		"t0_count":                   "1",
 		"ip_block_count":             "1",
@@ -453,13 +475,13 @@ func TestAccResourceNsxtPolicyProject_920basic(t *testing.T) {
 		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNsxtPolicyProjectCheckDestroy(state, accTestPolicyProjectUpdateAttributes["DisplayName"])
+			return testAccNsxtPolicyProjectCheckDestroy(state, updateAttrs["DisplayName"])
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNsxtPolicyProjectTemplate920(true, true, true, true, true, false),
+				Config: testAccNsxtPolicyProjectTemplate920(createAttrs, updateAttrs, true, true, true, true, true, false),
 				Check: resource.ComposeTestCheckFunc(
-					runChecksNsx410(testResourceName, accTestPolicyProjectCreateAttributes, expectedValuesStep1),
+					runChecksNsx410(testResourceName, createAttrs, expectedValuesStep1),
 					runChecksNsx411(testResourceName, expectedValuesStep1),
 					runChecksNsx420(testResourceName, expectedValuesStep1),
 					runChecksNsx900(testResourceName, expectedValuesStep1),
@@ -468,9 +490,9 @@ func TestAccResourceNsxtPolicyProject_920basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNsxtPolicyProjectTemplate920(false, true, false, false, false, true),
+				Config: testAccNsxtPolicyProjectTemplate920(createAttrs, updateAttrs, false, true, false, false, false, true),
 				Check: resource.ComposeTestCheckFunc(
-					runChecksNsx410(testResourceName, accTestPolicyProjectUpdateAttributes, expectedValuesStep2),
+					runChecksNsx410(testResourceName, updateAttrs, expectedValuesStep2),
 					runChecksNsx411(testResourceName, expectedValuesStep2),
 					runChecksNsx420(testResourceName, expectedValuesStep2),
 					runChecksNsx900(testResourceName, expectedValuesStep2),
@@ -479,9 +501,9 @@ func TestAccResourceNsxtPolicyProject_920basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNsxtPolicyProjectTemplate920(false, true, false, false, false, false),
+				Config: testAccNsxtPolicyProjectTemplate920(createAttrs, updateAttrs, false, true, false, false, false, false),
 				Check: resource.ComposeTestCheckFunc(
-					runChecksNsx410(testResourceName, accTestPolicyProjectUpdateAttributes, expectedValuesStep2),
+					runChecksNsx410(testResourceName, updateAttrs, expectedValuesStep2),
 					runChecksNsx411(testResourceName, expectedValuesStep2),
 					runChecksNsx420(testResourceName, expectedValuesStep2),
 					runChecksNsx900(testResourceName, expectedValuesStep2),
@@ -707,11 +729,11 @@ resource "nsxt_policy_project" "test" {
 }
 `
 
-func getBasicAttrMap(createFlow, includeT0GW bool) map[string]string {
+func getBasicAttrMap(createAttrs, updateAttrs map[string]string, createFlow, includeT0GW bool) map[string]string {
 	attrMap := make(map[string]string)
-	baseMap := accTestPolicyProjectUpdateAttributes
+	baseMap := updateAttrs
 	if createFlow {
-		baseMap = accTestPolicyProjectCreateAttributes
+		baseMap = createAttrs
 		//do not pass short_id on update
 		attrMap["ShortId"] = baseMap["ShortId"]
 	}
@@ -727,7 +749,7 @@ func getBasicAttrMap(createFlow, includeT0GW bool) map[string]string {
 }
 
 func testAccNsxtPolicyProjectTemplate410(createFlow, includeT0GW bool) string {
-	attrMap := getBasicAttrMap(createFlow, includeT0GW)
+	attrMap := getBasicAttrMap(accTestPolicyProjectCreateAttributes, accTestPolicyProjectUpdateAttributes, createFlow, includeT0GW)
 	buffer := new(bytes.Buffer)
 	tmpl, err := template.New("testAccNsxtPolicyProjectTemplate410").Parse(templateData)
 	if err != nil {
@@ -741,7 +763,7 @@ func testAccNsxtPolicyProjectTemplate410(createFlow, includeT0GW bool) string {
 }
 
 func testAccNsxtPolicyProjectTemplate411(createFlow, includeT0GW, includeExternalIPv4Block bool) string {
-	attrMap := getBasicAttrMap(createFlow, includeT0GW)
+	attrMap := getBasicAttrMap(accTestPolicyProjectCreateAttributes, accTestPolicyProjectUpdateAttributes, createFlow, includeT0GW)
 	if includeExternalIPv4Block {
 		attrMap["ExternalIPv4BlockPath"] = "nsxt_policy_ip_block.test_ip_block.path"
 	}
@@ -759,7 +781,7 @@ func testAccNsxtPolicyProjectTemplate411(createFlow, includeT0GW, includeExterna
 }
 
 func testAccNsxtPolicyProjectTemplate420(createFlow, includeT0GW, includeExternalIPv4Block, activateDefaultDfwRules bool) string {
-	attrMap := getBasicAttrMap(createFlow, includeT0GW)
+	attrMap := getBasicAttrMap(accTestPolicyProjectCreateAttributes, accTestPolicyProjectUpdateAttributes, createFlow, includeT0GW)
 	if includeExternalIPv4Block {
 		attrMap["ExternalIPv4BlockPath"] = "nsxt_policy_ip_block.test_ip_block.path"
 	}
@@ -778,7 +800,7 @@ func testAccNsxtPolicyProjectTemplate420(createFlow, includeT0GW, includeExterna
 }
 
 func testAccNsxtPolicyProjectTemplate900(createFlow, includeT0GW, includeExternalIPv4Block, activateDefaultDfwRules bool) string {
-	attrMap := getBasicAttrMap(createFlow, includeT0GW)
+	attrMap := getBasicAttrMap(accTestPolicyProjectCreateAttributes, accTestPolicyProjectUpdateAttributes, createFlow, includeT0GW)
 	if includeExternalIPv4Block {
 		attrMap["ExternalIPv4BlockPath"] = "nsxt_policy_ip_block.test_ip_block.path"
 	}
@@ -798,8 +820,8 @@ func testAccNsxtPolicyProjectTemplate900(createFlow, includeT0GW, includeExterna
 	return buffer.String()
 }
 
-func testAccNsxtPolicyProjectTemplate910(createFlow, includeT0GW, includeExternalIPv4Block, activateDefaultDfwRules bool) string {
-	attrMap := getBasicAttrMap(createFlow, includeT0GW)
+func testAccNsxtPolicyProjectTemplate910(createAttrs, updateAttrs map[string]string, createFlow, includeT0GW, includeExternalIPv4Block, activateDefaultDfwRules bool) string {
+	attrMap := getBasicAttrMap(createAttrs, updateAttrs, createFlow, includeT0GW)
 	if includeExternalIPv4Block {
 		attrMap["ExternalIPv4BlockPath"] = "nsxt_policy_ip_block.test_ip_block.path"
 	}
@@ -824,8 +846,8 @@ func testAccNsxtPolicyProjectTemplate910(createFlow, includeT0GW, includeExterna
 	return buffer.String()
 }
 
-func testAccNsxtPolicyProjectTemplate920(createFlow, includeT0GW, includeExternalIPv4Block, activateDefaultDfwRules, includeIPv6Block, orphanIPv6Block bool) string {
-	attrMap := getBasicAttrMap(createFlow, includeT0GW)
+func testAccNsxtPolicyProjectTemplate920(createAttrs, updateAttrs map[string]string, createFlow, includeT0GW, includeExternalIPv4Block, activateDefaultDfwRules, includeIPv6Block, orphanIPv6Block bool) string {
+	attrMap := getBasicAttrMap(createAttrs, updateAttrs, createFlow, includeT0GW)
 	if includeExternalIPv4Block {
 		attrMap["ExternalIPv4BlockPath"] = "nsxt_policy_ip_block.test_ip_block.path"
 	}


### PR DESCRIPTION
… collision

Tests TestAccResourceNsxtPolicyProject_910basic, _920basic, and TestAccDataSourceNsxtPolicyProject_920ipv6Blocks all run concurrently on NSX >= 9.2.0 and previously shared the same package-level display names. NSX enforces uniqueness for vCenter-folder-enabled projects, so the shared names caused random 'display name already configured' failures.

Each of those tests now generates its own local create/update attribute maps, and the getBasicAttrMap/template910/template920 helpers are updated to accept explicit maps instead of always reading the package-level globals.