### PR TITLE
Fix duplicate Authorization header in govulncheck job

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -36,3 +36,4 @@ jobs:
         uses: golang/govulncheck-action@v1
         with:
           go-package: ./...
+          repo-checkout: false


### PR DESCRIPTION
golang/govulncheck-action re-checks out the repo by default, duplicating auth headers set by the prior checkout step and causing git fetch to fail with a 400 error.