### PR TITLE
Move VNA/VNA cluster tests to extra coverage cycle

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware/terraform-provider-nsxt
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -173,8 +173,6 @@ github.com/vmware/vsphere-automation-sdk-go/lib v0.8.0 h1:u1SXOTM6D4Ygb3jeidj2Rd
 github.com/vmware/vsphere-automation-sdk-go/lib v0.8.0/go.mod h1:8d5JTwjpM/Z03n/IZb0fwmXkJNWvWwuLXBqoakqYio4=
 github.com/vmware/vsphere-automation-sdk-go/runtime v0.8.0 h1:KnDIX9LY0nru7iMQTg0sy9vChhyorPo5OdASM2MaAcI=
 github.com/vmware/vsphere-automation-sdk-go/runtime v0.8.0/go.mod h1:DzLetYAmw1+vj7bqElRWEpuy40WYE/woL3alsymYa/c=
-github.com/vmware/vsphere-automation-sdk-go/services/nsxt v0.12.1-0.20260517061842-508c01aec2fc h1:eiMYaZj7fQimyNjQkIsjtbr12RKIC5Dl+6uhtPZVtdo=
-github.com/vmware/vsphere-automation-sdk-go/services/nsxt v0.12.1-0.20260517061842-508c01aec2fc/go.mod h1:C3JVOHRVLrGBQ8kTWAiGYlRz5UQC5qAcTdt3tvA+5P0=
 github.com/vmware/vsphere-automation-sdk-go/services/nsxt v0.12.1-0.20260630133807-525a3b3f5961 h1:Be0trlK0tmSDPisSzsVYB4r6rp4OivR+hAXSOXJo7e8=
 github.com/vmware/vsphere-automation-sdk-go/services/nsxt v0.12.1-0.20260630133807-525a3b3f5961/go.mod h1:C3JVOHRVLrGBQ8kTWAiGYlRz5UQC5qAcTdt3tvA+5P0=
 github.com/vmware/vsphere-automation-sdk-go/services/nsxt-gm v0.9.1-0.20241118070726-666c7cd6e466 h1:SYBECpviZBcp/cUHKTDPQP7CSQb0lUfPPOClpGOFH44=

--- a/nsxt/data_source_nsxt_policy_virtual_network_appliance_cluster_test.go
+++ b/nsxt/data_source_nsxt_policy_virtual_network_appliance_cluster_test.go
@@ -21,6 +21,7 @@ func TestAccDataSourceNsxtPolicyVirtualNetworkApplianceCluster_basic(t *testing.
 			testAccOnlyLocalManager(t)
 			testAccNSXVersion(t, "9.1.1")
 			testAccEnvDefined(t, "NSXT_TEST_OVERLAY_TRANSPORT_ZONE")
+			testAccNsxtExtraCoverage(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccNsxtPolicyVirtualNetworkApplianceClusterCheckDestroy(testResourceName),

--- a/nsxt/resource_nsxt_policy_virtual_network_appliance_cluster_test.go
+++ b/nsxt/resource_nsxt_policy_virtual_network_appliance_cluster_test.go
@@ -26,6 +26,7 @@ func TestAccResourceNsxtPolicyVirtualNetworkApplianceCluster_basic(t *testing.T)
 			testAccOnlyLocalManager(t)
 			testAccNSXVersion(t, "9.1.1")
 			testAccEnvDefined(t, "NSXT_TEST_OVERLAY_TRANSPORT_ZONE")
+			testAccNsxtExtraCoverage(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccNsxtPolicyVirtualNetworkApplianceClusterCheckDestroy(testResourceName),
@@ -66,6 +67,7 @@ func TestAccResourceNsxtPolicyVirtualNetworkApplianceCluster_importBasic(t *test
 			testAccOnlyLocalManager(t)
 			testAccNSXVersion(t, "9.1.1")
 			testAccEnvDefined(t, "NSXT_TEST_OVERLAY_TRANSPORT_ZONE")
+			testAccNsxtExtraCoverage(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccNsxtPolicyVirtualNetworkApplianceClusterCheckDestroy(testResourceName),
@@ -206,6 +208,7 @@ func TestAccResourceNsxtPolicyVirtualNetworkApplianceCluster_noAdvancedConfig(t 
 			testAccPreCheck(t)
 			testAccOnlyLocalManager(t)
 			testAccNSXVersion(t, "9.1.1")
+			testAccNsxtExtraCoverage(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccNsxtPolicyVirtualNetworkApplianceClusterCheckDestroy(testResourceName),
@@ -252,6 +255,7 @@ func TestAccResourceNsxtPolicyVirtualNetworkApplianceCluster_coreAllocationProfi
 			testAccOnlyLocalManager(t)
 			testAccNSXVersion(t, "9.2.0")
 			testAccEnvDefined(t, "NSXT_TEST_OVERLAY_TRANSPORT_ZONE")
+			testAccNsxtExtraCoverage(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccNsxtPolicyVirtualNetworkApplianceClusterCheckDestroy(testResourceName),

--- a/nsxt/resource_nsxt_policy_virtual_network_appliance_test.go
+++ b/nsxt/resource_nsxt_policy_virtual_network_appliance_test.go
@@ -38,7 +38,10 @@ func TestAccResourceNsxtPolicyVirtualNetworkAppliance_basic(t *testing.T) {
 	updatedDisplayName := displayName + "-updated"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccVNAPreCheck(t) },
+		PreCheck: func() {
+			testAccVNAPreCheck(t)
+			testAccNsxtExtraCoverage(t)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccNsxtPolicyVirtualNetworkApplianceCheckDestroy(testResourceName),
 		Steps: []resource.TestStep{
@@ -80,7 +83,10 @@ func TestAccResourceNsxtPolicyVirtualNetworkAppliance_importWithCredentials(t *t
 	displayName := getAccTestResourceName()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccVNACredentialsPreCheck(t) },
+		PreCheck: func() {
+			testAccVNACredentialsPreCheck(t)
+			testAccNsxtExtraCoverage(t)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccNsxtPolicyVirtualNetworkApplianceCheckDestroy(testResourceName),
 		Steps: withImportIdempotencyChecks([]resource.TestStep{
@@ -112,7 +118,10 @@ func TestAccResourceNsxtPolicyVirtualNetworkAppliance_importBasic(t *testing.T) 
 	displayName := getAccTestResourceName()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccVNAPreCheck(t) },
+		PreCheck: func() {
+			testAccVNAPreCheck(t)
+			testAccNsxtExtraCoverage(t)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccNsxtPolicyVirtualNetworkApplianceCheckDestroy(testResourceName),
 		Steps: []resource.TestStep{
@@ -305,7 +314,10 @@ func TestAccResourceNsxtPolicyVirtualNetworkAppliance_credentialsDrift(t *testin
 	displayName := getAccTestResourceName()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccVNACredentialsPreCheck(t) },
+		PreCheck: func() {
+			testAccVNACredentialsPreCheck(t)
+			testAccNsxtExtraCoverage(t)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccNsxtPolicyVirtualNetworkApplianceCheckDestroy(testResourceName),
 		Steps: []resource.TestStep{


### PR DESCRIPTION
Run these on the daily job, to provide more stability to the CI.

Also bump the Go toolchain to 1.26.5, since CI's setup-go reads the
version from go.mod and 1.26.4's crypto/tls has a TLS ECH privacy
leak (GO-2026-5856) that failed govulncheck.
