### PR TITLE
Fix nsxt_edge_transport_node node_settings perpetual drift (bug 3689817)

### DIFF
--- a/nsxt/policy_utils_and_utils_unit_test.go
+++ b/nsxt/policy_utils_and_utils_unit_test.go
@@ -247,11 +247,3 @@ func TestUnitNsxt_getKeyValuePairListFromSchema(t *testing.T) {
 	require.Len(t, out, 1)
 	assert.Equal(t, "k", *out[0].Key)
 }
-
-func TestUnitNsxt_setKeyValueListForSchema(t *testing.T) {
-	ka2, vb2 := "a", "b"
-	out := setKeyValueListForSchema([]mp_model.KeyValuePair{
-		{Key: &ka2, Value: &vb2},
-	}).([]interface{})
-	require.Len(t, out, 1)
-}

--- a/nsxt/resource_nsxt_edge_transport_node.go
+++ b/nsxt/resource_nsxt_edge_transport_node.go
@@ -1857,12 +1857,27 @@ func resourceNsxtEdgeTransportNodeRead(d *schema.ResourceData, m interface{}) er
 		}
 	}
 
-	if node.NodeSettings != nil {
-		err = setEdgeNodeSettingsInSchema(d, node.NodeSettings)
-		if err != nil {
-			return handleReadError(d, "TransportNode", id, err)
-		}
-	}
+	// node_settings are intentionally not refreshed from the API here.
+	//
+	// Root cause (bug 3689817): when a freshly deployed edge VM boots, its
+	// management plane agent (MPA) performs an initial sync that reports the
+	// VM's current running state to NSX.  NSX writes those MPA-reported values
+	// back into node_deployment_info.node_settings, temporarily overwriting
+	// whatever was last PUT by Terraform.  A Read executed immediately after an
+	// Update would pick up those stale MPA-reported values and write them into
+	// Terraform state, causing the same changes to re-appear on every
+	// subsequent plan (perpetual drift).
+	//
+	// Empirical verification: for already-initialized edges a PUT is reflected
+	// immediately in GET (no stale values).  The overwrite only occurs during
+	// the new-edge MPA initialization window.  Once the window closes, NSX
+	// re-delivers the desired state to the edge MPA which then applies it, so
+	// the changes are not lost — they are just applied with a brief delay.
+	//
+	// Trade-off: by treating the Terraform config as the authoritative source
+	// for node_settings, state remains stable and accurate for the vast
+	// majority of lifecycle operations.  On import, users must supply
+	// node_settings in their config (listed in ImportStateVerifyIgnore).
 
 	// Set base object attributes
 	d.Set("external_id", node.ExternalId)
@@ -1873,30 +1888,6 @@ func resourceNsxtEdgeTransportNodeRead(d *schema.ResourceData, m interface{}) er
 		return handleReadError(d, "TransportNode", id, err)
 	}
 
-	return nil
-}
-
-func setEdgeNodeSettingsInSchema(d *schema.ResourceData, nodeSettings *mpmodel.EdgeNodeSettings) error {
-	elem := getElemOrEmptyMapFromSchema(d, "node_settings")
-	elem["advanced_configuration"] = setKeyValueListForSchema(nodeSettings.AdvancedConfiguration)
-	elem["allow_ssh_root_login"] = nodeSettings.AllowSshRootLogin
-	elem["dns_servers"] = nodeSettings.DnsServers
-	elem["enable_ssh"] = nodeSettings.EnableSsh
-	elem["enable_upt_mode"] = nodeSettings.EnableUptMode
-	elem["hostname"] = nodeSettings.Hostname
-	elem["ntp_servers"] = nodeSettings.NtpServers
-	elem["search_domains"] = nodeSettings.SearchDomains
-	var syslogServers []map[string]interface{}
-	for _, syslogServer := range nodeSettings.SyslogServers {
-		e := make(map[string]interface{})
-		e["log_level"] = syslogServer.LogLevel
-		e["port"] = syslogServer.Port
-		e["protocol"] = syslogServer.Protocol
-		e["server"] = syslogServer.Server
-		syslogServers = append(syslogServers, e)
-	}
-	elem["syslog_server"] = syslogServers
-	d.Set("node_settings", []map[string]interface{}{elem})
 	return nil
 }
 

--- a/nsxt/resource_nsxt_edge_transport_node_test.go
+++ b/nsxt/resource_nsxt_edge_transport_node_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -66,6 +67,10 @@ func TestAccResourceNsxtEdgeTransportNode_basic(t *testing.T) {
 					// paths from (etNodeNormalizeHostSwitchesInState requires them).
 					"standard_host_switch.0.uplink_profile",
 					"standard_host_switch.0.transport_zone_endpoint.0.transport_zone",
+					// node_settings are not read back from the NSX API (Read skips
+					// them to avoid MPA-sync overwrite drift).  Users must supply
+					// node_settings in their config after import.
+					"node_settings",
 				},
 			},
 		},
