### PR TITLE
Guard against nil list elements in schema-to-struct helpers

### DIFF
--- a/nsxt/metadata/metadata.go
+++ b/nsxt/metadata/metadata.go
@@ -661,7 +661,12 @@ func polyNestedSchemaToStruct(ctx string, elem reflect.Value, dataList []interfa
 	for i, dataElem := range dataList {
 		dataMap := dataElem.(map[string]interface{})
 		for k, v := range dataMap {
-			if len(v.([]interface{})) == 0 {
+			vList, isList := v.([]interface{})
+			if !isList || len(vList) == 0 || vList[0] == nil {
+				continue
+			}
+			nestedSchema, ok := vList[0].(map[string]interface{})
+			if !ok {
 				continue
 			}
 			rType, ok := item.Metadata.ResourceTypeMap[k]
@@ -678,7 +683,6 @@ func polyNestedSchemaToStruct(ctx string, elem reflect.Value, dataList []interfa
 
 			childMeta := childElem.Schema[k]
 			nestedObj := reflect.New(childMeta.Metadata.ReflectType)
-			nestedSchema := v.([]interface{})[0].(map[string]interface{})
 			if err = SchemaToStruct(nestedObj.Elem(), nil, childMeta.Schema.Elem.(*ExtendedResource).Schema, k, nestedSchema); err != nil {
 				return
 			}

--- a/nsxt/resource_nsxt_compute_manager.go
+++ b/nsxt/resource_nsxt_compute_manager.go
@@ -288,8 +288,8 @@ func getCredentialData(data map[string]interface{}) (string, map[string]interfac
 		"verifiable_asymmetric_login",
 	}
 	for _, credType := range credTypes {
-		if data[credType] != nil && len(data[credType].([]interface{})) > 0 {
-			return credType, data[credType].([]interface{})[0].(map[string]interface{})
+		if cred := getElemOrEmptyMapFromMap(data, credType); len(cred) > 0 {
+			return credType, cred
 		}
 	}
 	return "", nil

--- a/nsxt/resource_nsxt_edge_transport_node.go
+++ b/nsxt/resource_nsxt_edge_transport_node.go
@@ -1905,12 +1905,7 @@ func setEdgeDeploymentConfigInSchema(d *schema.ResourceData, deploymentConfig *m
 	elem := getElemOrEmptyMapFromSchema(d, "deployment_config")
 
 	elem["form_factor"] = deploymentConfig.FormFactor
-	var nodeUserSettings map[string]interface{}
-	if elem["node_user_settings"] != nil {
-		nodeUserSettings = elem["node_user_settings"].([]interface{})[0].(map[string]interface{})
-	} else {
-		nodeUserSettings = make(map[string]interface{})
-	}
+	nodeUserSettings := getElemOrEmptyMapFromMap(elem, "node_user_settings")
 	// Note: password attributes is sensitive and is not returned by NSX
 	if deploymentConfig.NodeUserSettings.AuditUsername != nil {
 		nodeUserSettings["audit_username"] = deploymentConfig.NodeUserSettings.AuditUsername

--- a/nsxt/resource_nsxt_policy_gateway_route_map.go
+++ b/nsxt/resource_nsxt_policy_gateway_route_map.go
@@ -230,8 +230,7 @@ func policyGatewayRouteMapBuildEntry(d *schema.ResourceData, entryNo int, schema
 		obj.PrefixListMatches = interfaceListToStringList(prefixListMatches)
 	}
 
-	if len(schemaEntry["set"].([]interface{})) > 0 {
-		data := schemaEntry["set"].([]interface{})[0].(map[string]interface{})
+	if data := getElemOrEmptyMapFromMap(schemaEntry, "set"); len(data) > 0 {
 		asPathPrepend := data["as_path_prepend"].(string)
 		community := data["community"].(string)
 		localPreferenceValue, lpSet := d.GetOk(fmt.Sprintf("entry.%d.set.0.local_preference", entryNo))

--- a/nsxt/segment_common.go
+++ b/nsxt/segment_common.go
@@ -990,7 +990,14 @@ func nsxtPolicySegmentProfilesSetInStruct(d *schema.ResourceData, segment *model
 }
 
 func getOldProfileDataForRemoval(oldProfiles interface{}) (string, int64) {
-	profileMap := oldProfiles.([]interface{})[0].(map[string]interface{})
+	profiles, ok := oldProfiles.([]interface{})
+	if !ok || len(profiles) == 0 || profiles[0] == nil {
+		return "", 0
+	}
+	profileMap, ok := profiles[0].(map[string]interface{})
+	if !ok {
+		return "", 0
+	}
 	segmentProfileMapID := getPolicyIDFromPath(profileMap["binding_map_path"].(string))
 	revision := int64(profileMap["revision"].(int))
 


### PR DESCRIPTION
Five locations shared the same latent panic: a len > 0 (or != nil) guard on a []interface{} attribute was sufficient to detect an absent block, but not a block present with all-default values that the Terraform SDK represents as a list containing a single nil element. A direct [0].(map[string]interface{}) assertion on that nil element triggers a panic at apply/read time.

Fixes:
- resource_nsxt_compute_manager.go: getCredentialData – replace the two-part guard with getElemOrEmptyMapFromMap, which already uses comma-ok on the element assertion.
- resource_nsxt_policy_gateway_route_map.go: policyGatewayRouteMapBuildEntry set block – same replacement.
- resource_nsxt_edge_transport_node.go: setEdgeDeploymentConfigInSchema node_user_settings – collapse the nil-guarded if/else into a single getElemOrEmptyMapFromMap call.
- segment_common.go: getOldProfileDataForRemoval – add comma-ok and nil-element guards (raw interface{} param, no map+key helper applies).
- metadata/metadata.go: polyNestedSchemaToStruct – replace the bare v.([]interface{}) cast and [0].(map[string]interface{}) chain with a vList intermediate, guarded by isList, len, and nil checks.