### PR TITLE
Update policy group import documentation

### DIFF
--- a/docs/resources/policy_group.md
+++ b/docs/resources/policy_group.md
@@ -313,7 +313,7 @@ An existing policy Group can be [imported][docs-import] into this resource, via 
 [docs-import]: https://developer.hashicorp.com/terraform/cli/import
 
 ```shell
-terraform import nsxt_policy_group.group1 ID
+terraform import nsxt_policy_group.group ID
 ```
 
 The above command imports the policy Group named `group` with the NSX Policy ID `ID`.
@@ -323,5 +323,11 @@ If the Group to import isn't in the `default` domain, the domain name can be add
 For example to import a Group with `ID` in the `MyDomain` domain:
 
 ```shell
-terraform import nsxt_policy_group.group1 MyDomain/ID
+terraform import nsxt_policy_group.group MyDomain/ID
 ```
+
+```shell
+terraform import nsxt_policy_group.group POLICY_PATH
+```
+
+The above command imports the policy Group named `group` with the policy path `POLICY_PATH`.


### PR DESCRIPTION
Correct the resource name in the import examples from group1 to group to match the accompanying explanatory text.

Additionally, document that a policy Group can be imported using its policy path (POLICY_PATH) as an alternative to the NSX Policy ID.