### PR TITLE
Fix dhcp_generic_option field name in docs

### DIFF
--- a/docs/resources/policy_dhcp_v4_static_binding.md
+++ b/docs/resources/policy_dhcp_v4_static_binding.md
@@ -77,7 +77,7 @@ The following arguments are supported:
     * `network` - (Required) Destination in cidr format.
     * `next_hop` - (Required) IP address of next hop.
 * `dhcp_generic_option` - (Optional) Generic DHCP options.
-    * `dhcp_generic_option` - (Optional) Generic DHCP option number. Please note not all options are supported by the platform.
+    * `code` - (Optional) Generic DHCP option number. Please note not all options are supported by the platform.
     * `values` - (Required) List of DHCP option values.
 
 ## Attributes Reference


### PR DESCRIPTION
Correct the nested attribute name under `dhcp_generic_option` from `dhcp_generic_option` to `code` to align the documentation with the actual resource schema.