### PR TITLE
Force delete policy sites on destruction via safe_to_force_delete

### DIFF
--- a/docs/resources/policy_site.md
+++ b/docs/resources/policy_site.md
@@ -44,6 +44,7 @@ The following arguments are supported:
     * `thumbprint` - (Optional) Thumbprint of Enforcement Point.
     * `username` - (Optional) Username.
 * `site_type` - (Required) Persistent Site Type. Allowed values are `ONPREM_LM`, `SDDC_LM`. This attribute is supported with NSX 4.1.0 onwards.
+* `safe_to_force_delete` - (Optional) Force delete site on destruction. Default is false.
 
 ## Attributes Reference
 

--- a/nsxt/resource_nsxt_policy_site.go
+++ b/nsxt/resource_nsxt_policy_site.go
@@ -66,6 +66,12 @@ func resourceNsxtPolicySite() *schema.Resource {
 				Description:  "Persistent Site Type",
 				ValidateFunc: validation.StringInSlice(siteTypeValues, false),
 			},
+			"safe_to_force_delete": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Force delete site on destruction",
+				Default:     false,
+			},
 		},
 	}
 }
@@ -274,7 +280,8 @@ func resourceNsxtPolicySiteDelete(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
 	sessionContext := utl.SessionContext{ClientType: utl.Global}
 	client := cliSitesClient(sessionContext, connector)
-	err := client.Delete(id, nil)
+	forceDelete := d.Get("safe_to_force_delete").(bool)
+	err := client.Delete(id, &forceDelete)
 	if err != nil {
 		return handleDeleteError("Site", id, err)
 	}

--- a/nsxt/utgomock_resource_nsxt_policy_site_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_site_test.go
@@ -207,11 +207,30 @@ func TestMockResourceNsxtPolicySiteDelete(t *testing.T) {
 	mockSDK, restore := setupSiteMock(t, ctrl)
 	defer restore()
 
-	t.Run("Delete success", func(t *testing.T) {
-		mockSDK.EXPECT().Delete(siteID, nil).Return(nil)
+	t.Run("Delete success with safe_to_force_delete false", func(t *testing.T) {
+		mockSDK.EXPECT().Delete(siteID, gomock.Any()).Do(func(_ string, force *bool) {
+			assert.NotNil(t, force)
+			assert.False(t, *force)
+		}).Return(nil)
 
 		res := resourceNsxtPolicySite()
 		d := schema.TestResourceDataRaw(t, res.Schema, minimalSiteData())
+		d.SetId(siteID)
+
+		err := resourceNsxtPolicySiteDelete(d, newGoMockGlobalProviderClient())
+		require.NoError(t, err)
+	})
+
+	t.Run("Delete success with safe_to_force_delete true", func(t *testing.T) {
+		mockSDK.EXPECT().Delete(siteID, gomock.Any()).Do(func(_ string, force *bool) {
+			assert.NotNil(t, force)
+			assert.True(t, *force)
+		}).Return(nil)
+
+		res := resourceNsxtPolicySite()
+		data := minimalSiteData()
+		data["safe_to_force_delete"] = true
+		d := schema.TestResourceDataRaw(t, res.Schema, data)
 		d.SetId(siteID)
 
 		err := resourceNsxtPolicySiteDelete(d, newGoMockGlobalProviderClient())


### PR DESCRIPTION
When destroying an NSX-T policy site, the standard delete operation can be blocked or fail if there are lingering dependencies or active connections. This leaves the system in an inconsistent or partially deleted state.

Address this by adding a boolean attribute 'safe_to_force_delete' (default: false) to the resource. When set to true, a forceDelete flag is passed to the API client's Delete call. This ensures the policy site is forcefully and successfully removed during Terraform's resource destruction phase.