### PR TITLE
Expand idempotency check coverage in acceptance tests

### DIFF
--- a/nsxt/resource_nsxt_compute_manager_test.go
+++ b/nsxt/resource_nsxt_compute_manager_test.go
@@ -29,7 +29,7 @@ func TestAccResourceNsxtComputeManager_basic(t *testing.T) {
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNSXComputeManagerCheckDestroy(state, updateComputeManagerName)
 		},
-		Steps: []resource.TestStep{
+		Steps: withIdempotencyChecks([]resource.TestStep{
 			{
 				Config: testAccNSXComputeManagerCreateTemplate(computeManagerName),
 				Check: resource.ComposeTestCheckFunc(
@@ -48,7 +48,7 @@ func TestAccResourceNsxtComputeManager_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
 				),
 			},
-		},
+		}),
 	})
 }
 

--- a/nsxt/resource_nsxt_node_user_test.go
+++ b/nsxt/resource_nsxt_node_user_test.go
@@ -46,7 +46,7 @@ func TestAccResourceNsxtNodeUser_basic(t *testing.T) {
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNodeUserCheckDestroy(state, testUsername)
 		},
-		Steps: []resource.TestStep{
+		Steps: withIdempotencyChecks([]resource.TestStep{
 			{
 				Config: testAccNodeUserCreate(testUsername),
 				Check: resource.ComposeTestCheckFunc(
@@ -93,7 +93,7 @@ func TestAccResourceNsxtNodeUser_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(testResourceName, "user_id"),
 				),
 			},
-		},
+		}),
 	})
 }
 
@@ -111,7 +111,7 @@ func TestAccResourceNsxtNodeUser_import_basic(t *testing.T) {
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNodeUserCheckDestroy(state, testUsername)
 		},
-		Steps: []resource.TestStep{
+		Steps: withImportIdempotencyChecks([]resource.TestStep{
 			{
 				Config: testAccNodeUserCreate(testUsername),
 			},
@@ -122,7 +122,7 @@ func TestAccResourceNsxtNodeUser_import_basic(t *testing.T) {
 				ImportStateIdFunc:       testAccNodeUserImporterGetID,
 				ImportStateVerifyIgnore: []string{"password"},
 			},
-		},
+		}),
 	})
 }
 

--- a/nsxt/resource_nsxt_policy_bgp_config_test.go
+++ b/nsxt/resource_nsxt_policy_bgp_config_test.go
@@ -41,7 +41,7 @@ func TestAccResourceNsxtPolicyBgpConfig_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
-		Steps: []resource.TestStep{
+		Steps: withIdempotencyChecks([]resource.TestStep{
 			{
 				Config: testAccNsxtPolicyBgpConfigTemplate(true),
 				Check: resource.ComposeTestCheckFunc(
@@ -78,7 +78,7 @@ func TestAccResourceNsxtPolicyBgpConfig_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
 				),
 			},
-		},
+		}),
 	})
 }
 

--- a/nsxt/resource_nsxt_policy_bgp_neighbor_test.go
+++ b/nsxt/resource_nsxt_policy_bgp_neighbor_test.go
@@ -54,7 +54,7 @@ func TestAccResourceNsxtPolicyBgpNeighbor_basic(t *testing.T) {
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNsxtPolicyBgpNeighborCheckDestroy(state, accTestPolicyBgpNeighborConfigCreateAttributes["display_name"])
 		},
-		Steps: []resource.TestStep{
+		Steps: withIdempotencyChecks([]resource.TestStep{
 			{
 				Config: testAccNsxtPolicyBgpNeighborTemplate(true, subnet, false),
 				Check: resource.ComposeTestCheckFunc(
@@ -102,7 +102,7 @@ func TestAccResourceNsxtPolicyBgpNeighbor_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
 				),
 			},
-		},
+		}),
 	})
 }
 
