### PR TITLE
Remove redundant attributes from TZ datasource doc

### DIFF
--- a/docs/data-sources/policy_transport_zone.md
+++ b/docs/data-sources/policy_transport_zone.md
@@ -51,7 +51,5 @@ data "nsxt_policy_transport_zone" "overlay_transport_zone" {
 In addition to arguments listed above, the following attributes are exported:
 
 * `description` - The description of the Transport Zone.
-* `is_default` - A boolean flag indicating if this Transport Zone is the default.
-* `transport_type` - The transport type of this transport zone.
 * `path` - The NSX path of the policy resource.
 * `realized_id` - The id of realized transport zone object. This id should be used in `nsxt_edge_transport_node` resource.


### PR DESCRIPTION
Remove 'is_default' and 'transport_type' from the exported attributes section of the 'nsxt_policy_transport_zone' data source documentation.

These fields are already fully documented in the 'Argument Reference' section as optional inputs. Since they function as both input arguments and computed attributes, listing them in both sections is redundant and unnecessary.