### PR TITLE
Fix project data source nil pointer panics

### DIFF
--- a/nsxt/data_source_nsxt_policy_project.go
+++ b/nsxt/data_source_nsxt_policy_project.go
@@ -78,6 +78,9 @@ func dataSourceNsxtPolicyProjectRead(d *schema.ResourceData, m interface{}) erro
 	connector := getPolicyConnector(m)
 	sessionContext := getSessionContext(d, m)
 	client := cliProjectsClient(sessionContext, connector)
+	if client == nil {
+		return policyResourceNotSupportedError()
+	}
 
 	// As Project resource type paths reside under project and not under /infra or /global_infra or such, and since
 	// this data source fetches extra attributes, e.g site_info and tier0_gateway_paths, it's simpler to implement using .List()
@@ -105,11 +108,13 @@ func dataSourceNsxtPolicyProjectRead(d *schema.ResourceData, m interface{}) erro
 		var perfectMatch []model.Project
 		var prefixMatch []model.Project
 		for _, objInList := range objList.Results {
-			if strings.HasPrefix(*objInList.DisplayName, objName) {
-				prefixMatch = append(prefixMatch, objInList)
-			}
-			if *objInList.DisplayName == objName {
-				perfectMatch = append(perfectMatch, objInList)
+			if objInList.DisplayName != nil {
+				if strings.HasPrefix(*objInList.DisplayName, objName) {
+					prefixMatch = append(prefixMatch, objInList)
+				}
+				if *objInList.DisplayName == objName {
+					perfectMatch = append(perfectMatch, objInList)
+				}
 			}
 		}
 		if len(perfectMatch) > 0 {

--- a/nsxt/utgomock_data_source_nsxt_policy_project_test.go
+++ b/nsxt/utgomock_data_source_nsxt_policy_project_test.go
@@ -13,9 +13,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	vapiErrors "github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
+	vapiProtocolClient "github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
 	nsxModel "github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 	"go.uber.org/mock/gomock"
 
+	orgsapi "github.com/vmware/terraform-provider-nsxt/api/orgs"
 	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
 	"github.com/vmware/terraform-provider-nsxt/nsxt/util"
 )
@@ -86,6 +88,23 @@ func TestMockDataSourceNsxtPolicyProjectRead(t *testing.T) {
 		assert.Equal(t, projectID, d.Id())
 	})
 
+	t.Run("by display_name with a project having nil display_name", func(t *testing.T) {
+		nilDisplayNameProj := projectAPIResponse()
+		nilDisplayNameProj.DisplayName = nil
+		mockSDK.EXPECT().List(utl.DefaultOrgID, nil, nil, nil, nil, nil, nil, nil).Return(nsxModel.ProjectListResult{
+			Results: []nsxModel.Project{nilDisplayNameProj, projectAPIResponse()},
+		}, nil)
+
+		ds := dataSourceNsxtPolicyProject()
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{
+			"display_name": projectDisplayName,
+		})
+
+		err := dataSourceNsxtPolicyProjectRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, projectID, d.Id())
+	})
+
 	t.Run("by display_name not found", func(t *testing.T) {
 		mockSDK.EXPECT().List(utl.DefaultOrgID, nil, nil, nil, nil, nil, nil, nil).Return(nsxModel.ProjectListResult{
 			Results: []nsxModel.Project{},
@@ -126,6 +145,23 @@ func TestMockDataSourceNsxtPolicyProjectRead(t *testing.T) {
 
 		err := dataSourceNsxtPolicyProjectRead(d, newGoMockProviderClient())
 		require.Error(t, err)
+	})
+
+	t.Run("unsupported client type", func(t *testing.T) {
+		originalCli := cliProjectsClient
+		cliProjectsClient = func(_ utl.SessionContext, _ vapiProtocolClient.Connector) *orgsapi.ProjectClientContext {
+			return nil
+		}
+		defer func() { cliProjectsClient = originalCli }()
+
+		ds := dataSourceNsxtPolicyProject()
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{
+			"display_name": projectDisplayName,
+		})
+
+		err := dataSourceNsxtPolicyProjectRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "policy resource is not supported")
 	})
 }
 


### PR DESCRIPTION
During display name lookups in the nsxt_policy_project data source, the provider lists all projects and matches them by display name. If any project in the retrieved list lacks a display name (the DisplayName pointer is nil), dereferencing it directly results in a nil pointer dereference panic, causing the provider plugin to crash.

Additionally, when reading the data source on a Global Manager, the policy client initialization returns nil because projects are only supported on Local and Multitenancy client types. The missing nil check for the client object also led to a nil pointer dereference panic.

Address these issues by checking that the DisplayName pointer is not nil before dereferencing, and validating that the client is not nil before performing read operations.