### PR TITLE
Fix state drift on VNA cluster when advanced_configuration omitted

### DIFF
--- a/nsxt/resource_nsxt_policy_virtual_network_appliance_cluster.go
+++ b/nsxt/resource_nsxt_policy_virtual_network_appliance_cluster.go
@@ -122,8 +122,14 @@ func resourceNsxtPolicyVirtualNetworkApplianceCluster() *schema.Resource {
 				},
 			},
 			"advanced_configuration": {
-				Type:        schema.TypeList,
-				Optional:    true,
+				Type:     schema.TypeList,
+				Optional: true,
+				// Computed is required because NSX auto-populates this block with
+				// server-side defaults (e.g. high_availability_profile,
+				// overlay_transport_zone_path, core_allocation_profile) even when
+				// the user omits it. Without Computed, Terraform plans perpetual
+				// in-place updates to remove the server-populated values.
+				Computed:    true,
 				MaxItems:    1,
 				Description: "Advanced configuration for virtual network appliances in the cluster",
 				Elem: &schema.Resource{
@@ -143,8 +149,10 @@ func resourceNsxtPolicyVirtualNetworkApplianceCluster() *schema.Resource {
 							ValidateFunc: validatePolicyPath(),
 						},
 						"overlay_transport_zone_path": {
-							Type:         schema.TypeString,
-							Optional:     true,
+							Type:     schema.TypeString,
+							Optional: true,
+							// Computed because NSX auto-populates this field server-side.
+							Computed:     true,
 							Description:  "Overlay transport zone path associated with the VNA host switch and TEP",
 							ValidateFunc: validatePolicyPath(),
 						},

--- a/nsxt/resource_nsxt_policy_virtual_network_appliance_cluster_test.go
+++ b/nsxt/resource_nsxt_policy_virtual_network_appliance_cluster_test.go
@@ -214,6 +214,56 @@ data "nsxt_policy_virtual_network_appliance_cluster_realization" "test" {
 `, edgeTransportNodeName, getOverlayTransportZoneName(), displayName)
 }
 
+// TestAccResourceNsxtPolicyVirtualNetworkApplianceCluster_noAdvancedConfig covers
+// the idempotency regression reported in bug 3713480: when advanced_configuration
+// is omitted from the manifest, NSX auto-populates server-side defaults for
+// high_availability_profile, overlay_transport_zone_path and
+// core_allocation_profile. A second plan must detect zero drift.
+func TestAccResourceNsxtPolicyVirtualNetworkApplianceCluster_noAdvancedConfig(t *testing.T) {
+	testResourceName := "nsxt_policy_virtual_network_appliance_cluster.test"
+	displayName := getAccTestResourceName()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccOnlyLocalManager(t)
+			testAccNSXVersion(t, "9.1.1")
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccNsxtPolicyVirtualNetworkApplianceClusterCheckDestroy(testResourceName),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyVirtualNetworkApplianceClusterNoAdvancedConfigTemplate(displayName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicyVirtualNetworkApplianceClusterExists(testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", displayName),
+					resource.TestCheckResourceAttr(testResourceName, "appliance_form_factor", "MEDIUM"),
+					resource.TestCheckResourceAttr(testResourceName, "service_type", "VPC_SERVICES"),
+				),
+			},
+			{
+				// Idempotency check: re-planning with the same config (no
+				// advanced_configuration) must produce no changes even after
+				// NSX has auto-populated the block with server-side defaults.
+				Config:             testAccNsxtPolicyVirtualNetworkApplianceClusterNoAdvancedConfigTemplate(displayName),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+func testAccNsxtPolicyVirtualNetworkApplianceClusterNoAdvancedConfigTemplate(displayName string) string {
+	return fmt.Sprintf(`
+resource "nsxt_policy_virtual_network_appliance_cluster" "test" {
+  display_name          = "%s"
+  description           = "Acceptance test cluster - no advanced configuration"
+  appliance_form_factor = "MEDIUM"
+  service_type          = "VPC_SERVICES"
+}
+`, displayName)
+}
+
 func TestAccResourceNsxtPolicyVirtualNetworkApplianceCluster_coreAllocationProfile(t *testing.T) {
 	testResourceName := "nsxt_policy_virtual_network_appliance_cluster.test"
 	displayName := getAccTestResourceName()


### PR DESCRIPTION
NSX auto-populates advanced_configuration (high_availability_profile, overlay_transport_zone_path, core_allocation_profile) when the block is absent from the manifest. The previous schema lacked Computed:true on the TypeList and on overlay_transport_zone_path, causing Terraform to plan a perpetual in-place update to remove the server-populated values.

Add Computed:true to the advanced_configuration list block and to overlay_transport_zone_path so Terraform preserves server-side defaults without generating a diff on subsequent plans.

Add TestAccResourceNsxtPolicyVirtualNetworkApplianceCluster_noAdvancedConfig to verify zero drift on re-plan when the block is omitted.

Fixes: https://bugzilla-vcf.lvn.broadcom.net/show_bug.cgi?id=3713480