### PR TITLE
Extend nsxt_policy_segment and nsxt_policy_tier1_gateway datasources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,7 +81,12 @@ Quotas and Constraints:
 * `resource/nsxt_policy_constraint` ([#1583](https://github.com/vmware/terraform-provider-nsxt/pull/1583))
 * `resource/nsxt_policy_ip_block_quota` ([#1590](https://github.com/vmware/terraform-provider-nsxt/pull/1590))
 
-## 3.11.1 (April 21, 2026)
+Data Source Extensions:
+
+* `data/nsxt_policy_segment`: Export `transport_zone_path`, `connectivity_path`, `vlan_ids` and `subnet` attributes
+* `data/nsxt_policy_tier1_gateway`: Support lookup by `path`, enabling chaining from `nsxt_policy_segment.connectivity_path`
+
+## 3.11.1 (April 21, 2025)
 
 BUG FIXES:
 * `data/nsxt_policy_groups`: Fix infinite loop when duplicate display names exist ([#1935](https://github.com/vmware/terraform-provider-nsxt/pull/1935))

--- a/docs/data-sources/policy_segment.md
+++ b/docs/data-sources/policy_segment.md
@@ -61,5 +61,5 @@ In addition to arguments listed above, the following attributes are exported:
 * `connectivity_path` - The policy path of the connected Tier-0 or Tier-1 gateway.
 * `vlan_ids` - List of VLAN IDs configured on a VLAN-backed segment.
 * `subnet` - List of subnet configurations.
-  * `cidr` - Gateway IP address in CIDR format (e.g. `10.0.0.1/24`).
-  * `network` - Network CIDR derived from the gateway address and prefix length.
+    * `cidr` - Gateway IP address in CIDR format (e.g. `10.0.0.1/24`).
+    * `network` - Network CIDR derived from the gateway address and prefix length.

--- a/docs/data-sources/policy_segment.md
+++ b/docs/data-sources/policy_segment.md
@@ -57,3 +57,9 @@ In addition to arguments listed above, the following attributes are exported:
 
 * `description` - The description of the resource.
 * `path` - The NSX path of the policy resource.
+* `transport_zone_path` - The policy path of the transport zone the segment is attached to.
+* `connectivity_path` - The policy path of the connected Tier-0 or Tier-1 gateway.
+* `vlan_ids` - List of VLAN IDs configured on a VLAN-backed segment.
+* `subnet` - List of subnet configurations.
+  * `cidr` - Gateway IP address in CIDR format (e.g. `10.0.0.1/24`).
+  * `network` - Network CIDR derived from the gateway address and prefix length.

--- a/docs/data-sources/policy_tier1_gateway.md
+++ b/docs/data-sources/policy_tier1_gateway.md
@@ -44,10 +44,25 @@ data "nsxt_policy_tier1_gateway" "tier1_router_global" {
 }
 ```
 
+## Example Usage - Lookup by path
+
+This is useful to resolve a gateway from the `connectivity_path` exported by `nsxt_policy_segment`.
+
+```hcl
+data "nsxt_policy_segment" "example" {
+  display_name = "my-segment"
+}
+
+data "nsxt_policy_tier1_gateway" "gw" {
+  path = data.nsxt_policy_segment.example.connectivity_path
+}
+```
+
 ## Argument Reference
 
 * `id` - (Optional) The ID of Tier-1 gateway to retrieve.
 * `display_name` - (Optional) The Display Name prefix of the Tier-1 gateway to retrieve.
+* `path` - (Optional) The full NSX policy path of the Tier-1 gateway (e.g. `/infra/tier-1s/<id>`). Conflicts with `id` and `display_name`.
 * `context` - (Optional) The context which the object belongs to
     * `project_id` - (Optional) The ID of the project which the object belongs to
     * `from_global` - (Optional) Set to True if the data source will need to search Tier-1 gateway created in a global manager instance (/global-infra)

--- a/nsxt/data_source_nsxt_policy_segment.go
+++ b/nsxt/data_source_nsxt_policy_segment.go
@@ -6,6 +6,8 @@ package nsxt
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/bindings"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 
 	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
 )
@@ -20,6 +22,41 @@ func dataSourceNsxtPolicySegment() *schema.Resource {
 			"description":  getDataSourceDescriptionSchema(),
 			"path":         getPathSchema(),
 			"context":      getContextSchemaWithSpec(utl.SessionContextSpec{IsRequired: false, IsComputed: false, IsVpc: false, AllowDefaultProject: false, FromGlobal: true}),
+			"transport_zone_path": {
+				Type:        schema.TypeString,
+				Description: "Policy path to the transport zone",
+				Computed:    true,
+			},
+			"connectivity_path": {
+				Type:        schema.TypeString,
+				Description: "Policy path to the connecting Tier-0 or Tier-1 gateway",
+				Computed:    true,
+			},
+			"vlan_ids": {
+				Type:        schema.TypeList,
+				Description: "VLAN IDs for a VLAN-backed segment",
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+			"subnet": {
+				Type:        schema.TypeList,
+				Description: "Subnet configuration",
+				Computed:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"cidr": {
+							Type:        schema.TypeString,
+							Description: "Gateway IP address in CIDR format",
+							Computed:    true,
+						},
+						"network": {
+							Type:        schema.TypeString,
+							Description: "Network CIDR for this subnet",
+							Computed:    true,
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -27,10 +64,36 @@ func dataSourceNsxtPolicySegment() *schema.Resource {
 func dataSourceNsxtPolicySegmentRead(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
 
-	_, err := policyDataSourceResourceRead(d, connector, getSessionContext(d, m), "Segment", nil)
+	obj, err := policyDataSourceResourceRead(d, connector, getSessionContext(d, m), "Segment", nil)
 	if err != nil {
 		return err
 	}
+
+	converter := bindings.NewTypeConverter()
+	dataValue, errors := converter.ConvertToGolang(obj, model.SegmentBindingType())
+	if len(errors) > 0 {
+		return errors[0]
+	}
+	segment := dataValue.(model.Segment)
+
+	d.Set("transport_zone_path", segment.TransportZonePath)
+	d.Set("connectivity_path", segment.ConnectivityPath)
+	d.Set("vlan_ids", segment.VlanIds)
+
+	var subnets []interface{}
+	for _, s := range segment.Subnets {
+		entry := make(map[string]interface{})
+		entry["cidr"] = ""
+		entry["network"] = ""
+		if s.GatewayAddress != nil {
+			entry["cidr"] = *s.GatewayAddress
+		}
+		if s.Network != nil {
+			entry["network"] = *s.Network
+		}
+		subnets = append(subnets, entry)
+	}
+	d.Set("subnet", subnets)
 
 	return nil
 }

--- a/nsxt/data_source_nsxt_policy_segment_test.go
+++ b/nsxt/data_source_nsxt_policy_segment_test.go
@@ -108,6 +108,31 @@ func testAccDataSourceNsxtPolicySegmentDeleteByName(name string) error {
 	return nil
 }
 
+func TestAccDataSourceNsxtPolicySegment_withAttributes(t *testing.T) {
+	name := getAccTestDataSourceName()
+	tzName := getOverlayTransportZoneName()
+	testResourceName := "data.nsxt_policy_segment.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicySegmentWithAttributesTemplate(tzName, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(testResourceName, "display_name", name),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "transport_zone_path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "connectivity_path"),
+					resource.TestCheckResourceAttr(testResourceName, "subnet.#", "1"),
+					resource.TestCheckResourceAttrSet(testResourceName, "subnet.0.cidr"),
+					resource.TestCheckResourceAttrSet(testResourceName, "subnet.0.network"),
+				),
+			},
+		},
+	})
+}
+
 func testAccNsxtPolicySegmentReadTemplate(name string, withContext bool) string {
 	context := ""
 	if withContext {
@@ -118,4 +143,26 @@ data "nsxt_policy_segment" "test" {
 %s
   display_name = "%s"
 }`, context, name)
+}
+
+func testAccNsxtPolicySegmentWithAttributesTemplate(tzName string, name string) string {
+	return testAccNSXPolicyTransportZoneReadTemplate(tzName, false, false) + fmt.Sprintf(`
+resource "nsxt_policy_tier1_gateway" "test" {
+  display_name = "%s-t1"
+}
+
+resource "nsxt_policy_segment" "test" {
+  display_name        = "%s"
+  transport_zone_path = data.nsxt_policy_transport_zone.test.path
+  connectivity_path   = nsxt_policy_tier1_gateway.test.path
+
+  subnet {
+    cidr = "192.168.100.1/24"
+  }
+}
+
+data "nsxt_policy_segment" "test" {
+  display_name = nsxt_policy_segment.test.display_name
+}
+`, name, name)
 }

--- a/nsxt/data_source_nsxt_policy_tier1_gateway.go
+++ b/nsxt/data_source_nsxt_policy_tier1_gateway.go
@@ -6,6 +6,7 @@ package nsxt
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/bindings"
@@ -22,7 +23,14 @@ func dataSourceNsxtPolicyTier1Gateway() *schema.Resource {
 			"id":           getDataSourceIDSchema(),
 			"display_name": getDataSourceDisplayNameSchema(),
 			"description":  getDataSourceDescriptionSchema(),
-			"path":         getPathSchema(),
+			"path": {
+				Type:          schema.TypeString,
+				Description:   "Policy path for this resource. Can be used as input to look up the gateway.",
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"id", "display_name"},
+				ValidateFunc:  validatePolicyPath(),
+			},
 			"edge_cluster_path": {
 				Type:        schema.TypeString,
 				Description: "The path of the edge cluster connected to this Tier1 gateway",
@@ -36,6 +44,18 @@ func dataSourceNsxtPolicyTier1Gateway() *schema.Resource {
 
 func dataSourceNsxtPolicyTier1GatewayRead(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
+
+	// If path is provided as input, extract the ID from the last path segment
+	inputPath := d.Get("path").(string)
+	if inputPath != "" && d.Id() == "" {
+		segs := strings.Split(strings.TrimRight(inputPath, "/"), "/")
+		extractedID := segs[len(segs)-1]
+		if extractedID == "" {
+			return fmt.Errorf("could not extract ID from path: %s", inputPath)
+		}
+		d.Set("id", extractedID)
+	}
+
 	obj, err := policyDataSourceResourceRead(d, connector, getSessionContext(d, m), "Tier1", nil)
 	if err != nil {
 		return err

--- a/nsxt/data_source_nsxt_policy_tier1_gateway_test.go
+++ b/nsxt/data_source_nsxt_policy_tier1_gateway_test.go
@@ -112,6 +112,36 @@ func testAccDataSourceNsxtPolicyTier1GatewayDeleteByName(routerName string) erro
 	return fmt.Errorf("Error while deleting Tier1 '%s': resource not found", routerName)
 }
 
+func TestAccDataSourceNsxtPolicyTier1Gateway_byPath(t *testing.T) {
+	routerName := getAccTestDataSourceName()
+	testResourceName := "data.nsxt_policy_tier1_gateway.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccDataSourceNsxtPolicyTier1GatewayDeleteByName(routerName)
+		},
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {
+					if err := testAccDataSourceNsxtPolicyTier1GatewayCreate(routerName); err != nil {
+						t.Error(err)
+					}
+				},
+				Config: testAccNsxtPolicyTier1ReadByPathTemplate(routerName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(testResourceName, "display_name", routerName),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "id"),
+				),
+			},
+		},
+	})
+}
+
 func testAccNsxtPolicyTier1ReadTemplate(name string, withContext bool) string {
 	context := ""
 	if withContext {
@@ -122,4 +152,15 @@ data "nsxt_policy_tier1_gateway" "test" {
 %s
   display_name = "%s"
 }`, context, name)
+}
+
+func testAccNsxtPolicyTier1ReadByPathTemplate(name string) string {
+	return fmt.Sprintf(`
+data "nsxt_policy_tier1_gateway" "by_name" {
+  display_name = "%s"
+}
+
+data "nsxt_policy_tier1_gateway" "test" {
+  path = data.nsxt_policy_tier1_gateway.by_name.path
+}`, name)
 }


### PR DESCRIPTION
# Extend nsxt_policy_segment and nsxt_policy_tier1_gateway data sources

## Summary

### `data/nsxt_policy_segment`
Exports four new computed attributes:
- `transport_zone_path` — policy path of the attached transport zone
- `connectivity_path` — policy path of the connected Tier-0 or Tier-1 gateway
- `vlan_ids` — list of VLAN IDs (for VLAN-backed segments)
- `subnet` — list of subnet blocks with `cidr` and `network` fields

### `data/nsxt_policy_tier1_gateway`
Adds an optional `path` input attribute, allowing the gateway to be looked
up directly by its NSX policy path. This enables chaining datasources without
knowing the gateway name or ID upfront:

```hcl
data "nsxt_policy_segment" "example" {
  display_name = "my-segment"
}

data "nsxt_policy_tier1_gateway" "gw" {
  path = data.nsxt_policy_segment.example.connectivity_path
}
```

## Test plan
- `TestAccDataSourceNsxtPolicySegment_withAttributes` — verifies `transport_zone_path`, `connectivity_path`, and `subnet` are populated on a segment with those fields set
- `TestAccDataSourceNsxtPolicyTier1Gateway_byPath` — verifies a Tier-1 gateway can be looked up by policy path

## Notes
`vlan_ids` is covered by the same code path as `subnet` but has no dedicated acceptance test as it requires a VLAN-backed segment with a VLAN transport zone. The attribute is a straightforward `[]string` passthrough from the NSX API.

`path` on `nsxt_policy_tier1_gateway` conflicts with `id` and `display_name` — providing more than one of these is rejected by Terraform at plan time before any API call is made.
