### PR TITLE
Fix parallel test races in acceptance tests

### DIFF
--- a/nsxt/resource_nsxt_policy_lb_service_test.go
+++ b/nsxt/resource_nsxt_policy_lb_service_test.go
@@ -32,24 +32,25 @@ var accTestPolicyLBServiceUpdateAttributes = map[string]string{
 	"size":              "SMALL",
 }
 
-var accTestPolicyLBServiceGateway1Name = getAccTestResourceName()
-var accTestPolicyLBServiceGateway2Name = getAccTestResourceName()
-
 func TestAccResourceNsxtPolicyLBService_basic(t *testing.T) {
 	testResourceName := "nsxt_policy_lb_service.test"
+	createName := getAccTestResourceName()
+	updateName := getAccTestResourceName()
+	gw1Name := getAccTestResourceName()
+	gw2Name := getAccTestResourceName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNsxtPolicyLBServiceCheckDestroy(state, accTestPolicyLBServiceCreateAttributes["display_name"])
+			return testAccNsxtPolicyLBServiceCheckDestroy(state, updateName)
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNsxtPolicyLBServiceTemplate(true),
+				Config: testAccNsxtPolicyLBServiceTemplate(true, createName, updateName, gw1Name, gw2Name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNsxtPolicyLBServiceExists(testResourceName),
-					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestPolicyLBServiceCreateAttributes["display_name"]),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", createName),
 					resource.TestCheckResourceAttr(testResourceName, "description", accTestPolicyLBServiceCreateAttributes["description"]),
 					resource.TestCheckResourceAttrSet(testResourceName, "connectivity_path"),
 					resource.TestCheckResourceAttr(testResourceName, "enabled", accTestPolicyLBServiceCreateAttributes["enabled"]),
@@ -63,10 +64,10 @@ func TestAccResourceNsxtPolicyLBService_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNsxtPolicyLBServiceTemplate(false),
+				Config: testAccNsxtPolicyLBServiceTemplate(false, createName, updateName, gw1Name, gw2Name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNsxtPolicyLBServiceExists(testResourceName),
-					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestPolicyLBServiceUpdateAttributes["display_name"]),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", updateName),
 					resource.TestCheckResourceAttr(testResourceName, "description", accTestPolicyLBServiceUpdateAttributes["description"]),
 					resource.TestCheckResourceAttrSet(testResourceName, "connectivity_path"),
 					resource.TestCheckResourceAttr(testResourceName, "enabled", accTestPolicyLBServiceUpdateAttributes["enabled"]),
@@ -80,7 +81,7 @@ func TestAccResourceNsxtPolicyLBService_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNsxtPolicyLBServiceMinimalistic(),
+				Config: testAccNsxtPolicyLBServiceMinimalistic(updateName, gw1Name, gw2Name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNsxtPolicyLBServiceExists(testResourceName),
 					resource.TestCheckResourceAttr(testResourceName, "description", ""),
@@ -96,7 +97,9 @@ func TestAccResourceNsxtPolicyLBService_basic(t *testing.T) {
 }
 
 func TestAccResourceNsxtPolicyLBService_importBasic(t *testing.T) {
-	name := accTestPolicyLBServiceUpdateAttributes["display_name"]
+	name := getAccTestResourceName()
+	gw1Name := getAccTestResourceName()
+	gw2Name := getAccTestResourceName()
 	testResourceName := "nsxt_policy_lb_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -107,7 +110,7 @@ func TestAccResourceNsxtPolicyLBService_importBasic(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNsxtPolicyLBServiceMinimalistic(),
+				Config: testAccNsxtPolicyLBServiceMinimalistic(name, gw1Name, gw2Name),
 			},
 			{
 				ResourceName:      testResourceName,
@@ -166,12 +169,16 @@ func testAccNsxtPolicyLBServiceCheckDestroy(state *terraform.State, displayName 
 	return nil
 }
 
-func testAccNsxtPolicyLBServiceTemplate(createFlow bool) string {
+func testAccNsxtPolicyLBServiceTemplate(createFlow bool, createName, updateName, gw1Name, gw2Name string) string {
 	var attrMap map[string]string
 	if createFlow {
 		attrMap = accTestPolicyLBServiceCreateAttributes
 	} else {
 		attrMap = accTestPolicyLBServiceUpdateAttributes
+	}
+	displayName := updateName
+	if createFlow {
+		displayName = createName
 	}
 	return testAccNsxtPolicyLBServiceDeps() + fmt.Sprintf(`
 
@@ -203,12 +210,12 @@ resource "nsxt_policy_lb_service" "test" {
 
 data "nsxt_policy_realization_info" "realization_info" {
   path = nsxt_policy_lb_service.test.path
-}`, accTestPolicyLBServiceGateway1Name, accTestPolicyLBServiceGateway2Name, attrMap["display_name"], attrMap["description"], attrMap["connectivity_path"], attrMap["enabled"], attrMap["error_log_level"], attrMap["size"])
+}`, gw1Name, gw2Name, displayName, attrMap["description"], attrMap["connectivity_path"], attrMap["enabled"], attrMap["error_log_level"], attrMap["size"])
 }
 
 // Terraform test does not respect T1-T0 dependency upon destroy,
 // so we need workaround that detaches T1 from T0 to avoid destroy error
-func testAccNsxtPolicyLBServiceMinimalistic() string {
+func testAccNsxtPolicyLBServiceMinimalistic(updateName, gw1Name, gw2Name string) string {
 	return testAccNsxtPolicyLBServiceDeps() + fmt.Sprintf(`
 resource "nsxt_policy_tier1_gateway" "test1" {
   display_name      = "%s"
@@ -225,7 +232,7 @@ resource "nsxt_policy_lb_service" "test" {
 
 data "nsxt_policy_realization_info" "realization_info" {
   path = nsxt_policy_lb_service.test.path
-}`, accTestPolicyLBServiceGateway1Name, accTestPolicyLBServiceGateway2Name, accTestPolicyLBServiceUpdateAttributes["display_name"])
+}`, gw1Name, gw2Name, updateName)
 }
 
 func testAccNsxtPolicyLBServiceDeps() string {

--- a/nsxt/resource_nsxt_policy_project_ip_address_allocation_test.go
+++ b/nsxt/resource_nsxt_policy_project_ip_address_allocation_test.go
@@ -27,19 +27,21 @@ var accTestProjectIpAddressAllocationUpdateAttributes = map[string]string{
 
 func TestAccResourceNsxtPolicyProjectIpAddressAllocation_basic(t *testing.T) {
 	testResourceName := "nsxt_policy_project_ip_address_allocation.test"
+	createName := getAccTestResourceName()
+	updateName := getAccTestResourceName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t); testAccOnlyVPC(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNsxtPolicyProjectIpAddressAllocationCheckDestroy(state, accTestProjectIpAddressAllocationUpdateAttributes["display_name"])
+			return testAccNsxtPolicyProjectIpAddressAllocationCheckDestroy(state, updateName)
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNsxtPolicyProjectIpAddressAllocationTemplate(true),
+				Config: testAccNsxtPolicyProjectIpAddressAllocationTemplate(true, createName, updateName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccNsxtPolicyProjectIpAddressAllocationExists(accTestProjectIpAddressAllocationCreateAttributes["display_name"], testResourceName),
-					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestProjectIpAddressAllocationCreateAttributes["display_name"]),
+					testAccNsxtPolicyProjectIpAddressAllocationExists(createName, testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", createName),
 					resource.TestCheckResourceAttr(testResourceName, "description", accTestProjectIpAddressAllocationCreateAttributes["description"]),
 					resource.TestCheckResourceAttrSet(testResourceName, "allocation_ips"),
 					resource.TestCheckResourceAttr(testResourceName, "allocation_size", accTestProjectIpAddressAllocationCreateAttributes["allocation_size"]),
@@ -50,10 +52,10 @@ func TestAccResourceNsxtPolicyProjectIpAddressAllocation_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNsxtPolicyProjectIpAddressAllocationTemplate(false),
+				Config: testAccNsxtPolicyProjectIpAddressAllocationTemplate(false, createName, updateName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccNsxtPolicyProjectIpAddressAllocationExists(accTestProjectIpAddressAllocationUpdateAttributes["display_name"], testResourceName),
-					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestProjectIpAddressAllocationUpdateAttributes["display_name"]),
+					testAccNsxtPolicyProjectIpAddressAllocationExists(updateName, testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", updateName),
 					resource.TestCheckResourceAttr(testResourceName, "description", accTestProjectIpAddressAllocationUpdateAttributes["description"]),
 					resource.TestCheckResourceAttrSet(testResourceName, "allocation_ips"),
 					resource.TestCheckResourceAttr(testResourceName, "allocation_size", accTestProjectIpAddressAllocationUpdateAttributes["allocation_size"]),
@@ -64,9 +66,9 @@ func TestAccResourceNsxtPolicyProjectIpAddressAllocation_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNsxtPolicyProjectIpAddressAllocationMinimalistic(),
+				Config: testAccNsxtPolicyProjectIpAddressAllocationMinimalistic(updateName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccNsxtPolicyProjectIpAddressAllocationExists(accTestProjectIpAddressAllocationCreateAttributes["display_name"], testResourceName),
+					testAccNsxtPolicyProjectIpAddressAllocationExists(updateName, testResourceName),
 					resource.TestCheckResourceAttr(testResourceName, "description", ""),
 					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
 					resource.TestCheckResourceAttrSet(testResourceName, "path"),
@@ -90,7 +92,7 @@ func TestAccResourceNsxtPolicyProjectIpAddressAllocation_importBasic(t *testing.
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNsxtPolicyProjectIpAddressAllocationMinimalistic(),
+				Config: testAccNsxtPolicyProjectIpAddressAllocationMinimalistic(name),
 			},
 			{
 				ResourceName:      testResourceName,
@@ -150,12 +152,16 @@ func testAccNsxtPolicyProjectIpAddressAllocationCheckDestroy(state *terraform.St
 	return nil
 }
 
-func testAccNsxtPolicyProjectIpAddressAllocationTemplate(createFlow bool) string {
+func testAccNsxtPolicyProjectIpAddressAllocationTemplate(createFlow bool, createName, updateName string) string {
 	var attrMap map[string]string
 	if createFlow {
 		attrMap = accTestProjectIpAddressAllocationCreateAttributes
 	} else {
 		attrMap = accTestProjectIpAddressAllocationUpdateAttributes
+	}
+	displayName := updateName
+	if createFlow {
+		displayName = createName
 	}
 	return fmt.Sprintf(`
 data "nsxt_policy_project" "test" {
@@ -177,10 +183,10 @@ resource "nsxt_policy_project_ip_address_allocation" "test" {
 data "nsxt_policy_project_ip_address_allocation" "test" {
   %s
   allocation_ips = nsxt_policy_project_ip_address_allocation.test.allocation_ips
-}`, os.Getenv("NSXT_VPC_PROJECT_ID"), testAccNsxtProjectContext(), attrMap["display_name"], attrMap["description"], attrMap["allocation_size"], testAccNsxtProjectContext())
+}`, os.Getenv("NSXT_VPC_PROJECT_ID"), testAccNsxtProjectContext(), displayName, attrMap["description"], attrMap["allocation_size"], testAccNsxtProjectContext())
 }
 
-func testAccNsxtPolicyProjectIpAddressAllocationMinimalistic() string {
+func testAccNsxtPolicyProjectIpAddressAllocationMinimalistic(updateName string) string {
 	return fmt.Sprintf(`
 data "nsxt_policy_project" "test" {
   id = "%s"
@@ -196,5 +202,5 @@ resource "nsxt_policy_project_ip_address_allocation" "test" {
 data "nsxt_policy_project_ip_address_allocation" "test" {
   %s
   allocation_ips = nsxt_policy_project_ip_address_allocation.test.allocation_ips
-}`, os.Getenv("NSXT_VPC_PROJECT_ID"), testAccNsxtProjectContext(), accTestProjectIpAddressAllocationUpdateAttributes["display_name"], accTestProjectIpAddressAllocationUpdateAttributes["allocation_size"], testAccNsxtProjectContext())
+}`, os.Getenv("NSXT_VPC_PROJECT_ID"), testAccNsxtProjectContext(), updateName, accTestProjectIpAddressAllocationUpdateAttributes["allocation_size"], testAccNsxtProjectContext())
 }

--- a/nsxt/resource_nsxt_policy_static_route_bfd_peer_test.go
+++ b/nsxt/resource_nsxt_policy_static_route_bfd_peer_test.go
@@ -28,19 +28,21 @@ var accTestPolicyStaticRouteBfdPeerUpdateAttributes = map[string]string{
 
 func TestAccResourceNsxtPolicyStaticRouteBfdPeer_basic(t *testing.T) {
 	testResourceName := "nsxt_policy_static_route_bfd_peer.test"
+	createName := getAccTestResourceName()
+	updateName := getAccTestResourceName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t); testAccNSXVersion(t, "3.1.0") },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNsxtPolicyStaticRouteBfdPeerCheckDestroy(state, accTestPolicyStaticRouteBfdPeerUpdateAttributes["display_name"])
+			return testAccNsxtPolicyStaticRouteBfdPeerCheckDestroy(state, updateName)
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNsxtPolicyStaticRouteBfdPeerTemplate(true),
+				Config: testAccNsxtPolicyStaticRouteBfdPeerTemplate(true, createName, updateName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccNsxtPolicyStaticRouteBfdPeerExists(accTestPolicyStaticRouteBfdPeerCreateAttributes["display_name"], testResourceName),
-					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestPolicyStaticRouteBfdPeerCreateAttributes["display_name"]),
+					testAccNsxtPolicyStaticRouteBfdPeerExists(createName, testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", createName),
 					resource.TestCheckResourceAttr(testResourceName, "description", accTestPolicyStaticRouteBfdPeerCreateAttributes["description"]),
 					resource.TestCheckResourceAttr(testResourceName, "enabled", accTestPolicyStaticRouteBfdPeerCreateAttributes["enabled"]),
 					resource.TestCheckResourceAttr(testResourceName, "peer_address", accTestPolicyStaticRouteBfdPeerCreateAttributes["peer_address"]),
@@ -53,10 +55,10 @@ func TestAccResourceNsxtPolicyStaticRouteBfdPeer_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNsxtPolicyStaticRouteBfdPeerTemplate(false),
+				Config: testAccNsxtPolicyStaticRouteBfdPeerTemplate(false, createName, updateName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccNsxtPolicyStaticRouteBfdPeerExists(accTestPolicyStaticRouteBfdPeerUpdateAttributes["display_name"], testResourceName),
-					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestPolicyStaticRouteBfdPeerUpdateAttributes["display_name"]),
+					testAccNsxtPolicyStaticRouteBfdPeerExists(updateName, testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", updateName),
 					resource.TestCheckResourceAttr(testResourceName, "description", accTestPolicyStaticRouteBfdPeerUpdateAttributes["description"]),
 					resource.TestCheckResourceAttr(testResourceName, "enabled", accTestPolicyStaticRouteBfdPeerUpdateAttributes["enabled"]),
 					resource.TestCheckResourceAttr(testResourceName, "peer_address", accTestPolicyStaticRouteBfdPeerUpdateAttributes["peer_address"]),
@@ -69,9 +71,9 @@ func TestAccResourceNsxtPolicyStaticRouteBfdPeer_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNsxtPolicyStaticRouteBfdPeerMinimalistic(),
+				Config: testAccNsxtPolicyStaticRouteBfdPeerMinimalistic(updateName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccNsxtPolicyStaticRouteBfdPeerExists(accTestPolicyStaticRouteBfdPeerCreateAttributes["display_name"], testResourceName),
+					testAccNsxtPolicyStaticRouteBfdPeerExists(updateName, testResourceName),
 					resource.TestCheckResourceAttr(testResourceName, "description", ""),
 					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
 					resource.TestCheckResourceAttrSet(testResourceName, "path"),
@@ -95,7 +97,7 @@ func TestAccResourceNsxtPolicyStaticRouteBfdPeer_importBasic(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNsxtPolicyStaticRouteBfdPeerMinimalistic(),
+				Config: testAccNsxtPolicyStaticRouteBfdPeerMinimalistic(name),
 			},
 			{
 				ResourceName:      testResourceName,
@@ -160,12 +162,16 @@ func testAccNsxtPolicyStaticRouteBfdPeerCheckDestroy(state *terraform.State, dis
 	return nil
 }
 
-func testAccNsxtPolicyStaticRouteBfdPeerTemplate(createFlow bool) string {
+func testAccNsxtPolicyStaticRouteBfdPeerTemplate(createFlow bool, createName, updateName string) string {
 	var attrMap map[string]string
 	if createFlow {
 		attrMap = accTestPolicyStaticRouteBfdPeerCreateAttributes
 	} else {
 		attrMap = accTestPolicyStaticRouteBfdPeerUpdateAttributes
+	}
+	displayName := updateName
+	if createFlow {
+		displayName = createName
 	}
 	return testAccNsxtPolicyEdgeClusterReadTemplate(getEdgeClusterName()) +
 		testAccNsxtPolicyTier0WithEdgeClusterTemplate("test", false) + fmt.Sprintf(`
@@ -186,10 +192,10 @@ resource "nsxt_policy_static_route_bfd_peer" "test" {
     scope = "scope1"
     tag   = "tag1"
   }
-}`, attrMap["display_name"], attrMap["description"], attrMap["enabled"], attrMap["peer_address"])
+}`, displayName, attrMap["description"], attrMap["enabled"], attrMap["peer_address"])
 }
 
-func testAccNsxtPolicyStaticRouteBfdPeerMinimalistic() string {
+func testAccNsxtPolicyStaticRouteBfdPeerMinimalistic(updateName string) string {
 	return testAccNsxtPolicyEdgeClusterReadTemplate(getEdgeClusterName()) +
 		testAccNsxtPolicyTier0WithEdgeClusterTemplate("test", false) + fmt.Sprintf(`
 data "nsxt_policy_bfd_profile" "test" {
@@ -202,5 +208,5 @@ resource "nsxt_policy_static_route_bfd_peer" "test" {
 
   display_name = "%s"
   peer_address = "%s"
-}`, accTestPolicyStaticRouteBfdPeerUpdateAttributes["display_name"], accTestPolicyStaticRouteBfdPeerUpdateAttributes["peer_address"])
+}`, updateName, accTestPolicyStaticRouteBfdPeerUpdateAttributes["peer_address"])
 }

--- a/nsxt/resource_nsxt_policy_transit_gateway_attachment_test.go
+++ b/nsxt/resource_nsxt_policy_transit_gateway_attachment_test.go
@@ -12,8 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
-var dependantEntityName = getAccTestResourceName()
-
 var accTestPolicyTransitGatewayAttachmentCreateAttributes = map[string]string{
 	"display_name": getAccTestResourceName(),
 	"description":  "terraform created",
@@ -26,6 +24,7 @@ var accTestPolicyTransitGatewayAttachmentUpdateAttributes = map[string]string{
 
 func TestAccResourceNsxtPolicyTransitGatewayAttachment_basic(t *testing.T) {
 	testResourceName := "nsxt_policy_transit_gateway_attachment.test"
+	prereqName := getAccTestResourceName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -39,7 +38,7 @@ func TestAccResourceNsxtPolicyTransitGatewayAttachment_basic(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNsxtPolicyTransitGatewayAttachmentTemplate(true),
+				Config: testAccNsxtPolicyTransitGatewayAttachmentTemplate(true, prereqName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNsxtPolicyTransitGatewayAttachmentExists(accTestPolicyTransitGatewayAttachmentCreateAttributes["display_name"], testResourceName),
 					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestPolicyTransitGatewayAttachmentCreateAttributes["display_name"]),
@@ -52,7 +51,7 @@ func TestAccResourceNsxtPolicyTransitGatewayAttachment_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNsxtPolicyTransitGatewayAttachmentTemplate(false),
+				Config: testAccNsxtPolicyTransitGatewayAttachmentTemplate(false, prereqName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNsxtPolicyTransitGatewayAttachmentExists(accTestPolicyTransitGatewayAttachmentUpdateAttributes["display_name"], testResourceName),
 					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestPolicyTransitGatewayAttachmentUpdateAttributes["display_name"]),
@@ -70,6 +69,7 @@ func TestAccResourceNsxtPolicyTransitGatewayAttachment_basic(t *testing.T) {
 
 func TestAccResourceNsxtPolicyTransitGatewayAttachment_importBasic(t *testing.T) {
 	name := getAccTestResourceName()
+	prereqName := getAccTestResourceName()
 	testResourceName := "nsxt_policy_transit_gateway_attachment.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -84,7 +84,7 @@ func TestAccResourceNsxtPolicyTransitGatewayAttachment_importBasic(t *testing.T)
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNsxtPolicyTransitGatewayAttachmentTemplate(true),
+				Config: testAccNsxtPolicyTransitGatewayAttachmentTemplate(true, prereqName),
 			},
 			{
 				ResourceName:      testResourceName,
@@ -146,7 +146,7 @@ func testAccNsxtPolicyTransitGatewayAttachmentCheckDestroy(state *terraform.Stat
 	return nil
 }
 
-func testAccNsxtPolicyTransitGatewayAttachmentTemplate(createFlow bool) string {
+func testAccNsxtPolicyTransitGatewayAttachmentTemplate(createFlow bool, prereqName string) string {
 	var attrMap map[string]string
 	if createFlow {
 		attrMap = accTestPolicyTransitGatewayAttachmentCreateAttributes
@@ -203,5 +203,5 @@ resource "nsxt_policy_transit_gateway_attachment" "test" {
     scope = "scope1"
     tag   = "tag1"
   }
-}`, getEdgeClusterName(), dependantEntityName, dependantEntityName, dependantEntityName, attrMap["display_name"], attrMap["description"])
+}`, getEdgeClusterName(), prereqName, prereqName, prereqName, attrMap["display_name"], attrMap["description"])
 }

--- a/nsxt/resource_nsxt_policy_transit_gateway_ipsec_vpn_local_endpoint_test.go
+++ b/nsxt/resource_nsxt_policy_transit_gateway_ipsec_vpn_local_endpoint_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
-var EpRelatedResourceName = getAccTestResourceName()
 var accTestPolicyTGWIPSecVpnLocalEndpointCreateAttributes = map[string]string{
 	"description": "terraform created",
 	"local_id":    "test-create",
@@ -27,6 +26,7 @@ func TestAccResourceNsxtPolicyTGWIPSecVpnLocalEndpoint_basic(t *testing.T) {
 	testResourceName := "nsxt_policy_transit_gateway_ipsec_vpn_local_endpoint.test"
 	createDisplayName := getAccTestResourceName()
 	updateDisplayName := getAccTestResourceName()
+	prereqName := getAccTestResourceName()
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -39,7 +39,7 @@ func TestAccResourceNsxtPolicyTGWIPSecVpnLocalEndpoint_basic(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNsxtPolicyTGWIPSecVpnLocalEndpointTemplate(true, createDisplayName),
+				Config: testAccNsxtPolicyTGWIPSecVpnLocalEndpointTemplate(true, createDisplayName, prereqName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNsxtPolicyTGWIPSecVpnLocalEndpointExists(createDisplayName, testResourceName),
 					resource.TestCheckResourceAttr(testResourceName, "display_name", createDisplayName),
@@ -54,7 +54,7 @@ func TestAccResourceNsxtPolicyTGWIPSecVpnLocalEndpoint_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNsxtPolicyTGWIPSecVpnLocalEndpointTemplate(false, updateDisplayName),
+				Config: testAccNsxtPolicyTGWIPSecVpnLocalEndpointTemplate(false, updateDisplayName, prereqName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNsxtPolicyTGWIPSecVpnLocalEndpointExists(updateDisplayName, testResourceName),
 					resource.TestCheckResourceAttr(testResourceName, "display_name", updateDisplayName),
@@ -69,7 +69,7 @@ func TestAccResourceNsxtPolicyTGWIPSecVpnLocalEndpoint_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNsxtPolicyTGWIPSecVpnLocalEndpointMinimalistic(updateDisplayName),
+				Config: testAccNsxtPolicyTGWIPSecVpnLocalEndpointMinimalistic(updateDisplayName, prereqName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNsxtPolicyTGWIPSecVpnLocalEndpointExists(createDisplayName, testResourceName),
 					resource.TestCheckResourceAttr(testResourceName, "description", ""),
@@ -85,6 +85,7 @@ func TestAccResourceNsxtPolicyTGWIPSecVpnLocalEndpoint_basic(t *testing.T) {
 
 func TestAccResourceNsxtPolicyTGWIPSecVpnLocalEndpoint_importBasic(t *testing.T) {
 	name := getAccTestResourceName()
+	prereqName := getAccTestResourceName()
 	testResourceName := "nsxt_policy_transit_gateway_ipsec_vpn_local_endpoint.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -99,7 +100,7 @@ func TestAccResourceNsxtPolicyTGWIPSecVpnLocalEndpoint_importBasic(t *testing.T)
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNsxtPolicyTGWIPSecVpnLocalEndpointMinimalistic(name),
+				Config: testAccNsxtPolicyTGWIPSecVpnLocalEndpointMinimalistic(name, prereqName),
 			},
 			{
 				ResourceName:      testResourceName,
@@ -160,14 +161,14 @@ func testAccNsxtPolicyTGWIPSecVpnLocalEndpointCheckDestroy(state *terraform.Stat
 	return nil
 }
 
-func testAccNsxtPolicyTGWIPSecVpnLocalEndpointTemplate(createFlow bool, displayName string) string {
+func testAccNsxtPolicyTGWIPSecVpnLocalEndpointTemplate(createFlow bool, displayName string, prereqName string) string {
 	var attrMap map[string]string
 	if createFlow {
 		attrMap = accTestPolicyTGWIPSecVpnLocalEndpointCreateAttributes
 	} else {
 		attrMap = accTestPolicyTGWIPSecVpnLocalEndpointUpdateAttributes
 	}
-	return testAccNsxtPolicyTGWIPSecVpnLocalEndpointPrerequisites() +
+	return testAccNsxtPolicyTGWIPSecVpnLocalEndpointPrerequisites(prereqName) +
 		fmt.Sprintf(`
 resource "nsxt_policy_transit_gateway_ipsec_vpn_local_endpoint" "test" {
   parent_path   =  nsxt_policy_transit_gateway_ipsec_vpn_service.test.path
@@ -183,8 +184,8 @@ resource "nsxt_policy_transit_gateway_ipsec_vpn_local_endpoint" "test" {
 }`, displayName, attrMap["description"], attrMap["local_id"])
 }
 
-func testAccNsxtPolicyTGWIPSecVpnLocalEndpointMinimalistic(displayName string) string {
-	return testAccNsxtPolicyTGWIPSecVpnLocalEndpointPrerequisites() + fmt.Sprintf(`
+func testAccNsxtPolicyTGWIPSecVpnLocalEndpointMinimalistic(displayName string, prereqName string) string {
+	return testAccNsxtPolicyTGWIPSecVpnLocalEndpointPrerequisites(prereqName) + fmt.Sprintf(`
 resource "nsxt_policy_transit_gateway_ipsec_vpn_local_endpoint" "test" {
   display_name = "%s"
   parent_path   =  nsxt_policy_transit_gateway_ipsec_vpn_service.test.path
@@ -192,7 +193,7 @@ resource "nsxt_policy_transit_gateway_ipsec_vpn_local_endpoint" "test" {
 }`, displayName)
 }
 
-func testAccNsxtPolicyTGWIPSecVpnLocalEndpointPrerequisites() string {
+func testAccNsxtPolicyTGWIPSecVpnLocalEndpointPrerequisites(prereqName string) string {
 	return fmt.Sprintf(`
 data "nsxt_policy_edge_cluster" "test" {
   display_name = "%s"
@@ -289,5 +290,5 @@ resource "nsxt_policy_transit_gateway_ipsec_vpn_service" "test" {
     tag   = "tag1"
   }
   depends_on = [data.nsxt_policy_transit_gateway.test]
-}`, getEdgeClusterName(), EpRelatedResourceName, EpRelatedResourceName, EpRelatedResourceName, EpRelatedResourceName, EpRelatedResourceName)
+}`, getEdgeClusterName(), prereqName, prereqName, prereqName, prereqName, prereqName)
 }

--- a/nsxt/resource_nsxt_policy_transit_gateway_ipsec_vpn_service_test.go
+++ b/nsxt/resource_nsxt_policy_transit_gateway_ipsec_vpn_service_test.go
@@ -12,8 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
-var RelatedResourceName = getAccTestResourceName()
-
 var accTestPolicyTGWIPSecVpnServicesCreateAttributes = map[string]string{
 	"display_name":  getAccTestResourceName(),
 	"description":   "terraform created",
@@ -38,6 +36,7 @@ func TestAccResourceNsxtPolicyTGWIPSecVpnServices_basic(t *testing.T) {
 	testResourceName := "nsxt_policy_transit_gateway_ipsec_vpn_service.test"
 	createDisplayName := getAccTestResourceName()
 	updateDisplayName := getAccTestResourceName()
+	prereqName := getAccTestResourceName()
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -50,7 +49,7 @@ func TestAccResourceNsxtPolicyTGWIPSecVpnServices_basic(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNsxtPolicyTGWIPSecVpnServicesTemplate(true, createDisplayName),
+				Config: testAccNsxtPolicyTGWIPSecVpnServicesTemplate(true, createDisplayName, prereqName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNsxtPolicyTGWIPSecVpnServicesExists(createDisplayName, testResourceName),
 					resource.TestCheckResourceAttr(testResourceName, "display_name", createDisplayName),
@@ -68,7 +67,7 @@ func TestAccResourceNsxtPolicyTGWIPSecVpnServices_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNsxtPolicyTGWIPSecVpnServicesTemplate(false, updateDisplayName),
+				Config: testAccNsxtPolicyTGWIPSecVpnServicesTemplate(false, updateDisplayName, prereqName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNsxtPolicyTGWIPSecVpnServicesExists(updateDisplayName, testResourceName),
 					resource.TestCheckResourceAttr(testResourceName, "display_name", updateDisplayName),
@@ -86,7 +85,7 @@ func TestAccResourceNsxtPolicyTGWIPSecVpnServices_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNsxtPolicyTGWIPSecVpnServicesMinimalistic(updateDisplayName),
+				Config: testAccNsxtPolicyTGWIPSecVpnServicesMinimalistic(updateDisplayName, prereqName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNsxtPolicyTGWIPSecVpnServicesExists(createDisplayName, testResourceName),
 					resource.TestCheckResourceAttr(testResourceName, "description", ""),
@@ -102,6 +101,7 @@ func TestAccResourceNsxtPolicyTGWIPSecVpnServices_basic(t *testing.T) {
 
 func TestAccResourceNsxtPolicyTGWIPSecVpnServices_importBasic(t *testing.T) {
 	name := getAccTestResourceName()
+	prereqName := getAccTestResourceName()
 	testResourceName := "nsxt_policy_transit_gateway_ipsec_vpn_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -116,7 +116,7 @@ func TestAccResourceNsxtPolicyTGWIPSecVpnServices_importBasic(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNsxtPolicyTGWIPSecVpnServicesMinimalistic(name),
+				Config: testAccNsxtPolicyTGWIPSecVpnServicesMinimalistic(name, prereqName),
 			},
 			{
 				ResourceName:      testResourceName,
@@ -177,14 +177,14 @@ func testAccNsxtPolicyTGWIPSecVpnServicesCheckDestroy(state *terraform.State, di
 	return nil
 }
 
-func testAccNsxtPolicyTGWIPSecVpnServicesTemplate(createFlow bool, displayName string) string {
+func testAccNsxtPolicyTGWIPSecVpnServicesTemplate(createFlow bool, displayName string, prereqName string) string {
 	var attrMap map[string]string
 	if createFlow {
 		attrMap = accTestPolicyTGWIPSecVpnServicesCreateAttributes
 	} else {
 		attrMap = accTestPolicyTGWIPSecVpnServicesUpdateAttributes
 	}
-	return testAccNsxtPolicyTGWIPSecVpnServicesPrerequisites() + fmt.Sprintf(`
+	return testAccNsxtPolicyTGWIPSecVpnServicesPrerequisites(prereqName) + fmt.Sprintf(`
 resource "nsxt_policy_transit_gateway_ipsec_vpn_service" "test" {
   display_name = "%s"
   parent_path  = data.nsxt_policy_transit_gateway.test.path
@@ -204,8 +204,8 @@ resource "nsxt_policy_transit_gateway_ipsec_vpn_service" "test" {
 }`, displayName, attrMap["description"], attrMap["enabled"], attrMap["ha_sync"], attrMap["ike_log_level"], attrMap["sources"], attrMap["destinations"])
 }
 
-func testAccNsxtPolicyTGWIPSecVpnServicesMinimalistic(displayName string) string {
-	return testAccNsxtPolicyTGWIPSecVpnServicesPrerequisites() + fmt.Sprintf(`
+func testAccNsxtPolicyTGWIPSecVpnServicesMinimalistic(displayName string, prereqName string) string {
+	return testAccNsxtPolicyTGWIPSecVpnServicesPrerequisites(prereqName) + fmt.Sprintf(`
 resource "nsxt_policy_transit_gateway_ipsec_vpn_service" "test" {
   display_name = "%s"
   parent_path      = data.nsxt_policy_transit_gateway.test.path
@@ -213,7 +213,7 @@ resource "nsxt_policy_transit_gateway_ipsec_vpn_service" "test" {
 }`, displayName)
 }
 
-func testAccNsxtPolicyTGWIPSecVpnServicesPrerequisites() string {
+func testAccNsxtPolicyTGWIPSecVpnServicesPrerequisites(prereqName string) string {
 	return fmt.Sprintf(`
 data "nsxt_policy_edge_cluster" "test" {
   display_name = "%s"
@@ -288,5 +288,5 @@ resource "nsxt_policy_transit_gateway_attachment" "test" {
     tag   = "tag1"
   }
   depends_on = [data.nsxt_policy_transit_gateway.test]
-}`, getEdgeClusterName(), RelatedResourceName, RelatedResourceName, RelatedResourceName, RelatedResourceName)
+}`, getEdgeClusterName(), prereqName, prereqName, prereqName, prereqName)
 }

--- a/nsxt/resource_nsxt_policy_transit_gateway_nat_rule_test.go
+++ b/nsxt/resource_nsxt_policy_transit_gateway_nat_rule_test.go
@@ -40,6 +40,7 @@ var accTestTransitGatewayNatRuleUpdateAttributes = map[string]string{
 
 func TestAccResourceNsxtTransitGatewayNatRule_basic(t *testing.T) {
 	testResourceName := "nsxt_policy_transit_gateway_nat_rule.test"
+	prereqName := getAccTestResourceName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -53,7 +54,7 @@ func TestAccResourceNsxtTransitGatewayNatRule_basic(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNsxtTransitGatewayNatRuleTemplate(true),
+				Config: testAccNsxtTransitGatewayNatRuleTemplate(true, prereqName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNsxtTransitGatewayNatRuleExists(accTestTransitGatewayNatRuleCreateAttributes["display_name"], testResourceName),
 					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestTransitGatewayNatRuleCreateAttributes["display_name"]),
@@ -75,7 +76,7 @@ func TestAccResourceNsxtTransitGatewayNatRule_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNsxtTransitGatewayNatRuleTemplate(false),
+				Config: testAccNsxtTransitGatewayNatRuleTemplate(false, prereqName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNsxtTransitGatewayNatRuleExists(accTestTransitGatewayNatRuleUpdateAttributes["display_name"], testResourceName),
 					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestTransitGatewayNatRuleUpdateAttributes["display_name"]),
@@ -97,7 +98,7 @@ func TestAccResourceNsxtTransitGatewayNatRule_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNsxtTransitGatewayNatRuleMinimalistic(),
+				Config: testAccNsxtTransitGatewayNatRuleMinimalistic(prereqName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNsxtTransitGatewayNatRuleExists(accTestTransitGatewayNatRuleCreateAttributes["display_name"], testResourceName),
 					resource.TestCheckResourceAttr(testResourceName, "description", ""),
@@ -116,6 +117,7 @@ func TestAccResourceNsxtTransitGatewayNatRule_changeTypes(t *testing.T) {
 	sourceIP := "2.2.2.34"
 	translatedNetwork := accTestTransitGatewayNatRuleCreateAttributes["translated_network"]
 	ruleName := getAccTestResourceName()
+	prereqName := getAccTestResourceName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -129,7 +131,7 @@ func TestAccResourceNsxtTransitGatewayNatRule_changeTypes(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNsxtTransitGatewayNatRuleSnatTemplate(ruleName, translatedNetwork),
+				Config: testAccNsxtTransitGatewayNatRuleSnatTemplate(ruleName, translatedNetwork, prereqName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNsxtTransitGatewayNatRuleExists(ruleName, testResourceName),
 					resource.TestCheckResourceAttr(testResourceName, "display_name", ruleName),
@@ -147,7 +149,7 @@ func TestAccResourceNsxtTransitGatewayNatRule_changeTypes(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNsxtTransitGatewayNatRuleReflexiveTemplate(ruleName, sourceIP, translatedNetwork),
+				Config: testAccNsxtTransitGatewayNatRuleReflexiveTemplate(ruleName, sourceIP, translatedNetwork, prereqName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNsxtTransitGatewayNatRuleExists(ruleName, testResourceName),
 					resource.TestCheckResourceAttr(testResourceName, "display_name", ruleName),
@@ -170,6 +172,7 @@ func TestAccResourceNsxtTransitGatewayNatRule_changeTypes(t *testing.T) {
 
 func TestAccResourceNsxtTransitGatewayNatRule_importBasic(t *testing.T) {
 	name := getAccTestResourceName()
+	prereqName := getAccTestResourceName()
 	testResourceName := "nsxt_policy_transit_gateway_nat_rule.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -184,7 +187,7 @@ func TestAccResourceNsxtTransitGatewayNatRule_importBasic(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNsxtTransitGatewayNatRuleMinimalistic(),
+				Config: testAccNsxtTransitGatewayNatRuleMinimalistic(prereqName),
 			},
 			{
 				ResourceName:      testResourceName,
@@ -248,8 +251,8 @@ func testAccNsxtTransitGatewayNatRuleCheckDestroy(state *terraform.State, displa
 	return nil
 }
 
-func testAccNsxtTransitGatewayNatRulePrerequisites(attrMap map[string]string) string {
-	return testAccNsxtPolicyTransitGatewayAttachmentTemplate(true) + fmt.Sprintf(`
+func testAccNsxtTransitGatewayNatRulePrerequisites(attrMap map[string]string, prereqName string) string {
+	return testAccNsxtPolicyTransitGatewayAttachmentTemplate(true, prereqName) + fmt.Sprintf(`
 
 resource "nsxt_policy_project_ip_address_allocation" "dest_nat" {
   context {
@@ -275,14 +278,14 @@ data "nsxt_policy_transit_gateway_nat" "test" {
 `, attrMap["destination_network"], attrMap["translated_network"])
 }
 
-func testAccNsxtTransitGatewayNatRuleTemplate(createFlow bool) string {
+func testAccNsxtTransitGatewayNatRuleTemplate(createFlow bool, prereqName string) string {
 	var attrMap map[string]string
 	if createFlow {
 		attrMap = accTestTransitGatewayNatRuleCreateAttributes
 	} else {
 		attrMap = accTestTransitGatewayNatRuleUpdateAttributes
 	}
-	return testAccNsxtTransitGatewayNatRulePrerequisites(attrMap) + fmt.Sprintf(`
+	return testAccNsxtTransitGatewayNatRulePrerequisites(attrMap, prereqName) + fmt.Sprintf(`
 resource "nsxt_policy_transit_gateway_nat_rule" "test" {
   parent_path         = data.nsxt_policy_transit_gateway_nat.test.path
   display_name        = "%s"
@@ -303,8 +306,8 @@ resource "nsxt_policy_transit_gateway_nat_rule" "test" {
 }`, attrMap["display_name"], attrMap["description"], attrMap["translated_network"], attrMap["logging"], attrMap["destination_network"], attrMap["action"], attrMap["firewall_match"], attrMap["source_network"], attrMap["enabled"], attrMap["sequence_number"])
 }
 
-func testAccNsxtTransitGatewayNatRuleMinimalistic() string {
-	return testAccNsxtTransitGatewayNatRulePrerequisites(accTestTransitGatewayNatRuleCreateAttributes) + fmt.Sprintf(`
+func testAccNsxtTransitGatewayNatRuleMinimalistic(prereqName string) string {
+	return testAccNsxtTransitGatewayNatRulePrerequisites(accTestTransitGatewayNatRuleCreateAttributes, prereqName) + fmt.Sprintf(`
 resource "nsxt_policy_transit_gateway_nat_rule" "test" {
   parent_path         = data.nsxt_policy_transit_gateway_nat.test.path
   display_name        = "%s"
@@ -314,8 +317,8 @@ resource "nsxt_policy_transit_gateway_nat_rule" "test" {
 }`, accTestTransitGatewayNatRuleUpdateAttributes["display_name"], accTestTransitGatewayNatRuleUpdateAttributes["translated_network"], accTestTransitGatewayNatRuleUpdateAttributes["destination_network"], accTestTransitGatewayNatRuleUpdateAttributes["action"])
 }
 
-func testAccNsxtTransitGatewayNatRuleSnatTemplate(name string, translatedNetwork string) string {
-	return testAccNsxtTransitGatewayNatRulePrerequisites(accTestTransitGatewayNatRuleCreateAttributes) + fmt.Sprintf(`
+func testAccNsxtTransitGatewayNatRuleSnatTemplate(name string, translatedNetwork string, prereqName string) string {
+	return testAccNsxtTransitGatewayNatRulePrerequisites(accTestTransitGatewayNatRuleCreateAttributes, prereqName) + fmt.Sprintf(`
 resource "nsxt_policy_transit_gateway_nat_rule" "test" {
   parent_path        = data.nsxt_policy_transit_gateway_nat.test.path
   display_name       = "%s"
@@ -324,8 +327,8 @@ resource "nsxt_policy_transit_gateway_nat_rule" "test" {
 }`, name, translatedNetwork)
 }
 
-func testAccNsxtTransitGatewayNatRuleReflexiveTemplate(name string, sourceIP string, translatedNetwork string) string {
-	return testAccNsxtTransitGatewayNatRulePrerequisites(accTestTransitGatewayNatRuleCreateAttributes) + fmt.Sprintf(`
+func testAccNsxtTransitGatewayNatRuleReflexiveTemplate(name string, sourceIP string, translatedNetwork string, prereqName string) string {
+	return testAccNsxtTransitGatewayNatRulePrerequisites(accTestTransitGatewayNatRuleCreateAttributes, prereqName) + fmt.Sprintf(`
 resource "nsxt_policy_transit_gateway_nat_rule" "test" {
   parent_path        = data.nsxt_policy_transit_gateway_nat.test.path
   display_name       = "%s"

--- a/nsxt/resource_nsxt_policy_transit_gateway_static_route_test.go
+++ b/nsxt/resource_nsxt_policy_transit_gateway_static_route_test.go
@@ -12,8 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
-var dependantResourceName = getAccTestResourceName()
-
 var accTestPolicyTransitGatewayStaticRouteCreateAttributes = map[string]string{
 	"display_name":         getAccTestResourceName(),
 	"description":          "terraform created",
@@ -32,6 +30,7 @@ var accTestPolicyTransitGatewayStaticRouteUpdateAttributes = map[string]string{
 
 func TestAccResourceNsxtPolicyTransitGatewayStaticRoute_basic(t *testing.T) {
 	testResourceName := "nsxt_policy_transit_gateway_static_route.test"
+	prereqName := getAccTestResourceName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -45,7 +44,7 @@ func TestAccResourceNsxtPolicyTransitGatewayStaticRoute_basic(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNsxtPolicyTransitGatewayStaticRouteTemplate(true),
+				Config: testAccNsxtPolicyTransitGatewayStaticRouteTemplate(true, prereqName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNsxtPolicyTransitGatewayStaticRouteExists(accTestPolicyTransitGatewayStaticRouteCreateAttributes["display_name"], testResourceName),
 					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestPolicyTransitGatewayStaticRouteCreateAttributes["display_name"]),
@@ -62,7 +61,7 @@ func TestAccResourceNsxtPolicyTransitGatewayStaticRoute_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNsxtPolicyTransitGatewayStaticRouteTemplate(false),
+				Config: testAccNsxtPolicyTransitGatewayStaticRouteTemplate(false, prereqName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNsxtPolicyTransitGatewayStaticRouteExists(accTestPolicyTransitGatewayStaticRouteUpdateAttributes["display_name"], testResourceName),
 					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestPolicyTransitGatewayStaticRouteUpdateAttributes["display_name"]),
@@ -79,7 +78,7 @@ func TestAccResourceNsxtPolicyTransitGatewayStaticRoute_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNsxtPolicyTransitGatewayStaticRouteMinimalistic(),
+				Config: testAccNsxtPolicyTransitGatewayStaticRouteMinimalistic(prereqName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNsxtPolicyTransitGatewayStaticRouteExists(accTestPolicyTransitGatewayStaticRouteCreateAttributes["display_name"], testResourceName),
 					resource.TestCheckResourceAttr(testResourceName, "description", ""),
@@ -95,6 +94,7 @@ func TestAccResourceNsxtPolicyTransitGatewayStaticRoute_basic(t *testing.T) {
 
 func TestAccResourceNsxtPolicyTransitGatewayStaticRoute_importBasic(t *testing.T) {
 	name := getAccTestResourceName()
+	prereqName := getAccTestResourceName()
 	testResourceName := "nsxt_policy_transit_gateway_static_route.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -109,7 +109,7 @@ func TestAccResourceNsxtPolicyTransitGatewayStaticRoute_importBasic(t *testing.T
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNsxtPolicyTransitGatewayStaticRouteMinimalistic(),
+				Config: testAccNsxtPolicyTransitGatewayStaticRouteMinimalistic(prereqName),
 			},
 			{
 				ResourceName:      testResourceName,
@@ -170,14 +170,14 @@ func testAccNsxtPolicyTransitGatewayStaticRouteCheckDestroy(state *terraform.Sta
 	return nil
 }
 
-func testAccNsxtPolicyTransitGatewayStaticRouteTemplate(createFlow bool) string {
+func testAccNsxtPolicyTransitGatewayStaticRouteTemplate(createFlow bool, prereqName string) string {
 	var attrMap map[string]string
 	if createFlow {
 		attrMap = accTestPolicyTransitGatewayStaticRouteCreateAttributes
 	} else {
 		attrMap = accTestPolicyTransitGatewayStaticRouteUpdateAttributes
 	}
-	return testAccNsxtPolicyTransitGatewayStaticRoutePrerequisites() + fmt.Sprintf(`
+	return testAccNsxtPolicyTransitGatewayStaticRoutePrerequisites(prereqName) + fmt.Sprintf(`
 resource "nsxt_policy_transit_gateway_static_route" "test" {
   display_name          = "%s"
   description           = "%s"
@@ -198,8 +198,8 @@ resource "nsxt_policy_transit_gateway_static_route" "test" {
 }`, attrMap["display_name"], attrMap["description"], attrMap["enabled_on_secondary"], attrMap["network"], attrMap["admin_distance"])
 }
 
-func testAccNsxtPolicyTransitGatewayStaticRouteMinimalistic() string {
-	return testAccNsxtPolicyTransitGatewayStaticRoutePrerequisites() + fmt.Sprintf(`
+func testAccNsxtPolicyTransitGatewayStaticRouteMinimalistic(prereqName string) string {
+	return testAccNsxtPolicyTransitGatewayStaticRoutePrerequisites(prereqName) + fmt.Sprintf(`
 resource "nsxt_policy_transit_gateway_static_route" "test" {
   display_name     = "%s"
   parent_path      = data.nsxt_policy_transit_gateway.test.path
@@ -213,7 +213,7 @@ resource "nsxt_policy_transit_gateway_static_route" "test" {
 }`, accTestPolicyTransitGatewayStaticRouteUpdateAttributes["display_name"], accTestPolicyTransitGatewayStaticRouteUpdateAttributes["network"], accTestPolicyTransitGatewayStaticRouteUpdateAttributes["admin_distance"])
 }
 
-func testAccNsxtPolicyTransitGatewayStaticRoutePrerequisites() string {
+func testAccNsxtPolicyTransitGatewayStaticRoutePrerequisites(prereqName string) string {
 	return fmt.Sprintf(`
 data "nsxt_policy_edge_cluster" "test" {
   display_name = "%s"
@@ -255,5 +255,5 @@ resource "nsxt_policy_transit_gateway_attachment" "test" {
     scope = "scope1"
     tag   = "tag1"
   }
-}`, getEdgeClusterName(), dependantResourceName, dependantResourceName, dependantResourceName, dependantResourceName)
+}`, getEdgeClusterName(), prereqName, prereqName, prereqName, prereqName)
 }

--- a/nsxt/resource_nsxt_vpc_ip_address_allocation_test.go
+++ b/nsxt/resource_nsxt_vpc_ip_address_allocation_test.go
@@ -26,19 +26,21 @@ var accTestVpcIpAddressAllocationUpdateAttributes = map[string]string{
 
 func TestAccResourceNsxtVpcIpAddressAllocation_basic(t *testing.T) {
 	testResourceName := "nsxt_vpc_ip_address_allocation.test"
+	createName := getAccTestResourceName()
+	updateName := getAccTestResourceName()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t); testAccOnlyVPC(t) },
 		Providers: testAccProviders,
 		CheckDestroy: func(state *terraform.State) error {
-			return testAccNsxtVpcIpAddressAllocationCheckDestroy(state, accTestVpcIpAddressAllocationUpdateAttributes["display_name"])
+			return testAccNsxtVpcIpAddressAllocationCheckDestroy(state, updateName)
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNsxtVpcIpAddressAllocationTemplate(true),
+				Config: testAccNsxtVpcIpAddressAllocationTemplate(true, createName, updateName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccNsxtVpcIpAddressAllocationExists(accTestVpcIpAddressAllocationCreateAttributes["display_name"], testResourceName),
-					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestVpcIpAddressAllocationCreateAttributes["display_name"]),
+					testAccNsxtVpcIpAddressAllocationExists(createName, testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", createName),
 					resource.TestCheckResourceAttr(testResourceName, "description", accTestVpcIpAddressAllocationCreateAttributes["description"]),
 					resource.TestCheckResourceAttrSet(testResourceName, "allocation_ips"),
 					resource.TestCheckResourceAttr(testResourceName, "allocation_size", accTestVpcIpAddressAllocationCreateAttributes["allocation_size"]),
@@ -50,10 +52,10 @@ func TestAccResourceNsxtVpcIpAddressAllocation_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNsxtVpcIpAddressAllocationTemplate(false),
+				Config: testAccNsxtVpcIpAddressAllocationTemplate(false, createName, updateName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccNsxtVpcIpAddressAllocationExists(accTestVpcIpAddressAllocationUpdateAttributes["display_name"], testResourceName),
-					resource.TestCheckResourceAttr(testResourceName, "display_name", accTestVpcIpAddressAllocationUpdateAttributes["display_name"]),
+					testAccNsxtVpcIpAddressAllocationExists(updateName, testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", updateName),
 					resource.TestCheckResourceAttr(testResourceName, "description", accTestVpcIpAddressAllocationUpdateAttributes["description"]),
 					resource.TestCheckResourceAttrSet(testResourceName, "allocation_ips"),
 					resource.TestCheckResourceAttr(testResourceName, "allocation_size", accTestVpcIpAddressAllocationUpdateAttributes["allocation_size"]),
@@ -65,9 +67,9 @@ func TestAccResourceNsxtVpcIpAddressAllocation_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNsxtVpcIpAddressAllocationMinimalistic(),
+				Config: testAccNsxtVpcIpAddressAllocationMinimalistic(updateName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccNsxtVpcIpAddressAllocationExists(accTestVpcIpAddressAllocationCreateAttributes["display_name"], testResourceName),
+					testAccNsxtVpcIpAddressAllocationExists(updateName, testResourceName),
 					resource.TestCheckResourceAttr(testResourceName, "description", ""),
 					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
 					resource.TestCheckResourceAttrSet(testResourceName, "path"),
@@ -91,7 +93,7 @@ func TestAccResourceNsxtVpcIpAddressAllocation_importBasic(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNsxtVpcIpAddressAllocationMinimalistic(),
+				Config: testAccNsxtVpcIpAddressAllocationMinimalistic(name),
 			},
 			{
 				ResourceName:      testResourceName,
@@ -151,12 +153,16 @@ func testAccNsxtVpcIpAddressAllocationCheckDestroy(state *terraform.State, displ
 	return nil
 }
 
-func testAccNsxtVpcIpAddressAllocationTemplate(createFlow bool) string {
+func testAccNsxtVpcIpAddressAllocationTemplate(createFlow bool, createName, updateName string) string {
 	var attrMap map[string]string
 	if createFlow {
 		attrMap = accTestVpcIpAddressAllocationCreateAttributes
 	} else {
 		attrMap = accTestVpcIpAddressAllocationUpdateAttributes
+	}
+	displayName := updateName
+	if createFlow {
+		displayName = createName
 	}
 	return fmt.Sprintf(`
 resource "nsxt_vpc_ip_address_allocation" "test" {
@@ -173,10 +179,10 @@ resource "nsxt_vpc_ip_address_allocation" "test" {
 data "nsxt_vpc_ip_address_allocation" "test" {
   %s
   allocation_ips = nsxt_vpc_ip_address_allocation.test.allocation_ips
-}`, testAccNsxtPolicyMultitenancyContext(), attrMap["display_name"], attrMap["description"], attrMap["allocation_size"], testAccNsxtPolicyMultitenancyContext())
+}`, testAccNsxtPolicyMultitenancyContext(), displayName, attrMap["description"], attrMap["allocation_size"], testAccNsxtPolicyMultitenancyContext())
 }
 
-func testAccNsxtVpcIpAddressAllocationMinimalistic() string {
+func testAccNsxtVpcIpAddressAllocationMinimalistic(updateName string) string {
 	return fmt.Sprintf(`
 resource "nsxt_vpc_ip_address_allocation" "test" {
   %s
@@ -187,5 +193,5 @@ resource "nsxt_vpc_ip_address_allocation" "test" {
 data "nsxt_vpc_ip_address_allocation" "test" {
   %s
   allocation_ips = nsxt_vpc_ip_address_allocation.test.allocation_ips
-}`, testAccNsxtPolicyMultitenancyContext(), accTestVpcIpAddressAllocationUpdateAttributes["display_name"], accTestVpcIpAddressAllocationUpdateAttributes["allocation_size"], testAccNsxtPolicyMultitenancyContext())
+}`, testAccNsxtPolicyMultitenancyContext(), updateName, accTestVpcIpAddressAllocationUpdateAttributes["allocation_size"], testAccNsxtPolicyMultitenancyContext())
 }


### PR DESCRIPTION
Generate unique names per test invocation instead of using package-level variables for resource display_names (LBService, ProjectIpAddressAllocation, StaticRouteBfdPeer, VpcIpAddressAllocation) and shared prerequisite infra names (TransitGateway attachment/service/endpoint/static-route/nat-rule).