### PR TITLE
Revert "Skip IDPS custom signature tests pending NSX fix for error 523940 (#2100)

### DIFF
--- a/nsxt/data_source_nsxt_policy_idps_custom_signature_test.go
+++ b/nsxt/data_source_nsxt_policy_idps_custom_signature_test.go
@@ -22,10 +22,6 @@ func TestAccDataSourceNsxtPolicyIdpsCustomSignature_basic(t *testing.T) {
 			testAccPreCheck(t)
 			testAccOnlyLocalManager(t)
 			testAccNSXVersion(t, "4.2.0")
-			// NSX backend regression (error 523940): ADD_CUSTOM_SIGNATURES fails with
-			// "Ids custom signature json file not found even after retry" on NSX builds
-			// >= 25433529. Remove this skip once the fix is available on the NSX side.
-			t.Skip("Skipped pending NSX fix for error 523940 in ADD_CUSTOM_SIGNATURES")
 		},
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{

--- a/nsxt/data_source_nsxt_policy_idps_signature_diff_test.go
+++ b/nsxt/data_source_nsxt_policy_idps_signature_diff_test.go
@@ -23,10 +23,6 @@ func TestAccDataSourceNsxtPolicyIdpsSignatureDiff_basic(t *testing.T) {
 			testAccPreCheck(t)
 			testAccOnlyLocalManager(t)
 			testAccNSXVersion(t, "4.2.0")
-			// NSX backend regression (error 523940): ADD_CUSTOM_SIGNATURES fails with
-			// "Ids custom signature json file not found even after retry" on NSX builds
-			// >= 25433529. Remove this skip once the fix is available on the NSX side.
-			t.Skip("Skipped pending NSX fix for error 523940 in ADD_CUSTOM_SIGNATURES")
 		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {

--- a/nsxt/resource_nsxt_policy_idps_custom_signature_test.go
+++ b/nsxt/resource_nsxt_policy_idps_custom_signature_test.go
@@ -33,10 +33,6 @@ func TestAccResourceNsxtPolicyIdpsCustomSignature_basic(t *testing.T) {
 			testAccPreCheck(t)
 			testAccOnlyLocalManager(t)
 			testAccNSXVersion(t, "4.2.0")
-			// NSX backend regression (error 523940): ADD_CUSTOM_SIGNATURES fails with
-			// "Ids custom signature json file not found even after retry" on NSX builds
-			// >= 25433529. Remove this skip once the fix is available on the NSX side.
-			t.Skip("Skipped pending NSX fix for error 523940 in ADD_CUSTOM_SIGNATURES")
 		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
@@ -74,10 +70,6 @@ func TestAccResourceNsxtPolicyIdpsCustomSignature_updateSignature(t *testing.T) 
 			testAccPreCheck(t)
 			testAccOnlyLocalManager(t)
 			testAccNSXVersion(t, "4.2.0")
-			// NSX backend regression (error 523940): ADD_CUSTOM_SIGNATURES fails with
-			// "Ids custom signature json file not found even after retry" on NSX builds
-			// >= 25433529. Remove this skip once the fix is available on the NSX side.
-			t.Skip("Skipped pending NSX fix for error 523940 in ADD_CUSTOM_SIGNATURES")
 		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
@@ -117,10 +109,6 @@ func TestAccResourceNsxtPolicyIdpsCustomSignature_withPublish(t *testing.T) {
 			testAccPreCheck(t)
 			testAccOnlyLocalManager(t)
 			testAccNSXVersion(t, "4.2.0")
-			// NSX backend regression (error 523940): ADD_CUSTOM_SIGNATURES fails with
-			// "Ids custom signature json file not found even after retry" on NSX builds
-			// >= 25433529. Remove this skip once the fix is available on the NSX side.
-			t.Skip("Skipped pending NSX fix for error 523940 in ADD_CUSTOM_SIGNATURES")
 		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {


### PR DESCRIPTION
This reverts commit 1011cbfa4c19a7a380d433bf9927acf95e671c5f.