@@ -148,7 +148,7 @@ func TestAccResourceNsxtPolicyBgpNeighborWithLocalAsNeighbour_basic(t *testing.T
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNsxtPolicyBgpNeighborCheckDestroy(state, accTestPolicyBgpNeighborConfigCreateAttributes["display_name"])
 		},
-		Steps: []resource.TestStep{
+		Steps: withIdempotencyChecks([]resource.TestStep{
 			{
 				Config: testAccNsxtPolicyBgpNeighborTemplate(true, subnet, true),
 				Check: resource.ComposeTestCheckFunc(
@@ -202,7 +202,7 @@ func TestAccResourceNsxtPolicyBgpNeighborWithLocalAsNeighbour_basic(t *testing.T
 					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
 				),
 			},
-		},
+		}),
 	})
 }
 func TestAccResourceNsxtPolicyBgpNeighbor_globalManager(t *testing.T) {
@@ -216,7 +216,7 @@ func TestAccResourceNsxtPolicyBgpNeighbor_globalManager(t *testing.T) {
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNsxtPolicyBgpNeighborCheckDestroy(state, accTestPolicyBgpNeighborConfigCreateAttributes["display_name"])
 		},
-		Steps: []resource.TestStep{
+		Steps: withIdempotencyChecks([]resource.TestStep{
 			{
 				Config: testAccNsxtPolicyBgpNeighborGMTemplate(true, subnet),
 				Check: resource.ComposeTestCheckFunc(
@@ -270,7 +270,7 @@ func TestAccResourceNsxtPolicyBgpNeighbor_globalManager(t *testing.T) {
 					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
 				),
 			},
-		},
+		}),
 	})
 }
 
@@ -307,7 +307,7 @@ func TestAccResourceNsxtPolicyBgpNeighbor_subConfig(t *testing.T) {
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNsxtPolicyBgpNeighborCheckDestroy(state, "tfbgp")
 		},
-		Steps: []resource.TestStep{
+		Steps: withIdempotencyChecks([]resource.TestStep{
 			{
 				Config: testAccNsxtPolicyBgpNeighborSubConfigCreate(),
 				Check: resource.ComposeTestCheckFunc(
@@ -344,7 +344,7 @@ func TestAccResourceNsxtPolicyBgpNeighbor_subConfig(t *testing.T) {
 					resource.TestCheckResourceAttr(testResourceName, "route_filtering.0.maximum_routes", "20"),
 				),
 			},
-		},
+		}),
 	})
 }
 
@@ -455,6 +455,31 @@ func TestAccResourceNsxtPolicyBgpNeighbor_importBasic(t *testing.T) {
 				ImportStateIdFunc: testAccNSXPolicyBgpNeighborImporterGetIDs,
 			},
 		},
+	})
+}
+
+func TestAccResourceNsxtPolicyBgpNeighbor_importWithPassword(t *testing.T) {
+	name := getAccTestResourceName()
+	testResourceName := "nsxt_policy_bgp_neighbor.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyBgpNeighborCheckDestroy(state, name)
+		},
+		Steps: withImportIdempotencyChecks([]resource.TestStep{
+			{
+				Config: testAccNsxtPolicyBgpNeighborMinimalisticWithPassword(),
+			},
+			{
+				ResourceName:            testResourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"password"},
+				ImportStateIdFunc:       testAccNSXPolicyBgpNeighborImporterGetIDs,
+			},
+		}),
 	})
 }
 
