### PR TITLE
nsxt_policy_route_controller_interface: mark interface_address as Required

### DIFF
--- a/docs/resources/policy_route_controller_interface.md
+++ b/docs/resources/policy_route_controller_interface.md
@@ -45,7 +45,7 @@ The following arguments are supported:
 * `urpf_mode` - (Optional) Unicast Reverse Path Forwarding mode. One of `NONE`, `STRICT`. Defaults to `STRICT`.
 * `mtu` - (Optional) Maximum transmission unit specifies the size of the largest packet that a network protocol can transmit. Minimum value is `64`.
 * `floating_ip_subnets` - (Optional) List of floating IP subnets in CIDR notation (IP/prefix-length) for this interface. Required when the Route Controller HA mode is `ACTIVE_STANDBY`.
-* `interface_address` - (Optional) List of interface address configurations. The following arguments are supported:
+* `interface_address` - (Required) List of interface address configurations. The following arguments are supported:
     * `subnets` - (Required) List of IP addresses and network prefixes in CIDR notation for this interface address.
     * `portgroup_id` - (Required) DV port group identifier discovered from vCenter.
     * `virtual_network_appliance_path` - (Optional) Policy path for the virtual network appliance.

--- a/nsxt/resource_nsxt_policy_route_controller_interface.go
+++ b/nsxt/resource_nsxt_policy_route_controller_interface.go
@@ -72,7 +72,8 @@ func resourceNsxtPolicyRouteControllerInterface() *schema.Resource {
 			},
 			"interface_address": {
 				Type:        schema.TypeList,
-				Optional:    true,
+				Required:    true,
+				MinItems:    1,
 				Description: "List of interface address configurations",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{


### PR DESCRIPTION
The NSX API enforces interface_address as a required field on RouteControllerInterface objects (error code 255: required property missing), but the Terraform schema declared it Optional. This caused apply to fail at the API layer with no prior Terraform-level validation.

- Change interface_address from Optional to Required with MinItems: 1
- Update docs to reflect the requirement