### PR TITLE
@ANS-TF-BMS: Overhaul the BMS guide and update the examples throughout the resource documentation.

### DIFF
--- a/docs/data-sources/policy_baremetal_server.md
+++ b/docs/data-sources/policy_baremetal_server.md
@@ -1,6 +1,6 @@
 ---
 subcategory: "Beta"
-page_title: "NSXT: policy_baremetal_server"
+page_title: "NSXT: nsxt_policy_baremetal_server"
 description: A bare metal server inventory data source.
 ---
 
@@ -50,6 +50,7 @@ output "server_os" {
 In addition to arguments listed above, the following attributes are exported:
 
 * `id` - ID of the data source.
+* `display_name` - Display name of the bare metal server.
 * `source_id` - Source ID of the bare metal server.
 * `cpu_cores` - Number of CPU cores.
 * `os_name` - Operating system name.

--- a/docs/data-sources/policy_baremetal_server_group_associations.md
+++ b/docs/data-sources/policy_baremetal_server_group_associations.md
@@ -1,6 +1,6 @@
 ---
 subcategory: "Beta"
-page_title: "NSXT: policy_baremetal_server_group_associations"
+page_title: "NSXT: nsxt_policy_baremetal_server_group_associations"
 description: Groups a bare metal server is a member of.
 ---
 
@@ -41,6 +41,7 @@ resource "nsxt_policy_service" "https" {
 resource "nsxt_policy_group" "web-servers" {
   display_name = "Web-Servers-Group"
   description  = "Group containing web server bare metal resources"
+  group_type   = "BareMetalServer"
 
   criteria {
     condition {

--- a/docs/data-sources/policy_baremetal_server_interface.md
+++ b/docs/data-sources/policy_baremetal_server_interface.md
@@ -1,6 +1,6 @@
 ---
 subcategory: "Beta"
-page_title: "NSXT: policy_baremetal_server_interface"
+page_title: "NSXT: nsxt_policy_baremetal_server_interface"
 description: A bare metal server interface inventory data source.
 ---
 
@@ -50,6 +50,7 @@ output "interface_ips" {
 In addition to arguments listed above, the following attributes are exported:
 
 * `id` - ID of the data source.
+* `display_name` - Display name of the bare metal server interface.
 * `bms_external_id` - External ID of the parent bare metal server.
 * `source_id` - Source ID of the bare metal server interface.
 * `is_mgmt_interface` - Whether this is a management interface.

--- a/docs/data-sources/policy_baremetal_server_interface_group_associations.md
+++ b/docs/data-sources/policy_baremetal_server_interface_group_associations.md
@@ -1,6 +1,6 @@
 ---
 subcategory: "Beta"
-page_title: "NSXT: policy_baremetal_server_interface_group_associations"
+page_title: "NSXT: nsxt_policy_baremetal_server_interface_group_associations"
 description: Groups a bare metal server interface is a member of.
 ---
 
@@ -22,6 +22,7 @@ data "nsxt_policy_baremetal_server_interface_group_associations" "if1_groups" {
 resource "nsxt_policy_group" "data-network" {
   display_name = "Data-Network-Group"
   description  = "Group containing data network interfaces"
+  group_type   = "BareMetalServer"
 
   criteria {
     condition {

--- a/docs/data-sources/policy_baremetal_server_interface_tags.md
+++ b/docs/data-sources/policy_baremetal_server_interface_tags.md
@@ -1,6 +1,6 @@
 ---
 subcategory: "Beta"
-page_title: "NSXT: policy_baremetal_server_interface_tags"
+page_title: "NSXT: nsxt_policy_baremetal_server_interface_tags"
 description: A Bare Metal Server Interface Tags data source.
 ---
 
@@ -44,6 +44,7 @@ resource "nsxt_policy_group" "data_plane_interfaces" {
   count = local.network_type == "data-plane" ? 1 : 0
 
   display_name = "Data-Plane-Interfaces"
+  group_type   = "BareMetalServer"
 
   criteria {
     condition {

--- a/docs/data-sources/policy_baremetal_server_interfaces.md
+++ b/docs/data-sources/policy_baremetal_server_interfaces.md
@@ -1,6 +1,6 @@
 ---
 subcategory: "Beta"
-page_title: "NSXT: policy_baremetal_server_interfaces"
+page_title: "NSXT: nsxt_policy_baremetal_server_interfaces"
 description: List of bare metal server interfaces in NSX inventory with advanced filtering.
 ---
 

--- a/docs/data-sources/policy_baremetal_server_tags.md
+++ b/docs/data-sources/policy_baremetal_server_tags.md
@@ -1,6 +1,6 @@
 ---
 subcategory: "Beta"
-page_title: "NSXT: policy_baremetal_server_tags"
+page_title: "NSXT: nsxt_policy_baremetal_server_tags"
 description: A Bare Metal Server Tags data source.
 ---
 

--- a/docs/data-sources/policy_baremetal_servers.md
+++ b/docs/data-sources/policy_baremetal_servers.md
@@ -1,6 +1,6 @@
 ---
 subcategory: "Beta"
-page_title: "NSXT: policy_baremetal_servers"
+page_title: "NSXT: nsxt_policy_baremetal_servers"
 description: List of bare metal servers discovered by NSX with advanced filtering.
 ---
 

--- a/docs/data-sources/policy_group_baremetal_server_interface_members.md
+++ b/docs/data-sources/policy_group_baremetal_server_interface_members.md
@@ -1,6 +1,6 @@
 ---
 subcategory: "Beta"
-page_title: "NSXT: policy_group_baremetal_server_interface_members"
+page_title: "NSXT: nsxt_policy_group_baremetal_server_interface_members"
 description: A policy data source to list bare metal server interface members in a group.
 ---
 

--- a/docs/data-sources/policy_group_baremetal_server_members.md
+++ b/docs/data-sources/policy_group_baremetal_server_members.md
@@ -1,6 +1,6 @@
 ---
 subcategory: "Beta"
-page_title: "NSXT: policy_group_baremetal_server_members"
+page_title: "NSXT: nsxt_policy_group_baremetal_server_members"
 description: A policy data source to list bare metal server members in a group.
 ---
 

--- a/docs/guides/baremetal_server_management.md
+++ b/docs/guides/baremetal_server_management.md
@@ -13,7 +13,7 @@ This guide demonstrates how to use the NSX-T Terraform provider to discover, tag
 - NSX-T Data Center 9.0.0 or higher
 - Bare metal servers discovered and registered with NSX-T through a compute manager
 - NSX-T Terraform Provider with BMS support
-- Local Manager access (BMS features are not supported on Global Manager)
+- Local Manager access
 
 ## Overview
 
@@ -24,47 +24,195 @@ The NSX-T Terraform provider supports the following BMS operations:
 3. **Grouping**: Create static and dynamic groups based on server attributes
 4. **Security**: Apply firewall policies using BMS groups
 
-## Basic Workflow
+## Resources and Data Sources Reference
 
-### Step 1: Discover Bare Metal Server Inventory
+| Resource / Data Source                                      | Type        | Purpose                                                                                                                                                                                                                 |
+|-------------------------------------------------------------|-------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `nsxt_policy_baremetal_server_tags`                         | Resource    | Apply tags to a bare metal server                                                                                                                                                                                       |
+| `nsxt_policy_baremetal_server_interface_tags`               | Resource    | Apply tags to a bare metal server interface                                                                                                                                                                             |
+| `nsxt_policy_group`                                         | Resource    | Create BMS groups with `group_type = "BareMetalServer"` and `member_type = "BareMetalServer"` or `"BareMetalServerInterface"`; supports dynamic conditions, static external ID expressions, and nested path expressions |
+| `nsxt_policy_security_policy`                               | Resource    | Apply DFW policies scoped to BMS groups with inline rules                                                                                                                                                               |
+| `nsxt_policy_parent_security_policy`                        | Resource    | Define a BMS-scoped DFW policy without inline rules (use with `nsxt_policy_security_policy_rule`)                                                                                                                       |
+| `nsxt_policy_security_policy_rule`                          | Resource    | Create standalone DFW rules that target BMS groups as source, destination, or scope                                                                                                                                     |
+| `nsxt_policy_baremetal_servers`                             | Data Source | Query BMS inventory with filtering (bulk)                                                                                                                                                                               |
+| `nsxt_policy_baremetal_server`                              | Data Source | Look up a single BMS by external ID or display name                                                                                                                                                                     |
+| `nsxt_policy_baremetal_server_interfaces`                   | Data Source | Query BMS interface inventory with filtering                                                                                                                                                                            |
+| `nsxt_policy_baremetal_server_interface`                    | Data Source | Look up a single BMS interface by external ID or display name                                                                                                                                                           |
+| `nsxt_policy_baremetal_server_tags`                         | Data Source | Read current tags on a BMS server                                                                                                                                                                                       |
+| `nsxt_policy_baremetal_server_interface_tags`               | Data Source | Read current tags on a BMS interface                                                                                                                                                                                    |
+| `nsxt_policy_baremetal_server_group_associations`           | Data Source | List all groups a BMS server belongs to; group paths can be used directly in policy rules                                                                                                                               |
+| `nsxt_policy_baremetal_server_interface_group_associations` | Data Source | List all groups a BMS interface belongs to                                                                                                                                                                              |
+| `nsxt_policy_group_baremetal_server_members`                | Data Source | List all BMS server members of a group                                                                                                                                                                                  |
+| `nsxt_policy_group_baremetal_server_interface_members`      | Data Source | List all BMS interface members of a group                                                                                                                                                                               |
+| `nsxt_policy_group`                                         | Data Source | Look up an existing BMS group by display name to obtain its path for use in policies                                                                                                                                    |
+| `nsxt_policy_security_policy`                               | Data Source | Look up an existing security policy by display name to obtain its path                                                                                                                                                  |
+
+## Known Limitations
+
+### Platform Limitations
+
+- **Multitenancy not supported** — BMS features are not available in multi-tenant (VPC/Project) deployments.
+- **Federation / Global Manager not supported** — BMS management is available on Local Manager only.
+
+### Firewall Limitations
+
+- **Only DFW (Distributed Firewall) is supported** — BMS groups cannot be used in Gateway Firewall (`nsxt_policy_gateway_policy`) or IDPS policies (`nsxt_policy_intrusion_service_policy`).
+- **Ethernet category not supported** — The `Ethernet` DFW category operates at Layer 2 only and does not support BMS groups. Use `Emergency`, `Infrastructure`, `Environment`, or `Application` categories.
+- **Layer 3 / Layer 4 only** — Application-layer (L7) rules are not supported for BMS targets.
+- **No L7 / FQDN context profiles** — The `context_profiles` field in security policy rules is not supported when BMS groups are in the policy scope, source, or destination.
+- **No time-based rules** — Rule schedulers are silently ignored by NSX for BMS rules.
+- **DFW Exclusion List does not apply to BMS** — Adding a BMS server to the DFW Exclusion List has no effect.
+
+### Group Constraints
+
+- **`group_type = "BareMetalServer"` is always required** when a group contains `BareMetalServer` or `BareMetalServerInterface` member types.
+- **BMS groups may only contain BMS or BMSI members** — mixing `BareMetalServer` / `BareMetalServerInterface` with `VirtualMachine` or any other member type in the same group is not supported.
+- Separate `BareMetalServer`-typed groups from VM groups. If a policy must cover both, reference them as separate groups in the policy's `scope`, `source_groups`, or `destination_groups`.
+
+## Workflow Overview
+
+``` Overview
+  Discover BMS Inventory
+  (nsxt_policy_baremetal_servers / nsxt_policy_baremetal_server)
+              |
+              v
+  Apply Tags for Classification
+  (nsxt_policy_baremetal_server_tags / nsxt_policy_baremetal_server_interface_tags)
+              |
+              v
+  Create Groups based on Attributes / Tags
+  (nsxt_policy_group with group_type = "BareMetalServer")
+              |
+              v
+  Apply DFW Security Policies           <----+
+  (nsxt_policy_security_policy /              |
+   nsxt_policy_parent_security_policy +        |  group paths used
+   nsxt_policy_security_policy_rule)           |  as source_groups /
+              |                               |  destination_groups
+              v                               |
+  Query Group Memberships & Associations -----+
+  (nsxt_policy_baremetal_server_group_associations —
+   discover which groups a server belongs to, then
+   feed those group paths directly into a policy rule)
+
+```
+
+`nsxt_policy_baremetal_server_group_associations` returns the list of group paths a given BMS server (or interface) is already a member of. You can pass those paths directly to `source_groups` or `destination_groups` in a security policy rule — see the [example in Step 6](#step-6-audit-group-membership-and-associations) below.
+
+---
+
+## BMS Group Condition Reference
+
+The following keys and operators are supported for BMS member types in `condition` blocks within `nsxt_policy_group` (requires NSX-T 9.0.0 or higher):
+
+**`member_type = "BareMetalServer"`**
+
+| Key         | Supported Operators                                         | Notes                                               |
+|-------------|-------------------------------------------------------------|-----------------------------------------------------|
+| `Tag`       | `EQUALS`, `CONTAINS`, `ENDSWITH`, `STARTSWITH`              | Use `scope\|value` notation for scoped tags         |
+| `Name`      | `EQUALS`, `CONTAINS`, `ENDSWITH`, `STARTSWITH`, `NOTEQUALS` |                                                     |
+| `OSName`    | `EQUALS`, `CONTAINS`, `ENDSWITH`, `STARTSWITH`, `NOTEQUALS` |                                                     |
+| `OSVersion` | `EQUALS` only                                               | Full OS version string, e.g. `"8.5.2111"`, `"8.10"` |
+| `ALL`       | `EQUALS` only                                               | Value must be `"ALL_BMS"`                           |
+
+**`member_type = "BareMetalServerInterface"`**
+
+| Key                   | Supported Operators            | Notes                                       |
+|-----------------------|--------------------------------|---------------------------------------------|
+| `Tag`                 | `EQUALS`, `NOTEQUALS`, `NOTIN` | Use `scope\|value` notation for scoped tags |
+| `ManagementInterface` | `EQUALS` only                  | Values: `"TRUE"` or `"FALSE"`               |
+
+---
+
+## Step 1: Discover Bare Metal Server Inventory
 
 ```hcl
-# Discover all bare metal servers
-data "nsxt_policy_baremetal_servers" "all_servers" {
+# List all bare metal servers
+data "nsxt_policy_baremetal_servers" "all_servers" {}
+
+# List all bare metal server interfaces
+data "nsxt_policy_baremetal_server_interfaces" "all_interfaces" {}
+
+# Filter by production environment tag
+data "nsxt_policy_baremetal_servers" "prod_servers" {
+  tag_scope = "environment"
+  tag       = "production"
 }
 
-# Discover all bare metal server interfaces
-data "nsxt_policy_baremetal_server_interfaces" "all_interfaces" {
+# Filter by OS name substring
+data "nsxt_policy_baremetal_servers" "linux_servers" {
+  os_name = "redhat"
 }
 
-# Output inventory for review
-output "bms_inventory_summary" {
+# Filter by display name using a regex pattern
+data "nsxt_policy_baremetal_servers" "web_servers" {
+  display_name = "web-.*"
+}
+
+# Filter interfaces by parent server
+data "nsxt_policy_baremetal_server_interfaces" "server_interfaces" {
+  bms_external_id = "71be0142-2ed1-1d53-9c60-5564cf4b7e2e"
+}
+
+# Look up a single server by external ID
+data "nsxt_policy_baremetal_server" "my_server" {
+  external_id = "71be0142-2ed1-1d53-9c60-5564cf4b7e2e"
+}
+
+# Look up a single server by display name (must return exactly one result)
+data "nsxt_policy_baremetal_server" "web_server_01" {
+  display_name = "web-server-01"
+}
+
+output "bms_inventory" {
   value = {
     total_servers    = length(data.nsxt_policy_baremetal_servers.all_servers.results)
     total_interfaces = length(data.nsxt_policy_baremetal_server_interfaces.all_interfaces.results)
-
     servers = [
-      for server in data.nsxt_policy_baremetal_servers.all_servers.results : {
-        id           = server.external_id
-        display_name = server.display_name
-        cpu_cores    = server.cpu_cores
-        os_name      = server.os_name
-        os_version   = server.os_version
+      for s in data.nsxt_policy_baremetal_servers.all_servers.results : {
+        id           = s.external_id
+        display_name = s.display_name
+        os           = "${s.os_name} ${s.os_version}"
+        cpu_cores    = s.cpu_cores
       }
     ]
   }
 }
 ```
 
-### Step 2: Apply Tags for Automation
+---
+
+## Step 2: Apply Tags for Classification
+
+Tags are the primary mechanism for dynamic group membership. Apply them with `nsxt_policy_baremetal_server_tags` (for servers) and `nsxt_policy_baremetal_server_interface_tags` (for interfaces).
 
 ```hcl
-# Tag servers based on naming conventions
+# Tag a single server with a known external ID
+resource "nsxt_policy_baremetal_server_tags" "prod_web_01" {
+  external_id = "71be0142-2ed1-1d53-9c60-5564cf4b7e2e"
+
+  tag {
+    scope = "environment"
+    tag   = "production"
+  }
+
+  tag {
+    scope = "application"
+    tag   = "web-server"
+  }
+
+  tag {
+    scope = "managed-by"
+    tag   = "terraform"
+  }
+}
+
+# Tag all servers matching a naming pattern using for_each
 resource "nsxt_policy_baremetal_server_tags" "production_servers" {
   for_each = {
-    for idx, server in data.nsxt_policy_baremetal_servers.all_servers.results :
-    server.external_id => server
-    if length(regexall("prod|production", lower(server.display_name))) > 0
+    for s in data.nsxt_policy_baremetal_servers.all_servers.results :
+    s.external_id => s
+    if length(regexall("prod", lower(s.display_name))) > 0
   }
 
   external_id = each.key
@@ -78,17 +226,12 @@ resource "nsxt_policy_baremetal_server_tags" "production_servers" {
     scope = "managed-by"
     tag   = "terraform"
   }
-
-  tag {
-    scope = "cpu-tier"
-    tag   = each.value.cpu_cores >= 16 ? "high" : "standard"
-  }
 }
 
-# Tag interfaces, excluding management interfaces
+# Tag data-plane interfaces (skip management interfaces)
 resource "nsxt_policy_baremetal_server_interface_tags" "data_interfaces" {
   for_each = {
-    for idx, iface in data.nsxt_policy_baremetal_server_interfaces.all_interfaces.results :
+    for iface in data.nsxt_policy_baremetal_server_interfaces.all_interfaces.results :
     iface.external_id => iface
     if !iface.is_mgmt_interface && iface.state == "UP"
   }
@@ -96,40 +239,72 @@ resource "nsxt_policy_baremetal_server_interface_tags" "data_interfaces" {
   external_id = each.key
 
   tag {
-    scope = "interface-role"
+    scope = "network-type"
     tag   = "data-plane"
   }
 
   tag {
-    scope = "speed"
-    tag   = contains(each.value.display_name, "10G") ? "10Gbps" : "1Gbps"
+    scope = "managed-by"
+    tag   = "terraform"
+  }
+}
+
+# Tag management interfaces
+resource "nsxt_policy_baremetal_server_interface_tags" "mgmt_interfaces" {
+  for_each = {
+    for iface in data.nsxt_policy_baremetal_server_interfaces.all_interfaces.results :
+    iface.external_id => iface
+    if iface.is_mgmt_interface
+  }
+
+  external_id = each.key
+
+  tag {
+    scope = "network-type"
+    tag   = "management"
   }
 }
 ```
 
-### Step 3: Create Groups for Policy Application
+---
+
+## Step 3: Read Back Existing Tags
+
+Use the tag data sources to read the current tag state on servers and interfaces — useful for drift detection or conditional logic.
 
 ```hcl
-# Static group for specific servers
-resource "nsxt_policy_group" "critical_servers" {
-  display_name = "Critical-BMS-Servers"
-  description  = "Manually selected critical bare metal servers"
-  group_type   = "BareMetalServer"
-
-  criteria {
-    external_id_expression {
-      member_type = "BareMetalServer"
-      external_ids = [
-        "server-001-uuid",
-        "server-002-uuid",
-        "server-003-uuid"
-      ]
-    }
-  }
+# Read tags on a specific server
+data "nsxt_policy_baremetal_server_tags" "server_tags" {
+  external_id = "71be0142-2ed1-1d53-9c60-5564cf4b7e2e"
 }
 
-# Dynamic group based on tags
-resource "nsxt_policy_group" "production_servers" {
+# Extract a tag value by scope
+locals {
+  server_environment = try(
+    [for t in data.nsxt_policy_baremetal_server_tags.server_tags.tag : t.tag if t.scope == "environment"][0],
+    "unknown"
+  )
+}
+
+# Read tags on a specific interface
+data "nsxt_policy_baremetal_server_interface_tags" "if_tags" {
+  external_id = "71be0142-2ed1-1d53-9c60-02005b4b7246"
+}
+
+output "interface_tags" {
+  value = data.nsxt_policy_baremetal_server_interface_tags.if_tags.tag
+}
+```
+
+---
+
+## Step 4: Create Groups
+
+All groups containing BMS or BMSI members **must** set `group_type = "BareMetalServer"`. Groups may contain either BMS or BMSI members (or both), but cannot mix them with `VirtualMachine` or other member types.
+
+```hcl
+# Dynamic group — all production BMS servers using Tags
+resource "nsxt_policy_group" "production_bms" {
   display_name = "Production-BMS-Servers"
   description  = "All production bare metal servers"
   group_type   = "BareMetalServer"
@@ -144,11 +319,184 @@ resource "nsxt_policy_group" "production_servers" {
   }
 }
 
-# High-performance server group
-resource "nsxt_policy_group" "high_performance_servers" {
-  display_name = "High-Performance-BMS"
-  description  = "High CPU bare metal servers"
+# Dynamic group — BMS servers AND/OR interfaces combined using OR conjunction
+resource "nsxt_policy_group" "web_tier_bms" {
+  display_name = "Web-Tier-BMS"
+  description  = "Web tier BMS servers and their data-plane interfaces"
   group_type   = "BareMetalServer"
+
+  criteria {
+    condition {
+      key         = "Tag"
+      member_type = "BareMetalServer"
+      operator    = "EQUALS"
+      value       = "application|web-server"
+    }
+  }
+
+  conjunction {
+    operator = "OR"
+  }
+
+  criteria {
+    condition {
+      key         = "Tag"
+      member_type = "BareMetalServerInterface"
+      operator    = "EQUALS"
+      value       = "network-type|data-plane"
+    }
+  }
+}
+
+# Dynamic group — servers by OS version (EQUALS only)
+resource "nsxt_policy_group" "redhat_810_servers" {
+  display_name = "RedHat-8-10-Servers"
+  description  = "BMS servers running RedHat 8.10"
+  group_type   = "BareMetalServer"
+
+  criteria {
+    condition {
+      key         = "OSVersion"
+      member_type = "BareMetalServer"
+      operator    = "EQUALS"
+      value       = "8.10"
+    }
+  }
+}
+
+# Dynamic group — management interfaces only
+resource "nsxt_policy_group" "mgmt_interfaces" {
+  display_name = "BMS-Management-Interfaces"
+  description  = "All BMS management interfaces"
+  group_type   = "BareMetalServer"
+
+  criteria {
+    condition {
+      key         = "ManagementInterface"
+      member_type = "BareMetalServerInterface"
+      operator    = "EQUALS"
+      value       = "TRUE"
+    }
+  }
+}
+
+# Dynamic group — Linux servers using OSName
+resource "nsxt_policy_group" "linux_bms" {
+  display_name = "Linux-BMS-Servers"
+  description  = "All Linux bare metal servers"
+  group_type   = "BareMetalServer"
+
+  criteria {
+    condition {
+      key         = "OSName"
+      member_type = "BareMetalServer"
+      operator    = "CONTAINS"
+      value       = "Linux"
+    }
+  }
+}
+```
+
+### Static Groups (External ID-based)
+
+```hcl
+# Static group — specific servers by external ID
+resource "nsxt_policy_group" "critical_servers" {
+  display_name = "Critical-BMS-Servers"
+  description  = "Manually selected critical bare metal servers"
+  group_type   = "BareMetalServer"
+
+  criteria {
+    external_id_expression {
+      member_type = "BareMetalServer"
+      external_ids = [
+        "71be0142-2ed1-1d53-9c60-5564cf4b7e2e",
+        "81be0142-2ed1-1d53-9c60-5564cf4b7e2f"
+      ]
+    }
+  }
+}
+
+# Static group — specific interfaces by external ID
+resource "nsxt_policy_group" "critical_interfaces" {
+  display_name = "Critical-BMS-Interfaces"
+  description  = "Manually selected critical BMS interfaces"
+  group_type   = "BareMetalServer"
+
+  criteria {
+    external_id_expression {
+      member_type = "BareMetalServerInterface"
+      external_ids = [
+        "71be0142-2ed1-1d53-9c60-02005b4b7246"
+      ]
+    }
+  }
+}
+
+# Static group — mix of servers and interfaces
+resource "nsxt_policy_group" "mixed_static_bms" {
+  display_name = "Mixed-Static-BMS"
+  description  = "Static group with both BMS servers and interfaces"
+  group_type   = "BareMetalServer"
+
+  criteria {
+    external_id_expression {
+      member_type  = "BareMetalServer"
+      external_ids = ["71be0142-2ed1-1d53-9c60-5564cf4b7e2e"]
+    }
+  }
+
+  conjunction {
+    operator = "OR"
+  }
+
+  criteria {
+    external_id_expression {
+      member_type  = "BareMetalServerInterface"
+      external_ids = ["71be0142-2ed1-1d53-9c60-02005b4b7246"]
+    }
+  }
+}
+
+# Nested group — reference another BMS group by path
+resource "nsxt_policy_group" "nested_bms" {
+  display_name = "Nested-BMS-Group"
+  description  = "Group that includes another BMS group by reference"
+  group_type   = "BareMetalServer"
+
+  criteria {
+    path_expression {
+      member_paths = [nsxt_policy_group.production_bms.path]
+    }
+  }
+}
+```
+
+### Tag-based Group from Discovery
+
+```hcl
+# Discover and tag, then group — all in one workflow
+data "nsxt_policy_baremetal_servers" "all" {}
+
+resource "nsxt_policy_baremetal_server_tags" "env_tags" {
+  for_each = {
+    for s in data.nsxt_policy_baremetal_servers.all.results :
+    s.external_id => s
+  }
+
+  external_id = each.key
+
+  tag {
+    scope = "environment"
+    tag   = length(regexall("prod", lower(each.value.display_name))) > 0 ? "production" : "non-production"
+  }
+}
+
+resource "nsxt_policy_group" "prod_bms_group" {
+  display_name = "All-Production-BMS"
+  group_type   = "BareMetalServer"
+
+  depends_on = [nsxt_policy_baremetal_server_tags.env_tags]
 
   criteria {
     condition {
@@ -157,68 +505,19 @@ resource "nsxt_policy_group" "high_performance_servers" {
       operator    = "EQUALS"
       value       = "environment|production"
     }
-    condition {
-      key         = "Tag"
-      member_type = "BareMetalServer"
-      operator    = "EQUALS"
-      value       = "cpu-tier|high"
-    }
-  }
-}
-
-# Interface groups for network policies
-resource "nsxt_policy_group" "high_speed_interfaces" {
-  display_name = "High-Speed-BMS-Interfaces"
-  description  = "10Gbps+ bare metal server interfaces"
-  group_type   = "BareMetalServer"
-
-  criteria {
-    condition {
-      key         = "Tag"
-      member_type = "BareMetalServerInterface"
-      operator    = "EQUALS"
-      value       = "speed|10Gbps"
-    }
-  }
-}
-
-# Management network groups for security policies
-resource "nsxt_policy_group" "management_network_group" {
-  display_name = "Management-Network-Group"
-  description  = "Management network access group"
-
-  criteria {
-    ipaddress_expression {
-      ip_addresses = [
-        "192.168.1.0/24", # Replace with your actual management network
-        "10.0.0.0/24"     # Add additional management networks as needed
-      ]
-    }
-  }
-}
-
-resource "nsxt_policy_group" "critical_management_group" {
-  display_name = "Critical-Management-Group"
-  description  = "Critical infrastructure management group"
-
-  criteria {
-    ipaddress_expression {
-      ip_addresses = [
-        "192.168.1.10/32", # Replace with your actual critical management IPs
-        "192.168.1.11/32"  # Add additional critical management IPs
-      ]
-    }
   }
 }
 ```
 
-### Step 4: Apply Security Policies
+-> For the full list of supported keys and operators per member type, see the [BMS Group Condition Reference](#bms-group-condition-reference) section above.
+
+---
+
+## Step 5: Apply DFW Security Policies
 
 ```hcl
-# Define required services
 resource "nsxt_policy_service" "ssh" {
-  display_name = "SSH-Service"
-
+  display_name = "SSH"
   l4_port_set_entry {
     protocol          = "TCP"
     destination_ports = ["22"]
@@ -226,8 +525,7 @@ resource "nsxt_policy_service" "ssh" {
 }
 
 resource "nsxt_policy_service" "http" {
-  display_name = "HTTP-Service"
-
+  display_name = "HTTP"
   l4_port_set_entry {
     protocol          = "TCP"
     destination_ports = ["80"]
@@ -235,129 +533,328 @@ resource "nsxt_policy_service" "http" {
 }
 
 resource "nsxt_policy_service" "https" {
-  display_name = "HTTPS-Service"
-
+  display_name = "HTTPS"
   l4_port_set_entry {
     protocol          = "TCP"
     destination_ports = ["443"]
   }
 }
 
-resource "nsxt_policy_service" "mysql" {
-  display_name = "MySQL-Service"
-
-  l4_port_set_entry {
-    protocol          = "TCP"
-    destination_ports = ["3306"]
-  }
-}
-
-resource "nsxt_policy_service" "postgresql" {
-  display_name = "PostgreSQL-Service"
-
-  l4_port_set_entry {
-    protocol          = "TCP"
-    destination_ports = ["5432"]
-  }
-}
-
-# Basic security policy for production servers
-resource "nsxt_policy_security_policy" "production_bms_security" {
-  display_name = "Production-BMS-Security"
+# Basic security policy scoped to a BMS group
+resource "nsxt_policy_security_policy" "prod_bms_policy" {
+  display_name = "Production-BMS-Policy"
   description  = "Security policy for production bare metal servers"
   category     = "Application"
+  stateful     = true
+  scope        = [nsxt_policy_group.production_bms.path]
 
   rule {
-    display_name       = "Allow-Internal-Communication"
-    source_groups      = [nsxt_policy_group.production_servers.path]
-    destination_groups = [nsxt_policy_group.production_servers.path]
+    display_name       = "allow_internal_communication"
+    description        = "Allow traffic between production BMS servers"
+    source_groups      = [nsxt_policy_group.production_bms.path]
+    destination_groups = [nsxt_policy_group.production_bms.path]
     action             = "ALLOW"
-    services           = [nsxt_policy_service.ssh.path, nsxt_policy_service.http.path, nsxt_policy_service.https.path]
+    services           = [nsxt_policy_service.http.path, nsxt_policy_service.https.path]
     logged             = true
+    sequence_number    = 100
   }
 
   rule {
-    display_name       = "Allow-Management-Access"
-    source_groups      = [nsxt_policy_group.management_network_group.path]
-    destination_groups = [nsxt_policy_group.production_servers.path]
+    display_name       = "allow_ssh_management"
+    description        = "Allow SSH from management network"
+    destination_groups = [nsxt_policy_group.production_bms.path]
     action             = "ALLOW"
     services           = [nsxt_policy_service.ssh.path]
     logged             = true
+    sequence_number    = 200
   }
 
   rule {
-    display_name       = "Drop-Unauthorized"
-    source_groups      = [] # Empty list means "ANY"
-    destination_groups = [nsxt_policy_group.production_servers.path]
-    action             = "DROP"
-    services           = []
-    logged             = true
+    display_name    = "default_deny"
+    description     = "Deny all other traffic"
+    action          = "DROP"
+    logged          = true
+    sequence_number = 1000
+  }
+
+  lifecycle {
+    create_before_destroy = true
   }
 }
 
-# High-security policy for critical servers
-resource "nsxt_policy_security_policy" "critical_bms_security" {
-  display_name = "Critical-BMS-Security"
-  description  = "High security policy for critical servers"
+# Policy using standalone rules with nsxt_policy_parent_security_policy
+resource "nsxt_policy_parent_security_policy" "bms_parent" {
+  display_name = "BMS-Parent-Policy"
   category     = "Application"
+  stateful     = true
+  scope = [
+    nsxt_policy_group.production_bms.path,
+    nsxt_policy_group.web_tier_bms.path
+  ]
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "nsxt_policy_security_policy_rule" "allow_web_traffic" {
+  display_name       = "allow-web-traffic"
+  description        = "Allow web traffic to BMS web tier"
+  policy_path        = nsxt_policy_parent_security_policy.bms_parent.path
+  sequence_number    = 100
+  destination_groups = [nsxt_policy_group.web_tier_bms.path]
+  action             = "ALLOW"
+  services           = [nsxt_policy_service.http.path, nsxt_policy_service.https.path]
+  logged             = true
+}
+
+resource "nsxt_policy_security_policy_rule" "allow_bms_internal" {
+  display_name       = "allow-bms-internal"
+  description        = "Allow BMS-to-BMS communication"
+  policy_path        = nsxt_policy_parent_security_policy.bms_parent.path
+  sequence_number    = 200
+  source_groups      = [nsxt_policy_group.production_bms.path]
+  destination_groups = [nsxt_policy_group.production_bms.path]
+  action             = "ALLOW"
+  services           = [nsxt_policy_service.ssh.path]
+  logged             = true
+}
+
+resource "nsxt_policy_security_policy_rule" "default_deny" {
+  display_name    = "default-deny"
+  policy_path     = nsxt_policy_parent_security_policy.bms_parent.path
+  sequence_number = 1000
+  action          = "DROP"
+  logged          = true
+}
+```
+
+### Example — BMS Interface Security Policy
+
+~> **NOTE:** `group_type = "BareMetalServer"` is **required** whenever a group contains `BareMetalServer` or `BareMetalServerInterface` member types. BMS groups may only contain BMS or BMSI members — mixing with `VirtualMachine` or other member types is not supported. Create separate policies for BMS and VM workloads.
+
+```hcl
+# BMS interface group — data-plane interfaces only
+resource "nsxt_policy_group" "bms_data_only" {
+  display_name = "BMS-Data-Interfaces"
+  description  = "Data-plane interfaces for all BMS servers"
+  group_type   = "BareMetalServer"
+
+  criteria {
+    condition {
+      key         = "Tag"
+      member_type = "BareMetalServerInterface"
+      operator    = "EQUALS"
+      value       = "network-type|data-plane"
+    }
+  }
+}
+
+resource "nsxt_policy_group" "trusted_management_hosts" {
+  display_name = "Trusted-Management-Hosts"
+  description  = "IP addresses of trusted management hosts"
+
+  criteria {
+    ipaddress_expression {
+      ip_addresses = ["10.0.0.0/24"]
+    }
+  }
+}
+
+# Policy applied specifically to BMS data-plane interfaces
+resource "nsxt_policy_security_policy" "bms_interface_policy" {
+  display_name = "BMS-Interface-Policy"
+  description  = "Security policy for BMS data-plane interfaces"
+  category     = "Application"
+  stateful     = true
+  scope        = [nsxt_policy_group.bms_data_only.path]
 
   rule {
-    display_name       = "Allow-Specific-Management"
-    source_groups      = [nsxt_policy_group.critical_management_group.path]
-    destination_groups = [nsxt_policy_group.critical_servers.path]
+    display_name       = "allow_management_ssh"
+    description        = "Allow SSH from trusted hosts to BMS servers"
+    source_groups      = [nsxt_policy_group.trusted_management_hosts.path]
+    destination_groups = [nsxt_policy_group.bms_data_only.path]
     action             = "ALLOW"
     services           = [nsxt_policy_service.ssh.path]
     logged             = true
   }
 
   rule {
-    display_name       = "Deny-All-Others"
-    destination_groups = [nsxt_policy_group.critical_servers.path]
-    action             = "DROP"
-    logged             = true
+    display_name    = "default_deny"
+    description     = "Default deny on data-plane interfaces"
+    action          = "DROP"
+    logged          = true
+    sequence_number = 1000
+  }
+
+  lifecycle {
+    create_before_destroy = true
   }
 }
 ```
 
-## Advanced Use Cases
+---
 
-### Multi-Tier Application Architecture
+## Step 6: Audit Group Membership and Associations
+
+Use the association and member-listing data sources to verify that servers and interfaces are in the right groups.
 
 ```hcl
-# Separate groups for different application tiers
-locals {
-  app_tiers = ["web", "app", "db"]
+# Which groups does a specific server belong to?
+data "nsxt_policy_baremetal_server_group_associations" "server_memberships" {
+  external_id = "71be0142-2ed1-1d53-9c60-5564cf4b7e2e"
 }
 
-resource "nsxt_policy_baremetal_server_tags" "app_tier_tags" {
-  for_each = {
-    for server in data.nsxt_policy_baremetal_servers.all_servers.results :
-    server.external_id => {
-      id   = server.external_id
-      tier = length([for tier in local.app_tiers : tier if contains(lower(server.display_name), tier)]) > 0 ? [for tier in local.app_tiers : tier if contains(lower(server.display_name), tier)][0] : "general"
+output "server_group_paths" {
+  value = [for g in data.nsxt_policy_baremetal_server_group_associations.server_memberships.groups : g.path]
+}
+
+# Which interfaces belong to a specific group?
+data "nsxt_policy_group_baremetal_server_interface_members" "group_interfaces" {
+  domain   = "default"
+  group_id = nsxt_policy_group.web_tier_bms.id
+}
+
+output "group_interface_external_ids" {
+  value = [for m in data.nsxt_policy_group_baremetal_server_interface_members.group_interfaces.items : m.external_id]
+}
+
+# Which servers belong to a specific group?
+data "nsxt_policy_group_baremetal_server_members" "group_servers" {
+  domain   = "default"
+  group_id = nsxt_policy_group.production_bms.id
+}
+
+output "group_server_names" {
+  value = [for m in data.nsxt_policy_group_baremetal_server_members.group_servers.items : m.display_name]
+}
+
+# Which groups does a specific interface belong to?
+data "nsxt_policy_baremetal_server_interface_group_associations" "if_memberships" {
+  external_id = "71be0142-2ed1-1d53-9c60-02005b4b7246"
+}
+
+output "interface_group_paths" {
+  value = [for g in data.nsxt_policy_baremetal_server_interface_group_associations.if_memberships.groups : g.path]
+}
+```
+
+### Using Group Associations as Policy Input
+
+`nsxt_policy_baremetal_server_group_associations` does not only serve as an audit tool — you can feed the discovered group paths directly into a security policy rule's `source_groups` or `destination_groups`. This is useful when you want to allow or restrict traffic based on the groups a specific server already belongs to, without hard-coding group paths.
+
+```hcl
+# Discover all groups the server is currently a member of
+data "nsxt_policy_baremetal_server_group_associations" "bms_groups" {
+  external_id = "71be0142-2ed1-1d53-9c60-5564cf4b7e2e"
+}
+
+# Target destination group — e.g. a monitoring server group
+resource "nsxt_policy_group" "monitoring_servers" {
+  display_name = "Monitoring-Servers"
+  description  = "Monitoring server IP addresses"
+
+  criteria {
+    ipaddress_expression {
+      ip_addresses = ["10.1.0.0/24"]
     }
+  }
+}
+
+resource "nsxt_policy_service" "monitoring" {
+  display_name = "Monitoring-Port"
+  l4_port_set_entry {
+    protocol          = "TCP"
+    destination_ports = ["9090", "9091"]
+  }
+}
+
+# Allow the server's existing groups to reach the monitoring servers
+resource "nsxt_policy_security_policy" "bms_monitoring_policy" {
+  display_name = "BMS-Monitoring-Access"
+  description  = "Allow discovered BMS groups to reach monitoring infrastructure"
+  category     = "Application"
+
+  rule {
+    display_name       = "allow_bms_to_monitoring"
+    description        = "Allow BMS group traffic to monitoring servers"
+    source_groups      = data.nsxt_policy_baremetal_server_group_associations.bms_groups.groups[*].path
+    destination_groups = [nsxt_policy_group.monitoring_servers.path]
+    action             = "ALLOW"
+    services           = [nsxt_policy_service.monitoring.path]
+    logged             = true
+    sequence_number    = 100
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# Similarly, use interface group associations in rules
+data "nsxt_policy_baremetal_server_interface_group_associations" "bms_if_groups" {
+  external_id = "71be0142-2ed1-1d53-9c60-02005b4b7246"
+}
+
+resource "nsxt_policy_security_policy" "bms_interface_access_policy" {
+  display_name = "BMS-Interface-Access"
+  description  = "Policy using interface group membership as source"
+  category     = "Application"
+
+  rule {
+    display_name       = "allow_interface_groups"
+    source_groups      = data.nsxt_policy_baremetal_server_interface_group_associations.bms_if_groups.groups[*].path
+    destination_groups = [nsxt_policy_group.monitoring_servers.path]
+    action             = "ALLOW"
+    services           = [nsxt_policy_service.monitoring.path]
+    logged             = true
+    sequence_number    = 100
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+```
+
+---
+
+## Advanced Use Cases
+
+### Multi-Tier Application
+
+```hcl
+locals {
+  tiers = ["web", "app", "db"]
+}
+
+# Tag servers by application tier
+resource "nsxt_policy_baremetal_server_tags" "tier_tags" {
+  for_each = {
+    for s in data.nsxt_policy_baremetal_servers.all.results :
+    s.external_id => (
+      contains(local.tiers, split("-", lower(s.display_name))[0])
+      ? split("-", lower(s.display_name))[0]
+      : "general"
+    )
   }
 
   external_id = each.key
 
   tag {
     scope = "app-tier"
-    tag   = each.value.tier
-  }
-
-  tag {
-    scope = "managed-by"
-    tag   = "terraform"
+    tag   = each.value
   }
 }
 
-# Create tier-specific groups
-resource "nsxt_policy_group" "app_tier_groups" {
-  for_each = toset(local.app_tiers)
+# One group per tier
+resource "nsxt_policy_group" "tier_groups" {
+  for_each = toset(local.tiers)
 
   display_name = "BMS-${title(each.key)}-Tier"
-  description  = "${title(each.key)} tier bare metal servers"
   group_type   = "BareMetalServer"
+
+  depends_on = [nsxt_policy_baremetal_server_tags.tier_tags]
 
   criteria {
     condition {
@@ -369,281 +866,314 @@ resource "nsxt_policy_group" "app_tier_groups" {
   }
 }
 
-# Tier-specific security policies
+# Tier-to-tier communication rules
 resource "nsxt_policy_security_policy" "tier_communication" {
-  display_name = "Multi-Tier-BMS-Communication"
-  description  = "Inter-tier communication rules"
+  display_name = "BMS-Tier-Communication"
   category     = "Application"
 
-  # Web tier can access app tier
   rule {
-    display_name       = "Web-to-App"
-    source_groups      = [nsxt_policy_group.app_tier_groups["web"].path]
-    destination_groups = [nsxt_policy_group.app_tier_groups["app"].path]
+    display_name       = "web-to-app"
+    source_groups      = [nsxt_policy_group.tier_groups["web"].path]
+    destination_groups = [nsxt_policy_group.tier_groups["app"].path]
     action             = "ALLOW"
     services           = [nsxt_policy_service.http.path, nsxt_policy_service.https.path]
     logged             = true
+    sequence_number    = 100
   }
 
-  # App tier can access database tier
   rule {
-    display_name       = "App-to-DB"
-    source_groups      = [nsxt_policy_group.app_tier_groups["app"].path]
-    destination_groups = [nsxt_policy_group.app_tier_groups["db"].path]
+    display_name       = "app-to-db"
+    source_groups      = [nsxt_policy_group.tier_groups["app"].path]
+    destination_groups = [nsxt_policy_group.tier_groups["db"].path]
     action             = "ALLOW"
-    services           = [nsxt_policy_service.mysql.path, nsxt_policy_service.postgresql.path]
     logged             = true
+    sequence_number    = 200
   }
 
-  # Deny direct web to database access
   rule {
-    display_name       = "Block-Web-to-DB"
-    source_groups      = [nsxt_policy_group.app_tier_groups["web"].path]
-    destination_groups = [nsxt_policy_group.app_tier_groups["db"].path]
+    display_name       = "block-web-to-db"
+    source_groups      = [nsxt_policy_group.tier_groups["web"].path]
+    destination_groups = [nsxt_policy_group.tier_groups["db"].path]
     action             = "DROP"
-    services           = []
     logged             = true
+    sequence_number    = 300
+  }
+
+  lifecycle {
+    create_before_destroy = true
   }
 }
 ```
 
-### Network Segmentation by VLAN
+### Interface Segmentation by Network Zone
 
 ```hcl
-# Tag interfaces by VLAN information
-resource "nsxt_policy_baremetal_server_interface_tags" "vlan_segmentation" {
+# Tag interfaces by network zone derived from naming
+resource "nsxt_policy_baremetal_server_interface_tags" "zone_tags" {
   for_each = {
     for iface in data.nsxt_policy_baremetal_server_interfaces.all_interfaces.results :
-    iface.external_id => {
-      id   = iface.external_id
-      vlan = can(regex("vlan[_-]?(\\d+)", lower(iface.display_name))) ? regex("vlan[_-]?(\\d+)", lower(iface.display_name))[0] : "unknown"
-    }
+    iface.external_id => (
+      length(regexall("dmz", lower(iface.display_name))) > 0 ? "dmz" :
+      length(regexall("internal", lower(iface.display_name))) > 0 ? "internal" : "general"
+    )
     if !iface.is_mgmt_interface
   }
 
   external_id = each.key
 
   tag {
-    scope = "vlan"
-    tag   = each.value.vlan
-  }
-
-  tag {
-    scope = "segment-type"
-    tag   = each.value.vlan == "100" ? "dmz" : each.value.vlan == "200" ? "internal" : "general"
+    scope = "network-zone"
+    tag   = each.value
   }
 }
 
-# Create VLAN-specific groups
 resource "nsxt_policy_group" "dmz_interfaces" {
   display_name = "DMZ-BMS-Interfaces"
-  description  = "DMZ VLAN interfaces"
   group_type   = "BareMetalServer"
+
+  depends_on = [nsxt_policy_baremetal_server_interface_tags.zone_tags]
 
   criteria {
     condition {
       key         = "Tag"
       member_type = "BareMetalServerInterface"
       operator    = "EQUALS"
-      value       = "segment-type|dmz"
+      value       = "network-zone|dmz"
     }
   }
 }
 
 resource "nsxt_policy_group" "internal_interfaces" {
   display_name = "Internal-BMS-Interfaces"
-  description  = "Internal VLAN interfaces"
   group_type   = "BareMetalServer"
+
+  depends_on = [nsxt_policy_baremetal_server_interface_tags.zone_tags]
 
   criteria {
     condition {
       key         = "Tag"
       member_type = "BareMetalServerInterface"
       operator    = "EQUALS"
-      value       = "segment-type|internal"
+      value       = "network-zone|internal"
     }
   }
 }
 ```
+
+---
+
+## Importing Existing Resources
+
+Both BMS tag resources support import using the server or interface external ID.
+
+```shell
+# Import server tags by external ID
+terraform import nsxt_policy_baremetal_server_tags.my_server 71be0142-2ed1-1d53-9c60-5564cf4b7e2e
+
+# Import interface tags by external ID
+terraform import nsxt_policy_baremetal_server_interface_tags.my_interface 71be0142-2ed1-1d53-9c60-02005b4b7246
+```
+
+After import, run `terraform plan` to verify the state matches expectations. If tags exist on the server that are not in your Terraform configuration, they will be removed on the next `terraform apply` (the resource manages all tags on the server).
+
+---
+
+## Drift Detection
+
+Use the tag data sources to detect configuration drift — tags applied outside Terraform.
+
+```hcl
+data "nsxt_policy_baremetal_server_tags" "live_tags" {
+  external_id = nsxt_policy_baremetal_server_tags.prod_web_01.id
+}
+
+resource "nsxt_policy_baremetal_server_tags" "prod_web_01" {
+  external_id = "71be0142-2ed1-1d53-9c60-5564cf4b7e2e"
+
+  tag {
+    scope = "environment"
+    tag   = "production"
+  }
+}
+
+# Compare live tags with expected — drift detected if lengths differ
+output "drift_check" {
+  value = {
+    expected_count = 1
+    actual_count   = length(data.nsxt_policy_baremetal_server_tags.live_tags.tag)
+    is_drifted     = length(data.nsxt_policy_baremetal_server_tags.live_tags.tag) != 1
+  }
+}
+```
+
+---
 
 ## Best Practices
 
-### 1. Consistent Tagging Strategy
+### Consistent Tagging Strategy
+
+Define tag scopes as locals and reuse them across resources:
 
 ```hcl
-# Define standard tags as locals
 locals {
-  standard_server_tags = {
-    managed-by          = "terraform"
-    provisioned         = formatdate("YYYY-MM-DD", timestamp())
-    terraform-workspace = terraform.workspace
+  bms_tag_scopes = {
+    environment = "environment"
+    application = "application"
+    tier        = "app-tier"
+    managed_by  = "managed-by"
+    owner       = "owner"
   }
 
-  environment_mapping = {
+  env_map = {
     prod = "production"
     dev  = "development"
-    test = "testing"
     stg  = "staging"
+    test = "testing"
   }
 }
 
-# Apply standard tags to all servers
-resource "nsxt_policy_baremetal_server_tags" "standard_tags" {
+resource "nsxt_policy_baremetal_server_tags" "standard" {
   for_each = {
-    for server in data.nsxt_policy_baremetal_servers.all_servers.results :
-    server.external_id => server
+    for s in data.nsxt_policy_baremetal_servers.all.results :
+    s.external_id => s
   }
 
   external_id = each.key
 
-  dynamic "tag" {
-    for_each = local.standard_server_tags
-    content {
-      scope = tag.key
-      tag   = tag.value
-    }
+  tag {
+    scope = local.bms_tag_scopes.managed_by
+    tag   = "terraform"
   }
 
-  # Environment-specific tag based on naming convention
   tag {
-    scope = "environment"
-    tag = lookup(
-      local.environment_mapping,
-      split("-", each.value.display_name)[0],
-      "unknown"
-    )
+    scope = local.bms_tag_scopes.environment
+    tag   = lookup(local.env_map, split("-", lower(each.value.display_name))[0], "unknown")
   }
 }
 ```
 
-### 2. Conditional Resource Creation
+### Guard Against Missing Inventory
 
 ```hcl
-# Only create security policies if servers exist
-resource "nsxt_policy_security_policy" "conditional_bms_policy" {
-  count = length(data.nsxt_policy_baremetal_servers.all_servers.results) > 0 ? 1 : 0
+resource "nsxt_policy_security_policy" "conditional_policy" {
+  count = length(data.nsxt_policy_baremetal_servers.prod_servers.results) > 0 ? 1 : 0
 
-  display_name = "BMS-Conditional-Policy"
-  description  = "Policy created only when BMS servers exist"
+  display_name = "Conditional-BMS-Policy"
   category     = "Application"
 
   rule {
-    display_name       = "Default-Allow-Internal"
-    source_groups      = [nsxt_policy_group.production_servers.path]
-    destination_groups = [nsxt_policy_group.production_servers.path]
+    display_name       = "allow_internal"
+    source_groups      = [nsxt_policy_group.production_bms.path]
+    destination_groups = [nsxt_policy_group.production_bms.path]
     action             = "ALLOW"
-    services           = [] # Empty list means "ANY"
     logged             = true
   }
-}
-```
 
-### 3. Error Handling and Validation
-
-```hcl
-# Validate that required servers exist before proceeding
-locals {
-  required_servers = ["critical-server-001", "critical-server-002"]
-
-  discovered_critical_servers = [
-    for server in data.nsxt_policy_baremetal_servers.all_servers.results :
-    server.display_name
-    if contains(local.required_servers, server.display_name)
-  ]
-}
-
-# Use validation to ensure critical servers are discovered
-resource "null_resource" "validate_critical_servers" {
-  count = length(local.discovered_critical_servers) == length(local.required_servers) ? 0 : 1
-
-  provisioner "local-exec" {
-    command = "echo 'ERROR: Not all required servers discovered' && exit 1"
+  lifecycle {
+    create_before_destroy = true
   }
 }
 ```
 
-### 4. Modular Organization
+### Module Pattern
 
 ```hcl
-# variables.tf
-variable "bms_tagging_strategy" {
-  description = "BMS tagging strategy configuration"
-  type = object({
-    environment_tag_scope = string
-    application_tag_scope = string
-    owner_tag_scope       = string
-  })
-  default = {
-    environment_tag_scope = "environment"
-    application_tag_scope = "application"
-    owner_tag_scope       = "owner"
-  }
-}
+# modules/bms-tier/variables.tf
+variable "tier_name" { type = string }
+variable "server_external_ids" { type = list(string) }
 
-# modules/bms-management/main.tf
-resource "nsxt_policy_baremetal_server_tags" "servers" {
-  for_each = var.server_configurations
-
+# modules/bms-tier/main.tf
+resource "nsxt_policy_baremetal_server_tags" "tags" {
+  for_each    = toset(var.server_external_ids)
   external_id = each.key
 
-  dynamic "tag" {
-    for_each = each.value.tags
-    content {
-      scope = tag.key
-      tag   = tag.value
+  tag {
+    scope = "app-tier"
+    tag   = var.tier_name
+  }
+}
+
+resource "nsxt_policy_group" "group" {
+  display_name = "BMS-${var.tier_name}"
+  group_type   = "BareMetalServer"
+
+  depends_on = [nsxt_policy_baremetal_server_tags.tags]
+
+  criteria {
+    condition {
+      key         = "Tag"
+      member_type = "BareMetalServer"
+      operator    = "EQUALS"
+      value       = "app-tier|${var.tier_name}"
     }
   }
 }
 
-# Call module from main configuration
-module "production_bms" {
-  source = "./modules/bms-management"
+# modules/bms-tier/outputs.tf
+output "group_path" { value = nsxt_policy_group.group.path }
 
-  server_configurations = {
-    for server in data.nsxt_policy_baremetal_servers.production.results :
-    server.external_id => {
-      tags = {
-        environment = "production"
-        application = "web-app"
-        owner       = "platform-team"
-      }
-    }
-  }
+# root/main.tf
+module "web_tier" {
+  source              = "./modules/bms-tier"
+  tier_name           = "web"
+  server_external_ids = ["uuid-1", "uuid-2"]
+}
+
+module "app_tier" {
+  source              = "./modules/bms-tier"
+  tier_name           = "app"
+  server_external_ids = ["uuid-3", "uuid-4"]
 }
 ```
+
+---
 
 ## Troubleshooting
 
-### Common Issues and Solutions
+### No BMS Servers Discovered
 
-1. **No BMS servers discovered**: Ensure compute manager is configured and servers are registered
-2. **Tagging failures**: Verify server external IDs are correct and accessible
-3. **Group membership issues**: Check tag scopes and values match exactly
-4. **Policy application failures**: Ensure groups exist before referencing in policies
+- Verify that a compute manager is configured in NSX-T and bare metal servers are registered.
+- Check that the NSX version is 9.0.0 or higher.
+- Run `data "nsxt_policy_baremetal_servers" "all" {}` with no filters to confirm the inventory is non-empty.
 
-### Debugging Data Sources
+### Group Membership Not Reflecting Expected Servers
+
+- Ensure tag scope and value strings match exactly (case-sensitive).
+- Tags must be applied before the group is evaluated. Add a `depends_on` from the group to the tag resource.
+- Use `nsxt_policy_group_baremetal_server_members` data source to inspect actual effective membership.
+
+### Policy Apply Fails with BMS Group
+
+- Confirm `group_type = "BareMetalServer"` is set on every group containing BMS/BMSI members.
+- Confirm the policy `category` is not `Ethernet` (unsupported for BMS).
+- Confirm no `context_profiles` are referenced in rules that target BMS groups.
+
+### Import Differences After `terraform plan`
+
+- If tags exist on the server outside of Terraform, they appear as planned deletions. Either add them to the Terraform configuration or accept removal on next apply.
+- Check that the `external_id` used for import matches the one in your configuration.
+
+### Debugging Inventory and Tags
 
 ```hcl
-# Debug server discovery
+# Dump full server inventory
 output "debug_servers" {
   value = {
-    for idx, server in data.nsxt_policy_baremetal_servers.all_servers.results :
-    idx => {
-      external_id  = server.external_id
-      display_name = server.display_name
-      cpu_cores    = server.cpu_cores
-      os_name      = server.os_name
-      os_version   = server.os_version
+    for s in data.nsxt_policy_baremetal_servers.all_servers.results :
+    s.external_id => {
+      display_name = s.display_name
+      os           = "${s.os_name} ${s.os_version}"
+      cpu_cores    = s.cpu_cores
+      tags         = s.tags
     }
   }
 }
 
-# Debug interface discovery
+# Dump full interface inventory
 output "debug_interfaces" {
   value = {
-    for idx, iface in data.nsxt_policy_baremetal_server_interfaces.all_interfaces.results :
-    idx => {
-      external_id       = iface.external_id
+    for iface in data.nsxt_policy_baremetal_server_interfaces.all_interfaces.results :
+    iface.external_id => {
       display_name      = iface.display_name
       bms_external_id   = iface.bms_external_id
       is_mgmt_interface = iface.is_mgmt_interface
@@ -653,5 +1183,3 @@ output "debug_interfaces" {
   }
 }
 ```
-
-This guide provides a foundation for managing bare metal servers with the NSX-T Terraform provider. Adapt the examples to your specific environment and requirements.

--- a/docs/resources/policy_baremetal_server_interface_tags.md
+++ b/docs/resources/policy_baremetal_server_interface_tags.md
@@ -1,6 +1,6 @@
 ---
 subcategory: "Beta"
-page_title: "NSXT: policy_baremetal_server_interface_tags"
+page_title: "NSXT: nsxt_policy_baremetal_server_interface_tags"
 description: A resource for applying tags to Bare Metal Server Interfaces.
 ---
 

--- a/docs/resources/policy_baremetal_server_tags.md
+++ b/docs/resources/policy_baremetal_server_tags.md
@@ -1,6 +1,6 @@
 ---
 subcategory: "Beta"
-page_title: "NSXT: policy_baremetal_server_tags"
+page_title: "NSXT: nsxt_policy_baremetal_server_tags"
 description: A resource for applying tags to Bare Metal Servers.
 ---
 

--- a/docs/resources/policy_group.md
+++ b/docs/resources/policy_group.md
@@ -147,7 +147,25 @@ resource "nsxt_policy_group" "bms_dynamic" {
     }
   }
 }
+
+# BMS group selecting management interfaces via ManagementInterface key
+resource "nsxt_policy_group" "bms_mgmt_interfaces" {
+  display_name = "tf-bms-management-interfaces"
+  description  = "All BMS management interfaces"
+  group_type   = "BareMetalServer"
+
+  criteria {
+    condition {
+      key         = "ManagementInterface"
+      member_type = "BareMetalServerInterface"
+      operator    = "EQUALS"
+      value       = "TRUE"
+    }
+  }
+}
 ```
+
+## Global Manager example
 
 Note: This usage is for Global Manager only using site
 
@@ -282,11 +300,9 @@ The following arguments are supported:
         * `external_ids` - (Required) List of external IDs for the specified member type.
     * `condition` (Optional) A repeatable condition block to select this Group's members. When multiple `condition` blocks are used in a single `criteria` they form a nested expression that's implicitly ANDed together and each nested condition must used the same `member_type`.
         * `key` (Required) Specifies the attribute to query. Must be one of: `Tag`, `ComputerName`, `OSName`, `Name`, `NodeType`, `GroupType`, `ALL`, `IPAddress`, `PodCidr`, `ManagementInterface`, `OSVersion`.
-          Please note that certain keys are only applicable to certain member types. For BMS groups (requires NSX 9.0.0 or higher):
-          `BareMetalServer` member type supports `Tag`, `Name`, `OSName`, `ALL`, `ManagementInterface`, and `OSVersion` keys.
-          `BareMetalServerInterface` member type supports only the `Tag` key.
-        * `member_type` (Required) Specifies the type of resource to query. Must be one of: `IPSet`, `LogicalPort`, `LogicalSwitch`, `Segment`, `SegmentPort`, `VirtualMachine`, `Group`, `DVPG`, `DVPort`, `IPAddress`, `TransportNode`, `Pod`, `Service`, `Namespace`, `KubernetesCluster`, `KubernetesNamespace`, `KubernetesIngress`, `KubernetesService`, `KubernetesNode`, `AntreaEgress`, `AntreaIPPool`, `VpcSubnet`, `VpcSubnetPort`, `BareMetalServer`,
-          `BareMetalServerInterface`. Note that certain member types are only applicable to certain environments.
+            Please note that certain keys are only applicable to certain member types. For BMS-specific supported keys and valid operators per member type, refer to the [Bare Metal Server Management guide](../guides/baremetal_server_management).
+        * `member_type` (Required) Specifies the type of resource to query. Must be one of: `IPSet`, `LogicalPort`, `LogicalSwitch`, `Segment`, `SegmentPort`, `VirtualMachine`, `Group`, `DVPG`, `DVPort`, `IPAddress`, `TransportNode`, `Pod`, `Service`, `Namespace`, `KubernetesCluster`, `KubernetesNamespace`, `KubernetesIngress`, `KubernetesService`, `KubernetesNode`, `AntreaEgress`, `AntreaIPPool`,
+          `VpcSubnet`, `VpcSubnetPort`, `BareMetalServer`, `BareMetalServerInterface`. Note that certain member types are only applicable to certain environments.
         * `operator` (Required) Specifies the query operator to use. Must be one of: `CONTAINS`, `ENDSWITH`, `EQUALS`, `NOTEQUALS`, `STARTSWITH`, `IN`, `NOTIN`, `MATCHES`. Note that certain operators are only applicable to certain keys/member types.
         * `value` (Required) User specified string value to use in the query. For `Tag` criteria, use 'scope|value' notation if you wish to specify scope in criteria.
 * `conjunction` (Required for multiple `criteria`) When specifying multiple `criteria`, a conjunction is used to specify if the criteria should selected using `AND` or `OR`.
@@ -296,7 +312,8 @@ The following arguments are supported:
         * `distinguished_name` (Required) LDAP distinguished name (DN). A valid fully qualified distinguished name should be provided here. This value is valid only if it matches to exactly 1 LDAP object on the LDAP server.
         * `domain_base_distinguished_name` (Required) Identity (Directory) domain base distinguished name. This is the base distinguished name for the domain where this identity group resides. (e.g. dc=example,dc=com)
         * `sid` (Optional) Identity (Directory) Group SID (security identifier). A security identifier (SID) is a unique value of variable length used to identify a trustee. This field is only populated for Microsoft Active Directory identity store.
-* `group_type` - (Optional) One of `IPAddress`, `ANTREA`, `BareMetalServer`. Empty group type indicates a generic group. Attribute is supported with NSX version 3.2.0 and above. Note that updating this attribute will trigger recreation of the group. `BareMetalServer` group type requires NSX version 9.0.0 or higher. **IMPORTANT**: `group_type = "BareMetalServer"` is **REQUIRED** when using `BareMetalServer` or `BareMetalServerInterface` member types in criteria.
+* `group_type` - (Optional) One of `IPAddress`, `ANTREA`, `BareMetalServer`. Empty group type indicates a generic group. Attribute is supported with NSX version 3.2.0 and above. Note that updating this attribute will trigger recreation of the group. `BareMetalServer` group type requires NSX version 9.0.0 or higher.
+    * **NOTE**: `group_type = "BareMetalServer"` **must** be set whenever `BareMetalServer` or `BareMetalServerInterface` member types are used. A `BareMetalServer`-typed group can only contain `BareMetalServer` and/or `BareMetalServerInterface` members.
 
 ## Attributes Reference
 

--- a/docs/resources/policy_group.md
+++ b/docs/resources/policy_group.md
@@ -147,7 +147,25 @@ resource "nsxt_policy_group" "bms_dynamic" {
     }
   }
 }
+
+# BMS group selecting management interfaces via ManagementInterface key
+resource "nsxt_policy_group" "bms_mgmt_interfaces" {
+  display_name = "tf-bms-management-interfaces"
+  description  = "All BMS management interfaces"
+  group_type   = "BareMetalServer"
+
+  criteria {
+    condition {
+      key         = "ManagementInterface"
+      member_type = "BareMetalServerInterface"
+      operator    = "EQUALS"
+      value       = "TRUE"
+    }
+  }
+}
 ```
+
+## Global Manager example
 
 Note: This usage is for Global Manager only using site
 
@@ -282,12 +300,10 @@ The following arguments are supported:
         * `external_ids` - (Required) List of external IDs for the specified member type.
     * `condition` (Optional) A repeatable condition block to select this Group's members. When multiple `condition` blocks are used in a single `criteria` they form a nested expression that's implicitly ANDed together and each nested condition must used the same `member_type`.
         * `key` (Required) Specifies the attribute to query. Must be one of: `Tag`, `ComputerName`, `OSName`, `Name`, `NodeType`, `GroupType`, `ALL`, `IPAddress`, `PodCidr`, `ManagementInterface`, `OSVersion`.
-          Please note that certain keys are only applicable to certain member types. For BMS groups (requires NSX 9.0.0 or higher):
-          `BareMetalServer` member type supports `Tag`, `Name`, `OSName`, `ALL`, `ManagementInterface`, and `OSVersion` keys.
-          `BareMetalServerInterface` member type supports only the `Tag` key.
-        * `member_type` (Required) Specifies the type of resource to query. Must be one of: `IPSet`, `LogicalPort`, `LogicalSwitch`, `Segment`, `SegmentPort`, `VirtualMachine`, `Group`, `DVPG`, `DVPort`, `IPAddress`, `TransportNode`, `Pod`, `Service`, `Namespace`, `KubernetesCluster`, `KubernetesNamespace`, `KubernetesIngress`, `KubernetesService`, `KubernetesNode`, `AntreaEgress`, `AntreaIPPool`, `VpcSubnet`, `VpcSubnetPort`, `BareMetalServer`,
-          `BareMetalServerInterface`. Note that certain member types are only applicable to certain environments.
-        * `operator` (Required) Specifies the query operator to use. Must be one of: `CONTAINS`, `ENDSWITH`, `EQUALS`, `NOTEQUALS`, `STARTSWITH`, `IN`, `NOTIN`, `MATCHES`. Note that certain operators are only applicable to certain keys/member types.
+            Please note that certain keys are only applicable to certain member types. For BMS-specific supported keys and valid operators per member type, refer to the [Bare Metal Server Management guide](../guides/baremetal_server_management).
+        * `member_type` (Required) Specifies the type of resource to query. Must be one of: `IPSet`, `LogicalPort`, `LogicalSwitch`, `Segment`, `SegmentPort`, `VirtualMachine`, `Group`, `DVPG`, `DVPort`, `IPAddress`, `TransportNode`, `Pod`, `Service`, `Namespace`, `KubernetesCluster`, `KubernetesNamespace`, `KubernetesIngress`, `KubernetesService`, `KubernetesNode`, `AntreaEgress`, `AntreaIPPool`,
+          `VpcSubnet`, `VpcSubnetPort`, `BareMetalServer`, `BareMetalServerInterface`. Note that certain member types are only applicable to certain environments.
+        * `operator` (Required) Specifies the query operator to use. Must be one of: `CONTAINS`, `ENDSWITH`, `EQUALS`, `NOTEQUALS`, `STARTSWITH`, `IN`, `NOTIN`, `MATCHES`, `TRUE`, `FALSE`. Note that certain operators are only applicable to certain keys/member types.
         * `value` (Required) User specified string value to use in the query. For `Tag` criteria, use 'scope|value' notation if you wish to specify scope in criteria.
 * `conjunction` (Required for multiple `criteria`) When specifying multiple `criteria`, a conjunction is used to specify if the criteria should selected using `AND` or `OR`.
     * `operator` (Required) The operator to use. Must be one of `AND` or `OR`. If `AND` is used, then the `criteria` block before/after must be of the same type and if using `condition` then also must use the same `member_type`.
@@ -296,7 +312,8 @@ The following arguments are supported:
         * `distinguished_name` (Required) LDAP distinguished name (DN). A valid fully qualified distinguished name should be provided here. This value is valid only if it matches to exactly 1 LDAP object on the LDAP server.
         * `domain_base_distinguished_name` (Required) Identity (Directory) domain base distinguished name. This is the base distinguished name for the domain where this identity group resides. (e.g. dc=example,dc=com)
         * `sid` (Optional) Identity (Directory) Group SID (security identifier). A security identifier (SID) is a unique value of variable length used to identify a trustee. This field is only populated for Microsoft Active Directory identity store.
-* `group_type` - (Optional) One of `IPAddress`, `ANTREA`, `BareMetalServer`. Empty group type indicates a generic group. Attribute is supported with NSX version 3.2.0 and above. Note that updating this attribute will trigger recreation of the group. `BareMetalServer` group type requires NSX version 9.0.0 or higher. **IMPORTANT**: `group_type = "BareMetalServer"` is **REQUIRED** when using `BareMetalServer` or `BareMetalServerInterface` member types in criteria.
+* `group_type` - (Optional) One of `IPAddress`, `ANTREA`, `BareMetalServer`. Empty group type indicates a generic group. Attribute is supported with NSX version 3.2.0 and above. Note that updating this attribute will trigger recreation of the group. `BareMetalServer` group type requires NSX version 9.0.0 or higher.
+    * **NOTE**: `group_type = "BareMetalServer"` **must** be set whenever `BareMetalServer` or `BareMetalServerInterface` member types are used. A `BareMetalServer`-typed group can only contain `BareMetalServer` and/or `BareMetalServerInterface` members.
 
 ## Attributes Reference
 

--- a/docs/resources/policy_parent_security_policy.md
+++ b/docs/resources/policy_parent_security_policy.md
@@ -118,7 +118,7 @@ resource "nsxt_policy_security_policy_rule" "rule1" {
 resource "nsxt_policy_group" "production_bms" {
   display_name = "Production-BMS-Servers"
   description  = "Production bare metal servers"
-
+  group_type   = "BareMetalServer"
   criteria {
     condition {
       key         = "Tag"
@@ -132,7 +132,7 @@ resource "nsxt_policy_group" "production_bms" {
 resource "nsxt_policy_group" "bms_data_interfaces" {
   display_name = "BMS-Data-Interfaces"
   description  = "BMS data plane interfaces"
-
+  group_type   = "BareMetalServer"
   criteria {
     condition {
       key         = "Tag"
@@ -183,93 +183,6 @@ resource "nsxt_policy_security_policy_rule" "block_mgmt_on_data" {
   action          = "DROP"
   services        = [nsxt_policy_service.ssh.path, nsxt_policy_service.snmp.path, nsxt_policy_service.telnet.path]
   logged          = true
-}
-```
-
-## Example Usage - Mixed BMS and VM Parent Policy
-
-```hcl
-# Create mixed BMS and VM groups
-resource "nsxt_policy_group" "all_app_servers" {
-  display_name = "All-Application-Servers"
-  description  = "Application servers across BMS and VMs"
-
-  criteria {
-    condition {
-      key         = "Tag"
-      member_type = "BareMetalServer"
-      operator    = "EQUALS"
-      value       = "tier|application"
-    }
-  }
-
-  conjunction {
-    operator = "OR"
-  }
-
-  criteria {
-    condition {
-      key         = "Tag"
-      member_type = "VirtualMachine"
-      operator    = "EQUALS"
-      value       = "tier|application"
-    }
-  }
-}
-
-resource "nsxt_policy_group" "web_tier_bms" {
-  display_name = "Web-Tier-BMS"
-  description  = "BMS servers in web tier (static group)"
-
-  criteria {
-    external_id_expression {
-      member_type = "BareMetalServer"
-      external_ids = [
-        "71be0142-2ed1-1d53-9c60-5564cf4b7e2e",
-        "81be0142-2ed1-1d53-9c60-5564cf4b7e2f"
-      ]
-    }
-  }
-}
-
-# Parent policy with mixed scope
-resource "nsxt_policy_parent_security_policy" "mixed_environment_policy" {
-  display_name = "Mixed-Environment-Policy"
-  description  = "Parent policy for mixed BMS and VM environment"
-  category     = "Application"
-  stateful     = true
-  scope = [
-    nsxt_policy_group.all_app_servers.path,
-    nsxt_policy_group.web_tier_bms.path
-  ]
-
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
-# Rules under the mixed environment policy
-resource "nsxt_policy_security_policy_rule" "allow_web_traffic" {
-  display_name       = "allow-web-traffic"
-  description        = "Allow web traffic to all web servers"
-  policy_path        = nsxt_policy_parent_security_policy.mixed_environment_policy.path
-  sequence_number    = 100
-  destination_groups = [nsxt_policy_group.web_tier_bms.path]
-  action             = "ALLOW"
-  services           = [nsxt_policy_service.http.path, nsxt_policy_service.https.path]
-  logged             = true
-}
-
-resource "nsxt_policy_security_policy_rule" "app_tier_communication" {
-  display_name       = "app-tier-communication"
-  description        = "Allow communication within application tier"
-  policy_path        = nsxt_policy_parent_security_policy.mixed_environment_policy.path
-  sequence_number    = 200
-  source_groups      = [nsxt_policy_group.all_app_servers.path]
-  destination_groups = [nsxt_policy_group.all_app_servers.path]
-  action             = "ALLOW"
-  services           = [nsxt_policy_service.http.path, nsxt_policy_service.https.path, nsxt_policy_service.mysql.path, data.nsxt_policy_service.postgresql.path]
-  logged             = true
 }
 ```
 

--- a/docs/resources/policy_security_policy.md
+++ b/docs/resources/policy_security_policy.md
@@ -97,6 +97,7 @@ resource "nsxt_policy_security_policy" "policy1" {
 resource "nsxt_policy_group" "production_bms" {
   display_name = "Production-BMS-Servers"
   description  = "Production bare metal servers"
+  group_type   = "BareMetalServer"
 
   criteria {
     condition {
@@ -111,6 +112,7 @@ resource "nsxt_policy_group" "production_bms" {
 resource "nsxt_policy_group" "bms_data_interfaces" {
   display_name = "BMS-Data-Interfaces"
   description  = "Bare metal server data plane interfaces"
+  group_type   = "BareMetalServer"
 
   criteria {
     condition {
@@ -125,6 +127,7 @@ resource "nsxt_policy_group" "bms_data_interfaces" {
 resource "nsxt_policy_group" "web_servers_bms" {
   display_name = "Web-Servers-BMS"
   description  = "Static group of web server BMS"
+  group_type   = "BareMetalServer"
 
   criteria {
     external_id_expression {
@@ -180,52 +183,9 @@ resource "nsxt_policy_security_policy" "bms_security_policy" {
     logged          = true
     sequence_number = 1000
   }
-}
-```
 
-## Example Usage - Mixed BMS and VM Policy
-
-```hcl
-# Mixed environment with both BMS and VMs
-resource "nsxt_policy_group" "all_web_servers" {
-  display_name = "All-Web-Servers"
-  description  = "Web servers across BMS and VMs"
-
-  criteria {
-    condition {
-      key         = "Tag"
-      member_type = "BareMetalServer"
-      operator    = "EQUALS"
-      value       = "application|web-server"
-    }
-  }
-
-  conjunction {
-    operator = "OR"
-  }
-
-  criteria {
-    condition {
-      key         = "Tag"
-      member_type = "VirtualMachine"
-      operator    = "EQUALS"
-      value       = "application|web-server"
-    }
-  }
-}
-
-resource "nsxt_policy_security_policy" "web_tier_policy" {
-  display_name = "Web-Tier-Policy"
-  description  = "Policy for web tier (BMS + VMs)"
-  category     = "Application"
-
-  rule {
-    display_name       = "allow_load_balancer"
-    description        = "Allow traffic from load balancer to all web servers"
-    source_groups      = [nsxt_policy_group.load_balancers.path]
-    destination_groups = [nsxt_policy_group.all_web_servers.path]
-    action             = "ALLOW"
-    services           = [nsxt_policy_service.http.path, nsxt_policy_service.https.path]
+  lifecycle {
+    create_before_destroy = true
   }
 }
 ```

--- a/docs/resources/policy_security_policy_rule.md
+++ b/docs/resources/policy_security_policy_rule.md
@@ -57,7 +57,7 @@ resource "nsxt_policy_parent_security_policy" "bms_parent_policy" {
 resource "nsxt_policy_group" "production_bms" {
   display_name = "Production-BMS-Servers"
   description  = "Production bare metal servers"
-
+  group_type   = "BareMetalServer"
   criteria {
     condition {
       key         = "Tag"
@@ -71,7 +71,7 @@ resource "nsxt_policy_group" "production_bms" {
 resource "nsxt_policy_group" "bms_web_servers" {
   display_name = "BMS-Web-Servers"
   description  = "BMS web servers (static group)"
-
+  group_type   = "BareMetalServer"
   criteria {
     external_id_expression {
       member_type = "BareMetalServer"
@@ -86,7 +86,7 @@ resource "nsxt_policy_group" "bms_web_servers" {
 resource "nsxt_policy_group" "bms_data_interfaces" {
   display_name = "BMS-Data-Interfaces"
   description  = "BMS data plane interfaces"
-
+  group_type   = "BareMetalServer"
   criteria {
     condition {
       key         = "Tag"
@@ -132,72 +132,6 @@ resource "nsxt_policy_security_policy_rule" "block_mgmt_access" {
   action          = "DROP"
   services        = [nsxt_policy_service.ssh.path, nsxt_policy_service.snmp.path, nsxt_policy_service.telnet.path]
   logged          = true
-}
-```
-
-## Example Usage - Mixed BMS and VM Standalone Rules
-
-```hcl
-# Create parent policy
-resource "nsxt_policy_parent_security_policy" "mixed_parent_policy" {
-  display_name = "Mixed-Environment-Policy"
-  description  = "Parent policy for mixed BMS and VM rules"
-  category     = "Application"
-}
-
-# Mixed BMS and VM groups
-resource "nsxt_policy_group" "all_web_servers" {
-  display_name = "All-Web-Servers"
-  description  = "Web servers across BMS and VMs"
-
-  criteria {
-    condition {
-      key         = "Tag"
-      member_type = "BareMetalServer"
-      operator    = "EQUALS"
-      value       = "application|web-server"
-    }
-  }
-
-  conjunction {
-    operator = "OR"
-  }
-
-  criteria {
-    condition {
-      key         = "Tag"
-      member_type = "VirtualMachine"
-      operator    = "EQUALS"
-      value       = "application|web-server"
-    }
-  }
-}
-
-resource "nsxt_policy_group" "load_balancers" {
-  display_name = "Load-Balancers"
-  description  = "Load balancer VMs"
-
-  criteria {
-    condition {
-      key         = "Tag"
-      member_type = "VirtualMachine"
-      operator    = "EQUALS"
-      value       = "application|load-balancer"
-    }
-  }
-}
-
-# Standalone rule allowing load balancer to mixed web servers
-resource "nsxt_policy_security_policy_rule" "lb_to_web_servers" {
-  display_name       = "lb-to-web-servers"
-  description        = "Allow load balancer traffic to all web servers"
-  policy_path        = nsxt_policy_parent_security_policy.mixed_parent_policy.path
-  sequence_number    = 100
-  source_groups      = [nsxt_policy_group.load_balancers.path]
-  destination_groups = [nsxt_policy_group.all_web_servers.path]
-  action             = "ALLOW"
-  services           = [nsxt_policy_service.http.path, nsxt_policy_service.https.path]
-  logged             = true
 }
 ```
 


### PR DESCRIPTION
@ANS-TF-BMS: Overhaul the BMS guide and update the examples throughout the resource documentation.

Significantly expand docs/guides/baremetal_server_management.md with a resources/data-sources reference table, a comprehensive Known Limitations section (platform, firewall, and group constraints), and a restructured workflow overview.
Fix BMS group examples in policy_security_policy, policy_parent_security_policy, and policy_security_policy_rule docs to include the required group_type = "BareMetalServer" attribute.
Remove unsupported mixed
BMS/VM policy examples that incorrectly implied cross-type grouping. Apply minor wording and formatting corrections across all BMS data-source and resource doc pages.

Testing Environment:
- NSX-T Version: 9.0.0+
- Provider Version: >3.12.0
- Infrastructure: Local Manager only (Federation and Multi-tenancy not supported for BMS)

JIRA: #ANSD-120216