### PR TITLE
Skip IDPS custom signature tests pending NSX fix for error 523940

### DIFF
--- a/nsxt/data_source_nsxt_policy_idps_custom_signature_test.go
+++ b/nsxt/data_source_nsxt_policy_idps_custom_signature_test.go
@@ -22,6 +22,10 @@ func TestAccDataSourceNsxtPolicyIdpsCustomSignature_basic(t *testing.T) {
 			testAccPreCheck(t)
 			testAccOnlyLocalManager(t)
 			testAccNSXVersion(t, "4.2.0")
+			// NSX backend regression (error 523940): ADD_CUSTOM_SIGNATURES fails with
+			// "Ids custom signature json file not found even after retry" on NSX builds
+			// >= 25433529. Remove this skip once the fix is available on the NSX side.
+			t.Skip("Skipped pending NSX fix for error 523940 in ADD_CUSTOM_SIGNATURES")
 		},
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{

--- a/nsxt/data_source_nsxt_policy_idps_signature_diff_test.go
+++ b/nsxt/data_source_nsxt_policy_idps_signature_diff_test.go
@@ -23,6 +23,10 @@ func TestAccDataSourceNsxtPolicyIdpsSignatureDiff_basic(t *testing.T) {
 			testAccPreCheck(t)
 			testAccOnlyLocalManager(t)
 			testAccNSXVersion(t, "4.2.0")
+			// NSX backend regression (error 523940): ADD_CUSTOM_SIGNATURES fails with
+			// "Ids custom signature json file not found even after retry" on NSX builds
+			// >= 25433529. Remove this skip once the fix is available on the NSX side.
+			t.Skip("Skipped pending NSX fix for error 523940 in ADD_CUSTOM_SIGNATURES")
 		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {

--- a/nsxt/resource_nsxt_policy_idps_custom_signature_test.go
+++ b/nsxt/resource_nsxt_policy_idps_custom_signature_test.go
@@ -33,6 +33,10 @@ func TestAccResourceNsxtPolicyIdpsCustomSignature_basic(t *testing.T) {
 			testAccPreCheck(t)
 			testAccOnlyLocalManager(t)
 			testAccNSXVersion(t, "4.2.0")
+			// NSX backend regression (error 523940): ADD_CUSTOM_SIGNATURES fails with
+			// "Ids custom signature json file not found even after retry" on NSX builds
+			// >= 25433529. Remove this skip once the fix is available on the NSX side.
+			t.Skip("Skipped pending NSX fix for error 523940 in ADD_CUSTOM_SIGNATURES")
 		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
@@ -70,6 +74,10 @@ func TestAccResourceNsxtPolicyIdpsCustomSignature_updateSignature(t *testing.T) 
 			testAccPreCheck(t)
 			testAccOnlyLocalManager(t)
 			testAccNSXVersion(t, "4.2.0")
+			// NSX backend regression (error 523940): ADD_CUSTOM_SIGNATURES fails with
+			// "Ids custom signature json file not found even after retry" on NSX builds
+			// >= 25433529. Remove this skip once the fix is available on the NSX side.
+			t.Skip("Skipped pending NSX fix for error 523940 in ADD_CUSTOM_SIGNATURES")
 		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
@@ -109,6 +117,10 @@ func TestAccResourceNsxtPolicyIdpsCustomSignature_withPublish(t *testing.T) {
 			testAccPreCheck(t)
 			testAccOnlyLocalManager(t)
 			testAccNSXVersion(t, "4.2.0")
+			// NSX backend regression (error 523940): ADD_CUSTOM_SIGNATURES fails with
+			// "Ids custom signature json file not found even after retry" on NSX builds
+			// >= 25433529. Remove this skip once the fix is available on the NSX side.
+			t.Skip("Skipped pending NSX fix for error 523940 in ADD_CUSTOM_SIGNATURES")
 		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {


### PR DESCRIPTION
NSX builds >= 25433529 (first seen in 9.2.0.0.25433544) return error 523940 "Ids custom signature json file not found even after retry" when the provider calls ADD_CUSTOM_SIGNATURES. The regression was introduced between NSX builds 25432250 (last passing, 9.2.0.0.25432225) and 25433529. All five affected tests are skipped until a fix lands on the NSX side:

- TestAccDataSourceNsxtPolicyIdpsCustomSignature_basic
- TestAccDataSourceNsxtPolicyIdpsSignatureDiff_basic
- TestAccResourceNsxtPolicyIdpsCustomSignature_basic
- TestAccResourceNsxtPolicyIdpsCustomSignature_updateSignature
- TestAccResourceNsxtPolicyIdpsCustomSignature_withPublish