### PR TITLE
Fix nsxt_policy_project ipv6_blocks version guard in read (bug 3705663)

### DIFF
--- a/nsxt/data_source_nsxt_policy_project.go
+++ b/nsxt/data_source_nsxt_policy_project.go
@@ -10,8 +10,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
-
-	"github.com/vmware/terraform-provider-nsxt/nsxt/util"
 )
 
 const defaultOrgID = "default"
@@ -144,9 +142,7 @@ func dataSourceNsxtPolicyProjectRead(d *schema.ResourceData, m interface{}) erro
 	d.Set("site_info", siteInfosList)
 	d.Set("tier0_gateway_paths", obj.Tier0s)
 	d.Set("external_ipv4_blocks", obj.ExternalIpv4Blocks)
-	if util.NsxVersionHigherOrEqual("9.2.0") && obj.Ipv6Blocks != nil {
-		d.Set("ipv6_blocks", obj.Ipv6Blocks)
-	}
+	d.Set("ipv6_blocks", obj.Ipv6Blocks)
 
 	return nil
 }

--- a/nsxt/resource_nsxt_policy_project.go
+++ b/nsxt/resource_nsxt_policy_project.go
@@ -490,9 +490,7 @@ func resourceNsxtPolicyProjectRead(d *schema.ResourceData, m interface{}) error 
 		d.Set("quotas", obj.Limits)
 	}
 
-	if util.NsxVersionHigherOrEqual("9.2.0") {
-		d.Set("ipv6_blocks", obj.Ipv6Blocks)
-	}
+	d.Set("ipv6_blocks", obj.Ipv6Blocks)
 
 	if util.NsxVersionHigherOrEqual("9.1.0") {
 		// Set id_suffix if available

--- a/nsxt/utgomock_data_source_nsxt_policy_project_test.go
+++ b/nsxt/utgomock_data_source_nsxt_policy_project_test.go
@@ -153,7 +153,7 @@ func TestMockDataSourceNsxtPolicyProjectRead_ipv6Blocks(t *testing.T) {
 		assert.Equal(t, ipv6BlockPath, blocks[0])
 	})
 
-	t.Run("by ID does not populate ipv6_blocks when NSX below 9.2", func(t *testing.T) {
+	t.Run("by ID sets ipv6_blocks regardless of NSX version", func(t *testing.T) {
 		util.NsxVersion = "9.1.0"
 		defer func() { util.NsxVersion = "" }()
 
@@ -166,8 +166,9 @@ func TestMockDataSourceNsxtPolicyProjectRead_ipv6Blocks(t *testing.T) {
 
 		err := dataSourceNsxtPolicyProjectRead(d, newGoMockProviderClient())
 		require.NoError(t, err)
-		_, ok := d.GetOk("ipv6_blocks")
-		assert.False(t, ok)
+		blocks := d.Get("ipv6_blocks").([]interface{})
+		require.Len(t, blocks, 1)
+		assert.Equal(t, ipv6BlockPath, blocks[0])
 	})
 
 	t.Run("by display_name sets ipv6_blocks when NSX 9.2.0+", func(t *testing.T) {

--- a/nsxt/utgomock_resource_nsxt_policy_project_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_project_test.go
@@ -189,7 +189,7 @@ func TestMockResourceNsxtPolicyProjectRead(t *testing.T) {
 		assert.Equal(t, ipv6BlockPath, blocks[0])
 	})
 
-	t.Run("Read does not populate ipv6_blocks when NSX below 9.2", func(t *testing.T) {
+	t.Run("Read sets ipv6_blocks regardless of NSX version", func(t *testing.T) {
 		util.NsxVersion = "9.1.0"
 		defer func() { util.NsxVersion = "" }()
 
@@ -204,8 +204,9 @@ func TestMockResourceNsxtPolicyProjectRead(t *testing.T) {
 
 		err := resourceNsxtPolicyProjectRead(d, newGoMockProviderClient())
 		require.NoError(t, err)
-		_, ok := d.GetOk("ipv6_blocks")
-		assert.False(t, ok)
+		blocks := d.Get("ipv6_blocks").([]interface{})
+		require.Len(t, blocks, 1)
+		assert.Equal(t, ipv6BlockPath, blocks[0])
 	})
 
 	t.Run("Read not found clears ID", func(t *testing.T) {


### PR DESCRIPTION
Both NSX 9.1.x and 9.2.x return "ipv6_blocks": [] (an explicit empty array) in the project API response, even when no IPv6 blocks are configured. The version guard NsxVersionHigherOrEqual("9.2.0") therefore prevented the data source and resource reads from setting ipv6_blocks in state on NSX 9.1.x, leaving it as null while the API returned []. The FVT verify_data test then failed with:
  "Value None for attribute ipv6_blocks not equal to API"

Fix: remove the version guard from ipv6_blocks in both dataSourceNsxtPolicyProjectRead and resourceNsxtPolicyProjectRead so the state always reflects the API response, regardless of NSX version. The write-path guard in resourceNsxtPolicyProjectPatch (9.2.0+) is intentionally kept.