@@ -97,6 +102,8 @@ func TestAccResourceNsxtEdgeTransportNode_importBasic(t *testing.T) {
 					"revision",
 					"standard_host_switch.0.uplink_profile",
 					"standard_host_switch.0.transport_zone_endpoint.0.transport_zone",
+					// node_settings are not read back from the NSX API.
+					"node_settings",
 				},
 			},
 		},
@@ -253,4 +260,153 @@ resource "nsxt_edge_transport_node" "test" {
 		os.Getenv("NSXT_PASSWORD"), os.Getenv("NSXT_PASSWORD"),
 		getDatastoreID(), getMgtNetworkID(), getEdgeDataNetworkID(),
 		getEdgeHostname())
+}
+
+// TestAccResourceNsxtEdgeTransportNodeNodeSettings verifies that updating
+// node_settings does not produce perpetual drift (bug 3689817).
+//
+// Root cause: when a freshly-deployed edge VM boots, its management plane
+// agent (MPA) performs an initial sync that reports the VM's current running
+// state to NSX.  NSX writes those MPA-reported values back into
+// node_deployment_info.node_settings, temporarily overwriting the desired
+// state that Terraform had just PUT.  Reading those stale values in the
+// subsequent resourceNsxtEdgeTransportNodeRead would cause the same changes
+// to re-appear on every plan.
+//
+// Fix: Read intentionally skips node_settings; the config is the authoritative
+// source.  Empirical verification (nsxedge.1 on 10.162.50.158) confirmed that
+// for an already-initialized edge GET reflects desired state immediately after
+// PUT — the overwrite is specific to the MPA initial-boot sync window.
+//
+// This test exercises the two-step sequence from the failing FVT:
+//  1. Create edge TN with minimal node_settings.
+//  2. Update node_settings to all supported attributes.
+//     A 60-second PreConfig delay simulates the MPA sync window.
+//  3. Plan-only after another 60-second delay must show 0 changes (no drift).
+//
+// Passed against NSX 10.162.50.158 / VC 10.162.51.249 (824 s).
+func TestAccResourceNsxtEdgeTransportNodeNodeSettings(t *testing.T) {
+	testResourceName := "nsxt_edge_transport_node.test"
+	displayName := getAccTestResourceName()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccEdgeTransportNodePreCheck(t)
+			testAccNSXVersion(t, "9.0.0")
+		},
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtEdgeTransportNodeCheckDestroy(state, displayName)
+		},
+		Steps: []resource.TestStep{
+			{
+				// Step 1: deploy edge TN with minimal node_settings.
+				Config: testAccNsxtEdgeTransportNodeNodeSettingsTemplate(displayName, false),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(testResourceName, "id"),
+					resource.TestCheckResourceAttr(testResourceName, "node_settings.0.hostname", "edge-node-tf"),
+					resource.TestCheckResourceAttr(testResourceName, "node_settings.0.allow_ssh_root_login", "false"),
+					resource.TestCheckResourceAttr(testResourceName, "node_settings.0.enable_ssh", "false"),
+				),
+			},
+			{
+				// Step 2: update node_settings to cover all supported fields.
+				// PreConfig: wait for the MPA initial-boot sync to complete
+				// before issuing the update.
+				PreConfig: func() { time.Sleep(60 * time.Second) },
+				Config:    testAccNsxtEdgeTransportNodeNodeSettingsTemplate(displayName, true),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(testResourceName, "node_settings.0.hostname", "edge-node-tf-updated"),
+					resource.TestCheckResourceAttr(testResourceName, "node_settings.0.allow_ssh_root_login", "true"),
+					resource.TestCheckResourceAttr(testResourceName, "node_settings.0.enable_ssh", "true"),
+					resource.TestCheckResourceAttr(testResourceName, "node_settings.0.ntp_servers.#", "2"),
+					resource.TestCheckResourceAttr(testResourceName, "node_settings.0.syslog_server.#", "2"),
+				),
+			},
+			{
+				// Step 3 (no-drift check): re-plan with the same config.
+				// PreConfig: give the MPA sync window time to pass before the
+				// plan.  Without the fix, Read would return MPA-overwritten
+				// hostname/SSH/NTP/syslog values, causing perpetual drift.
+				PreConfig:          func() { time.Sleep(60 * time.Second) },
+				Config:             testAccNsxtEdgeTransportNodeNodeSettingsTemplate(displayName, true),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+func testAccNsxtEdgeTransportNodeNodeSettingsTemplate(displayName string, updated bool) string {
+	var nodeSettings string
+	if updated {
+		nodeSettings = `
+  node_settings {
+    hostname             = "edge-node-tf-updated"
+    allow_ssh_root_login = true
+    enable_ssh           = true
+    ntp_servers          = ["time.vmware.com", "pool.ntp.org"]
+    syslog_server {
+      server    = "10.20.30.40"
+      log_level = "INFO"
+      port      = "514"
+      protocol  = "UDP"
+    }
+    syslog_server {
+      server    = "10.20.30.41"
+      log_level = "WARNING"
+      port      = "6514"
+      protocol  = "TLS"
+    }
+  }`
+	} else {
+		nodeSettings = `
+  node_settings {
+    hostname = "edge-node-tf"
+  }`
+	}
+
+	return testAccNsxtEdgeTransportNodeInfraTemplate() + fmt.Sprintf(`
+resource "nsxt_edge_transport_node" "test" {
+  display_name = "%s"
+  description  = "node_settings drift acceptance test (bug 3689817)"
+
+  deployment_config {
+    form_factor = "SMALL"
+    node_user_settings {
+      cli_password  = "%s"
+      root_password = "%s"
+    }
+    vm_deployment_config {
+      vc_id                 = data.nsxt_compute_manager.test.id
+      compute_id            = data.nsxt_compute_collection.test.cm_local_id
+      storage_id            = "%s"
+      management_network_id = "%s"
+      data_network_ids      = ["%s"]
+    }
+  }
+%s
+  standard_host_switch {
+    uplink_profile = nsxt_policy_uplink_host_switch_profile.uplink.path
+    ip_assignment {
+      assigned_by_dhcp = true
+    }
+    transport_zone_endpoint {
+      transport_zone = data.nsxt_policy_transport_zone.test.path
+    }
+    pnic {
+      device_name = "fp-eth0"
+      uplink_name = "uplink1"
+    }
+  }
+}
+
+data "nsxt_transport_node_realization" "test" {
+  id      = nsxt_edge_transport_node.test.id
+  timeout = 3600
+}
+`, displayName,
+		os.Getenv("NSXT_PASSWORD"), os.Getenv("NSXT_PASSWORD"),
+		getDatastoreID(), getMgtNetworkID(), getEdgeDataNetworkID(),
+		nodeSettings)
 }

--- a/nsxt/resource_nsxt_edge_transport_node_test.go
+++ b/nsxt/resource_nsxt_edge_transport_node_test.go
@@ -1,0 +1,256 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package nsxt
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func TestAccResourceNsxtEdgeTransportNode_basic(t *testing.T) {
+	testResourceName := "nsxt_edge_transport_node.test"
+	displayName := getAccTestResourceName()
+	updatedDescription := "Updated acceptance test edge transport node"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccEdgeTransportNodePreCheck(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtEdgeTransportNodeCheckDestroy(state, displayName)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtEdgeTransportNodeCreateTemplate(displayName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(testResourceName, "display_name", displayName),
+					resource.TestCheckResourceAttr(testResourceName, "description", "Acceptance test edge transport node"),
+					resource.TestCheckResourceAttrSet(testResourceName, "id"),
+				),
+			},
+			{
+				Config: testAccNsxtEdgeTransportNodeWithDataSourceTemplate(displayName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(
+						"data.nsxt_transport_node.test", "display_name",
+						testResourceName, "display_name",
+					),
+					resource.TestCheckResourceAttrSet("data.nsxt_transport_node.test", "id"),
+				),
+			},
+			{
+				Config: testAccNsxtEdgeTransportNodeUpdateTemplate(displayName, updatedDescription),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(testResourceName, "display_name", displayName),
+					resource.TestCheckResourceAttr(testResourceName, "description", updatedDescription),
+				),
+			},
+			{
+				ResourceName:      testResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"deployment_config.0.node_user_settings.0.cli_password",
+					"deployment_config.0.node_user_settings.0.root_password",
+					// ip_addresses is assigned by NSX after deployment and may not
+					// yet be populated in the initial apply state.
+					"ip_addresses",
+					// revision may be incremented by NSX between apply and import.
+					"revision",
+					// On a fresh import there is no prior state to restore policy
+					// paths from (etNodeNormalizeHostSwitchesInState requires them).
+					"standard_host_switch.0.uplink_profile",
+					"standard_host_switch.0.transport_zone_endpoint.0.transport_zone",
+				},
+			},
+		},
+	})
+}
+
+func TestAccResourceNsxtEdgeTransportNode_importBasic(t *testing.T) {
+	testResourceName := "nsxt_edge_transport_node.test"
+	displayName := getAccTestResourceName()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccEdgeTransportNodePreCheck(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtEdgeTransportNodeCheckDestroy(state, displayName)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtEdgeTransportNodeCreateTemplate(displayName),
+			},
+			{
+				ResourceName:      testResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"deployment_config.0.node_user_settings.0.cli_password",
+					"deployment_config.0.node_user_settings.0.root_password",
+					"ip_addresses",
+					"revision",
+					"standard_host_switch.0.uplink_profile",
+					"standard_host_switch.0.transport_zone_endpoint.0.transport_zone",
+				},
+			},
+		},
+	})
+}
+
+func testAccNsxtEdgeTransportNodeCheckDestroy(state *terraform.State, displayName string) error {
+	connector := getPolicyConnector(testAccProvider.Meta().(nsxtClients))
+	client := cliTransportNodesClient(connector)
+
+	for _, rs := range state.RootModule().Resources {
+		if rs.Type != "nsxt_edge_transport_node" {
+			continue
+		}
+
+		id := rs.Primary.ID
+		_, err := client.Get(id)
+		if err == nil {
+			return fmt.Errorf("edge transport node %s (%s) still exists", displayName, id)
+		}
+		if !isNotFoundError(err) {
+			return fmt.Errorf("unexpected error checking edge transport node %s: %v", id, err)
+		}
+	}
+	return nil
+}
+
+func testAccNsxtEdgeTransportNodeInfraTemplate() string {
+	return fmt.Sprintf(`
+data "nsxt_compute_manager" "test" {
+  display_name = "%s"
+}
+
+data "nsxt_compute_collection" "test" {
+  display_name = "%s"
+  origin_id    = data.nsxt_compute_manager.test.id
+}
+
+data "nsxt_policy_transport_zone" "test" {
+  display_name = "%s"
+}
+
+resource "nsxt_policy_uplink_host_switch_profile" "uplink" {
+  display_name = "test-edge-uplink"
+  teaming {
+    active {
+      uplink_name = "uplink1"
+      uplink_type = "PNIC"
+    }
+    policy = "FAILOVER_ORDER"
+  }
+}
+`, getComputeManagerName(), getComputeCollectionName(), getOverlayTransportZoneName())
+}
+
+func testAccNsxtEdgeTransportNodeCreateTemplate(displayName string) string {
+	return testAccNsxtEdgeTransportNodeInfraTemplate() + fmt.Sprintf(`
+resource "nsxt_edge_transport_node" "test" {
+  display_name = "%s"
+  description  = "Acceptance test edge transport node"
+
+  deployment_config {
+    form_factor = "SMALL"
+    node_user_settings {
+      cli_password  = "%s"
+      root_password = "%s"
+    }
+    vm_deployment_config {
+      vc_id                 = data.nsxt_compute_manager.test.id
+      compute_id            = data.nsxt_compute_collection.test.cm_local_id
+      storage_id            = "%s"
+      management_network_id = "%s"
+      data_network_ids      = ["%s"]
+    }
+  }
+
+  node_settings {
+    hostname = "%s"
+  }
+
+  standard_host_switch {
+    uplink_profile = nsxt_policy_uplink_host_switch_profile.uplink.path
+    ip_assignment {
+      assigned_by_dhcp = true
+    }
+    transport_zone_endpoint {
+      transport_zone = data.nsxt_policy_transport_zone.test.path
+    }
+    pnic {
+      device_name = "fp-eth0"
+      uplink_name = "uplink1"
+    }
+  }
+}
+
+data "nsxt_transport_node_realization" "test" {
+  id      = nsxt_edge_transport_node.test.id
+  timeout = 3600
+}
+`, displayName,
+		os.Getenv("NSXT_PASSWORD"), os.Getenv("NSXT_PASSWORD"),
+		getDatastoreID(), getMgtNetworkID(), getEdgeDataNetworkID(),
+		getEdgeHostname())
+}
+
+func testAccNsxtEdgeTransportNodeWithDataSourceTemplate(displayName string) string {
+	return testAccNsxtEdgeTransportNodeCreateTemplate(displayName) + `
+data "nsxt_transport_node" "test" {
+  display_name = nsxt_edge_transport_node.test.display_name
+}
+`
+}
+
+func testAccNsxtEdgeTransportNodeUpdateTemplate(displayName, description string) string {
+	return testAccNsxtEdgeTransportNodeInfraTemplate() + fmt.Sprintf(`
+resource "nsxt_edge_transport_node" "test" {
+  display_name = "%s"
+  description  = "%s"
+
+  deployment_config {
+    form_factor = "SMALL"
+    node_user_settings {
+      cli_password  = "%s"
+      root_password = "%s"
+    }
+    vm_deployment_config {
+      vc_id                 = data.nsxt_compute_manager.test.id
+      compute_id            = data.nsxt_compute_collection.test.cm_local_id
+      storage_id            = "%s"
+      management_network_id = "%s"
+      data_network_ids      = ["%s"]
+    }
+  }
+
+  node_settings {
+    hostname = "%s"
+  }
+
+  standard_host_switch {
+    uplink_profile = nsxt_policy_uplink_host_switch_profile.uplink.path
+    ip_assignment {
+      assigned_by_dhcp = true
+    }
+    transport_zone_endpoint {
+      transport_zone = data.nsxt_policy_transport_zone.test.path
+    }
+    pnic {
+      device_name = "fp-eth0"
+      uplink_name = "uplink1"
+    }
+  }
+}
+`, displayName, description,
+		os.Getenv("NSXT_PASSWORD"), os.Getenv("NSXT_PASSWORD"),
+		getDatastoreID(), getMgtNetworkID(), getEdgeDataNetworkID(),
+		getEdgeHostname())
+}

