### PR TITLE
fix(nsxt_policy_route_controller_bgp_neighbor): suppress password drift after import

### DIFF
--- a/nsxt/resource_nsxt_policy_route_controller_bgp_neighbor.go
+++ b/nsxt/resource_nsxt_policy_route_controller_bgp_neighbor.go
@@ -127,11 +127,12 @@ func resourceNsxtPolicyRouteControllerBgpNeighbor() *schema.Resource {
 				ValidateFunc: validateSingleIP(),
 			},
 			"password": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Description:  "Password for BGP neighbor authentication",
-				ValidateFunc: validation.StringLenBetween(0, 32),
-				Sensitive:    true,
+				Type:             schema.TypeString,
+				Optional:         true,
+				Description:      "Password for BGP neighbor authentication",
+				ValidateFunc:     validation.StringLenBetween(0, 32),
+				Sensitive:        true,
+				DiffSuppressFunc: suppressIfEmptyPriorState,
 			},
 			"remote_as_num": {
 				Type:         schema.TypeString,


### PR DESCRIPTION


NSX never returns password on GET, so terraform import leaves it empty in state, causing a spurious diff/re-apply on every plan. Reuse the suppressIfEmptyPriorState DiffSuppressFunc already used by nsxt_policy_virtual_network_appliance for the same write-only-field import issue.