### PR TITLE
fix(nsxt_policy_transit_gateway): mark span.zone_based_span as Computed

### DIFF
--- a/docs/resources/policy_transit_gateway.md
+++ b/docs/resources/policy_transit_gateway.md
@@ -84,7 +84,7 @@ The following arguments are supported:
 * `span` - (Optional) Span configuration. Note that one of `cluster_based_span` and `zone_based_span` is required. Available since NSX 9.1.0.
     * `cluster_based_span` - (Optional) Span based on vSphere Clusters.
         * `span_path` - (Required) Policy path of the network span object.
-    * `zone_based_span` - (Optional) Span based on zones.
+    * `zone_based_span` - (Optional, Computed) Span based on zones.
         * `zone_external_ids` - (Required) An array of Zone object's external IDs.
 
 ## Attributes Reference

--- a/nsxt/data_source_nsxt_policy_route_controller_bgp_neighbor_test.go
+++ b/nsxt/data_source_nsxt_policy_route_controller_bgp_neighbor_test.go
@@ -40,9 +40,9 @@ func testAccNsxtPolicyRCBgpNeighborDataSourceTemplate(displayName string) string
 resource "nsxt_policy_route_controller_bgp_neighbor" "test" {
   display_name     = "%s"
   parent_path      = "${nsxt_policy_route_controller.rc.path}/bgp"
-  neighbor_address = "192.168.100.1"
+  neighbor_address = "192.168.200.102"
   remote_as_num    = "65099"
-  source_addresses = ["192.168.200.1"]
+  source_addresses = ["192.168.200.10"]
 
   depends_on = [nsxt_policy_route_controller_interface.bgp_src]
 }

--- a/nsxt/resource_nsxt_policy_route_controller_bgp_neighbor_test.go
+++ b/nsxt/resource_nsxt_policy_route_controller_bgp_neighbor_test.go
@@ -18,17 +18,17 @@ import (
 var accTestPolicyRCBgpNeighborCreateAttributes = map[string]string{
 	"display_name":     getAccTestResourceName(),
 	"description":      "terraform created",
-	"neighbor_address": "192.168.100.1",
+	"neighbor_address": "192.168.200.100",
 	"remote_as_num":    "65001",
-	"source_address":   "192.168.200.1",
+	"source_address":   "192.168.200.10",
 }
 
 var accTestPolicyRCBgpNeighborUpdateAttributes = map[string]string{
 	"display_name":     getAccTestResourceName(),
 	"description":      "terraform updated",
-	"neighbor_address": "192.168.100.2",
+	"neighbor_address": "192.168.200.101",
 	"remote_as_num":    "65002",
-	"source_address":   "192.168.200.1",
+	"source_address":   "192.168.200.10",
 }
 
 func testAccNsxtPolicyRCBgpNeighborPreCheck(t *testing.T) {
@@ -267,7 +267,7 @@ resource "nsxt_policy_route_controller_bgp_neighbor" "test" {
   neighbor_address = "%s"
   remote_as_num    = "%s"
   enabled          = %s
-  source_addresses = ["192.168.200.1"]
+  source_addresses = ["192.168.200.10"]
 
   tag {
     scope = "scope1"
@@ -294,7 +294,7 @@ resource "nsxt_policy_route_controller_bgp_neighbor" "test" {
   parent_path      = "${nsxt_policy_route_controller.rc.path}/bgp"
   neighbor_address = "%s"
   remote_as_num    = "%s"
-  source_addresses = ["192.168.200.1"]
+  source_addresses = ["192.168.200.10"]
 
   route_filtering {
     address_family = "IPV4"
@@ -313,7 +313,7 @@ resource "nsxt_policy_route_controller_bgp_neighbor" "test" {
   parent_path      = "${nsxt_policy_route_controller.rc.path}/bgp"
   neighbor_address = "%s"
   remote_as_num    = "%s"
-  source_addresses = ["192.168.200.1"]
+  source_addresses = ["192.168.200.10"]
 
   depends_on = [nsxt_policy_route_controller_interface.bgp_src]
 }`, attrMap["display_name"], attrMap["neighbor_address"], attrMap["remote_as_num"])

--- a/nsxt/resource_nsxt_policy_transit_gateway.go
+++ b/nsxt/resource_nsxt_policy_transit_gateway.go
@@ -210,6 +210,7 @@ var transitGatewaySchema = map[string]*metadata.ExtendedSchema{
 							Type:     schema.TypeList,
 							MaxItems: 1,
 							Optional: true,
+							Computed: true,
 							Elem: &metadata.ExtendedResource{
 								Schema: map[string]*metadata.ExtendedSchema{
 									"zone_external_ids": {

--- a/nsxt/utils_test.go
+++ b/nsxt/utils_test.go
@@ -275,7 +275,7 @@ func testAccEnvDefined(t *testing.T, envVar string) {
 // Tests guarded by this helper still run in periodic CI jobs where
 // NSXT_TEST_EXTRA_COVERAGE=true is set, so coverage is not lost permanently.
 func testAccNsxtExtraCoverage(t *testing.T) {
-	if os.Getenv("NSXT_TEST_EXTRA_COVERAGE") == "" {
+	if os.Getenv("NSXT_TEST_EXTRA_COVERAGE") == "" || os.Getenv("NSXT_TEST_EXTRA_COVERAGE") == "false" {
 		t.Skipf("set NSXT_TEST_EXTRA_COVERAGE to run extra-coverage tests")
 	}
 }


### PR DESCRIPTION
span.cluster_based_span and span.zone_based_span are mutually exclusive nested blocks (governed by ExactlyOneOf), but only cluster_based_span was declared Computed. This asymmetry caused Terraform to fail to reconcile the server-returned zone_based_span value with state, showing a perpetual "add zone_based_span" diff on every re-apply.

Add Computed: true to zone_based_span to match its sibling. Update docs to reflect (Optional, Computed).