### PR TITLE
Fix nsx_id client type and TGW routing child parent_path bugs

### DIFF
--- a/nsxt/policy_utils.go
+++ b/nsxt/policy_utils.go
@@ -87,7 +87,7 @@ func getOrGenerateIDWithParent(d *schema.ResourceData, m interface{}, presenceCh
 
 	parentPath := d.Get("parent_path").(string)
 
-	exists, err := presenceChecker(getSessionContext(d, m), parentPath, id, connector)
+	exists, err := presenceChecker(getParentContext(d, m, parentPath), parentPath, id, connector)
 	if err != nil {
 		return "", err
 	}
@@ -538,6 +538,22 @@ func nsxtParentPathResourceImporter(d *schema.ResourceData, m interface{}) ([]*s
 	truncateSize := len(pathSegs[segCount-1]) + len(pathSegs[segCount-2]) + 2
 	d.Set("parent_path", importID[:len(importID)-truncateSize])
 	return []*schema.ResourceData{d}, nil
+}
+
+// nsxtTGWRoutingChildResourceImporter handles import for Transit Gateway child
+// resources that NSX nests under an intermediate "routing" singleton (prefix
+// lists, route maps, community lists, BFD peers), e.g.
+// .../transit-gateways/[tgw]/routing/prefix-lists/[id]. That singleton has no
+// corresponding schema attribute, so parent_path must resolve to the Transit
+// Gateway path itself, matching what users supply in config.
+func nsxtTGWRoutingChildResourceImporter(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	rd, err := nsxtParentPathResourceImporter(d, m)
+	if err != nil {
+		return rd, err
+	}
+	parentPath := rd[0].Get("parent_path").(string)
+	rd[0].Set("parent_path", strings.TrimSuffix(parentPath, "/routing"))
+	return rd, nil
 }
 
 func isPolicyPath(policyPath string) bool {

--- a/nsxt/policy_utils_test.go
+++ b/nsxt/policy_utils_test.go
@@ -369,6 +369,20 @@ func TestUnitNsxt_nsxtParentPathResourceImporter(t *testing.T) {
 	assert.Equal(t, "/infra/domains/default", rd[0].Get("parent_path"))
 }
 
+func TestUnitNsxt_nsxtTGWRoutingChildResourceImporter(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, map[string]*schema.Schema{
+		"parent_path": {Type: schema.TypeString, Optional: true, Computed: true},
+	}, map[string]interface{}{})
+	d.SetId("/orgs/default/projects/proj1/transit-gateways/tgw-1/routing/prefix-lists/pl-1")
+	rd, err := nsxtTGWRoutingChildResourceImporter(d, nil)
+	require.NoError(t, err)
+	require.Len(t, rd, 1)
+	assert.Equal(t, "pl-1", rd[0].Id())
+	// The intermediate "routing" singleton has no schema attribute, so it must be
+	// stripped for parent_path to match the Transit Gateway path users configure.
+	assert.Equal(t, "/orgs/default/projects/proj1/transit-gateways/tgw-1", rd[0].Get("parent_path"))
+}
+
 func TestUnitNsxt_getVpcParentsFromContext(t *testing.T) {
 	out := getVpcParentsFromContext(utl.SessionContext{ProjectID: "proj1", VPCID: "vpc1"})
 	assert.Equal(t, []string{utl.DefaultOrgID, "proj1", "vpc1"}, out)

--- a/nsxt/resource_nsxt_policy_transit_gateway_bfd_peer.go
+++ b/nsxt/resource_nsxt_policy_transit_gateway_bfd_peer.go
@@ -25,7 +25,7 @@ func resourceNsxtPolicyTransitGatewayBfdPeer() *schema.Resource {
 		Update: resourceNsxtPolicyTransitGatewayBfdPeerUpdate,
 		Delete: resourceNsxtPolicyTransitGatewayBfdPeerDelete,
 		Importer: &schema.ResourceImporter{
-			State: nsxtParentPathResourceImporter,
+			State: nsxtTGWRoutingChildResourceImporter,
 		},
 		Schema: map[string]*schema.Schema{
 			"nsx_id":       getNsxIDSchema(),

--- a/nsxt/resource_nsxt_policy_transit_gateway_bfd_peer_test.go
+++ b/nsxt/resource_nsxt_policy_transit_gateway_bfd_peer_test.go
@@ -1,0 +1,215 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package nsxt
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func TestAccResourceNsxtPolicyTransitGatewayBfdPeer_basic(t *testing.T) {
+	testResourceName := "nsxt_policy_transit_gateway_bfd_peer.test"
+	prereqName := getAccTestResourceName()
+	displayName := getAccTestResourceName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccOnlyLocalManager(t)
+			testAccNSXVersion(t, "9.2.0")
+		},
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyTransitGatewayBfdPeerCheckDestroy(state, displayName)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyTransitGatewayBfdPeerTemplate(prereqName, displayName, "100.64.0.5", true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicyTransitGatewayBfdPeerExists(displayName, testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", displayName),
+					resource.TestCheckResourceAttr(testResourceName, "peer_address", "100.64.0.5"),
+					resource.TestCheckResourceAttr(testResourceName, "enabled", "true"),
+					resource.TestCheckResourceAttr(testResourceName, "source_attachment.#", "1"),
+					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+					resource.TestCheckResourceAttrSet(testResourceName, "parent_path"),
+					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
+				),
+			},
+			{
+				Config: testAccNsxtPolicyTransitGatewayBfdPeerTemplate(prereqName, displayName, "100.64.0.6", false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicyTransitGatewayBfdPeerExists(displayName, testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", displayName),
+					resource.TestCheckResourceAttr(testResourceName, "peer_address", "100.64.0.6"),
+					resource.TestCheckResourceAttr(testResourceName, "enabled", "false"),
+					resource.TestCheckResourceAttr(testResourceName, "source_attachment.#", "1"),
+					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+					resource.TestCheckResourceAttrSet(testResourceName, "parent_path"),
+					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceNsxtPolicyTransitGatewayBfdPeer_importBasic(t *testing.T) {
+	prereqName := getAccTestResourceName()
+	displayName := getAccTestResourceName()
+	testResourceName := "nsxt_policy_transit_gateway_bfd_peer.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccOnlyLocalManager(t)
+			testAccNSXVersion(t, "9.2.0")
+		},
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyTransitGatewayBfdPeerCheckDestroy(state, displayName)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyTransitGatewayBfdPeerTemplate(prereqName, displayName, "100.64.0.5", true),
+			},
+			{
+				ResourceName:      testResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccResourceNsxtPolicyImportIDRetriever(testResourceName),
+			},
+		},
+	})
+}
+
+func testAccNsxtPolicyTransitGatewayBfdPeerExists(displayName string, resourceName string) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+		connector := getPolicyConnector(testAccProvider.Meta().(nsxtClients))
+
+		rs, ok := state.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Policy TransitGatewayBfdPeer resource %s not found in resources", resourceName)
+		}
+
+		resourceID := rs.Primary.ID
+		if resourceID == "" {
+			return fmt.Errorf("Policy TransitGatewayBfdPeer resource ID not set in resources")
+		}
+
+		parentPath := rs.Primary.Attributes["parent_path"]
+		sessionContext := getSessionContextFromParentPath(testAccProvider.Meta(), parentPath)
+		exists, err := resourceNsxtPolicyTransitGatewayBfdPeerExists(sessionContext, parentPath, resourceID, connector)
+		if err != nil {
+			return err
+		}
+		if !exists {
+			return fmt.Errorf("Policy TransitGatewayBfdPeer %s does not exist", resourceID)
+		}
+
+		return nil
+	}
+}
+
+func testAccNsxtPolicyTransitGatewayBfdPeerCheckDestroy(state *terraform.State, displayName string) error {
+	connector := getPolicyConnector(testAccProvider.Meta().(nsxtClients))
+	for _, rs := range state.RootModule().Resources {
+		if rs.Type != "nsxt_policy_transit_gateway_bfd_peer" {
+			continue
+		}
+		resourceID := rs.Primary.Attributes["id"]
+		parentPath := rs.Primary.Attributes["parent_path"]
+		sessionContext := getSessionContextFromParentPath(testAccProvider.Meta(), parentPath)
+		exists, err := resourceNsxtPolicyTransitGatewayBfdPeerExists(sessionContext, parentPath, resourceID, connector)
+		if err != nil {
+			return err
+		}
+		if exists {
+			return fmt.Errorf("Policy TransitGatewayBfdPeer %s still exists", displayName)
+		}
+	}
+	return nil
+}
+
+// testAccNsxtPolicyTransitGatewayBfdPeerTemplate builds a Transit Gateway, a Centralized
+// Network Attachment backed by a VPC subnet, and a Transit Gateway Attachment using that CNA,
+// which serves as the required source_attachment for the BFD peer.
+func testAccNsxtPolicyTransitGatewayBfdPeerTemplate(prereqName string, displayName string, peerAddress string, enabled bool) string {
+	return fmt.Sprintf(`
+data "nsxt_policy_edge_cluster" "test" {
+  display_name = "%s"
+}
+
+resource "nsxt_policy_project" "test" {
+  display_name = "%s"
+  site_info {
+    edge_cluster_paths = [data.nsxt_policy_edge_cluster.test.path]
+  }
+}
+
+resource "nsxt_policy_transit_gateway" "test" {
+  context {
+    project_id = nsxt_policy_project.test.id
+  }
+  display_name    = "%s"
+  transit_subnets = ["100.64.0.0/16"]
+  centralized_config {
+    ha_mode            = "ACTIVE_STANDBY"
+    edge_cluster_paths = [data.nsxt_policy_edge_cluster.test.path]
+  }
+}
+
+resource "nsxt_vpc" "test" {
+  context {
+    project_id = nsxt_policy_project.test.id
+  }
+  display_name = "%s"
+  private_ips  = ["192.168.240.0/24"]
+}
+
+resource "nsxt_vpc_subnet" "test" {
+  context {
+    project_id = nsxt_policy_project.test.id
+    vpc_id     = nsxt_vpc.test.id
+  }
+  display_name = "%s"
+  ip_addresses = ["192.168.240.0/26"]
+  access_mode  = "Private"
+}
+
+resource "nsxt_policy_project_centralized_network_attachment" "test" {
+  context {
+    project_id = nsxt_policy_project.test.id
+  }
+  display_name = "%s"
+  subnet_path  = nsxt_vpc_subnet.test.path
+}
+
+resource "nsxt_policy_transit_gateway_attachment" "test" {
+  parent_path  = nsxt_policy_transit_gateway.test.path
+  display_name = "%s"
+  cna_path     = nsxt_policy_project_centralized_network_attachment.test.path
+}
+
+resource "nsxt_policy_transit_gateway_bfd_peer" "test" {
+  parent_path  = nsxt_policy_transit_gateway.test.path
+  display_name = "%s"
+  peer_address = "%s"
+  enabled      = %t
+
+  source_attachment = [nsxt_policy_transit_gateway_attachment.test.path]
+
+  tag {
+    scope = "scope1"
+    tag   = "tag1"
+  }
+}`, getEdgeClusterName(), prereqName, prereqName, prereqName, prereqName, prereqName, prereqName, displayName, peerAddress, enabled)
+}

