### PR TITLE
Support import for predefined security policy resource

### DIFF
--- a/docs/resources/policy_predefined_security_policy.md
+++ b/docs/resources/policy_predefined_security_policy.md
@@ -149,3 +149,16 @@ In addition to arguments listed above, the following attributes are exported:
     * `path` - The NSX path of the policy resource.
     * `sequence_number` - Sequence number of the this rule, is defined by order of rules in the list.
     * `rule_id` - Unique positive number that is assigned by the system and is useful for debugging.
+
+## Importing
+
+An existing Security Policy can be [imported][docs-import] into this resource, via the following command:
+
+[docs-import]: https://developer.hashicorp.com/terraform/cli/import
+
+```shell
+terraform import nsxt_policy_predefined_security_policy.test POLICY_PATH
+```
+
+The above command imports the predefined Security Policy named `test` with policy path `POLICY_PATH`.
+The import command is recommended in case the NSX policy in question already has rules configured, and you wish to reconfigure the policy from scratch.

--- a/nsxt/resource_nsxt_policy_predefined_security_policy.go
+++ b/nsxt/resource_nsxt_policy_predefined_security_policy.go
@@ -29,6 +29,9 @@ func resourceNsxtPolicyPredefinedSecurityPolicy() *schema.Resource {
 		Read:   resourceNsxtPolicyPredefinedSecurityPolicyRead,
 		Update: resourceNsxtPolicyPredefinedSecurityPolicyUpdate,
 		Delete: resourceNsxtPolicyPredefinedSecurityPolicyDelete,
+		Importer: &schema.ResourceImporter{
+			State: nsxtPredefinedPolicyImporter,
+		},
 
 		Schema: getPolicyPredefinedSecurityPolicySchema(),
 	}

--- a/nsxt/resource_nsxt_policy_predefined_security_policy_test.go
+++ b/nsxt/resource_nsxt_policy_predefined_security_policy_test.go
@@ -64,6 +64,42 @@ func testAccResourceNsxtPolicyPredefinedSecurityPolicyBasic(t *testing.T, withCo
 	})
 }
 
+func TestAccResourceNsxtPolicyPredefinedSecurityPolicy_importBasic(t *testing.T) {
+	testAccResourceNsxtPolicyPredefinedSecurityPolicyImportBasic(t, func() {
+		testAccPreCheck(t)
+		testAccOnlyLocalManager(t)
+		testAccNSXVersion(t, "3.0.0")
+	})
+}
+
+func TestAccResourceNsxtPolicyPredefinedSecurityPolicy_importBasic_globalManager(t *testing.T) {
+	testAccResourceNsxtPolicyPredefinedSecurityPolicyImportBasic(t, func() {
+		testAccPreCheck(t)
+		testAccOnlyGlobalManager(t)
+	})
+}
+
+func testAccResourceNsxtPolicyPredefinedSecurityPolicyImportBasic(t *testing.T, preCheck func()) {
+	testResourceName := "nsxt_policy_predefined_security_policy.test"
+
+	// NOTE: This test cannot be parallel, as it modifies the same default policy
+	resource.Test(t, resource.TestCase{
+		PreCheck:  preCheck,
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyPredefinedSecurityPolicyBasic("import test", "", false),
+			},
+			{
+				ResourceName:      testResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccResourceNsxtPolicyImportIDRetriever(testResourceName),
+			},
+		},
+	})
+}
+
 func TestAccResourceNsxtPolicyPredefinedSecurityPolicy_defaultRule(t *testing.T) {
 	testResourceName := "nsxt_policy_predefined_security_policy.test"
 	action1 := "DROP"


### PR DESCRIPTION
Wire up the same generic predefined-policy Importer already used by nsxt_policy_predefined_gateway_policy, and add LM/GM import tests.