### PR TITLE
Gate slow/redundant acc tests behind NSXT_TEST_EXTRA_COVERAGE

### DIFF
--- a/nsxt/data_source_nsxt_policy_idps_system_signatures_test.go
+++ b/nsxt/data_source_nsxt_policy_idps_system_signatures_test.go
@@ -67,6 +67,7 @@ func TestAccDataSourceNsxtPolicyIdpsSystemSignatures_withVersionID(t *testing.T)
 			testAccPreCheck(t)
 			testAccOnlyLocalManager(t)
 			testAccNSXVersion(t, "4.2.0")
+			testAccNsxtExtraCoverage(t)
 		},
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
@@ -115,6 +116,7 @@ func TestAccDataSourceNsxtPolicyIdpsSystemSignatures_signatureAttributes(t *test
 			testAccPreCheck(t)
 			testAccOnlyLocalManager(t)
 			testAccNSXVersion(t, "4.2.0")
+			testAccNsxtExtraCoverage(t)
 		},
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{

--- a/nsxt/resource_nsxt_edge_transport_node_test.go
+++ b/nsxt/resource_nsxt_edge_transport_node_test.go
@@ -19,7 +19,10 @@ func TestAccResourceNsxtEdgeTransportNode_basic(t *testing.T) {
 	updatedDescription := "Updated acceptance test edge transport node"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccEdgeTransportNodePreCheck(t) },
+		PreCheck: func() {
+			testAccEdgeTransportNodePreCheck(t)
+			testAccNsxtExtraCoverage(t)
+		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNsxtEdgeTransportNodeCheckDestroy(state, displayName)
@@ -77,7 +80,10 @@ func TestAccResourceNsxtEdgeTransportNode_importBasic(t *testing.T) {
 	displayName := getAccTestResourceName()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccEdgeTransportNodePreCheck(t) },
+		PreCheck: func() {
+			testAccEdgeTransportNodePreCheck(t)
+			testAccNsxtExtraCoverage(t)
+		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNsxtEdgeTransportNodeCheckDestroy(state, displayName)

--- a/nsxt/resource_nsxt_policy_edge_transport_node_test.go
+++ b/nsxt/resource_nsxt_policy_edge_transport_node_test.go
@@ -21,7 +21,10 @@ func TestAccResourceNsxtPolicyEdgeTransportNode_basic(t *testing.T) {
 	updatedDescription := "Updated acceptance test policy edge transport node"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPolicyEdgeTransportNodePreCheck(t) },
+		PreCheck: func() {
+			testAccPolicyEdgeTransportNodePreCheck(t)
+			testAccNsxtExtraCoverage(t)
+		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNsxtPolicyEdgeTransportNodeCheckDestroy(state, displayName)
@@ -78,7 +81,10 @@ func TestAccResourceNsxtPolicyEdgeTransportNode_importBasic(t *testing.T) {
 	displayName := getAccTestResourceName()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPolicyEdgeTransportNodePreCheck(t) },
+		PreCheck: func() {
+			testAccPolicyEdgeTransportNodePreCheck(t)
+			testAccNsxtExtraCoverage(t)
+		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNsxtPolicyEdgeTransportNodeCheckDestroy(state, displayName)

--- a/nsxt/resource_nsxt_policy_tier0_gateway_interface_test.go
+++ b/nsxt/resource_nsxt_policy_tier0_gateway_interface_test.go
@@ -451,7 +451,11 @@ func TestAccResourceNsxtPolicyTier0GatewayInterface_withV6(t *testing.T) {
 	testResourceName := "nsxt_policy_tier0_gateway_interface.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccOnlyLocalManager(t)
+			testAccNsxtExtraCoverage(t)
+		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNsxtPolicyTier0InterfaceCheckDestroy(state, updatedName)

--- a/nsxt/resource_nsxt_policy_tier1_gateway_interface_test.go
+++ b/nsxt/resource_nsxt_policy_tier1_gateway_interface_test.go
@@ -307,7 +307,11 @@ func TestAccResourceNsxtPolicyTier1GatewayInterface_withIPv6(t *testing.T) {
 	testResourceName := "nsxt_policy_tier1_gateway_interface.test"
 	profilePath := testAccAdjustPolicyInfraConfig("/infra/ipv6-ndra-profiles/default")
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t); testAccNSXVersion(t, "3.0.0") },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccNSXVersion(t, "3.0.0")
+			testAccNsxtExtraCoverage(t)
+		},
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNsxtPolicyTier1InterfaceCheckDestroy(state, name)

--- a/nsxt/utils_test.go
+++ b/nsxt/utils_test.go
@@ -244,6 +244,30 @@ func testAccEnvDefined(t *testing.T, envVar string) {
 	}
 }
 
+// testAccNsxtExtraCoverage skips a test unless NSXT_TEST_EXTRA_COVERAGE is set.
+//
+// Apply this guard to tests that are expensive to run and cover scenarios that
+// are already exercised by a sibling test in the same file, or that target a
+// resource/data-source whose implementation has been stable for a long time.
+// Typical candidates:
+//
+//   - Import-only variants (_importBasic) when a _basic test already deploys
+//     the same resource and the import code path is not under active change.
+//   - IPv6 / protocol-variant tests (_withV6, _withIPv6) when a non-IPv6
+//     sibling test covers the same create/update/read lifecycle.
+//   - Data-source tests that use an identical Terraform config to another
+//     test in the same file and differ only in their Check assertions.
+//   - Any test whose execution time is unusually long (>5 min) and whose
+//     resource has had no functional changes in the past 3–6 months.
+//
+// Tests guarded by this helper still run in periodic CI jobs where
+// NSXT_TEST_EXTRA_COVERAGE=true is set, so coverage is not lost permanently.
+func testAccNsxtExtraCoverage(t *testing.T) {
+	if os.Getenv("NSXT_TEST_EXTRA_COVERAGE") == "" {
+		t.Skipf("set NSXT_TEST_EXTRA_COVERAGE to run extra-coverage tests")
+	}
+}
+
 func testAccIsGlobalManager() bool {
 	return os.Getenv("NSXT_GLOBAL_MANAGER") == "true" || os.Getenv("NSXT_GLOBAL_MANAGER") == "1"
 }


### PR DESCRIPTION
Add testAccNsxtExtraCoverage helper to utils_test.go with documentation describing when to apply it, then gate 8 tests that are either expensive to run (ETN basic+import at ~800s each), stable IPv6 variants (T0/T1 interface _withV6/_withIPv6), or redundant IDPS data source variants (~163-423s). Tests remain available in periodic CI runs where NSXT_TEST_EXTRA_COVERAGE=true is set.