### PR TITLE
Document realized_id is LM-only for nsxt_policy_transport_zone DS

### DIFF
--- a/docs/data-sources/policy_transport_zone.md
+++ b/docs/data-sources/policy_transport_zone.md
@@ -52,4 +52,4 @@ In addition to arguments listed above, the following attributes are exported:
 
 * `description` - The description of the Transport Zone.
 * `path` - The NSX path of the policy resource.
-* `realized_id` - The id of realized transport zone object. This id should be used in `nsxt_edge_transport_node` resource.
+* `realized_id` - The id of realized transport zone object. This id should be used in `nsxt_edge_transport_node` resource. Note: `realized_id` is populated only when this data source is used against NSX Local Manager. On NSX Global Manager, this attribute is not populated by NSX and will be returned as an empty string.


### PR DESCRIPTION
NSX only populates realization_id for Local Manager Policy resources (it correlates a migrated MP unique_id); Global Manager intent objects have no MP-migration lineage, so the field is always empty there. This is expected NSX API behavior, not a provider defect, so clarify the doc instead of changing code.