### PR TITLE
fix(nsxt_policy_transit_gateway): wire up advanced/redistribution config

### DIFF
--- a/docs/resources/policy_transit_gateway.md
+++ b/docs/resources/policy_transit_gateway.md
@@ -60,9 +60,9 @@ The following arguments are supported:
     * `failover_mode` - (Optional) Failover mode for active/standby centralized transit gateway (`PREEMPTIVE` or `NON_PREEMPTIVE`). Available since NSX 9.2.0.
     * `ha_mode` - (Optional) High-availability mode. Values: `ACTIVE_ACTIVE`, `ACTIVE_STANDBY`. Default is `ACTIVE_ACTIVE`.
     * `edge_cluster_paths` - (Optional) Policy paths of edge clusters. At most one item. Must be authorized for the project.
-* `advanced_config` - (Optional) Advanced settings for the transit gateway. Applied via hierarchical API as the `TransitGatewayRoutingConfig` singleton child (same transaction as the transit gateway when possible). Read uses the routing-config GET API.
+* `advanced_config` - (Optional) Advanced settings for the transit gateway. Sent and read as part of the same BGP routing config object as `bgp_config` (via the BGP API), not a separate object.
     * `forwarding_up_timer` - (Optional/Computed) Time in seconds the transit gateway waits before marking forwarding as active after a failover event. Valid range is `0` to `100`. Default is `5`.
-* `redistribution_config` - (Optional) Route redistribution configuration. Applied as part of the `TransitGatewayRoutingConfig` singleton (same API object as `advanced_config`).
+* `redistribution_config` - (Optional) Route redistribution configuration. Sent and read as part of the same BGP routing config object as `bgp_config` (same API object as `advanced_config`).
     * `rule` - (Required) List of redistribution rules. Minimum 1, maximum 5.
         * `types` - (Required) List of route types to redistribute. Supported values: `PUBLIC` (public networks from connected VPC subnets, NAT rules, and VPC static routes), `TGW_PRIVATE` (transit gateway private networks; only redistributed to BGP neighbors whose centralized network attachment has `allow_private` set to `true`), `TGW_STATIC_ROUTE` (user-configured static routes on the transit gateway), `CONNECTED_SUBNET` (centralized network attachment interface subnets).
         * `route_map_path` - (Optional) Policy path of a route map to apply for filtering routes in this rule. The route map must exist under the same transit gateway.