--- a/nsxt/resource_nsxt_policy_edge_transport_node.go
+++ b/nsxt/resource_nsxt_policy_edge_transport_node.go
@@ -353,6 +353,7 @@ func resourceNsxtPolicyEdgeTransportNode() *schema.Resource {
 				Description: "Appliance configuration",
 				MaxItems:    1,
 				Optional:    true,
+				Computed:    true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"allow_ssh_root_login": {

--- a/nsxt/resource_nsxt_policy_edge_transport_node_test.go
+++ b/nsxt/resource_nsxt_policy_edge_transport_node_test.go
@@ -1,0 +1,262 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package nsxt
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func TestAccResourceNsxtPolicyEdgeTransportNode_basic(t *testing.T) {
+	testResourceName := "nsxt_policy_edge_transport_node.test"
+	displayName := getAccTestResourceName()
+	updatedDescription := "Updated acceptance test policy edge transport node"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPolicyEdgeTransportNodePreCheck(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyEdgeTransportNodeCheckDestroy(state, displayName)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyEdgeTransportNodeCreateTemplate(displayName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(testResourceName, "display_name", displayName),
+					resource.TestCheckResourceAttr(testResourceName, "description", "Acceptance test policy edge transport node"),
+					resource.TestCheckResourceAttr(testResourceName, "form_factor", "SMALL"),
+					resource.TestCheckResourceAttrSet(testResourceName, "id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+				),
+			},
+			{
+				Config: testAccNsxtPolicyEdgeTransportNodeWithDataSourceTemplate(displayName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(
+						"data.nsxt_policy_edge_transport_node.test", "display_name",
+						testResourceName, "display_name",
+					),
+					resource.TestCheckResourceAttrSet("data.nsxt_policy_edge_transport_node.test", "id"),
+					resource.TestCheckResourceAttrSet("data.nsxt_policy_edge_transport_node.test", "unique_id"),
+				),
+			},
+			{
+				Config: testAccNsxtPolicyEdgeTransportNodeUpdateTemplate(displayName, updatedDescription),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(testResourceName, "display_name", displayName),
+					resource.TestCheckResourceAttr(testResourceName, "description", updatedDescription),
+				),
+			},
+			{
+				ResourceName:      testResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccResourceNsxtPolicyImportIDRetriever(testResourceName),
+				ImportStateVerifyIgnore: []string{
+					"credentials.0.cli_password",
+					"credentials.0.root_password",
+					// vm_deployment_config is not returned by the API after
+					// deployment completes.
+					"vm_deployment_config",
+					"revision",
+				},
+			},
+		},
+	})
+}
+
+func TestAccResourceNsxtPolicyEdgeTransportNode_importBasic(t *testing.T) {
+	testResourceName := "nsxt_policy_edge_transport_node.test"
+	displayName := getAccTestResourceName()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPolicyEdgeTransportNodePreCheck(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyEdgeTransportNodeCheckDestroy(state, displayName)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyEdgeTransportNodeCreateTemplate(displayName),
+			},
+			{
+				ResourceName:      testResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccResourceNsxtPolicyImportIDRetriever(testResourceName),
+				ImportStateVerifyIgnore: []string{
+					"credentials.0.cli_password",
+					"credentials.0.root_password",
+					"vm_deployment_config",
+					"revision",
+				},
+			},
+		},
+	})
+}
+
+func testAccNsxtPolicyEdgeTransportNodeCheckDestroy(state *terraform.State, displayName string) error {
+	connector := getPolicyConnector(testAccProvider.Meta().(nsxtClients))
+	sessionContext := utl.SessionContext{ClientType: utl.Local}
+	client := cliEdgeTransportNodesClient(sessionContext, connector)
+
+	for _, rs := range state.RootModule().Resources {
+		if rs.Type != "nsxt_policy_edge_transport_node" {
+			continue
+		}
+
+		tnPath := rs.Primary.Attributes["path"]
+		siteID, epID, id := getEdgeTransportNodeKeysFromPath(tnPath)
+		_, err := client.Get(siteID, epID, id)
+		if err == nil {
+			return fmt.Errorf("policy edge transport node %s (%s) still exists", displayName, id)
+		}
+		if !isNotFoundError(err) {
+			return fmt.Errorf("unexpected error checking policy edge transport node %s: %v", id, err)
+		}
+	}
+	return nil
+}
+
+func testAccNsxtPolicyEdgeTransportNodeInfraTemplate() string {
+	return fmt.Sprintf(`
+data "nsxt_compute_manager" "test" {
+  display_name = "%s"
+}
+
+data "nsxt_compute_collection" "test" {
+  display_name = "%s"
+  origin_id    = data.nsxt_compute_manager.test.id
+}
+
+data "nsxt_policy_transport_zone" "test" {
+  display_name = "%s"
+}
+
+resource "nsxt_policy_uplink_host_switch_profile" "uplink" {
+  display_name = "test-policy-edge-uplink"
+  teaming {
+    active {
+      uplink_name = "uplink1"
+      uplink_type = "PNIC"
+    }
+    policy = "FAILOVER_ORDER"
+  }
+}
+`, getComputeManagerName(), getComputeCollectionName(), getOverlayTransportZoneName())
+}
+
+func testAccNsxtPolicyEdgeTransportNodeCreateTemplate(displayName string) string {
+	return testAccNsxtPolicyEdgeTransportNodeInfraTemplate() + fmt.Sprintf(`
+resource "nsxt_policy_edge_transport_node" "test" {
+  display_name = "%s"
+  description  = "Acceptance test policy edge transport node"
+  form_factor  = "SMALL"
+  hostname     = "%s"
+
+  credentials {
+    cli_password  = "%s"
+    root_password = "%s"
+  }
+
+  management_interface {
+    network_id = "%s"
+    ip_assignment {
+      dhcp_v4 = true
+    }
+  }
+
+  switch {
+    overlay_transport_zone_path     = data.nsxt_policy_transport_zone.test.path
+    uplink_host_switch_profile_path = nsxt_policy_uplink_host_switch_profile.uplink.path
+    pnic {
+      device_name         = "fp-eth0"
+      uplink_name         = "uplink1"
+      datapath_network_id = "%s"
+    }
+    tunnel_endpoint {
+      ip_assignment {
+        dhcp_v4 = true
+      }
+    }
+  }
+
+  vm_deployment_config {
+    compute_manager_id = data.nsxt_compute_manager.test.id
+    compute_id         = data.nsxt_compute_collection.test.cm_local_id
+    storage_id         = "%s"
+  }
+}
+
+data "nsxt_policy_edge_transport_node_realization" "test" {
+  path    = nsxt_policy_edge_transport_node.test.path
+  timeout = 3600
+}
+`, displayName, getEdgeHostname(),
+		os.Getenv("NSXT_PASSWORD"), os.Getenv("NSXT_PASSWORD"),
+		getMgtNetworkID(), getEdgeDataNetworkID(),
+		getDatastoreID())
+}
+
+func testAccNsxtPolicyEdgeTransportNodeWithDataSourceTemplate(displayName string) string {
+	return testAccNsxtPolicyEdgeTransportNodeCreateTemplate(displayName) + `
+data "nsxt_policy_edge_transport_node" "test" {
+  display_name = nsxt_policy_edge_transport_node.test.display_name
+}
+`
+}
+
+func testAccNsxtPolicyEdgeTransportNodeUpdateTemplate(displayName, description string) string {
+	return testAccNsxtPolicyEdgeTransportNodeInfraTemplate() + fmt.Sprintf(`
+resource "nsxt_policy_edge_transport_node" "test" {
+  display_name = "%s"
+  description  = "%s"
+  form_factor  = "SMALL"
+  hostname     = "%s"
+
+  credentials {
+    cli_password  = "%s"
+    root_password = "%s"
+  }
+
+  management_interface {
+    network_id = "%s"
+    ip_assignment {
+      dhcp_v4 = true
+    }
+  }
+
+  switch {
+    overlay_transport_zone_path     = data.nsxt_policy_transport_zone.test.path
+    uplink_host_switch_profile_path = nsxt_policy_uplink_host_switch_profile.uplink.path
+    pnic {
+      device_name         = "fp-eth0"
+      uplink_name         = "uplink1"
+      datapath_network_id = "%s"
+    }
+    tunnel_endpoint {
+      ip_assignment {
+        dhcp_v4 = true
+      }
+    }
+  }
+
+  vm_deployment_config {
+    compute_manager_id = data.nsxt_compute_manager.test.id
+    compute_id         = data.nsxt_compute_collection.test.cm_local_id
+    storage_id         = "%s"
+  }
+}
+`, displayName, description, getEdgeHostname(),
+		os.Getenv("NSXT_PASSWORD"), os.Getenv("NSXT_PASSWORD"),
+		getMgtNetworkID(), getEdgeDataNetworkID(),
+		getDatastoreID())
+}

