### PR TITLE
Fix nsxt_policy_project data source ipv6_blocks version guard (bug 3705663)

### DIFF
--- a/nsxt/data_source_nsxt_policy_project.go
+++ b/nsxt/data_source_nsxt_policy_project.go
@@ -10,8 +10,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
-
-	"github.com/vmware/terraform-provider-nsxt/nsxt/util"
 )
 
 const defaultOrgID = "default"
@@ -144,9 +142,7 @@ func dataSourceNsxtPolicyProjectRead(d *schema.ResourceData, m interface{}) erro
 	d.Set("site_info", siteInfosList)
 	d.Set("tier0_gateway_paths", obj.Tier0s)
 	d.Set("external_ipv4_blocks", obj.ExternalIpv4Blocks)
-	if util.NsxVersionHigherOrEqual("9.2.0") && obj.Ipv6Blocks != nil {
-		d.Set("ipv6_blocks", obj.Ipv6Blocks)
-	}
+	d.Set("ipv6_blocks", obj.Ipv6Blocks)
 
 	return nil
 }

--- a/nsxt/utgomock_data_source_nsxt_policy_project_test.go
+++ b/nsxt/utgomock_data_source_nsxt_policy_project_test.go
@@ -153,7 +153,7 @@ func TestMockDataSourceNsxtPolicyProjectRead_ipv6Blocks(t *testing.T) {
 		assert.Equal(t, ipv6BlockPath, blocks[0])
 	})
 
-	t.Run("by ID does not populate ipv6_blocks when NSX below 9.2", func(t *testing.T) {
+	t.Run("by ID sets ipv6_blocks regardless of NSX version", func(t *testing.T) {
 		util.NsxVersion = "9.1.0"
 		defer func() { util.NsxVersion = "" }()
 
@@ -166,8 +166,9 @@ func TestMockDataSourceNsxtPolicyProjectRead_ipv6Blocks(t *testing.T) {
 
 		err := dataSourceNsxtPolicyProjectRead(d, newGoMockProviderClient())
 		require.NoError(t, err)
-		_, ok := d.GetOk("ipv6_blocks")
-		assert.False(t, ok)
+		blocks := d.Get("ipv6_blocks").([]interface{})
+		require.Len(t, blocks, 1)
+		assert.Equal(t, ipv6BlockPath, blocks[0])
 	})
 
 	t.Run("by display_name sets ipv6_blocks when NSX 9.2.0+", func(t *testing.T) {


### PR DESCRIPTION
NSX 9.1.x returns "ipv6_blocks": [] (explicit empty array) in the project API response, but the previous version guard NsxVersionHigherOrEqual("9.2.0") prevented the provider from reading/setting that value for NSX < 9.2.0. This left the Terraform state with ipv6_blocks=null while the API returned [], causing the FVT test verify_data to fail with:
  "Value None for attribute ipv6_blocks not equal to API"

Fix: remove the version guard from the data source read entirely. The API response is the source of truth — always reflect whatever the API returns for ipv6_blocks, regardless of NSX version. The write-path guard in resourceNsxtPolicyProjectPatch (9.2.0+) is unchanged.