--- a/nsxt/resource_nsxt_policy_transit_gateway.go
+++ b/nsxt/resource_nsxt_policy_transit_gateway.go
@@ -424,76 +424,144 @@ func initTGWChildBgpConfig(config *model.TransitGatewayBgpRoutingConfig) (*data.
 
 func getTGWBgpConfigFromSchema(d *schema.ResourceData) *model.TransitGatewayBgpRoutingConfig {
 	bgpConfig := d.Get("bgp_config").([]interface{})
-	if len(bgpConfig) == 0 || bgpConfig[0] == nil {
+	advancedConfig := d.Get("advanced_config").([]interface{})
+	redistributionConfig := d.Get("redistribution_config").([]interface{})
+
+	haveBgpConfig := len(bgpConfig) > 0 && bgpConfig[0] != nil
+	haveAdvancedConfig := len(advancedConfig) > 0 && advancedConfig[0] != nil
+	haveRedistributionConfig := len(redistributionConfig) > 0 && redistributionConfig[0] != nil
+	if !haveBgpConfig && !haveAdvancedConfig && !haveRedistributionConfig {
 		return nil
-	}
-	cfgMap := bgpConfig[0].(map[string]interface{})
-
-	revision := int64(cfgMap["revision"].(int))
-	ecmp := cfgMap["ecmp"].(bool)
-	enabled := cfgMap["enabled"].(bool)
-	localAsNum := cfgMap["local_as_num"].(string)
-	multipathRelax := cfgMap["multipath_relax"].(bool)
-	restartMode := cfgMap["graceful_restart_mode"].(string)
-	restartTimer := int64(cfgMap["graceful_restart_timer"].(int))
-	staleTimer := int64(cfgMap["graceful_restart_stale_route_timer"].(int))
-
-	var tagStructs []model.Tag
-	if cfgMap["tag"] != nil {
-		for _, tag := range cfgMap["tag"].(*schema.Set).List() {
-			data := tag.(map[string]interface{})
-			tagScope := data["scope"].(string)
-			tagTag := data["tag"].(string)
-			tagStructs = append(tagStructs, model.Tag{Scope: &tagScope, Tag: &tagTag})
-		}
-	}
-
-	var aggregationStructs []model.RouteAggregationEntry
-	for _, agg := range cfgMap["route_aggregation"].([]interface{}) {
-		data := agg.(map[string]interface{})
-		prefix := data["prefix"].(string)
-		summary := data["summary_only"].(bool)
-		aggregationStructs = append(aggregationStructs, model.RouteAggregationEntry{
-			Prefix:      &prefix,
-			SummaryOnly: &summary,
-		})
-	}
-
-	restartTimerStruct := model.BgpGracefulRestartTimer{
-		RestartTimer:    &restartTimer,
-		StaleRouteTimer: &staleTimer,
-	}
-	restartConfigStruct := model.BgpGracefulRestartConfig{
-		Mode:  &restartMode,
-		Timer: &restartTimerStruct,
 	}
 
 	id := "bgp"
 	resourceType := "TransitGatewayBgpRoutingConfig"
 	cfg := &model.TransitGatewayBgpRoutingConfig{
-		Ecmp:                  &ecmp,
-		Enabled:               &enabled,
-		RouteAggregations:     aggregationStructs,
-		ResourceType:          &resourceType,
-		Tags:                  tagStructs,
-		Id:                    &id,
-		Revision:              &revision,
-		MultipathRelax:        &multipathRelax,
-		GracefulRestartConfig: &restartConfigStruct,
+		ResourceType: &resourceType,
+		Id:           &id,
 	}
-	if len(localAsNum) > 0 {
-		cfg.LocalAsNum = &localAsNum
+
+	// advanced_config.forwarding_up_timer and redistribution_config.rule are
+	// not separate API objects: they map onto the ForwardingUpTimer and
+	// RouteRedistributionConfig fields of this same TransitGatewayBgpRoutingConfig,
+	// sent through the same /routing/bgp calls as bgp_config.
+	if haveBgpConfig {
+		cfgMap := bgpConfig[0].(map[string]interface{})
+
+		revision := int64(cfgMap["revision"].(int))
+		ecmp := cfgMap["ecmp"].(bool)
+		enabled := cfgMap["enabled"].(bool)
+		localAsNum := cfgMap["local_as_num"].(string)
+		multipathRelax := cfgMap["multipath_relax"].(bool)
+		restartMode := cfgMap["graceful_restart_mode"].(string)
+		restartTimer := int64(cfgMap["graceful_restart_timer"].(int))
+		staleTimer := int64(cfgMap["graceful_restart_stale_route_timer"].(int))
+
+		var tagStructs []model.Tag
+		if cfgMap["tag"] != nil {
+			for _, tag := range cfgMap["tag"].(*schema.Set).List() {
+				data := tag.(map[string]interface{})
+				tagScope := data["scope"].(string)
+				tagTag := data["tag"].(string)
+				tagStructs = append(tagStructs, model.Tag{Scope: &tagScope, Tag: &tagTag})
+			}
+		}
+
+		var aggregationStructs []model.RouteAggregationEntry
+		for _, agg := range cfgMap["route_aggregation"].([]interface{}) {
+			data := agg.(map[string]interface{})
+			prefix := data["prefix"].(string)
+			summary := data["summary_only"].(bool)
+			aggregationStructs = append(aggregationStructs, model.RouteAggregationEntry{
+				Prefix:      &prefix,
+				SummaryOnly: &summary,
+			})
+		}
+
+		restartTimerStruct := model.BgpGracefulRestartTimer{
+			RestartTimer:    &restartTimer,
+			StaleRouteTimer: &staleTimer,
+		}
+		restartConfigStruct := model.BgpGracefulRestartConfig{
+			Mode:  &restartMode,
+			Timer: &restartTimerStruct,
+		}
+
+		cfg.Ecmp = &ecmp
+		cfg.Enabled = &enabled
+		cfg.RouteAggregations = aggregationStructs
+		cfg.Tags = tagStructs
+		cfg.Revision = &revision
+		cfg.MultipathRelax = &multipathRelax
+		cfg.GracefulRestartConfig = &restartConfigStruct
+		if len(localAsNum) > 0 {
+			cfg.LocalAsNum = &localAsNum
+		}
+		if interSrIbgp, ok := cfgMap["inter_sr_ibgp"].(bool); ok {
+			cfg.InterSrIbgp = &interSrIbgp
+		}
 	}
-	if interSrIbgp, ok := cfgMap["inter_sr_ibgp"].(bool); ok {
-		cfg.InterSrIbgp = &interSrIbgp
+
+	if haveAdvancedConfig {
+		advMap := advancedConfig[0].(map[string]interface{})
+		if v, ok := advMap["forwarding_up_timer"].(int); ok {
+			timer := int64(v)
+			cfg.ForwardingUpTimer = &timer
+		}
 	}
+
+	if haveRedistributionConfig {
+		redisMap := redistributionConfig[0].(map[string]interface{})
+		var rules []model.TransitGatewayBgpRedistributionRule
+		for _, r := range redisMap["rule"].([]interface{}) {
+			ruleMap := r.(map[string]interface{})
+			rule := model.TransitGatewayBgpRedistributionRule{
+				RouteRedistributionTypes: interfaceListToStringList(ruleMap["types"].([]interface{})),
+			}
+			if routeMapPath, ok := ruleMap["route_map_path"].(string); ok && len(routeMapPath) > 0 {
+				rule.RouteMapPath = &routeMapPath
+			}
+			rules = append(rules, rule)
+		}
+		cfg.RouteRedistributionConfig = &model.TransitGatewayRouteRedistributionConfig{
+			Rules: rules,
+		}
+	}
+
 	return cfg
 }
 
 func setTGWBgpConfigInSchema(d *schema.ResourceData, bgpConfig *model.TransitGatewayBgpRoutingConfig) error {
 	if bgpConfig == nil {
+		_ = d.Set("advanced_config", make([]map[string]interface{}, 0))
+		_ = d.Set("redistribution_config", make([]map[string]interface{}, 0))
 		return d.Set("bgp_config", make([]map[string]interface{}, 0))
 	}
+
+	if bgpConfig.ForwardingUpTimer != nil {
+		_ = d.Set("advanced_config", []interface{}{map[string]interface{}{
+			"forwarding_up_timer": int(*bgpConfig.ForwardingUpTimer),
+		}})
+	} else {
+		_ = d.Set("advanced_config", make([]map[string]interface{}, 0))
+	}
+
+	if bgpConfig.RouteRedistributionConfig != nil && len(bgpConfig.RouteRedistributionConfig.Rules) > 0 {
+		var rules []map[string]interface{}
+		for _, rule := range bgpConfig.RouteRedistributionConfig.Rules {
+			ruleMap := map[string]interface{}{
+				"types": rule.RouteRedistributionTypes,
+			}
+			if rule.RouteMapPath != nil {
+				ruleMap["route_map_path"] = *rule.RouteMapPath
+			}
+			rules = append(rules, ruleMap)
+		}
+		_ = d.Set("redistribution_config", []interface{}{map[string]interface{}{"rule": rules}})
+	} else {
+		_ = d.Set("redistribution_config", make([]map[string]interface{}, 0))
+	}
+
 	cfgMap := make(map[string]interface{})
 	cfgMap["revision"] = bgpConfig.Revision
 	cfgMap["path"] = bgpConfig.Path
@@ -744,9 +812,6 @@ func resourceNsxtPolicyTransitGatewayRead(d *schema.ResourceData, m interface{})
 		}
 	}
 
-	_ = d.Set("advanced_config", nil)
-	_ = d.Set("redistribution_config", nil)
-
 	bgpClient := cliTransitGatewayBgpClient(sessionContext, connector)
 	if bgpClient != nil {
 		bgpConfig, err := bgpClient.Get(parents[0], parents[1], id)
@@ -894,7 +959,7 @@ func resourceNsxtPolicyTransitGatewayUpdate(d *schema.ResourceData, m interface{
 		return handleUpdateError("TransitGateway", id, err)
 	}
 
-	if d.HasChange("bgp_config") {
+	if d.HasChange("bgp_config") || d.HasChange("advanced_config") || d.HasChange("redistribution_config") {
 		newBgp := getTGWBgpConfigFromSchema(d)
 		bgpAPIClient := cliTransitGatewayBgpClient(sessionContext, connector)
 		if bgpAPIClient != nil {

--- a/nsxt/utgomock_resource_nsxt_policy_transit_gateway_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_transit_gateway_test.go
@@ -436,6 +436,103 @@ func TestGetSpanFromSchemaZoneBasedEmptyZones(t *testing.T) {
 	require.Len(t, zbs, 1)
 }
 
+// TestGetTGWBgpConfigFromSchemaAdvancedAndRedistribution guards against a
+// regression where advanced_config and redistribution_config were never
+// merged into the TransitGatewayBgpRoutingConfig sent to NSX. Both map onto
+// fields of that same struct (ForwardingUpTimer, RouteRedistributionConfig)
+// rather than separate API objects, so they must be read alongside
+// bgp_config, not ignored.
+func TestGetTGWBgpConfigFromSchemaAdvancedAndRedistribution(t *testing.T) {
+	data := minimalTGWData()
+	data["bgp_config"] = minimalBgpConfigData()
+	data["advanced_config"] = []interface{}{
+		map[string]interface{}{"forwarding_up_timer": 10},
+	}
+	data["redistribution_config"] = []interface{}{
+		map[string]interface{}{
+			"rule": []interface{}{
+				map[string]interface{}{
+					"types":          []interface{}{"PUBLIC", "TGW_STATIC_ROUTE"},
+					"route_map_path": "",
+				},
+			},
+		},
+	}
+
+	res := resourceNsxtPolicyTransitGateway()
+	d := schema.TestResourceDataRaw(t, res.Schema, data)
+
+	cfg := getTGWBgpConfigFromSchema(d)
+	require.NotNil(t, cfg)
+	require.NotNil(t, cfg.ForwardingUpTimer)
+	assert.Equal(t, int64(10), *cfg.ForwardingUpTimer)
+
+	require.NotNil(t, cfg.RouteRedistributionConfig)
+	require.Len(t, cfg.RouteRedistributionConfig.Rules, 1)
+	assert.Equal(t, []string{"PUBLIC", "TGW_STATIC_ROUTE"}, cfg.RouteRedistributionConfig.Rules[0].RouteRedistributionTypes)
+}
+
+// TestMockResourceNsxtPolicyTransitGatewayAdvancedAndRedistributionConfig
+// guards against a regression where Read unconditionally reset
+// advanced_config and redistribution_config to nil regardless of what NSX
+// actually returned, causing perpetual drift.
+func TestMockResourceNsxtPolicyTransitGatewayAdvancedAndRedistributionConfig(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	m := setupTransitGatewayMockFull(t, ctrl)
+
+	t.Run("Read sets advanced_config and redistribution_config from bgp API response", func(t *testing.T) {
+		bgpResp := tgwBgpAPIResponse()
+		timer := int64(10)
+		bgpResp.ForwardingUpTimer = &timer
+		bgpResp.RouteRedistributionConfig = &nsxModel.TransitGatewayRouteRedistributionConfig{
+			Rules: []nsxModel.TransitGatewayBgpRedistributionRule{
+				{RouteRedistributionTypes: []string{"PUBLIC", "TGW_STATIC_ROUTE"}},
+			},
+		}
+
+		gomock.InOrder(
+			m.tgw.EXPECT().Get(tgwOrgID, tgwProjectID, tgwID).Return(tgwAPIResponse(), nil),
+			m.cc.EXPECT().Get(tgwOrgID, tgwProjectID, tgwID, centralizedConfigID).Return(nsxModel.CentralizedConfig{}, vapiErrors.NotFound{}),
+			m.bgp.EXPECT().Get(tgwOrgID, tgwProjectID, tgwID).Return(bgpResp, nil),
+		)
+
+		res := resourceNsxtPolicyTransitGateway()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalTGWData())
+		d.SetId(tgwID)
+
+		err := resourceNsxtPolicyTransitGatewayRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+
+		advList := d.Get("advanced_config").([]interface{})
+		require.Len(t, advList, 1)
+		assert.Equal(t, 10, advList[0].(map[string]interface{})["forwarding_up_timer"])
+
+		redisList := d.Get("redistribution_config").([]interface{})
+		require.Len(t, redisList, 1)
+		rules := redisList[0].(map[string]interface{})["rule"].([]interface{})
+		require.Len(t, rules, 1)
+		assert.Equal(t, []interface{}{"PUBLIC", "TGW_STATIC_ROUTE"}, rules[0].(map[string]interface{})["types"])
+	})
+
+	t.Run("Read with no advanced or redistribution config sets empty lists", func(t *testing.T) {
+		gomock.InOrder(
+			m.tgw.EXPECT().Get(tgwOrgID, tgwProjectID, tgwID).Return(tgwAPIResponse(), nil),
+			m.cc.EXPECT().Get(tgwOrgID, tgwProjectID, tgwID, centralizedConfigID).Return(nsxModel.CentralizedConfig{}, vapiErrors.NotFound{}),
+			m.bgp.EXPECT().Get(tgwOrgID, tgwProjectID, tgwID).Return(tgwBgpAPIResponse(), nil),
+		)
+
+		res := resourceNsxtPolicyTransitGateway()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalTGWData())
+		d.SetId(tgwID)
+
+		err := resourceNsxtPolicyTransitGatewayRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Empty(t, d.Get("advanced_config").([]interface{}))
+		assert.Empty(t, d.Get("redistribution_config").([]interface{}))
+	})
+}
+
 func TestMockResourceNsxtPolicyTransitGatewayDelete(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()


### PR DESCRIPTION
advanced_config.forwarding_up_timer and redistribution_config.rule were declared in the schema but never read into the API request, and Read unconditionally reset both to nil on every refresh regardless of what NSX returned. Both map onto the ForwardingUpTimer and RouteRedistributionConfig fields of the same TransitGatewayBgpRoutingConfig struct already used for bgp_config (same /routing/bgp API), not a separate object as a stale comment and the docs assumed.

Merge them into getTGWBgpConfigFromSchema/setTGWBgpConfigInSchema alongside bgp_config, drop the unconditional Read-time clear, and widen the Update change-detection gate so edits to either block are sent even when bgp_config itself is unchanged.