### PR TITLE
nsxt_policy_route_controller: mark virtual_network_appliance_cluster_path as Required

### DIFF
--- a/docs/resources/policy_route_controller.md
+++ b/docs/resources/policy_route_controller.md
@@ -14,9 +14,10 @@ This resource is applicable to NSX Policy Manager.
 
 ```hcl
 resource "nsxt_policy_route_controller" "test" {
-  display_name = "test"
-  description  = "Terraform provisioned Route Controller"
-  ha_mode      = "ACTIVE_STANDBY"
+  display_name                           = "test"
+  description                            = "Terraform provisioned Route Controller"
+  ha_mode                                = "ACTIVE_STANDBY"
+  virtual_network_appliance_cluster_path = nsxt_policy_virtual_network_appliance_cluster.cluster.path
 
   bgp_config {
     ecmp                   = true
@@ -36,7 +37,7 @@ The following arguments are supported:
 * `tag` - (Optional) A list of scope + tag pairs to associate with this resource.
 * `nsx_id` - (Optional) The NSX ID of this resource. If set, this ID will be used to create the resource.
 * `ha_mode` - (Optional) High-availability mode for route controller. Currently only `ACTIVE_STANDBY` is supported. This value is computed if not specified.
-* `virtual_network_appliance_cluster_path` - (Optional) Policy path for the virtual network appliance cluster.
+* `virtual_network_appliance_cluster_path` - (Required) Policy path for the virtual network appliance cluster.
 * `bgp_config` - (Optional) BGP routing configuration block. The following arguments are supported:
     * `ecmp` - (Optional) Flag to enable ECMP. Defaults to `true`.
     * `local_as_num` - (Required) BGP AS number in ASPLAIN/ASDOT format.

--- a/nsxt/resource_nsxt_policy_route_controller.go
+++ b/nsxt/resource_nsxt_policy_route_controller.go
@@ -54,14 +54,13 @@ var routeControllerSchema = map[string]*metadata.ExtendedSchema{
 	"virtual_network_appliance_cluster_path": {
 		Schema: schema.Schema{
 			Type:         schema.TypeString,
-			Optional:     true,
+			Required:     true,
 			Description:  "Policy path for the virtual network appliance cluster.",
 			ValidateFunc: validatePolicyPath(),
 		},
 		Metadata: metadata.Metadata{
 			SchemaType:   "string",
 			SdkFieldName: "VirtualNetworkApplianceClusterPath",
-			OmitIfEmpty:  true,
 		},
 	},
 }
@@ -235,8 +234,8 @@ func routeControllerToInfraStruct(d *schema.ResourceData, id string, markBgpDele
 		ResourceType: &rcType,
 	}
 
-	// OmitIfEmpty metadata on ha_mode and virtual_network_appliance_cluster_path
-	// ensures SchemaToStruct leaves those fields nil when the user omits them.
+	// OmitIfEmpty metadata on ha_mode ensures SchemaToStruct leaves that field
+	// nil when the user omits it.
 	elem := reflect.ValueOf(&rcObj).Elem()
 	if err := metadata.SchemaToStruct(elem, d, routeControllerSchema, "", nil); err != nil {
 		return infraStruct, err


### PR DESCRIPTION
The NSX API enforces virtual_network_appliance_cluster_path as a required field on RouteController objects (error code 255: required property missing), but the Terraform schema declared it Optional. This caused apply to fail at the API layer with no prior Terraform-level validation.

- Change schema attribute from Optional to Required
- Remove OmitIfEmpty from metadata (not applicable to required fields)
- Update docs and example usage to reflect the requirement