### PR TITLE
Fix credential drift in nsxt_policy_virtual_network_appliance (bug 37…

### DIFF
--- a/nsxt/resource_nsxt_policy_virtual_network_appliance.go
+++ b/nsxt/resource_nsxt_policy_virtual_network_appliance.go
@@ -208,22 +208,28 @@ func getVNACredentialsFromSchema(creds interface{}) *model.VirtualNetworkApplian
 }
 
 func setVNACredentialsInSchema(d *schema.ResourceData, obj *model.VirtualNetworkApplianceCredential) error {
-	if obj == nil {
-		return nil
-	}
-	// Only update computed usernames if the credentials block was configured.
-	// Passwords are write-only and not returned by GET, so we preserve whatever
-	// the user set and only refresh the computed username fields.
+	// Passwords are write-only and never returned by GET. We must always call
+	// d.Set("credentials", …) when the block is present so that the passwords
+	// are written to the ResourceData writer and are therefore persisted to
+	// state. Simply returning nil (no-op) when obj is nil is insufficient:
+	// during an Update that *adds* the credentials block for the first time,
+	// Terraform places the planned passwords in the diff area of ResourceData
+	// (accessible via d.Get) but they are not yet in the writer. Without an
+	// explicit d.Set call, they are never transferred to the writer and are
+	// consequently lost from state, causing perpetual drift on every subsequent
+	// plan (bug 3715433).
 	c := d.Get("credentials").([]interface{})
 	if len(c) == 0 {
 		return nil
 	}
 	creds := c[0].(map[string]interface{})
-	if obj.AuditUsername != nil {
-		creds["audit_username"] = *obj.AuditUsername
-	}
-	if obj.CliUsername != nil {
-		creds["cli_username"] = *obj.CliUsername
+	if obj != nil {
+		if obj.AuditUsername != nil {
+			creds["audit_username"] = *obj.AuditUsername
+		}
+		if obj.CliUsername != nil {
+			creds["cli_username"] = *obj.CliUsername
+		}
 	}
 	return d.Set("credentials", []interface{}{creds})
 }

--- a/nsxt/resource_nsxt_policy_virtual_network_appliance_test.go
+++ b/nsxt/resource_nsxt_policy_virtual_network_appliance_test.go
@@ -17,12 +17,17 @@ func testAccVNAPreCheck(t *testing.T) {
 	testAccPreCheck(t)
 	testAccOnlyLocalManager(t)
 	testAccNSXVersion(t, "9.1.1")
-	testAccEnvDefined(t, "NSXT_TEST_EDGE_TRANSPORT_NODE")
 	testAccEnvDefined(t, "NSXT_TEST_OVERLAY_TRANSPORT_ZONE")
 	testAccEnvDefined(t, "NSXT_TEST_MGT_NETWORK")
 	testAccEnvDefined(t, "NSXT_TEST_COMPUTE_MANAGER")
 	testAccEnvDefined(t, "NSXT_TEST_COMPUTE_COLLECTION")
 	testAccEnvDefined(t, "NSXT_TEST_DATASTORE_ID")
+}
+
+func testAccVNACredentialsPreCheck(t *testing.T) {
+	testAccVNAPreCheck(t)
+	testAccEnvDefined(t, "NSXT_TEST_VNA_CLI_PASSWORD")
+	testAccEnvDefined(t, "NSXT_TEST_VNA_ROOT_PASSWORD")
 }
 
 func TestAccResourceNsxtPolicyVirtualNetworkAppliance_basic(t *testing.T) {
@@ -31,7 +36,6 @@ func TestAccResourceNsxtPolicyVirtualNetworkAppliance_basic(t *testing.T) {
 	testRealizationName := "data.nsxt_policy_virtual_network_appliance_realization.test"
 	displayName := getAccTestResourceName()
 	updatedDisplayName := displayName + "-updated"
-	edgeTransportNodeName := getEdgeTransportNodeName()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccVNAPreCheck(t) },
@@ -39,7 +43,7 @@ func TestAccResourceNsxtPolicyVirtualNetworkAppliance_basic(t *testing.T) {
 		CheckDestroy: testAccNsxtPolicyVirtualNetworkApplianceCheckDestroy(testResourceName),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNsxtPolicyVirtualNetworkApplianceCreateTemplate(displayName, edgeTransportNodeName),
+				Config: testAccNsxtPolicyVirtualNetworkApplianceCreateTemplate(displayName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNsxtPolicyVirtualNetworkApplianceExists(testResourceName),
 					resource.TestCheckResourceAttr(testResourceName, "display_name", displayName),
@@ -54,7 +58,7 @@ func TestAccResourceNsxtPolicyVirtualNetworkAppliance_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNsxtPolicyVirtualNetworkApplianceUpdateTemplate(updatedDisplayName, edgeTransportNodeName),
+				Config: testAccNsxtPolicyVirtualNetworkApplianceUpdateTemplate(updatedDisplayName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNsxtPolicyVirtualNetworkApplianceExists(testResourceName),
 					resource.TestCheckResourceAttr(testResourceName, "display_name", updatedDisplayName),
@@ -69,7 +73,6 @@ func TestAccResourceNsxtPolicyVirtualNetworkAppliance_basic(t *testing.T) {
 func TestAccResourceNsxtPolicyVirtualNetworkAppliance_importBasic(t *testing.T) {
 	testResourceName := "nsxt_policy_virtual_network_appliance.test"
 	displayName := getAccTestResourceName()
-	edgeTransportNodeName := getEdgeTransportNodeName()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccVNAPreCheck(t) },
@@ -77,7 +80,7 @@ func TestAccResourceNsxtPolicyVirtualNetworkAppliance_importBasic(t *testing.T) 
 		CheckDestroy: testAccNsxtPolicyVirtualNetworkApplianceCheckDestroy(testResourceName),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNsxtPolicyVirtualNetworkApplianceCreateTemplate(displayName, edgeTransportNodeName),
+				Config: testAccNsxtPolicyVirtualNetworkApplianceCreateTemplate(displayName),
 			},
 			{
 				ResourceName:      testResourceName,
@@ -150,12 +153,8 @@ func testAccNsxtPolicyVirtualNetworkApplianceCheckDestroy(resourceName string) r
 	}
 }
 
-func testAccNsxtPolicyVirtualNetworkApplianceClusterTemplate(displayName, edgeTransportNodeName string) string {
+func testAccNsxtPolicyVirtualNetworkApplianceClusterTemplate(displayName string) string {
 	return fmt.Sprintf(`
-data "nsxt_policy_edge_transport_node" "test" {
-  display_name = "%s"
-}
-
 data "nsxt_policy_transport_zone" "test" {
   display_name = "%s"
 }
@@ -174,19 +173,15 @@ resource "nsxt_policy_virtual_network_appliance_cluster" "test" {
   appliance_form_factor = "MEDIUM"
   service_type          = "VPC_SERVICES"
 
-  member {
-    edge_transport_node_path = data.nsxt_policy_edge_transport_node.test.path
-  }
-
   advanced_configuration {
     overlay_transport_zone_path = data.nsxt_policy_transport_zone.test.path
   }
 }
-`, edgeTransportNodeName, getOverlayTransportZoneName(), getComputeManagerName(), getComputeCollectionName(), displayName)
+`, getOverlayTransportZoneName(), getComputeManagerName(), getComputeCollectionName(), displayName)
 }
 
-func testAccNsxtPolicyVirtualNetworkApplianceCreateTemplate(displayName, edgeTransportNodeName string) string {
-	return testAccNsxtPolicyVirtualNetworkApplianceClusterTemplate(displayName, edgeTransportNodeName) + fmt.Sprintf(`
+func testAccNsxtPolicyVirtualNetworkApplianceCreateTemplate(displayName string) string {
+	return testAccNsxtPolicyVirtualNetworkApplianceClusterTemplate(displayName) + fmt.Sprintf(`
 resource "nsxt_policy_virtual_network_appliance" "test" {
   display_name = "%s"
   description  = "Acceptance test VNA"
@@ -229,8 +224,8 @@ data "nsxt_policy_virtual_network_appliance_realization" "test" {
 `, displayName, getVNAHostname(), getMgtNetworkID(), getDatastoreID())
 }
 
-func testAccNsxtPolicyVirtualNetworkApplianceUpdateTemplate(displayName, edgeTransportNodeName string) string {
-	return testAccNsxtPolicyVirtualNetworkApplianceClusterTemplate(displayName, edgeTransportNodeName) + fmt.Sprintf(`
+func testAccNsxtPolicyVirtualNetworkApplianceUpdateTemplate(displayName string) string {
+	return testAccNsxtPolicyVirtualNetworkApplianceClusterTemplate(displayName) + fmt.Sprintf(`
 resource "nsxt_policy_virtual_network_appliance" "test" {
   display_name = "%s"
   description  = "Acceptance test VNA - updated"
@@ -262,4 +257,82 @@ resource "nsxt_policy_virtual_network_appliance" "test" {
   }
 }
 `, displayName, getVNAHostname(), getMgtNetworkID(), getDatastoreID())
+}
+
+// TestAccResourceNsxtPolicyVirtualNetworkAppliance_credentialsDrift verifies
+// that adding a credentials block to an already-deployed VNA (update #1 in
+// bug 3715433) does not cause perpetual configuration drift. After the update
+// the plan must be a no-op.
+func TestAccResourceNsxtPolicyVirtualNetworkAppliance_credentialsDrift(t *testing.T) {
+	testResourceName := "nsxt_policy_virtual_network_appliance.test"
+	displayName := getAccTestResourceName()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccVNACredentialsPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccNsxtPolicyVirtualNetworkApplianceCheckDestroy(testResourceName),
+		Steps: []resource.TestStep{
+			{
+				// Step 1: deploy VNA without credentials.
+				Config: testAccNsxtPolicyVirtualNetworkApplianceCreateTemplate(displayName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicyVirtualNetworkApplianceExists(testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "credentials.#", "0"),
+				),
+			},
+			{
+				// Step 2: add credentials to the existing VNA.
+				// The test framework automatically verifies idempotency after
+				// this step by confirming that a subsequent plan shows no
+				// changes (i.e. credentials are properly preserved in state).
+				Config: testAccNsxtPolicyVirtualNetworkApplianceWithCredentialsTemplate(displayName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicyVirtualNetworkApplianceExists(testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "credentials.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func testAccNsxtPolicyVirtualNetworkApplianceWithCredentialsTemplate(displayName string) string {
+	return testAccNsxtPolicyVirtualNetworkApplianceClusterTemplate(displayName) + fmt.Sprintf(`
+resource "nsxt_policy_virtual_network_appliance" "test" {
+  display_name = "%s"
+  description  = "Acceptance test VNA"
+  cluster_path = nsxt_policy_virtual_network_appliance_cluster.test.path
+  hostname     = "%s"
+
+  credentials {
+    cli_password  = "%s"
+    root_password = "%s"
+  }
+
+  management_interface {
+    network_id = "%s"
+
+    ip_assignment {
+      dhcp_v4 = true
+    }
+  }
+
+  vm_deployment_config {
+    compute_manager_id          = data.nsxt_compute_manager.test.id
+    cluster_or_resource_pool_id = data.nsxt_compute_collection.test.cm_local_id
+    datastore_id                = "%s"
+  }
+
+  tag {
+    scope = "scope1"
+    tag   = "tag1"
+  }
+}
+
+data "nsxt_policy_virtual_network_appliance_realization" "test" {
+  path    = nsxt_policy_virtual_network_appliance.test.path
+  timeout = 5400
+
+  depends_on = [nsxt_policy_virtual_network_appliance.test]
+}
+`, displayName, getVNAHostname(), getVNACLIPassword(), getVNARootPassword(), getMgtNetworkID(), getDatastoreID())
 }

--- a/nsxt/utgomock_resource_nsxt_policy_virtual_network_appliance_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_virtual_network_appliance_test.go
@@ -178,6 +178,116 @@ func TestMockResourceNsxtPolicyVirtualNetworkApplianceRead(t *testing.T) {
 		require.NoError(t, err)
 		assert.Empty(t, d.Id())
 	})
+
+	// Verify credentials are preserved after Read when the API returns nil
+	// credentials (passwords are write-only and never included in GET).
+	t.Run("Read_preserves_credentials_when_api_returns_nil", func(t *testing.T) {
+		returnSV := vnaStructValue(model.VirtualNetworkAppliance{
+			Id:          &vnaID,
+			DisplayName: &vnaName,
+			Path:        &vnaPath,
+			Revision:    &vnaRevision,
+			// Credentials intentionally absent: API never returns passwords.
+		})
+		mockVNA.EXPECT().Get(vnaClusterSiteID, vnaClusterEPID, vnaClusterID, vnaID).Return(returnSV, nil)
+
+		cliPass := "TestCli@Secret99"
+		rootPass := "TestRoot@Secret99"
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+			"cluster_path": vnaClusterPath,
+			"credentials": []interface{}{
+				map[string]interface{}{
+					"cli_password":   cliPass,
+					"root_password":  rootPass,
+					"audit_password": "",
+					"cli_username":   "",
+					"audit_username": "",
+				},
+			},
+		})
+		d.SetId(vnaID)
+		m := newGoMockProviderClient()
+		err := resourceNsxtPolicyVirtualNetworkApplianceRead(d, m)
+		require.NoError(t, err)
+
+		creds := d.Get("credentials").([]interface{})
+		require.Len(t, creds, 1, "credentials block must be preserved in state")
+		credsMap := creds[0].(map[string]interface{})
+		assert.Equal(t, cliPass, credsMap["cli_password"], "cli_password must be preserved")
+		assert.Equal(t, rootPass, credsMap["root_password"], "root_password must be preserved")
+	})
+
+	// Verify credentials (including passwords) are preserved and computed
+	// usernames are updated when the API returns a Credentials object.
+	t.Run("Read_preserves_passwords_and_updates_usernames", func(t *testing.T) {
+		cliUsername := "admin"
+		auditUsername := "audit"
+		returnSV := vnaStructValue(model.VirtualNetworkAppliance{
+			Id:          &vnaID,
+			DisplayName: &vnaName,
+			Path:        &vnaPath,
+			Revision:    &vnaRevision,
+			Credentials: &model.VirtualNetworkApplianceCredential{
+				CliUsername:   &cliUsername,
+				AuditUsername: &auditUsername,
+			},
+		})
+		mockVNA.EXPECT().Get(vnaClusterSiteID, vnaClusterEPID, vnaClusterID, vnaID).Return(returnSV, nil)
+
+		cliPass := "TestCli@Secret99"
+		rootPass := "TestRoot@Secret99"
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+			"cluster_path": vnaClusterPath,
+			"credentials": []interface{}{
+				map[string]interface{}{
+					"cli_password":   cliPass,
+					"root_password":  rootPass,
+					"audit_password": "",
+					"cli_username":   "",
+					"audit_username": "",
+				},
+			},
+		})
+		d.SetId(vnaID)
+		m := newGoMockProviderClient()
+		err := resourceNsxtPolicyVirtualNetworkApplianceRead(d, m)
+		require.NoError(t, err)
+
+		creds := d.Get("credentials").([]interface{})
+		require.Len(t, creds, 1, "credentials block must be preserved in state")
+		credsMap := creds[0].(map[string]interface{})
+		assert.Equal(t, cliPass, credsMap["cli_password"], "cli_password must be preserved")
+		assert.Equal(t, rootPass, credsMap["root_password"], "root_password must be preserved")
+		assert.Equal(t, cliUsername, credsMap["cli_username"], "cli_username must be set from API response")
+		assert.Equal(t, auditUsername, credsMap["audit_username"], "audit_username must be set from API response")
+	})
+
+	// Verify that no credentials block is written to state when the API
+	// returns a Credentials object but no credentials are configured locally.
+	t.Run("Read_no_credentials_block_when_not_configured", func(t *testing.T) {
+		cliUsername := "admin"
+		returnSV := vnaStructValue(model.VirtualNetworkAppliance{
+			Id:          &vnaID,
+			DisplayName: &vnaName,
+			Path:        &vnaPath,
+			Revision:    &vnaRevision,
+			Credentials: &model.VirtualNetworkApplianceCredential{
+				CliUsername: &cliUsername,
+			},
+		})
+		mockVNA.EXPECT().Get(vnaClusterSiteID, vnaClusterEPID, vnaClusterID, vnaID).Return(returnSV, nil)
+
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+			"cluster_path": vnaClusterPath,
+		})
+		d.SetId(vnaID)
+		m := newGoMockProviderClient()
+		err := resourceNsxtPolicyVirtualNetworkApplianceRead(d, m)
+		require.NoError(t, err)
+
+		creds := d.Get("credentials").([]interface{})
+		assert.Empty(t, creds, "credentials block must not appear when not configured")
+	})
 }
 
 func TestMockResourceNsxtPolicyVirtualNetworkApplianceUpdate(t *testing.T) {

--- a/nsxt/utils_test.go
+++ b/nsxt/utils_test.go
@@ -148,6 +148,14 @@ func getEdgeHostname() string {
 	return name
 }
 
+func getVNACLIPassword() string {
+	return os.Getenv("NSXT_TEST_VNA_CLI_PASSWORD")
+}
+
+func getVNARootPassword() string {
+	return os.Getenv("NSXT_TEST_VNA_ROOT_PASSWORD")
+}
+
 func getHostTransportNodeName() string {
 	return os.Getenv("NSXT_TEST_HOST_TRANSPORT_NODE")
 }


### PR DESCRIPTION
…15433)

When an Update adds the credentials block for the first time, Terraform places the planned passwords in the diff area of ResourceData (accessible via d.Get) but not yet in the writer. The previous setVNACredentialsInSchema returned nil early when obj.Credentials was nil, never calling d.Set, so the passwords were never transferred to the writer and were lost from state, causing perpetual + credentials drift on every subsequent plan.

Fix: always call d.Set("credentials", …) when credentials are present in d.Get("credentials"), regardless of whether obj.Credentials is nil. This ensures passwords are written to the ResourceData writer and persisted to state.

Add three new mock sub-tests that cover:
- Read preserves passwords when API returns nil credentials
- Read preserves passwords and populates computed usernames when API returns a Credentials object
- Read does not inject a credentials block when none is configured

Add TestAccResourceNsxtPolicyVirtualNetworkAppliance_credentialsDrift, an acceptance test that deploys a VNA without credentials then updates it to add credentials, verifying the plan is a no-op after the update (the scenario described in bug update #1).