@@ -652,6 +677,36 @@ resource "nsxt_policy_bgp_neighbor" "test" {
 
 }
 `, getEdgeClusterName(), accTestPolicyBgpNeighborConfigCreateAttributes["display_name"], accTestPolicyBgpNeighborConfigCreateAttributes["neighbor_address"], accTestPolicyBgpNeighborConfigCreateAttributes["remote_as_num"])
+}
+
+func testAccNsxtPolicyBgpNeighborMinimalisticWithPassword() string {
+	return fmt.Sprintf(`
+data "nsxt_policy_edge_cluster" "EC" {
+  display_name = "%s"
+}
+
+resource "nsxt_policy_tier0_gateway" "test" {
+  display_name      = "terraformt0gw"
+  description       = "Acceptance Test"
+  edge_cluster_path = data.nsxt_policy_edge_cluster.EC.path
+
+  bgp_config {
+    local_as_num    = "60000"
+    multipath_relax = true
+    route_aggregation {
+      prefix = "12.12.12.0/24"
+    }
+  }
+}
+
+resource "nsxt_policy_bgp_neighbor" "test" {
+  bgp_path         = nsxt_policy_tier0_gateway.test.bgp_config.0.path
+  display_name     = "%s"
+  neighbor_address = "%s"
+  remote_as_num    = "%s"
+  password         = "%s"
+}
+`, getEdgeClusterName(), accTestPolicyBgpNeighborConfigCreateAttributes["display_name"], accTestPolicyBgpNeighborConfigCreateAttributes["neighbor_address"], accTestPolicyBgpNeighborConfigCreateAttributes["remote_as_num"], accTestPolicyBgpNeighborConfigCreateAttributes["password"])
 }
 
 func testAccNsxtPolicyBgpNeighborSubConfigCreate() string {

--- a/nsxt/resource_nsxt_policy_edge_transport_node_test.go
+++ b/nsxt/resource_nsxt_policy_edge_transport_node_test.go
@@ -29,7 +29,7 @@ func TestAccResourceNsxtPolicyEdgeTransportNode_basic(t *testing.T) {
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNsxtPolicyEdgeTransportNodeCheckDestroy(state, displayName)
 		},
-		Steps: []resource.TestStep{
+		Steps: withImportIdempotencyChecks([]resource.TestStep{
 			{
 				Config: testAccNsxtPolicyEdgeTransportNodeCreateTemplate(displayName),
 				Check: resource.ComposeTestCheckFunc(
@@ -72,7 +72,7 @@ func TestAccResourceNsxtPolicyEdgeTransportNode_basic(t *testing.T) {
 					"revision",
 				},
 			},
-		},
+		}),
 	})
 }
 
@@ -89,7 +89,7 @@ func TestAccResourceNsxtPolicyEdgeTransportNode_importBasic(t *testing.T) {
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNsxtPolicyEdgeTransportNodeCheckDestroy(state, displayName)
 		},
-		Steps: []resource.TestStep{
+		Steps: withImportIdempotencyChecks([]resource.TestStep{
 			{
 				Config: testAccNsxtPolicyEdgeTransportNodeCreateTemplate(displayName),
 			},
@@ -105,7 +105,7 @@ func TestAccResourceNsxtPolicyEdgeTransportNode_importBasic(t *testing.T) {
 					"revision",
 				},
 			},
-		},
+		}),
 	})
 }
 

--- a/nsxt/resource_nsxt_policy_ipsec_vpn_session_test.go
+++ b/nsxt/resource_nsxt_policy_ipsec_vpn_session_test.go
@@ -178,7 +178,7 @@ func TestAccResourceNsxtPolicyIPSecVpnSessionRouteBased_basic(t *testing.T) {
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNsxtPolicyIPSecVpnSessionCheckDestroy(state, accTestPolicyIPSecVpnSessionRouteBasedCreateAttributes["display_name"])
 		},
-		Steps: []resource.TestStep{
+		Steps: withIdempotencyChecks([]resource.TestStep{
 			{
 				Config: testAccNsxtPolicyIPSecVpnSessionRouteBasedTemplate(true, true),
 				Check: resource.ComposeTestCheckFunc(
@@ -263,7 +263,7 @@ func TestAccResourceNsxtPolicyIPSecVpnSessionRouteBased_basic(t *testing.T) {
 			{
 				Config: testAccNsxtPolicyGatewayTemplate(true),
 			},
-		},
+		}),
 	})
 }
 
@@ -427,7 +427,7 @@ func testAccResourceNsxtPolicyIPSecVpnSessionImport(t *testing.T, withContext bo
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNsxtPolicyIPSecVpnSessionCheckDestroy(state, accTestPolicyIPSecVpnSessionRouteBasedCreateAttributes["display_name"])
 		},
-		Steps: []resource.TestStep{
+		Steps: withImportIdempotencyChecks([]resource.TestStep{
 			{
 				Config: config,
 			},
@@ -437,7 +437,7 @@ func testAccResourceNsxtPolicyIPSecVpnSessionImport(t *testing.T, withContext bo
 				ImportStateVerify: false,
 				ImportStateIdFunc: testAccNSXPolicyIPSecVpnSessionImporterGetID,
 			},
-		},
+		}),
 	})
 }
 
@@ -450,7 +450,7 @@ func TestAccResourceNsxtPolicyIPSecVpnSessionPolicyBased_basic(t *testing.T) {
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNsxtPolicyIPSecVpnSessionCheckDestroy(state, accTestPolicyIPSecVpnSessionPolicyBasedCreateAttributes["display_name"])
 		},
-		Steps: []resource.TestStep{
+		Steps: withIdempotencyChecks([]resource.TestStep{
 			{
 				Config: testAccNsxtPolicyIPSecVpnSessionPolicyBasedTemplate(true, true),
 				Check: resource.ComposeTestCheckFunc(
@@ -512,7 +512,7 @@ func TestAccResourceNsxtPolicyIPSecVpnSessionPolicyBased_basic(t *testing.T) {
 			{
 				Config: testAccNsxtPolicyGatewayTemplate(true),
 			},
-		},
+		}),
 	})
 }
 

--- a/nsxt/resource_nsxt_policy_ldap_identity_source_test.go
+++ b/nsxt/resource_nsxt_policy_ldap_identity_source_test.go
@@ -159,7 +159,7 @@ func TestAccResourceNsxtPolicyLdapIdentitySource_import_basic(t *testing.T) {
 			}
 			return testAccDeleteAllLdapIdentitySources()
 		},
-		Steps: []resource.TestStep{
+		Steps: withImportIdempotencyChecks([]resource.TestStep{
 			{
 				Config: testAccNsxtPolicyLdapIdentitySourceCreate(
 					ldapType, getTestLdapDomain(), getTestLdapBaseDN(), getTestLdapAdminUser(), getTestLdapAdminPassword(), getTestLdapURL()),
@@ -170,7 +170,7 @@ func TestAccResourceNsxtPolicyLdapIdentitySource_import_basic(t *testing.T) {
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"ldap_server.0.password"},
 			},
-		},
+		}),
 	})
 }
 

--- a/nsxt/resource_nsxt_policy_metadata_proxy_test.go
+++ b/nsxt/resource_nsxt_policy_metadata_proxy_test.go
@@ -84,7 +84,7 @@ func TestAccResourceNsxtPolicyMetadataProxy_importBasic(t *testing.T) {
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNsxtPolicyMetadataProxyCheckDestroy(state, accTestPolicyMetadataProxyUpdateAttributes["display_name"])
 		},
-		Steps: []resource.TestStep{
+		Steps: withImportIdempotencyChecks([]resource.TestStep{
 			{
 				Config: testAccNsxtPolicyMetadataProxyTemplate(true),
 			},
@@ -94,7 +94,7 @@ func TestAccResourceNsxtPolicyMetadataProxy_importBasic(t *testing.T) {
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"secret"},
 			},
-		},
+		}),
 	})
 }
 

--- a/nsxt/resource_nsxt_policy_ospf_area_test.go
+++ b/nsxt/resource_nsxt_policy_ospf_area_test.go
@@ -43,7 +43,7 @@ func TestAccResourceNsxtPolicyOspfArea_basic(t *testing.T) {
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNsxtPolicyOspfAreaCheckDestroy(state, accTestPolicyOspfAreaCreateAttributes["display_name"])
 		},
-		Steps: []resource.TestStep{
+		Steps: withIdempotencyChecks([]resource.TestStep{
 			{
 				Config: testAccNsxtPolicyOspfAreaTemplate(true),
 				Check: resource.ComposeTestCheckFunc(
@@ -88,7 +88,7 @@ func TestAccResourceNsxtPolicyOspfArea_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(testResourceName, "tag.#", "0"),
 				),
 			},
-		},
+		}),
 	})
 }
 
@@ -113,6 +113,31 @@ func TestAccResourceNsxtPolicyOspfArea_importBasic(t *testing.T) {
 				ImportStateIdFunc: testAccNSXPolicyOspfAreaImporterGetIDs,
 			},
 		},
+	})
+}
+
+func TestAccResourceNsxtPolicyOspfArea_importWithSecretKey(t *testing.T) {
+	testResourceName := "nsxt_policy_ospf_area.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccOnlyLocalManager(t); testAccPreCheck(t); testAccNSXVersion(t, "3.1.1") },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyOspfAreaCheckDestroy(state, accTestPolicyOspfAreaCreateAttributes["display_name"])
+		},
+		Steps: withImportIdempotencyChecks([]resource.TestStep{
+			{
+				Config: testAccNsxtPolicyOspfAreaTemplate(true),
+			},
+			{
+				ResourceName:      testResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				// key_id and secret_key are sensitive and not returned on API
+				ImportStateVerifyIgnore: []string{"secret_key", "key_id"},
+				ImportStateIdFunc:       testAccNSXPolicyOspfAreaImporterGetIDs,
+			},
+		}),
 	})
 }
 

--- a/nsxt/resource_nsxt_policy_tier0_gateway_test.go
+++ b/nsxt/resource_nsxt_policy_tier0_gateway_test.go
@@ -301,7 +301,7 @@ func TestAccResourceNsxtPolicyTier0Gateway_redistribution(t *testing.T) {
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNsxtPolicyTier0CheckDestroy(state, name)
 		},
-		Steps: []resource.TestStep{
+		Steps: withIdempotencyChecks([]resource.TestStep{
 			{
 				Config: testAccNsxtPolicyTier0CreateWithRedistribution(name),
 				Check: resource.ComposeTestCheckFunc(
@@ -340,7 +340,7 @@ func TestAccResourceNsxtPolicyTier0Gateway_redistribution(t *testing.T) {
 					resource.TestCheckResourceAttr(realizationResourceName, "state", "REALIZED"),
 				),
 			},
-		},
+		}),
 	})
 }
 

--- a/nsxt/resource_nsxt_policy_transit_gateway_ipsec_vpn_session_test.go
+++ b/nsxt/resource_nsxt_policy_transit_gateway_ipsec_vpn_session_test.go
@@ -84,7 +84,7 @@ func TestAccResourceNsxtPolicyTGWIPSecVpnSessionRouteBased_basic(t *testing.T) {
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNsxtPolicyTGWIPSecVpnSessionCheckDestroy(state, createDisplayName)
 		},
-		Steps: []resource.TestStep{
+		Steps: withIdempotencyChecks([]resource.TestStep{
 			{
 				Config: testAccNsxtPolicyTGWIPSecVpnSessionRouteBasedTemplate(true, createDisplayName),
 				Check: resource.ComposeTestCheckFunc(
@@ -164,7 +164,7 @@ func TestAccResourceNsxtPolicyTGWIPSecVpnSessionRouteBased_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(testResourceName, "tag.#", "0"),
 				),
 			},
-		},
+		}),
 	})
 }
 
@@ -183,7 +183,7 @@ func TestAccResourceNsxtPolicyTGWIPSecVpnSessionPolicyBased_basic(t *testing.T) 
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNsxtPolicyTGWIPSecVpnSessionCheckDestroy(state, createDisplayName)
 		},
-		Steps: []resource.TestStep{
+		Steps: withIdempotencyChecks([]resource.TestStep{
 			{
 				Config: testAccNsxtPolicyTGWIPSecVpnSessionPolicyBasedTemplate(true, createDisplayName),
 				Check: resource.ComposeTestCheckFunc(
@@ -230,7 +230,7 @@ func TestAccResourceNsxtPolicyTGWIPSecVpnSessionPolicyBased_basic(t *testing.T) 
 					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
 				),
 			},
-		},
+		}),
 	})
 }
 
@@ -435,7 +435,7 @@ func TestAccResourceNsxtPolicyTGWIPSecVpnSession_importBasic(t *testing.T) {
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNsxtPolicyTGWIPSecVpnSessionCheckDestroy(state, name)
 		},
-		Steps: []resource.TestStep{
+		Steps: withImportIdempotencyChecks([]resource.TestStep{
 			{
 				Config: testAccNsxtPolicyTGWIPSecVpnSessionRouteBasedMinimalistic(name),
 			},
@@ -446,7 +446,7 @@ func TestAccResourceNsxtPolicyTGWIPSecVpnSession_importBasic(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"psk"},
 				ImportStateIdFunc:       testAccResourceNsxtPolicyImportIDRetriever(testResourceName),
 			},
-		},
+		}),
 	})
 }
 

--- a/nsxt/resource_nsxt_policy_uplink_host_switch_profile_test.go
+++ b/nsxt/resource_nsxt_policy_uplink_host_switch_profile_test.go
@@ -72,7 +72,7 @@ func TestAccResourceNsxtPolicyUplinkHostSwitchProfile_basic(t *testing.T) {
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNsxtUplinkHostSwitchProfileCheckDestroy(state, updateDisplayName)
 		},
-		Steps: []resource.TestStep{
+		Steps: withIdempotencyChecks([]resource.TestStep{
 			{
 				Config: testAccNsxtUplinkHostSwitchProfileTemplate(createDisplayName, true),
 				Check: resource.ComposeTestCheckFunc(
@@ -177,7 +177,7 @@ func TestAccResourceNsxtPolicyUplinkHostSwitchProfile_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(testResourceName, "transport_vlan", "0"),
 				),
 			},
-		},
+		}),
 	})
 }
 

--- a/nsxt/resource_nsxt_proxy_config_test.go
+++ b/nsxt/resource_nsxt_proxy_config_test.go
@@ -38,7 +38,7 @@ func testAccResourceNsxtPolicyProxyConfigBasic(t *testing.T, withContext bool, p
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccNsxtProxyConfigCheckDestroy(state, updatedName)
 		},
-		Steps: []resource.TestStep{
+		Steps: withImportIdempotencyChecks(withIdempotencyChecks([]resource.TestStep{
 			{
 				// Test with disabled proxy first (no connectivity validation)
 				Config: testAccNsxtProxyConfigDisabledWithDetails(name, server1, port1, username1, withContext),
@@ -74,7 +74,7 @@ func testAccResourceNsxtPolicyProxyConfigBasic(t *testing.T, withContext bool, p
 				// Password is sensitive and not returned by API
 				ImportStateVerifyIgnore: []string{"password"},
 			},
-		},
+		})),
 	})
 }
 


### PR DESCRIPTION
Apply withIdempotencyChecks to multi-step apply tests on resources with complex schemas or write-only fields (BGP neighbor, OSPF area, IPSec VPN sessions, TGW IPSec VPN sessions, uplink host switch profile, BGP config, Tier-0 redistribution, node user, proxy config, compute manager).

Apply withImportIdempotencyChecks to import tests that use ImportStateVerifyIgnore for write-only fields (metadata proxy secret, proxy config password, node user password, edge transport node credentials, TGW IPSec psk, IPSec VPN psk, LDAP server password).

Add new dedicated import tests TestAccResourceNsxtPolicyBgpNeighbor_ importWithPassword and TestAccResourceNsxtPolicyOspfArea_importWithSecretKey to cover post-import drift for write-only fields not exercised by existing import tests.