--- a/nsxt/resource_nsxt_policy_transit_gateway_community_list.go
+++ b/nsxt/resource_nsxt_policy_transit_gateway_community_list.go
@@ -25,7 +25,7 @@ func resourceNsxtPolicyTransitGatewayCommunityList() *schema.Resource {
 		Update: resourceNsxtPolicyTransitGatewayCommunityListUpdate,
 		Delete: resourceNsxtPolicyTransitGatewayCommunityListDelete,
 		Importer: &schema.ResourceImporter{
-			State: nsxtParentPathResourceImporter,
+			State: nsxtTGWRoutingChildResourceImporter,
 		},
 		Schema: map[string]*schema.Schema{
 			"nsx_id":       getNsxIDSchema(),

--- a/nsxt/resource_nsxt_policy_transit_gateway_community_list_test.go
+++ b/nsxt/resource_nsxt_policy_transit_gateway_community_list_test.go
@@ -1,0 +1,218 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package nsxt
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+var accTestPolicyTransitGatewayCommunityListCreateAttributes = map[string]string{
+	"display_name": getAccTestResourceName(),
+	"description":  "terraform created",
+	"list":         `"NO_EXPORT_SUBCONFED", "65001:12"`,
+}
+
+var accTestPolicyTransitGatewayCommunityListUpdateAttributes = map[string]string{
+	"display_name": getAccTestResourceName(),
+	"description":  "terraform updated",
+	"list":         `"562:00:12"`,
+}
+
+func TestAccResourceNsxtPolicyTransitGatewayCommunityList_basic(t *testing.T) {
+	testResourceName := "nsxt_policy_transit_gateway_community_list.test"
+	prereqName := getAccTestResourceName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccOnlyLocalManager(t)
+			testAccNSXVersion(t, "9.2.0")
+		},
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyTransitGatewayCommunityListCheckDestroy(state, accTestPolicyTransitGatewayCommunityListUpdateAttributes["display_name"])
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyTransitGatewayCommunityListTemplate(true, prereqName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicyTransitGatewayCommunityListExists(accTestPolicyTransitGatewayCommunityListCreateAttributes["display_name"], testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestPolicyTransitGatewayCommunityListCreateAttributes["display_name"]),
+					resource.TestCheckResourceAttr(testResourceName, "description", accTestPolicyTransitGatewayCommunityListCreateAttributes["description"]),
+					resource.TestCheckResourceAttr(testResourceName, "communities.#", "2"),
+					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+					resource.TestCheckResourceAttrSet(testResourceName, "parent_path"),
+					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
+				),
+			},
+			{
+				Config: testAccNsxtPolicyTransitGatewayCommunityListTemplate(false, prereqName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicyTransitGatewayCommunityListExists(accTestPolicyTransitGatewayCommunityListUpdateAttributes["display_name"], testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestPolicyTransitGatewayCommunityListUpdateAttributes["display_name"]),
+					resource.TestCheckResourceAttr(testResourceName, "description", accTestPolicyTransitGatewayCommunityListUpdateAttributes["description"]),
+					resource.TestCheckResourceAttr(testResourceName, "communities.#", "1"),
+					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+					resource.TestCheckResourceAttrSet(testResourceName, "parent_path"),
+					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
+				),
+			},
+			{
+				Config: testAccNsxtPolicyTransitGatewayCommunityListMinimalistic(prereqName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicyTransitGatewayCommunityListExists(accTestPolicyTransitGatewayCommunityListCreateAttributes["display_name"], testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "description", ""),
+					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+					resource.TestCheckResourceAttr(testResourceName, "tag.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceNsxtPolicyTransitGatewayCommunityList_importBasic(t *testing.T) {
+	prereqName := getAccTestResourceName()
+	name := getAccTestResourceName()
+	testResourceName := "nsxt_policy_transit_gateway_community_list.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccOnlyLocalManager(t)
+			testAccNSXVersion(t, "9.2.0")
+		},
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyTransitGatewayCommunityListCheckDestroy(state, name)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyTransitGatewayCommunityListMinimalistic(prereqName),
+			},
+			{
+				ResourceName:      testResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccResourceNsxtPolicyImportIDRetriever(testResourceName),
+			},
+		},
+	})
+}
+
+func testAccNsxtPolicyTransitGatewayCommunityListExists(displayName string, resourceName string) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+		connector := getPolicyConnector(testAccProvider.Meta().(nsxtClients))
+
+		rs, ok := state.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Policy TransitGatewayCommunityList resource %s not found in resources", resourceName)
+		}
+
+		resourceID := rs.Primary.ID
+		if resourceID == "" {
+			return fmt.Errorf("Policy TransitGatewayCommunityList resource ID not set in resources")
+		}
+
+		parentPath := rs.Primary.Attributes["parent_path"]
+		sessionContext := getSessionContextFromParentPath(testAccProvider.Meta(), parentPath)
+		exists, err := resourceNsxtPolicyTransitGatewayCommunityListExists(sessionContext, parentPath, resourceID, connector)
+		if err != nil {
+			return err
+		}
+		if !exists {
+			return fmt.Errorf("Policy TransitGatewayCommunityList %s does not exist", resourceID)
+		}
+
+		return nil
+	}
+}
+
+func testAccNsxtPolicyTransitGatewayCommunityListCheckDestroy(state *terraform.State, displayName string) error {
+	connector := getPolicyConnector(testAccProvider.Meta().(nsxtClients))
+	for _, rs := range state.RootModule().Resources {
+		if rs.Type != "nsxt_policy_transit_gateway_community_list" {
+			continue
+		}
+		resourceID := rs.Primary.Attributes["id"]
+		parentPath := rs.Primary.Attributes["parent_path"]
+		sessionContext := getSessionContextFromParentPath(testAccProvider.Meta(), parentPath)
+		exists, err := resourceNsxtPolicyTransitGatewayCommunityListExists(sessionContext, parentPath, resourceID, connector)
+		if err != nil {
+			return err
+		}
+		if exists {
+			return fmt.Errorf("Policy TransitGatewayCommunityList %s still exists", displayName)
+		}
+	}
+	return nil
+}
+
+func testAccNsxtPolicyTransitGatewayCommunityListPrerequisites(prereqName string) string {
+	return fmt.Sprintf(`
+data "nsxt_policy_edge_cluster" "test" {
+  display_name = "%s"
+}
+
+resource "nsxt_policy_project" "test" {
+  display_name = "%s"
+  site_info {
+    edge_cluster_paths = [data.nsxt_policy_edge_cluster.test.path]
+  }
+}
+
+resource "nsxt_policy_transit_gateway" "test" {
+  context {
+    project_id = nsxt_policy_project.test.id
+  }
+  display_name    = "%s"
+  transit_subnets = ["100.64.0.0/16"]
+  centralized_config {
+    ha_mode            = "ACTIVE_STANDBY"
+    edge_cluster_paths = [data.nsxt_policy_edge_cluster.test.path]
+  }
+}`, getEdgeClusterName(), prereqName, prereqName)
+}
+
+func testAccNsxtPolicyTransitGatewayCommunityListTemplate(createFlow bool, prereqName string) string {
+	var attrMap map[string]string
+	if createFlow {
+		attrMap = accTestPolicyTransitGatewayCommunityListCreateAttributes
+	} else {
+		attrMap = accTestPolicyTransitGatewayCommunityListUpdateAttributes
+	}
+	return testAccNsxtPolicyTransitGatewayCommunityListPrerequisites(prereqName) + fmt.Sprintf(`
+resource "nsxt_policy_transit_gateway_community_list" "test" {
+  display_name = "%s"
+  description  = "%s"
+  parent_path  = nsxt_policy_transit_gateway.test.path
+  communities  = [%s]
+
+  tag {
+    scope = "scope1"
+    tag   = "tag1"
+  }
+}`, attrMap["display_name"], attrMap["description"], attrMap["list"])
+}
+
+func testAccNsxtPolicyTransitGatewayCommunityListMinimalistic(prereqName string) string {
+	return testAccNsxtPolicyTransitGatewayCommunityListPrerequisites(prereqName) + fmt.Sprintf(`
+resource "nsxt_policy_transit_gateway_community_list" "test" {
+  display_name = "%s"
+  description  = ""
+  parent_path  = nsxt_policy_transit_gateway.test.path
+  communities  = [%s]
+}`, accTestPolicyTransitGatewayCommunityListUpdateAttributes["display_name"],
+		accTestPolicyTransitGatewayCommunityListUpdateAttributes["list"])
+}

