### PR TITLE
Avoid duplicate CI runs by dropping push triggers on PRs

### DIFF
--- a/.github/workflows/fmt-check.yml
+++ b/.github/workflows/fmt-check.yml
@@ -2,14 +2,22 @@
 name: Formatting check (nsxt)
 
 on:
-  push:
-    paths:
-      - 'nsxt/**'
-      - '.github/workflows/fmt-check.yml'
   pull_request:
     paths:
       - 'nsxt/**'
       - '.github/workflows/fmt-check.yml'
+  push:
+    branches:
+      - master
+      - 'branch_*'
+      - 'release-*'
+    paths:
+      - 'nsxt/**'
+      - '.github/workflows/fmt-check.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/go-security.yml
+++ b/.github/workflows/go-security.yml
@@ -6,10 +6,18 @@ on:
     paths-ignore:
       - README.md
   push:
+    branches:
+      - master
+      - 'branch_*'
+      - 'release-*'
     paths-ignore:
       - README.md
   schedule:
     - cron: 0 0 * * 0
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -6,10 +6,18 @@ on:
     paths-ignore:
       - README.md
   push:
+    branches:
+      - master
+      - 'branch_*'
+      - 'release-*'
     paths-ignore:
       - README.md
   schedule:
     - cron: 0 0 * * 0
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -6,10 +6,18 @@ on:
     paths-ignore:
       - README.md
   push:
+    branches:
+      - master
+      - 'branch_*'
+      - 'release-*'
     paths-ignore:
       - README.md
   schedule:
     - cron: 0 0 * * 0
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/unit-tests-nsxt.yml
+++ b/.github/workflows/unit-tests-nsxt.yml
@@ -2,16 +2,24 @@
 name: Unit Tests (nsxt)
 
 on:
-  push:
-    paths:
-      - 'nsxt/**'
-      - 'mocks/**'
-      - '.github/workflows/unit-tests-nsxt.yml'
   pull_request:
     paths:
       - 'nsxt/**'
       - 'mocks/**'
       - '.github/workflows/unit-tests-nsxt.yml'
+  push:
+    branches:
+      - master
+      - 'branch_*'
+      - 'release-*'
+    paths:
+      - 'nsxt/**'
+      - 'mocks/**'
+      - '.github/workflows/unit-tests-nsxt.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read


### PR DESCRIPTION
fmt-check, go-security, golangci-lint, security-scan, and unit-tests-nsxt had both push and pull_request triggers, causing each PR commit to run twice. pull_request already fires on every commit pushed to a PR via the synchronize event, so push is removed.