### PR TITLE
Fix acknowledgment of non-ackable upgrade precheck warnings

### DIFF
--- a/nsxt/resource_nsxt_upgrade_precheck_acknowledge.go
+++ b/nsxt/resource_nsxt_upgrade_precheck_acknowledge.go
@@ -127,7 +127,11 @@ func acknowledgePrecheckWarnings(m interface{}, precheckIDs []string) error {
 	}
 	var warns []string
 	for _, warn := range precheckWarnings {
-		warns = append(warns, *warn.Id)
+		// Only append warnings that actually need acknowledgment and are not already acknowledged.
+		// If NeedsAck is nil (e.g. for backward compatibility or in tests), we default to true.
+		if (warn.NeedsAck == nil || *warn.NeedsAck) && (warn.Acked == nil || !*warn.Acked) {
+			warns = append(warns, *warn.Id)
+		}
 	}
 
 	client := cliPreUpgradeChecksClient(connector)
@@ -135,11 +139,19 @@ func acknowledgePrecheckWarnings(m interface{}, precheckIDs []string) error {
 		if slices.Contains(warns, precheckID) {
 			err := client.Acknowledge(precheckID)
 			if err != nil {
-				msg := fmt.Sprintf("Failed to acknowledge precheck warning with ID %s", precheckID)
-				return logAPIError(msg, err)
+				errStr := err.Error()
+				// If the warning does not need acknowledgment or is already acknowledged,
+				// the NSX API might return error code 30976 (Invalid pre-check id provided).
+				// We ignore this error and log it, since the precheck is already in the desired state.
+				if strings.Contains(errStr, "30976") || strings.Contains(errStr, "Invalid pre-check id provided") {
+					log.Printf("[INFO] Ignoring error acknowledging precheck warning %s: %s", precheckID, errStr)
+				} else {
+					msg := fmt.Sprintf("Failed to acknowledge precheck warning with ID %s", precheckID)
+					return logAPIError(msg, err)
+				}
 			}
 		} else {
-			log.Printf("[INFO] Precheck warning with ID %s has not been triggered by NSX", precheckID)
+			log.Printf("[INFO] Precheck warning with ID %s has not been triggered by NSX, or doesn't need acknowledgment", precheckID)
 		}
 	}
 	return nil

--- a/nsxt/utgomock_resource_nsxt_upgrade_precheck_acknowledge_test.go
+++ b/nsxt/utgomock_resource_nsxt_upgrade_precheck_acknowledge_test.go
@@ -133,6 +133,83 @@ func TestMockResourceNsxtUpgradePrecheckAcknowledgeCreate(t *testing.T) {
 		assert.NotEmpty(t, d.Id())
 	})
 
+	t.Run("Create success when precheck warning does not need acknowledgment", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockChecksInfo, _, mockFailures, restore := setupPrecheckAcknowledgeMocks(ctrl)
+		defer restore()
+
+		warningType := nsxModel.UpgradeCheckFailure_TYPE_WARNING
+		needsAck := false
+		acked := false
+		warnItem := precheckWarningItem(precheckID, acked)
+		warnItem.NeedsAck = &needsAck
+
+		gomock.InOrder(
+			// validatePrecheckIDs
+			mockChecksInfo.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(checksInfoResult(precheckID), nil),
+			// acknowledgePrecheckWarnings -> getPrecheckErrors (WARNING type)
+			mockFailures.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), &warningType, gomock.Any(), gomock.Any()).Return(
+				nsxModel.UpgradeCheckFailureListResult{
+					Results: []nsxModel.UpgradeCheckFailure{warnItem},
+				}, nil,
+			),
+			// Acknowledge should NOT be called because NeedsAck is false
+			// Read -> getPrecheckErrors (WARNING type, same as acknowledgePrecheckWarnings)
+			mockFailures.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(
+				nsxModel.UpgradeCheckFailureListResult{
+					Results: []nsxModel.UpgradeCheckFailure{},
+				}, nil,
+			),
+		)
+
+		res := resourceNsxtUpgradePrecheckAcknowledge()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalPrecheckAcknowledgeData())
+
+		err := resourceNsxtUpgradePrecheckAcknowledgeCreate(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.NotEmpty(t, d.Id())
+	})
+
+	t.Run("Create success when Acknowledge returns code 30976", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockChecksInfo, mockPreChecks, mockFailures, restore := setupPrecheckAcknowledgeMocks(ctrl)
+		defer restore()
+
+		warningType := nsxModel.UpgradeCheckFailure_TYPE_WARNING
+		needsAck := true
+		acked := false
+		warnItem := precheckWarningItem(precheckID, acked)
+		warnItem.NeedsAck = &needsAck
+
+		gomock.InOrder(
+			// validatePrecheckIDs
+			mockChecksInfo.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(checksInfoResult(precheckID), nil),
+			// acknowledgePrecheckWarnings -> getPrecheckErrors (WARNING type)
+			mockFailures.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), &warningType, gomock.Any(), gomock.Any()).Return(
+				nsxModel.UpgradeCheckFailureListResult{
+					Results: []nsxModel.UpgradeCheckFailure{warnItem},
+				}, nil,
+			),
+			// acknowledge the warning but it returns error code 30976
+			mockPreChecks.EXPECT().Acknowledge(precheckID).Return(errors.New("Invalid pre-check id provided (code 30976)")),
+			// Read -> getPrecheckErrors (WARNING type, same as acknowledgePrecheckWarnings)
+			mockFailures.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(
+				nsxModel.UpgradeCheckFailureListResult{
+					Results: []nsxModel.UpgradeCheckFailure{},
+				}, nil,
+			),
+		)
+
+		res := resourceNsxtUpgradePrecheckAcknowledge()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalPrecheckAcknowledgeData())
+
+		err := resourceNsxtUpgradePrecheckAcknowledgeCreate(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.NotEmpty(t, d.Id())
+	})
+
 	t.Run("Create fails when precheck ID invalid", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()


### PR DESCRIPTION
Skip acknowledgment of upgrade precheck warnings when needs_ack is false.

The Upgrade Coordinator returns CannotAcknowledgeException (code 30976) when trying to acknowledge prechecks that do not require acknowledgment. Precheck warnings like edgeNodeAlarmCheckCheck (which are informational warnings with needs_ack set to false) can be collected and requested for acknowledgment, but there is no need to ack them.

Update acknowledgePrecheckWarnings to filter out warnings where needs_ack is false or has already been acknowledged, preventing unnecessary and invalid API calls. Additionally, handle and gracefully ignore any 30976 error code returned by the NSX API in case the precheck's state changed.