### PR TITLE
fix(nsxt_policy_route_controller_bgp_neighbor): mark source_addresses as Required

### DIFF
--- a/docs/resources/policy_route_controller_bgp_neighbor.md
+++ b/docs/resources/policy_route_controller_bgp_neighbor.md
@@ -54,7 +54,7 @@ The following arguments are supported:
 * `keep_alive_time` - (Optional) Interval between keep alive messages sent to peer. Must be between 1 and 65535. Defaults to `60`.
 * `maximum_hop_limit` - (Optional) Maximum number of hops allowed to reach BGP neighbor. Must be between 1 and 255. Defaults to `1`.
 * `password` - (Optional) Password for BGP neighbor authentication. Sensitive value. Maximum 32 characters.
-* `source_addresses` - (Optional) List of source IP addresses for BGP peering. Maximum 8 entries.
+* `source_addresses` - (Required) List of source IP addresses for BGP peering. Maximum 8 entries.
 * `bfd_config` - (Optional) BFD configuration for failure detection. The following arguments are supported:
     * `enabled` - (Optional) Flag to enable/disable BFD configuration. Defaults to `false`.
     * `interval` - (Optional) Time interval between heartbeat packets in milliseconds. Must be between 50 and 60000. Defaults to `500`.

--- a/nsxt/resource_nsxt_policy_route_controller_bgp_neighbor.go
+++ b/nsxt/resource_nsxt_policy_route_controller_bgp_neighbor.go
@@ -141,7 +141,8 @@ func resourceNsxtPolicyRouteControllerBgpNeighbor() *schema.Resource {
 			},
 			"source_addresses": {
 				Type:        schema.TypeList,
-				Optional:    true,
+				Required:    true,
+				MinItems:    1,
 				Description: "Source IP Addresses for BGP peering",
 				MaxItems:    8,
 				Elem: &schema.Schema{
@@ -286,11 +287,8 @@ func rcBgpNeighborToStruct(d *schema.ResourceData, id string) (model.RouteContro
 		NeighborAddress:     &neighborAddress,
 		RemoteAsNum:         &remoteAsNum,
 		RouteFiltering:      rFilters,
+		SourceAddresses:     sourceAddresses,
 		Id:                  &id,
-	}
-
-	if len(sourceAddresses) > 0 {
-		obj.SourceAddresses = sourceAddresses
 	}
 	if len(gatewayIPs) > 0 {
 		obj.GatewayIps = gatewayIPs


### PR DESCRIPTION
The NSX API enforces source_addresses as a required field on RouteControllerBgpNeighbor objects (error code 255: required property missing), but the Terraform schema declared it Optional. This caused updates to fail at the API layer with no prior Terraform-level validation.

- Change source_addresses from Optional to Required with MinItems: 1
- Update docs to reflect the requirement