### PR TITLE
Resolve the drift caused by the site connection information

### DIFF
--- a/nsxt/resource_nsxt_policy_site.go
+++ b/nsxt/resource_nsxt_policy_site.go
@@ -90,10 +90,11 @@ func getConnectionInfoSchema() *schema.Schema {
 					Description: "Fully Qualified Domain Name of the Management Node",
 				},
 				"password": {
-					Type:        schema.TypeString,
-					Optional:    true,
-					Sensitive:   true,
-					Description: "Password",
+					Type:             schema.TypeString,
+					Optional:         true,
+					Sensitive:        true,
+					Description:      "Password",
+					DiffSuppressFunc: suppressIfEmptyPriorState,
 				},
 				"site_uuid": {
 					Type:        schema.TypeString,

--- a/nsxt/utgomock_resource_nsxt_policy_site_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_site_test.go
@@ -245,3 +245,26 @@ func TestMockResourceNsxtPolicySiteDelete(t *testing.T) {
 		require.Error(t, err)
 	})
 }
+
+func TestSiteConnectionInfoPasswordDiffSuppress(t *testing.T) {
+	res := resourceNsxtPolicySite()
+
+	// Build a ResourceData that simulates an existing (imported) resource: ID is set.
+	existing := schema.TestResourceDataRaw(t, res.Schema, minimalSiteData())
+	existing.SetId(siteID)
+
+	// Build a ResourceData that simulates a new resource (no ID yet).
+	fresh := schema.TestResourceDataRaw(t, res.Schema, minimalSiteData())
+
+	// Existing resource, old state is empty: suppress (import scenario).
+	assert.True(t, suppressIfEmptyPriorState("site_connection_info.0.password", "", "secret-password-123", existing),
+		"must suppress diff when old (state) is empty and resource exists (import)")
+
+	// New resource (no ID), old state is empty: do not suppress so passwords are included in the Create diff.
+	assert.False(t, suppressIfEmptyPriorState("site_connection_info.0.password", "", "secret-password-123", fresh),
+		"must not suppress diff for a new resource (no ID)")
+
+	// Non-empty old value: never suppress so password changes are applied.
+	assert.False(t, suppressIfEmptyPriorState("site_connection_info.0.password", "old-password", "new-password", existing),
+		"must not suppress diff when old (state) is non-empty")
+}


### PR DESCRIPTION
The NSX-T API does not return site node connection passwords in its
responses. During read operations, the empty password returned from the
API overrides the existing password in the schema, causing Terraform to
detect drift and prompt for a perpetual update.

Address this by adding the suppressIfEmptyPriorState DiffSuppressFunc
to the password field in the connection info schema. This suppresses
spurious diffs when the password is empty in the state (such as after
an import) while still allowing users to update the password in their
configuration.