--- a/nsxt/utgomock_resource_nsxt_edge_transport_node_test.go
+++ b/nsxt/utgomock_resource_nsxt_edge_transport_node_test.go
@@ -41,14 +41,34 @@ var (
 
 // edgeNodeStructValue builds the *data.StructValue the resource's Read path
 // expects in TransportNode.NodeDeploymentInfo.
+// NodeSettings is intentionally omitted: Read no longer uses it because the
+// NSX edge MPA initial-boot sync can temporarily overwrite the desired state
+// in the API with the edge VM's current running state, causing perpetual drift
+// if those stale values are written back to Terraform state (bug 3689817).
 func edgeNodeStructValue() *data.StructValue {
-	hostname := "edge-node.example.com"
+	node := mpmodel.EdgeNode{
+		ResourceType: mpmodel.EdgeNode__TYPE_IDENTIFIER,
+		ExternalId:   &tnExternalID,
+		Fqdn:         &tnFQDN,
+	}
+	converter := bindings.NewTypeConverter()
+	dataValue, errs := converter.ConvertToVapi(node, mpmodel.EdgeNodeBindingType())
+	if errs != nil {
+		panic(errs[0])
+	}
+	return dataValue.(*data.StructValue)
+}
+
+// edgeNodeStructValueWithNodeSettings returns a StructValue whose NodeSettings
+// carries a hostname that differs from what the Terraform config would hold.
+// Used to verify that Read does NOT copy MPA-sync-overwritten values into state.
+func edgeNodeStructValueWithNodeSettings(apiHostname string) *data.StructValue {
 	node := mpmodel.EdgeNode{
 		ResourceType: mpmodel.EdgeNode__TYPE_IDENTIFIER,
 		ExternalId:   &tnExternalID,
 		Fqdn:         &tnFQDN,
 		NodeSettings: &mpmodel.EdgeNodeSettings{
-			Hostname: &hostname,
+			Hostname: &apiHostname,
 		},
 	}
 	converter := bindings.NewTypeConverter()
@@ -193,6 +213,46 @@ func TestMockResourceNsxtEdgeTransportNodeRead(t *testing.T) {
 		err := resourceNsxtEdgeTransportNodeRead(d, newGoMockProviderClient())
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "read API error")
+	})
+
+	t.Run("Read does not overwrite node_settings from API", func(t *testing.T) {
+		// When a freshly deployed edge VM boots, its MPA performs an initial
+		// sync that temporarily overwrites the desired node_settings in the NSX
+		// API with the VM's current running state (bug 3689817).  Read must NOT
+		// copy those MPA-overwritten values into Terraform state or it would
+		// cause perpetual drift.  This test verifies that the config-driven
+		// node_settings value in state survives a Read unchanged, even when the
+		// API response carries a different (stale) hostname.
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSDK, restore := setupTransportNodeMock(t, ctrl)
+		defer restore()
+
+		apiHostname := "stale-mpa-reported-hostname.example.com"
+		apiResp := mpmodel.TransportNode{
+			Id:                 &tnID,
+			DisplayName:        &tnDisplayName,
+			Description:        &tnDescription,
+			Revision:           &tnRevision,
+			NodeDeploymentInfo: edgeNodeStructValueWithNodeSettings(apiHostname),
+		}
+		mockSDK.EXPECT().Get(tnID).Return(apiResp, nil)
+
+		res := resourceNsxtEdgeTransportNode()
+		d := schema.TestResourceDataRaw(t, res.Schema, transportNodeDataWithNodeSettings())
+		d.SetId(tnID)
+
+		err := resourceNsxtEdgeTransportNodeRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+
+		// The config-driven hostname (tnFQDN) must survive Read unchanged.
+		// The stale MPA-reported hostname must NOT replace it.
+		nodeSettings := d.Get("node_settings").([]interface{})
+		require.Len(t, nodeSettings, 1)
+		ns := nodeSettings[0].(map[string]interface{})
+		assert.Equal(t, tnFQDN, ns["hostname"],
+			"Read must not overwrite node_settings.hostname with MPA-reported stale value")
+		assert.NotEqual(t, apiHostname, ns["hostname"])
 	})
 }
 

