### PR TITLE
Documentation issues with policy_transit_gateway zone_based_spans

### DIFF
--- a/docs/resources/policy_transit_gateway.md
+++ b/docs/resources/policy_transit_gateway.md
@@ -85,8 +85,7 @@ The following arguments are supported:
     * `cluster_based_span` - (Optional) Span based on vSphere Clusters.
         * `span_path` - (Required) Policy path of the network span object.
     * `zone_based_span` - (Optional) Span based on zones.
-        * `zone_external_ids` - (Optional) An array of Zone object's external IDs.
-        * `use_all_zones` - (Optional) Flag to indicate that TransitGateway is associated with all project zones.
+        * `zone_external_ids` - (Required) An array of Zone object's external IDs.
 
 ## Attributes Reference
 


### PR DESCRIPTION
use_all_zones has no implementation or API behind it. zone_external_ids is required as it's the only attribute in the zone_based_span block.