### PR TITLE
fix(nsxt_policy_transit_gateway): fix zone_based_span empty-list drop

### DIFF
--- a/nsxt/resource_nsxt_policy_transit_gateway.go
+++ b/nsxt/resource_nsxt_policy_transit_gateway.go
@@ -292,8 +292,15 @@ func getSpanFromSchema(iSpan interface{}) (*data.StructValue, error) {
 		return nil, nil
 	}
 	converter := bindings.NewTypeConverter()
-	if cbs := getElemOrEmptyMapFromMap(span, "cluster_based_span"); len(cbs) > 0 {
-		spanPath := cbs["span_path"].(string)
+	// Presence is determined by list length rather than getElemOrEmptyMapFromMap:
+	// when zone_external_ids is explicitly set to an empty list, the SDKv2 diff
+	// engine emits no attribute entries for the nested block's contents (only the
+	// "#" count), so the reconstructed element can be a bare nil even though the
+	// block itself is present. Checking len(list) > 0 matches the correctly
+	// diffed "#" count and avoids treating a present-but-empty block as absent.
+	if cbsList, ok := span["cluster_based_span"].([]interface{}); ok && len(cbsList) > 0 {
+		cbs, _ := cbsList[0].(map[string]interface{})
+		spanPath, _ := cbs["span_path"].(string)
 		clusterBasedSpan := model.ClusterBasedSpan{
 			SpanPath: &spanPath,
 			Type_:    model.BaseSpan_TYPE_CLUSTERBASEDSPAN,
@@ -304,8 +311,11 @@ func getSpanFromSchema(iSpan interface{}) (*data.StructValue, error) {
 		}
 		return dataValue.(*data.StructValue), nil
 	}
-	if zbs := getElemOrEmptyMapFromMap(span, "zone_based_span"); len(zbs) > 0 {
-		zoneExternalIds := interfaceListToStringList(zbs["zone_external_ids"].([]interface{}))
+	if zbsList, ok := span["zone_based_span"].([]interface{}); ok && len(zbsList) > 0 {
+		var zoneExternalIds []string
+		if zbs, ok := zbsList[0].(map[string]interface{}); ok {
+			zoneExternalIds = interfaceListToStringList(zbs["zone_external_ids"].([]interface{}))
+		}
 		zoneBasedSpan := model.ZoneBasedSpan{
 			ZoneExternalIds: zoneExternalIds,
 			Type_:           model.BaseSpan_TYPE_ZONEBASEDSPAN,

--- a/nsxt/utgomock_resource_nsxt_policy_transit_gateway_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_transit_gateway_test.go
@@ -403,6 +403,39 @@ func TestMockResourceNsxtPolicyTransitGatewayBgpConfig(t *testing.T) {
 	})
 }
 
+// TestGetSpanFromSchemaZoneBasedEmptyZones guards against a regression where
+// span.zone_based_span with an explicitly empty zone_external_ids list was
+// dropped from the create/update payload entirely. The SDKv2 diff engine
+// emits no attribute entries for the nested block's contents when the list
+// stays at zero elements, so the reconstructed ResourceData can hand
+// getSpanFromSchema a zone_based_span element that is a bare nil instead of
+// a map. getSpanFromSchema must still recognize the block as present (via
+// the list length) and produce a ZoneBasedSpan rather than silently
+// returning nil, which previously caused NSX to fall back to its own
+// default ClusterBasedSpan and produced perpetual drift.
+func TestGetSpanFromSchemaZoneBasedEmptyZones(t *testing.T) {
+	span := []interface{}{
+		map[string]interface{}{
+			"cluster_based_span": []interface{}{},
+			"zone_based_span":    []interface{}{nil},
+		},
+	}
+
+	structVal, err := getSpanFromSchema(span)
+	require.NoError(t, err)
+	require.NotNil(t, structVal, "getSpanFromSchema must not drop a present-but-empty zone_based_span block")
+
+	out, err := setSpanFromSchema(structVal)
+	require.NoError(t, err)
+	require.NotNil(t, out)
+
+	spanList := out.([]interface{})
+	require.Len(t, spanList, 1)
+	spanMap := spanList[0].(map[string]interface{})
+	zbs := spanMap["zone_based_span"].([]interface{})
+	require.Len(t, zbs, 1)
+}
+
 func TestMockResourceNsxtPolicyTransitGatewayDelete(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()


### PR DESCRIPTION
getSpanFromSchema treated an explicitly empty zone_external_ids list as an absent zone_based_span block, because the SDKv2 diff engine emits no attribute entries for a nested list's contents when it stays at zero elements, leaving the reconstructed element as a bare nil. Since neither span variant registered as present, no span was sent on create, so NSX fell back to its own default ClusterBasedSpan and every subsequent plan showed a perpetual span drift.

Determine block presence from the list length (which the diff engine does populate correctly) instead of the reconstructed element map, and tolerate a nil element by defaulting to an empty zone list.