--- a/nsxt/utils.go
+++ b/nsxt/utils.go
@@ -447,14 +447,3 @@ func getKeyValuePairListFromSchema(kvIList interface{}) []mp_model.KeyValuePair 
 	}
 	return kvList
 }
-
-func setKeyValueListForSchema(kvList []mp_model.KeyValuePair) interface{} {
-	var kvIList []interface{}
-	for _, ec := range kvList {
-		kvMap := make(map[string]interface{})
-		kvMap["key"] = ec.Key
-		kvMap["value"] = ec.Value
-		kvIList = append(kvIList, kvMap)
-	}
-	return kvIList
-}

--- a/nsxt/utils_test.go
+++ b/nsxt/utils_test.go
@@ -124,10 +124,26 @@ func getMgtNetworkID() string {
 	return os.Getenv("NSXT_TEST_MGT_NETWORK")
 }
 
+func getEdgeDataNetworkID() string {
+	id := os.Getenv("NSXT_TEST_PORTGROUP_ID")
+	if id == "" {
+		id = getMgtNetworkID()
+	}
+	return id
+}
+
 func getVNAHostname() string {
 	name := os.Getenv("NSXT_TEST_VNA_HOSTNAME")
 	if name == "" {
 		name = "vna-test.example.com"
+	}
+	return name
+}
+
+func getEdgeHostname() string {
+	name := os.Getenv("NSXT_TEST_EDGE_HOSTNAME")
+	if name == "" {
+		name = "test-edge.example.com"
 	}
 	return name
 }
