### PR TITLE
Add withIdempotencyChecks test helper; apply to edge transport node

### DIFF
--- a/nsxt/resource_nsxt_edge_transport_node_test.go
+++ b/nsxt/resource_nsxt_edge_transport_node_test.go
@@ -24,7 +24,7 @@ func TestAccResourceNsxtEdgeTransportNode_basic(t *testing.T) {
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNsxtEdgeTransportNodeCheckDestroy(state, displayName)
 		},
-		Steps: []resource.TestStep{
+		Steps: withIdempotencyChecks([]resource.TestStep{
 			{
 				Config: testAccNsxtEdgeTransportNodeCreateTemplate(displayName),
 				Check: resource.ComposeTestCheckFunc(
@@ -68,7 +68,7 @@ func TestAccResourceNsxtEdgeTransportNode_basic(t *testing.T) {
 					"standard_host_switch.0.transport_zone_endpoint.0.transport_zone",
 				},
 			},
-		},
+		}),
 	})
 }
 
@@ -82,7 +82,7 @@ func TestAccResourceNsxtEdgeTransportNode_importBasic(t *testing.T) {
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNsxtEdgeTransportNodeCheckDestroy(state, displayName)
 		},
-		Steps: []resource.TestStep{
+		Steps: withIdempotencyChecks([]resource.TestStep{
 			{
 				Config: testAccNsxtEdgeTransportNodeCreateTemplate(displayName),
 			},
@@ -99,7 +99,7 @@ func TestAccResourceNsxtEdgeTransportNode_importBasic(t *testing.T) {
 					"standard_host_switch.0.transport_zone_endpoint.0.transport_zone",
 				},
 			},
-		},
+		}),
 	})
 }
 

--- a/nsxt/utils_test.go
+++ b/nsxt/utils_test.go
@@ -884,3 +884,20 @@ resource "nsxt_policy_shared_resource" "test" {
   }
 }`, context, name, projectPath, name, sharedResourcePath)
 }
+
+// withIdempotencyChecks inserts a PlanOnly step after every non-import,
+// non-plan-only step to verify the apply leaves no residual diff.
+func withIdempotencyChecks(steps []resource.TestStep) []resource.TestStep {
+	expanded := make([]resource.TestStep, 0, len(steps)*2)
+	for _, step := range steps {
+		expanded = append(expanded, step)
+		if step.ImportState || step.PlanOnly || step.Config == "" {
+			continue
+		}
+		expanded = append(expanded, resource.TestStep{
+			Config:   step.Config,
+			PlanOnly: true,
+		})
+	}
+	return expanded
+}


### PR DESCRIPTION
Add a reusable withIdempotencyChecks() helper in utils_test.go that wraps a []resource.TestStep slice and inserts a PlanOnly step after each non-import, non-plan-only step, verifying that every apply leaves no residual diff.

Apply the helper to both acceptance tests in
resource_nsxt_edge_transport_node_test.go.