--- a/nsxt/resource_nsxt_policy_transit_gateway_prefix_list.go
+++ b/nsxt/resource_nsxt_policy_transit_gateway_prefix_list.go
@@ -26,7 +26,7 @@ func resourceNsxtPolicyTransitGatewayPrefixList() *schema.Resource {
 		Update: resourceNsxtPolicyTransitGatewayPrefixListUpdate,
 		Delete: resourceNsxtPolicyTransitGatewayPrefixListDelete,
 		Importer: &schema.ResourceImporter{
-			State: nsxtParentPathResourceImporter,
+			State: nsxtTGWRoutingChildResourceImporter,
 		},
 		Schema: map[string]*schema.Schema{
 			"nsx_id":       getNsxIDSchema(),

--- a/nsxt/resource_nsxt_policy_transit_gateway_prefix_list_test.go
+++ b/nsxt/resource_nsxt_policy_transit_gateway_prefix_list_test.go
@@ -1,0 +1,284 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package nsxt
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+var accTestPolicyTransitGatewayPrefixListCreateAttributes = map[string]string{
+	"display_name": getAccTestResourceName(),
+	"description":  "terraform created",
+	"network":      "10.0.0.0/8",
+	"action":       "PERMIT",
+}
+
+var accTestPolicyTransitGatewayPrefixListUpdateAttributes = map[string]string{
+	"display_name": getAccTestResourceName(),
+	"description":  "terraform updated",
+	"network":      "172.16.0.0/12",
+	"action":       "DENY",
+}
+
+func TestAccResourceNsxtPolicyTransitGatewayPrefixList_basic(t *testing.T) {
+	testResourceName := "nsxt_policy_transit_gateway_prefix_list.test"
+	prereqName := getAccTestResourceName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccOnlyLocalManager(t)
+			testAccNSXVersion(t, "9.2.0")
+		},
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyTransitGatewayPrefixListCheckDestroy(state, accTestPolicyTransitGatewayPrefixListUpdateAttributes["display_name"])
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyTransitGatewayPrefixListTemplate(true, prereqName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicyTransitGatewayPrefixListExists(accTestPolicyTransitGatewayPrefixListCreateAttributes["display_name"], testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestPolicyTransitGatewayPrefixListCreateAttributes["display_name"]),
+					resource.TestCheckResourceAttr(testResourceName, "description", accTestPolicyTransitGatewayPrefixListCreateAttributes["description"]),
+					resource.TestCheckResourceAttr(testResourceName, "prefix.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "prefix.0.network", accTestPolicyTransitGatewayPrefixListCreateAttributes["network"]),
+					resource.TestCheckResourceAttr(testResourceName, "prefix.0.action", accTestPolicyTransitGatewayPrefixListCreateAttributes["action"]),
+					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+					resource.TestCheckResourceAttrSet(testResourceName, "parent_path"),
+					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
+				),
+			},
+			{
+				Config: testAccNsxtPolicyTransitGatewayPrefixListTemplate(false, prereqName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicyTransitGatewayPrefixListExists(accTestPolicyTransitGatewayPrefixListUpdateAttributes["display_name"], testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestPolicyTransitGatewayPrefixListUpdateAttributes["display_name"]),
+					resource.TestCheckResourceAttr(testResourceName, "description", accTestPolicyTransitGatewayPrefixListUpdateAttributes["description"]),
+					resource.TestCheckResourceAttr(testResourceName, "prefix.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "prefix.0.network", accTestPolicyTransitGatewayPrefixListUpdateAttributes["network"]),
+					resource.TestCheckResourceAttr(testResourceName, "prefix.0.action", accTestPolicyTransitGatewayPrefixListUpdateAttributes["action"]),
+					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+					resource.TestCheckResourceAttrSet(testResourceName, "parent_path"),
+					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
+				),
+			},
+			{
+				Config: testAccNsxtPolicyTransitGatewayPrefixListMinimalistic(prereqName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicyTransitGatewayPrefixListExists(accTestPolicyTransitGatewayPrefixListCreateAttributes["display_name"], testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "description", ""),
+					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+					resource.TestCheckResourceAttr(testResourceName, "tag.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccResourceNsxtPolicyTransitGatewayPrefixList_withNsxID verifies that creating the
+// resource with an explicit nsx_id inside a project context succeeds. Regression test for
+// BZ#3713681: the existence check in getOrGenerateIDWithParent was deriving a Local client
+// context instead of Multitenancy, causing "unsupported client type" when nsx_id was set.
+func TestAccResourceNsxtPolicyTransitGatewayPrefixList_withNsxID(t *testing.T) {
+	testResourceName := "nsxt_policy_transit_gateway_prefix_list.test"
+	prereqName := getAccTestResourceName()
+	nsxID := getAccTestResourceName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccOnlyLocalManager(t)
+			testAccNSXVersion(t, "9.2.0")
+		},
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyTransitGatewayPrefixListCheckDestroy(state, accTestPolicyTransitGatewayPrefixListCreateAttributes["display_name"])
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyTransitGatewayPrefixListWithNsxID(nsxID, prereqName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicyTransitGatewayPrefixListExists(accTestPolicyTransitGatewayPrefixListCreateAttributes["display_name"], testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "nsx_id", nsxID),
+					resource.TestCheckResourceAttr(testResourceName, "id", nsxID),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "parent_path"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceNsxtPolicyTransitGatewayPrefixList_importBasic(t *testing.T) {
+	prereqName := getAccTestResourceName()
+	name := getAccTestResourceName()
+	testResourceName := "nsxt_policy_transit_gateway_prefix_list.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccOnlyLocalManager(t)
+			testAccNSXVersion(t, "9.2.0")
+		},
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyTransitGatewayPrefixListCheckDestroy(state, name)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyTransitGatewayPrefixListMinimalistic(prereqName),
+			},
+			{
+				ResourceName:      testResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccResourceNsxtPolicyImportIDRetriever(testResourceName),
+			},
+		},
+	})
+}
+
+func testAccNsxtPolicyTransitGatewayPrefixListExists(displayName string, resourceName string) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+		connector := getPolicyConnector(testAccProvider.Meta().(nsxtClients))
+
+		rs, ok := state.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Policy TransitGatewayPrefixList resource %s not found in resources", resourceName)
+		}
+
+		resourceID := rs.Primary.ID
+		if resourceID == "" {
+			return fmt.Errorf("Policy TransitGatewayPrefixList resource ID not set in resources")
+		}
+
+		parentPath := rs.Primary.Attributes["parent_path"]
+		sessionContext := getSessionContextFromParentPath(testAccProvider.Meta(), parentPath)
+		exists, err := resourceNsxtPolicyTransitGatewayPrefixListExists(sessionContext, parentPath, resourceID, connector)
+		if err != nil {
+			return err
+		}
+		if !exists {
+			return fmt.Errorf("Policy TransitGatewayPrefixList %s does not exist", resourceID)
+		}
+
+		return nil
+	}
+}
+
+func testAccNsxtPolicyTransitGatewayPrefixListCheckDestroy(state *terraform.State, displayName string) error {
+	connector := getPolicyConnector(testAccProvider.Meta().(nsxtClients))
+	for _, rs := range state.RootModule().Resources {
+		if rs.Type != "nsxt_policy_transit_gateway_prefix_list" {
+			continue
+		}
+		resourceID := rs.Primary.Attributes["id"]
+		parentPath := rs.Primary.Attributes["parent_path"]
+		sessionContext := getSessionContextFromParentPath(testAccProvider.Meta(), parentPath)
+		exists, err := resourceNsxtPolicyTransitGatewayPrefixListExists(sessionContext, parentPath, resourceID, connector)
+		if err != nil {
+			return err
+		}
+		if exists {
+			return fmt.Errorf("Policy TransitGatewayPrefixList %s still exists", displayName)
+		}
+	}
+	return nil
+}
+
+func testAccNsxtPolicyTransitGatewayPrefixListPrerequisites(prereqName string) string {
+	return fmt.Sprintf(`
+data "nsxt_policy_edge_cluster" "test" {
+  display_name = "%s"
+}
+
+resource "nsxt_policy_project" "test" {
+  display_name = "%s"
+  site_info {
+    edge_cluster_paths = [data.nsxt_policy_edge_cluster.test.path]
+  }
+}
+
+resource "nsxt_policy_transit_gateway" "test" {
+  context {
+    project_id = nsxt_policy_project.test.id
+  }
+  display_name    = "%s"
+  transit_subnets = ["100.64.0.0/16"]
+  centralized_config {
+    ha_mode            = "ACTIVE_STANDBY"
+    edge_cluster_paths = [data.nsxt_policy_edge_cluster.test.path]
+  }
+}`, getEdgeClusterName(), prereqName, prereqName)
+}
+
+func testAccNsxtPolicyTransitGatewayPrefixListTemplate(createFlow bool, prereqName string) string {
+	var attrMap map[string]string
+	if createFlow {
+		attrMap = accTestPolicyTransitGatewayPrefixListCreateAttributes
+	} else {
+		attrMap = accTestPolicyTransitGatewayPrefixListUpdateAttributes
+	}
+	return testAccNsxtPolicyTransitGatewayPrefixListPrerequisites(prereqName) + fmt.Sprintf(`
+resource "nsxt_policy_transit_gateway_prefix_list" "test" {
+  display_name = "%s"
+  description  = "%s"
+  parent_path  = nsxt_policy_transit_gateway.test.path
+
+  prefix {
+    action  = "%s"
+    network = "%s"
+  }
+
+  tag {
+    scope = "scope1"
+    tag   = "tag1"
+  }
+}`, attrMap["display_name"], attrMap["description"], attrMap["action"], attrMap["network"])
+}
+
+func testAccNsxtPolicyTransitGatewayPrefixListMinimalistic(prereqName string) string {
+	return testAccNsxtPolicyTransitGatewayPrefixListPrerequisites(prereqName) + fmt.Sprintf(`
+resource "nsxt_policy_transit_gateway_prefix_list" "test" {
+  display_name = "%s"
+  description  = ""
+  parent_path  = nsxt_policy_transit_gateway.test.path
+
+  prefix {
+    action  = "%s"
+    network = "%s"
+  }
+}`, accTestPolicyTransitGatewayPrefixListUpdateAttributes["display_name"],
+		accTestPolicyTransitGatewayPrefixListUpdateAttributes["action"],
+		accTestPolicyTransitGatewayPrefixListUpdateAttributes["network"])
+}
+
+func testAccNsxtPolicyTransitGatewayPrefixListWithNsxID(nsxID string, prereqName string) string {
+	return testAccNsxtPolicyTransitGatewayPrefixListPrerequisites(prereqName) + fmt.Sprintf(`
+resource "nsxt_policy_transit_gateway_prefix_list" "test" {
+  display_name = "%s"
+  nsx_id       = "%s"
+  parent_path  = nsxt_policy_transit_gateway.test.path
+
+  prefix {
+    action  = "%s"
+    network = "%s"
+  }
+}`, accTestPolicyTransitGatewayPrefixListCreateAttributes["display_name"],
+		nsxID,
+		accTestPolicyTransitGatewayPrefixListCreateAttributes["action"],
+		accTestPolicyTransitGatewayPrefixListCreateAttributes["network"])
+}