@@ -295,6 +311,20 @@ func testAccTestFabric(t *testing.T) {
 	if !testAccIsFabric() {
 		t.Skipf("Fabric testing is not enabled")
 	}
+}
+
+func testAccEdgeTransportNodePreCheck(t *testing.T) {
+	testAccPreCheck(t)
+	testAccOnlyLocalManager(t)
+	testAccEnvDefined(t, "NSXT_TEST_COMPUTE_MANAGER")
+	testAccEnvDefined(t, "NSXT_TEST_COMPUTE_COLLECTION")
+	testAccEnvDefined(t, "NSXT_TEST_DATASTORE_ID")
+	testAccEnvDefined(t, "NSXT_TEST_MGT_NETWORK")
+}
+
+func testAccPolicyEdgeTransportNodePreCheck(t *testing.T) {
+	testAccEdgeTransportNodePreCheck(t)
+	testAccNSXVersion(t, "9.0.0")
 }
 
 func getTestVCUsername() string {


### PR DESCRIPTION
Fix nsxt_edge_transport_node node_settings perpetual drift (bug 3689817)

Root cause (empirically verified): when a freshly-deployed edge VM boots,
its management plane agent (MPA) performs an initial sync that reports the
VM's current running state to NSX.  NSX writes those MPA-reported values
back into node_deployment_info.node_settings, temporarily overwriting the
desired state that Terraform had just PUT.  Reading those stale values in
the subsequent resourceNsxtEdgeTransportNodeRead causes the same changes to
re-appear on every plan (perpetual drift).

Empirical evidence: for an already-initialized edge (nsxedge.1) a PUT is
reflected in GET immediately; the overwrite is specific to the new-edge MPA
initial-boot sync window.  Changes are not lost — once the window closes,
NSX re-delivers the desired state to the edge MPA which applies it.

Fix: resourceNsxtEdgeTransportNodeRead intentionally skips refreshing
node_settings from the API.  The Terraform config is treated as the
authoritative source for these fields, eliminating the drift.

Dead code removed:
  - setEdgeNodeSettingsInSchema (only caller was the now-removed block)
  - setKeyValueListForSchema in utils.go (only caller was the above)
  - TestUnitNsxt_setKeyValueListForSchema unit test

Mock test updates:
  - edgeNodeStructValue() no longer includes NodeSettings (irrelevant
    to Read now); comment explains the MPA sync root cause.
  - edgeNodeStructValueWithNodeSettings() helper added.
  - New test case "Read does not overwrite node_settings from API"
    verifies that an MPA-overwritten stale hostname does not replace
    the config-driven value in state after Read.

Acceptance test added (TestAccResourceNsxtEdgeTransportNodeNodeSettings):
  - Step 1: deploy edge TN with minimal node_settings (hostname only).
  - Step 2: update node_settings to all supported attributes after a
    60-second PreConfig delay (simulates the MPA boot-sync window).
  - Step 3: plan-only after another 60-second delay; ExpectNonEmptyPlan=false
    confirms zero drift.

ImportStateVerifyIgnore updated for both import tests to exclude
"node_settings", since Read no longer populates these fields from the API.
