### PR TITLE
fix: address route controller interface acc test failures on LM 9.1

### DIFF
--- a/nsxt/resource_nsxt_node_user_test.go
+++ b/nsxt/resource_nsxt_node_user_test.go
@@ -17,19 +17,17 @@ import (
 )
 
 var accTestNodeUserCreateAttributes = map[string]string{ //nolint:gosec
-	"full_name":                 getAccTestRandomString(10),
-	"password":                  "Q5&WfLqv9Zd5",
-	"active":                    "true",
-	"password_change_frequency": "180",
-	"password_change_warning":   "30",
+	"full_name":               getAccTestRandomString(10),
+	"password":                "Q5&WfLqv9Zd5",
+	"active":                  "true",
+	"password_change_warning": "30",
 }
 
 var accTestNodeUserUpdateAttributes = map[string]string{ //nolint:gosec
-	"full_name":                 getAccTestRandomString(10),
-	"password":                  "Q5&WfLqv9Zd5",
-	"active":                    "false",
-	"password_change_frequency": "75",
-	"password_change_warning":   "20",
+	"full_name":               getAccTestRandomString(10),
+	"password":                "Q5&WfLqv9Zd5",
+	"active":                  "false",
+	"password_change_warning": "20",
 }
 
 func TestAccResourceNsxtNodeUser_basic(t *testing.T) {
@@ -53,7 +51,6 @@ func TestAccResourceNsxtNodeUser_basic(t *testing.T) {
 					testAccNodeUserExists(testResourceName),
 					resource.TestCheckResourceAttr(testResourceName, "full_name", accTestNodeUserCreateAttributes["full_name"]),
 					resource.TestCheckResourceAttr(testResourceName, "active", accTestNodeUserCreateAttributes["active"]),
-					resource.TestCheckResourceAttr(testResourceName, "password_change_frequency", accTestNodeUserCreateAttributes["password_change_frequency"]),
 					resource.TestCheckResourceAttr(testResourceName, "password_change_warning", accTestNodeUserCreateAttributes["password_change_warning"]),
 					resource.TestCheckResourceAttr(testResourceName, "username", testUsername),
 					resource.TestCheckResourceAttr(testResourceName, "status", nsxModel.NodeUserProperties_STATUS_ACTIVE),
@@ -68,7 +65,6 @@ func TestAccResourceNsxtNodeUser_basic(t *testing.T) {
 					testAccNodeUserExists(testResourceName),
 					resource.TestCheckResourceAttr(testResourceName, "full_name", accTestNodeUserUpdateAttributes["full_name"]),
 					resource.TestCheckResourceAttr(testResourceName, "active", accTestNodeUserUpdateAttributes["active"]),
-					resource.TestCheckResourceAttr(testResourceName, "password_change_frequency", accTestNodeUserUpdateAttributes["password_change_frequency"]),
 					resource.TestCheckResourceAttr(testResourceName, "password_change_warning", accTestNodeUserUpdateAttributes["password_change_warning"]),
 					resource.TestCheckResourceAttr(testResourceName, "username", testUsername),
 					resource.TestCheckResourceAttr(testResourceName, "status", nsxModel.NodeUserProperties_STATUS_NOT_ACTIVATED),
@@ -84,7 +80,6 @@ func TestAccResourceNsxtNodeUser_basic(t *testing.T) {
 					testAccNodeUserExists(testResourceName),
 					resource.TestCheckResourceAttr(testResourceName, "full_name", accTestNodeUserUpdateAttributes["full_name"]),
 					resource.TestCheckResourceAttr(testResourceName, "active", accTestNodeUserUpdateAttributes["active"]),
-					resource.TestCheckResourceAttr(testResourceName, "password_change_frequency", accTestNodeUserUpdateAttributes["password_change_frequency"]),
 					resource.TestCheckResourceAttr(testResourceName, "password_change_warning", accTestNodeUserUpdateAttributes["password_change_warning"]),
 					resource.TestCheckResourceAttr(testResourceName, "username", testUsername),
 					resource.TestCheckResourceAttr(testResourceName, "status", nsxModel.NodeUserProperties_STATUS_NOT_ACTIVATED),
@@ -195,9 +190,8 @@ resource "nsxt_node_user" "test" {
   full_name                 = "%s"
   password                  = "%s"
   username                  = "%s"
-  password_change_frequency = %s
   password_change_warning   = %s
-}`, attrMap["active"], attrMap["full_name"], attrMap["password"], username, attrMap["password_change_frequency"], attrMap["password_change_warning"])
+}`, attrMap["active"], attrMap["full_name"], attrMap["password"], username, attrMap["password_change_warning"])
 }
 
 func testAccNodeUserUpdate(username, password string) string {
@@ -208,7 +202,6 @@ resource "nsxt_node_user" "test" {
   full_name                 = "%s"
   password                  = "%s"
   username                  = "%s"
-  password_change_frequency = %s
   password_change_warning   = %s
-}`, attrMap["active"], attrMap["full_name"], password, username, attrMap["password_change_frequency"], attrMap["password_change_warning"])
+}`, attrMap["active"], attrMap["full_name"], password, username, attrMap["password_change_warning"])
 }

--- a/nsxt/resource_nsxt_policy_route_controller_bgp_neighbor_test.go
+++ b/nsxt/resource_nsxt_policy_route_controller_bgp_neighbor_test.go
@@ -237,10 +237,10 @@ func testAccNsxtPolicyRCBgpNeighborInterfaceTemplate() string {
 resource "nsxt_policy_route_controller_interface" "bgp_src" {
   display_name        = "tf-acc-bgp-nbr-intf"
   parent_path         = nsxt_policy_route_controller.rc.path
-  floating_ip_subnets = ["192.168.200.1/24"]
+  floating_ip_subnets = ["192.168.200.10/24"]
 
   interface_address {
-    subnets                        = ["192.168.201.1/24"]
+    subnets                        = ["192.168.200.1/24"]
     portgroup_id                   = "%s"
     virtual_network_appliance_path = data.nsxt_policy_virtual_network_appliance.vna.path
   }

--- a/nsxt/resource_nsxt_policy_route_controller_interface.go
+++ b/nsxt/resource_nsxt_policy_route_controller_interface.go
@@ -51,6 +51,7 @@ func resourceNsxtPolicyRouteControllerInterface() *schema.Resource {
 			"mtu": {
 				Type:         schema.TypeInt,
 				Optional:     true,
+				Computed:     true,
 				Description:  "Maximum transmission unit specifies the size of the largest packet that a network protocol can transmit",
 				ValidateFunc: validation.IntAtLeast(64),
 			},


### PR DESCRIPTION
Two distinct backend changes broke 7 acceptance tests:

1. NSX now enforces (code 640171) that interface_address subnets must belong to the same network as floating_ip_subnets. Fix the BGP neighbor test helper: align both to 192.168.200.0/24, consistent with the source_addresses used in the BGP neighbor configs.

2. NSX always returns mtu=1500 (default) in read responses. The mtu schema field was Optional-only, causing a perpetual diff (1500->null) after every apply. Add Computed:true so Terraform accepts the API-returned default when the user has not explicitly set the field.