--- a/nsxt/resource_nsxt_policy_transit_gateway_route_map.go
+++ b/nsxt/resource_nsxt_policy_transit_gateway_route_map.go
@@ -25,7 +25,7 @@ func resourceNsxtPolicyTransitGatewayRouteMap() *schema.Resource {
 		Update: resourceNsxtPolicyTransitGatewayRouteMapUpdate,
 		Delete: resourceNsxtPolicyTransitGatewayRouteMapDelete,
 		Importer: &schema.ResourceImporter{
-			State: nsxtParentPathResourceImporter,
+			State: nsxtTGWRoutingChildResourceImporter,
 		},
 		Schema: map[string]*schema.Schema{
 			"nsx_id":       getNsxIDSchema(),

--- a/nsxt/resource_nsxt_policy_transit_gateway_route_map_test.go
+++ b/nsxt/resource_nsxt_policy_transit_gateway_route_map_test.go
@@ -1,0 +1,243 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package nsxt
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func TestAccResourceNsxtPolicyTransitGatewayRouteMap_basic(t *testing.T) {
+	testResourceName := "nsxt_policy_transit_gateway_route_map.test"
+	prereqName := getAccTestResourceName()
+	displayName := getAccTestResourceName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccOnlyLocalManager(t)
+			testAccNSXVersion(t, "9.2.0")
+		},
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyTransitGatewayRouteMapCheckDestroy(state, displayName)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyTransitGatewayRouteMapCreateTemplate(prereqName, displayName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicyTransitGatewayRouteMapExists(displayName, testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", displayName),
+					resource.TestCheckResourceAttr(testResourceName, "description", "terraform created"),
+					resource.TestCheckResourceAttr(testResourceName, "entry.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "entry.0.action", "PERMIT"),
+					resource.TestCheckResourceAttr(testResourceName, "entry.0.community_list_match.#", "1"),
+					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+					resource.TestCheckResourceAttrSet(testResourceName, "parent_path"),
+					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
+				),
+			},
+			{
+				Config: testAccNsxtPolicyTransitGatewayRouteMapUpdateTemplate(prereqName, displayName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicyTransitGatewayRouteMapExists(displayName, testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", displayName),
+					resource.TestCheckResourceAttr(testResourceName, "description", "terraform updated"),
+					resource.TestCheckResourceAttr(testResourceName, "entry.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "entry.0.action", "DENY"),
+					resource.TestCheckResourceAttr(testResourceName, "entry.0.community_list_match.#", "2"),
+					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+					resource.TestCheckResourceAttrSet(testResourceName, "parent_path"),
+					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
+				),
+			},
+			{
+				Config: testAccNsxtPolicyTransitGatewayRouteMapMinimalistic(prereqName, displayName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicyTransitGatewayRouteMapExists(displayName, testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "description", ""),
+					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+					resource.TestCheckResourceAttr(testResourceName, "tag.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceNsxtPolicyTransitGatewayRouteMap_importBasic(t *testing.T) {
+	prereqName := getAccTestResourceName()
+	displayName := getAccTestResourceName()
+	testResourceName := "nsxt_policy_transit_gateway_route_map.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccOnlyLocalManager(t)
+			testAccNSXVersion(t, "9.2.0")
+		},
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyTransitGatewayRouteMapCheckDestroy(state, displayName)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyTransitGatewayRouteMapMinimalistic(prereqName, displayName),
+			},
+			{
+				ResourceName:      testResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccResourceNsxtPolicyImportIDRetriever(testResourceName),
+			},
+		},
+	})
+}
+
+func testAccNsxtPolicyTransitGatewayRouteMapExists(displayName string, resourceName string) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+		connector := getPolicyConnector(testAccProvider.Meta().(nsxtClients))
+
+		rs, ok := state.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Policy TransitGatewayRouteMap resource %s not found in resources", resourceName)
+		}
+
+		resourceID := rs.Primary.ID
+		if resourceID == "" {
+			return fmt.Errorf("Policy TransitGatewayRouteMap resource ID not set in resources")
+		}
+
+		parentPath := rs.Primary.Attributes["parent_path"]
+		sessionContext := getSessionContextFromParentPath(testAccProvider.Meta(), parentPath)
+		exists, err := resourceNsxtPolicyTransitGatewayRouteMapExists(sessionContext, parentPath, resourceID, connector)
+		if err != nil {
+			return err
+		}
+		if !exists {
+			return fmt.Errorf("Policy TransitGatewayRouteMap %s does not exist", resourceID)
+		}
+
+		return nil
+	}
+}
+
+func testAccNsxtPolicyTransitGatewayRouteMapCheckDestroy(state *terraform.State, displayName string) error {
+	connector := getPolicyConnector(testAccProvider.Meta().(nsxtClients))
+	for _, rs := range state.RootModule().Resources {
+		if rs.Type != "nsxt_policy_transit_gateway_route_map" {
+			continue
+		}
+		resourceID := rs.Primary.Attributes["id"]
+		parentPath := rs.Primary.Attributes["parent_path"]
+		sessionContext := getSessionContextFromParentPath(testAccProvider.Meta(), parentPath)
+		exists, err := resourceNsxtPolicyTransitGatewayRouteMapExists(sessionContext, parentPath, resourceID, connector)
+		if err != nil {
+			return err
+		}
+		if exists {
+			return fmt.Errorf("Policy TransitGatewayRouteMap %s still exists", displayName)
+		}
+	}
+	return nil
+}
+
+func testAccNsxtPolicyTransitGatewayRouteMapPrerequisites(prereqName string) string {
+	return fmt.Sprintf(`
+data "nsxt_policy_edge_cluster" "test" {
+  display_name = "%s"
+}
+
+resource "nsxt_policy_project" "test" {
+  display_name = "%s"
+  site_info {
+    edge_cluster_paths = [data.nsxt_policy_edge_cluster.test.path]
+  }
+}
+
+resource "nsxt_policy_transit_gateway" "test" {
+  context {
+    project_id = nsxt_policy_project.test.id
+  }
+  display_name    = "%s"
+  transit_subnets = ["100.64.0.0/16"]
+  centralized_config {
+    ha_mode            = "ACTIVE_STANDBY"
+    edge_cluster_paths = [data.nsxt_policy_edge_cluster.test.path]
+  }
+}`, getEdgeClusterName(), prereqName, prereqName)
+}
+
+func testAccNsxtPolicyTransitGatewayRouteMapCreateTemplate(prereqName string, displayName string) string {
+	return testAccNsxtPolicyTransitGatewayRouteMapPrerequisites(prereqName) + fmt.Sprintf(`
+resource "nsxt_policy_transit_gateway_route_map" "test" {
+  parent_path  = nsxt_policy_transit_gateway.test.path
+  display_name = "%s"
+  description  = "terraform created"
+
+  entry {
+    action = "PERMIT"
+    community_list_match {
+      criteria       = "11:22"
+      match_operator = "MATCH_COMMUNITY_REGEX"
+    }
+  }
+
+  tag {
+    scope = "scope1"
+    tag   = "tag1"
+  }
+}`, displayName)
+}
+
+func testAccNsxtPolicyTransitGatewayRouteMapUpdateTemplate(prereqName string, displayName string) string {
+	return testAccNsxtPolicyTransitGatewayRouteMapPrerequisites(prereqName) + fmt.Sprintf(`
+resource "nsxt_policy_transit_gateway_route_map" "test" {
+  parent_path  = nsxt_policy_transit_gateway.test.path
+  display_name = "%s"
+  description  = "terraform updated"
+
+  entry {
+    action = "DENY"
+    community_list_match {
+      criteria       = "11:22"
+      match_operator = "MATCH_COMMUNITY_REGEX"
+    }
+    community_list_match {
+      criteria       = "33:44"
+      match_operator = "MATCH_COMMUNITY_REGEX"
+    }
+  }
+
+  tag {
+    scope = "scope1"
+    tag   = "tag1"
+  }
+}`, displayName)
+}
+
+func testAccNsxtPolicyTransitGatewayRouteMapMinimalistic(prereqName string, displayName string) string {
+	return testAccNsxtPolicyTransitGatewayRouteMapPrerequisites(prereqName) + fmt.Sprintf(`
+resource "nsxt_policy_transit_gateway_route_map" "test" {
+  parent_path  = nsxt_policy_transit_gateway.test.path
+  display_name = "%s"
+
+  entry {
+    action = "PERMIT"
+    community_list_match {
+      criteria       = "11:22"
+      match_operator = "MATCH_COMMUNITY_REGEX"
+    }
+  }
+}`, displayName)
+}

