### PR TITLE
Fix parallel test race in IDPS signature version acceptance tests

### DIFF
--- a/nsxt/resource_nsxt_policy_idps_signature_version_test.go
+++ b/nsxt/resource_nsxt_policy_idps_signature_version_test.go
@@ -18,7 +18,7 @@ import (
 func TestAccResourceNsxtPolicyIdpsSignatureVersion_basic(t *testing.T) {
 	testResourceName := "nsxt_policy_idps_signature_version.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccOnlyLocalManager(t)
@@ -53,7 +53,7 @@ func TestAccResourceNsxtPolicyIdpsSignatureVersion_basic(t *testing.T) {
 func TestAccResourceNsxtPolicyIdpsSignatureVersion_makeActive(t *testing.T) {
 	testResourceName := "nsxt_policy_idps_signature_version.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccOnlyLocalManager(t)


### PR DESCRIPTION
Both TestAccResourceNsxtPolicyIdpsSignatureVersion_basic and _makeActive wrote to the same singleton NSX object (nsx_id="DEFAULT") while running as ParallelTest, causing one test to clobber the other. Switch both to resource.Test (sequential) following the same pattern used by the IDPS settings acceptance tests.