--- a/nsxt/utgomock_resource_nsxt_policy_transit_gateway_prefix_list_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_transit_gateway_prefix_list_test.go
@@ -220,6 +220,50 @@ func TestMockResourceNsxtPolicyTransitGatewayPrefixListDelete(t *testing.T) {
 	})
 }
 
+// TestMockResourceNsxtPolicyTransitGatewayPrefixListCreateNsxIDProjectContext verifies that
+// when nsx_id is set and parent_path contains a project path, the existence check inside
+// getOrGenerateIDWithParent uses a Multitenancy context derived from parent_path rather than
+// a Local context derived from the (absent) schema context block. Regression test for BZ#3713681.
+func TestMockResourceNsxtPolicyTransitGatewayPrefixListCreateNsxIDProjectContext(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockSDK := tgwmocks.NewMockPrefixListsClient(ctrl)
+	mockWrapper := &tgwrouting.TGWPrefixListClientContext{
+		Client:     mockSDK,
+		ClientType: utl.Multitenancy,
+		ProjectID:  tgwPLProjectID,
+	}
+
+	// Context-sensitive factory: returns nil for non-Multitenancy contexts, mirroring
+	// the real NewPrefixListsClient behaviour. Before the fix, getOrGenerateIDWithParent
+	// derived a Local context (ignoring parent_path), causing a nil client and
+	// "unsupported client type" error.
+	original := cliTGWPrefixListsClient
+	cliTGWPrefixListsClient = func(ctx utl.SessionContext, _ vapiProtocolClient.Connector) *tgwrouting.TGWPrefixListClientContext {
+		if ctx.ClientType != utl.Multitenancy {
+			return nil
+		}
+		return mockWrapper
+	}
+	defer func() { cliTGWPrefixListsClient = original }()
+
+	notFoundErr := vapiErrors.NotFound{}
+	gomock.InOrder(
+		mockSDK.EXPECT().Get(tgwPLOrgID, tgwPLProjectID, tgwPLTGWID, tgwPLID).Return(nsxModel.PrefixList{}, notFoundErr),
+		mockSDK.EXPECT().Patch(tgwPLOrgID, tgwPLProjectID, tgwPLTGWID, tgwPLID, gomock.Any()).Return(nil),
+		mockSDK.EXPECT().Get(tgwPLOrgID, tgwPLProjectID, tgwPLTGWID, tgwPLID).Return(tgwPrefixListAPIResponse(), nil),
+	)
+
+	res := resourceNsxtPolicyTransitGatewayPrefixList()
+	d := schema.TestResourceDataRaw(t, res.Schema, minimalTGWPrefixListData())
+
+	err := resourceNsxtPolicyTransitGatewayPrefixListCreate(d, newGoMockProviderClient())
+	require.NoError(t, err)
+	assert.Equal(t, tgwPLID, d.Id())
+	assert.Equal(t, tgwPLDisplayName, d.Get("display_name"))
+}
+
 func TestMockResourceNsxtPolicyTransitGatewayPrefixListMultiplePrefixes(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()


### PR DESCRIPTION
Root cause (client type)
-------------------------
getOrGenerateIDWithParent passed getSessionContext(d, m) to the
presence-checker, which derives the client type from the schema context
block. Resources that carry context in parent_path (such as
nsxt_policy_transit_gateway_prefix_list) have no context block, so
clientType resolved to Local and the Multitenancy-only client factory
returned nil, producing "unsupported client type". The bug was only
triggered when nsx_id was explicitly set (the existence check is
skipped when nsx_id is absent).

Fix (nsxt/policy_utils.go)
--------------------------
Pass getParentContext(d, m, parentPath) instead of getSessionContext,
so the correct Multitenancy context is derived from parent_path.
Affects all 16 resources that call getOrGenerateIDWithParent.

Root cause (parent_path on import)
-----------------------------------
NSX nests some Transit Gateway children (prefix lists, route maps,
community lists, BFD peers) under an intermediate "routing" singleton
that has no corresponding schema attribute, so the real API path is
.../transit-gateways/[tgw]/routing/prefix-lists/[id]. The generic
nsxtParentPathResourceImporter truncated only the last two path
segments, leaving a spurious "/routing" suffix in parent_path that
didn't match the Transit Gateway path users configure, failing
ImportStateVerify.

Fix (nsxt/policy_utils.go)
--------------------------
Added nsxtTGWRoutingChildResourceImporter, which wraps the generic
importer and strips the "/routing" suffix, and switched
nsxt_policy_transit_gateway_prefix_list/route_map/community_list/
bfd_peer to use it. This keeps the special case visible at each
resource's Importer declaration rather than hidden inside the shared
helper.

Tests
-----
Unit test (utgomock_resource_nsxt_policy_transit_gateway_prefix_list
_test.go): TestMockResourceNsxtPolicyTransitGatewayPrefixListCreate
NsxIDProjectContext installs a context-sensitive client factory that
returns nil for non-Multitenancy contexts, mirroring NewPrefixListsClient.
Without the fix the test fails with "unsupported client type".

Unit test (policy_utils_test.go):
TestUnitNsxt_nsxtTGWRoutingChildResourceImporter verifies the
"/routing" suffix is stripped from parent_path on import.

Acceptance tests (resource_nsxt_policy_transit_gateway_prefix_list
_test.go): three tests exercising basic CRUD, nsx_id creation (direct
regression for BZ#3713681), and import. Prerequisites use an explicit
nsxt_policy_transit_gateway resource with centralized_config (matching
the bug-report setup) rather than a default TGW data source, which
ensures the prefix-list API is available. CheckDestroy correctly uses
err != nil to catch surviving resources.

Added the same basic/import acceptance test coverage - previously
missing entirely - for the other three TGW routing children:
resource_nsxt_policy_transit_gateway_community_list_test.go,
resource_nsxt_policy_transit_gateway_route_map_test.go, and
resource_nsxt_policy_transit_gateway_bfd_peer_test.go. Verified against
a live NSX manager: prefix_list, community_list, and route_map all
pass end-to-end (basic + import). bfd_peer's config applies correctly
and exercises the same fix, but GET on
.../routing/bfd-peers/[id] returns an empty body on that manager - a
server-side gap unrelated to this fix - so its test is included but
unverified in that environment.
