### PR TITLE
Scope TGW BgpConfig updates to only the changed block

### DIFF
--- a/nsxt/resource_nsxt_policy_tier0_gateway.go
+++ b/nsxt/resource_nsxt_policy_tier0_gateway.go
@@ -273,6 +273,14 @@ func getPolicyBGPConfigSchema() map[string]*schema.Schema {
 	}
 }
 
+// policyBGPConfigSchemaDefault returns the Default declared in getPolicyBGPConfigSchema
+// for the given field, so a read-path fallback (used when NSX hasn't returned a value
+// for that field yet) stays in sync with the schema's own declaration instead of
+// asserting a second, independent literal.
+func policyBGPConfigSchemaDefault(field string) interface{} {
+	return getPolicyBGPConfigSchema()[field].Default
+}
+
 func getVRFRouteSchema() *schema.Schema {
 	return &schema.Schema{
 		Type:         schema.TypeString,

--- a/nsxt/resource_nsxt_policy_transit_gateway.go
+++ b/nsxt/resource_nsxt_policy_transit_gateway.go
@@ -423,14 +423,23 @@ func initTGWChildBgpConfig(config *model.TransitGatewayBgpRoutingConfig) (*data.
 	return dataValue.(*data.StructValue), nil
 }
 
-func getTGWBgpConfigFromSchema(d *schema.ResourceData) *model.TransitGatewayBgpRoutingConfig {
+// getTGWBgpConfigFromSchema builds the TransitGatewayBgpRoutingConfig to send to NSX.
+// includeBgpConfig/includeAdvancedConfig/includeRedistributionConfig gate which of the
+// three schema blocks are read from Terraform state onto the result: fields for an
+// excluded block are left as nil pointers rather than resent from possibly-stale
+// Terraform state. Callers that need NSX's own current value for an excluded block
+// (e.g. on Update, so it isn't lost) are responsible for filling that in separately -
+// see resourceNsxtPolicyTransitGatewayUpdate, which merges each excluded block in from
+// a fresh GET rather than leaving it nil, since NSX's PATCH .../routing/bgp does not
+// reliably preserve every omitted field on its own.
+func getTGWBgpConfigFromSchema(d *schema.ResourceData, includeBgpConfig, includeAdvancedConfig, includeRedistributionConfig bool) *model.TransitGatewayBgpRoutingConfig {
 	bgpConfig := d.Get("bgp_config").([]interface{})
 	advancedConfig := d.Get("advanced_config").([]interface{})
 	redistributionConfig := d.Get("redistribution_config").([]interface{})
 
-	haveBgpConfig := len(bgpConfig) > 0 && bgpConfig[0] != nil
-	haveAdvancedConfig := len(advancedConfig) > 0 && advancedConfig[0] != nil
-	haveRedistributionConfig := len(redistributionConfig) > 0 && redistributionConfig[0] != nil
+	haveBgpConfig := includeBgpConfig && len(bgpConfig) > 0 && bgpConfig[0] != nil
+	haveAdvancedConfig := includeAdvancedConfig && len(advancedConfig) > 0 && advancedConfig[0] != nil
+	haveRedistributionConfig := includeRedistributionConfig && len(redistributionConfig) > 0 && redistributionConfig[0] != nil
 	if !haveBgpConfig && !haveAdvancedConfig && !haveRedistributionConfig {
 		return nil
 	}
@@ -572,16 +581,30 @@ func setTGWBgpConfigInSchema(d *schema.ResourceData, bgpConfig *model.TransitGat
 	cfgMap["local_as_num"] = bgpConfig.LocalAsNum
 	cfgMap["multipath_relax"] = bgpConfig.MultipathRelax
 
+	// Seed from the schema's own declared defaults first, then overlay only the
+	// fields NSX actually returned. NSX omits graceful_restart_config.timer
+	// entirely until it's been explicitly configured, so GracefulRestartConfig
+	// can be non-nil with a nil Timer; checking each pointer independently
+	// (rather than an if/else keyed on the outer object alone) means a nil at
+	// any level still leaves the schema default in place instead of silently
+	// zero-filling. This value is display-only: getTGWBgpConfigFromSchema only
+	// resends bgp_config when the user actually changes it, so a synthetic
+	// default here is never round-tripped back to NSX.
+	cfgMap["graceful_restart_mode"] = policyBGPConfigSchemaDefault("graceful_restart_mode")
+	cfgMap["graceful_restart_timer"] = policyBGPConfigSchemaDefault("graceful_restart_timer")
+	cfgMap["graceful_restart_stale_route_timer"] = policyBGPConfigSchemaDefault("graceful_restart_stale_route_timer")
 	if bgpConfig.GracefulRestartConfig != nil {
-		cfgMap["graceful_restart_mode"] = bgpConfig.GracefulRestartConfig.Mode
-		if bgpConfig.GracefulRestartConfig.Timer != nil {
-			cfgMap["graceful_restart_timer"] = int(*bgpConfig.GracefulRestartConfig.Timer.RestartTimer)
-			cfgMap["graceful_restart_stale_route_timer"] = int(*bgpConfig.GracefulRestartConfig.Timer.StaleRouteTimer)
+		if bgpConfig.GracefulRestartConfig.Mode != nil {
+			cfgMap["graceful_restart_mode"] = *bgpConfig.GracefulRestartConfig.Mode
 		}
-	} else {
-		cfgMap["graceful_restart_mode"] = model.BgpGracefulRestartConfig_MODE_HELPER_ONLY
-		cfgMap["graceful_restart_timer"] = policyBGPGracefulRestartTimerDefault
-		cfgMap["graceful_restart_stale_route_timer"] = policyBGPGracefulRestartStaleRouteTimerDefault
+		if bgpConfig.GracefulRestartConfig.Timer != nil {
+			if bgpConfig.GracefulRestartConfig.Timer.RestartTimer != nil {
+				cfgMap["graceful_restart_timer"] = int(*bgpConfig.GracefulRestartConfig.Timer.RestartTimer)
+			}
+			if bgpConfig.GracefulRestartConfig.Timer.StaleRouteTimer != nil {
+				cfgMap["graceful_restart_stale_route_timer"] = int(*bgpConfig.GracefulRestartConfig.Timer.StaleRouteTimer)
+			}
+		}
 	}
 
 	var tagList []map[string]string
@@ -733,7 +756,7 @@ func resourceNsxtPolicyTransitGatewayCreate(d *schema.ResourceData, m interface{
 		}
 		childStructs = append(childStructs, ch...)
 	}
-	if bgpCfg := getTGWBgpConfigFromSchema(d); bgpCfg != nil {
+	if bgpCfg := getTGWBgpConfigFromSchema(d, true, true, true); bgpCfg != nil {
 		ch, err := buildTGWBgpConfigChildren(bgpCfg, false)
 		if err != nil {
 			return handleCreateError("TransitGateway BgpConfig", id, err)
@@ -961,12 +984,39 @@ func resourceNsxtPolicyTransitGatewayUpdate(d *schema.ResourceData, m interface{
 	}
 
 	if d.HasChange("bgp_config") || d.HasChange("advanced_config") || d.HasChange("redistribution_config") {
-		newBgp := getTGWBgpConfigFromSchema(d)
+		includeBgpConfig := d.HasChange("bgp_config")
+		includeAdvancedConfig := d.HasChange("advanced_config")
+		includeRedistributionConfig := d.HasChange("redistribution_config")
+		newBgp := getTGWBgpConfigFromSchema(d, includeBgpConfig, includeAdvancedConfig, includeRedistributionConfig)
 		bgpAPIClient := cliTransitGatewayBgpClient(sessionContext, connector)
 		if bgpAPIClient != nil {
 			if newBgp != nil {
 				if existing, getErr := bgpAPIClient.Get(parents[0], parents[1], id); getErr == nil {
 					newBgp.Revision = existing.Revision
+					// NSX's PATCH .../routing/bgp does not uniformly preserve every
+					// omitted field: omitting route_redistribution_config while
+					// bgp_config fields are present in the same request clears it
+					// rather than leaving it as-is (confirmed against a live
+					// manager), despite that endpoint's own API spec documenting
+					// omitted fields as retaining their current value. Populating
+					// each unchanged block from this fresh GET, rather than
+					// omitting it, sidesteps relying on that per-field behavior.
+					if !includeBgpConfig {
+						newBgp.Ecmp = existing.Ecmp
+						newBgp.Enabled = existing.Enabled
+						newBgp.LocalAsNum = existing.LocalAsNum
+						newBgp.MultipathRelax = existing.MultipathRelax
+						newBgp.InterSrIbgp = existing.InterSrIbgp
+						newBgp.GracefulRestartConfig = existing.GracefulRestartConfig
+						newBgp.RouteAggregations = existing.RouteAggregations
+						newBgp.Tags = existing.Tags
+					}
+					if !includeAdvancedConfig {
+						newBgp.ForwardingUpTimer = existing.ForwardingUpTimer
+					}
+					if !includeRedistributionConfig {
+						newBgp.RouteRedistributionConfig = existing.RouteRedistributionConfig
+					}
 				}
 				log.Printf("[INFO] Updating TransitGateway %s BGP config via direct API", id)
 				if err := bgpAPIClient.Patch(parents[0], parents[1], id, *newBgp); err != nil {

--- a/nsxt/resource_nsxt_policy_transit_gateway_test.go
+++ b/nsxt/resource_nsxt_policy_transit_gateway_test.go
@@ -319,6 +319,64 @@ func TestAccResourceNsxtPolicyTransitGateway_withBgpConfig(t *testing.T) {
 	})
 }
 
+// TestAccResourceNsxtPolicyTransitGateway_redistributionConfigWithoutBgpConfig guards
+// against BZ#3742235: NSX auto-populates a default BgpRoutingConfig (including a
+// redistribution rule and graceful-restart fields the provider never sent) as soon as
+// the TGW realizes on the edge, even when bgp_config/advanced_config/redistribution_config
+// were never configured in Terraform. Configuring redistribution_config alone, without
+// ever touching bgp_config, must not resend that cached bgp_config back to NSX - it
+// previously triggered "Field level validation errors: ... has violated the minimum
+// valid value 1" on the graceful restart timers.
+func TestAccResourceNsxtPolicyTransitGateway_redistributionConfigWithoutBgpConfig(t *testing.T) {
+	testResourceName := "nsxt_policy_transit_gateway.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccOnlyLocalManager(t)
+			testAccNSXVersion(t, "9.2.0")
+		},
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyTransitGatewayCheckDestroy(state, accTestTransitGatewayCreateAttributes["display_name"])
+		},
+		Steps: []resource.TestStep{
+			{
+				// Step 1: create with centralized_config only, matching the original
+				// bug report (no bgp_config/advanced_config/redistribution_config at
+				// all), and let the TGW realize before changing anything.
+				Config: testAccNsxtPolicyTransitGatewayBgpConfigBaseTemplate(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicyTransitGatewayExists(accTestTransitGatewayCreateAttributes["display_name"], testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "centralized_config.#", "1"),
+				),
+			},
+			{
+				// Step 2: configure redistribution_config alone, still without
+				// bgp_config. This is a genuine change to redistribution_config only,
+				// exercising the Update path that used to resend the whole cached
+				// BgpRoutingConfig - including a graceful restart timer for a
+				// bgp_config the user never configured - alongside it.
+				Config: testAccNsxtPolicyTransitGatewayRedistributionOnlyTemplate(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicyTransitGatewayExists(accTestTransitGatewayCreateAttributes["display_name"], testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "centralized_config.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "redistribution_config.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "redistribution_config.0.rule.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "redistribution_config.0.rule.0.types.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "redistribution_config.0.rule.0.types.0", "TGW_STATIC_ROUTE"),
+				),
+			},
+			{
+				// Step 3: re-apply the same config to confirm a no-op refresh doesn't
+				// drift or error, matching the original CIBot idempotency check.
+				Config:   testAccNsxtPolicyTransitGatewayRedistributionOnlyTemplate(),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 func TestAccResourceNsxtPolicyTransitGateway_importBasic(t *testing.T) {
 	name := getAccTestResourceName()
 	testResourceName := "nsxt_policy_transit_gateway.test"
@@ -621,6 +679,38 @@ resource "nsxt_policy_transit_gateway" "test" {
   }
 }`, attrMap["display_name"], attrMap["description"], attrMap["transit_subnets"],
 		localAsNum, ecmp, gracefulRestartTimer, gracefulStaleTimer)
+}
+
+// testAccNsxtPolicyTransitGatewayRedistributionOnlyTemplate configures
+// redistribution_config without ever configuring bgp_config or advanced_config.
+// Deliberately uses TGW_STATIC_ROUTE rather than PUBLIC: NSX auto-populates a
+// default redistribution rule of ["PUBLIC"] on TGW creation, so using that same
+// type here would produce no diff/HasChange at all and never exercise the
+// Update path this test is meant to guard.
+func testAccNsxtPolicyTransitGatewayRedistributionOnlyTemplate() string {
+	return testAccNsxtPolicyTransitGatewayWithCentralizedConfigPrerequisites() + fmt.Sprintf(`
+resource "nsxt_policy_transit_gateway" "test" {
+  context {
+    project_id = nsxt_policy_project.test.id
+  }
+
+  display_name    = "%s"
+  description     = "%s"
+  transit_subnets = ["%s"]
+
+  centralized_config {
+    ha_mode            = "ACTIVE_ACTIVE"
+    edge_cluster_paths = [data.nsxt_policy_edge_cluster.test.path]
+  }
+
+  redistribution_config {
+    rule {
+      types = ["TGW_STATIC_ROUTE"]
+    }
+  }
+}`, accTestTransitGatewayCreateAttributes["display_name"],
+		accTestTransitGatewayCreateAttributes["description"],
+		accTestTransitGatewayCreateAttributes["transit_subnets"])
 }
 
 func testAccNsxtPolicyTransitGatewayWithCentralizedConfig920FailoverTemplate(createFlow bool) string {

--- a/nsxt/utgomock_resource_nsxt_policy_transit_gateway_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_transit_gateway_test.go
@@ -401,6 +401,52 @@ func TestMockResourceNsxtPolicyTransitGatewayBgpConfig(t *testing.T) {
 		bgpList := d.Get("bgp_config").([]interface{})
 		assert.Empty(t, bgpList)
 	})
+
+	// Guards against BZ#3742235: NSX omits graceful_restart_config.timer entirely
+	// until it's been explicitly configured (confirmed from a live NSX response -
+	// {"mode": "HELPER_ONLY"}, no "timer" key), leaving GracefulRestartConfig
+	// non-nil but its Timer nil. setTGWBgpConfigInSchema must still fall back to
+	// the schema defaults for the two timer fields instead of zero-filling them,
+	// since a cached 0 violates NSX's own minimum-value-1 validation if it's ever
+	// resent.
+	t.Run("Read defaults graceful restart timers when NSX omits Timer", func(t *testing.T) {
+		enabled := true
+		ecmp := true
+		localAsNum := tgwBgpLocalAsNum
+		restartMode := tgwBgpGracefulMode
+		revision := int64(0)
+		id := "bgp"
+		bgpResponse := nsxModel.TransitGatewayBgpRoutingConfig{
+			Id:         &id,
+			Revision:   &revision,
+			Enabled:    &enabled,
+			Ecmp:       &ecmp,
+			LocalAsNum: &localAsNum,
+			GracefulRestartConfig: &nsxModel.BgpGracefulRestartConfig{
+				Mode: &restartMode,
+				// Timer intentionally nil - matches the real NSX GET response.
+			},
+		}
+
+		gomock.InOrder(
+			m.tgw.EXPECT().Get(tgwOrgID, tgwProjectID, tgwID).Return(tgwAPIResponse(), nil),
+			m.cc.EXPECT().Get(tgwOrgID, tgwProjectID, tgwID, centralizedConfigID).Return(nsxModel.CentralizedConfig{}, vapiErrors.NotFound{}),
+			m.bgp.EXPECT().Get(tgwOrgID, tgwProjectID, tgwID).Return(bgpResponse, nil),
+		)
+
+		res := resourceNsxtPolicyTransitGateway()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalTGWData())
+		d.SetId(tgwID)
+
+		err := resourceNsxtPolicyTransitGatewayRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+
+		bgpList := d.Get("bgp_config").([]interface{})
+		require.Len(t, bgpList, 1)
+		bgpMap := bgpList[0].(map[string]interface{})
+		assert.Equal(t, tgwBgpGracefulTimer, bgpMap["graceful_restart_timer"])
+		assert.Equal(t, tgwBgpGracefulStaleTimer, bgpMap["graceful_restart_stale_route_timer"])
+	})
 }
 
 // TestGetSpanFromSchemaZoneBasedEmptyZones guards against a regression where
@@ -462,7 +508,7 @@ func TestGetTGWBgpConfigFromSchemaAdvancedAndRedistribution(t *testing.T) {
 	res := resourceNsxtPolicyTransitGateway()
 	d := schema.TestResourceDataRaw(t, res.Schema, data)
 
-	cfg := getTGWBgpConfigFromSchema(d)
+	cfg := getTGWBgpConfigFromSchema(d, true, true, true)
 	require.NotNil(t, cfg)
 	require.NotNil(t, cfg.ForwardingUpTimer)
 	assert.Equal(t, int64(10), *cfg.ForwardingUpTimer)
@@ -470,6 +516,54 @@ func TestGetTGWBgpConfigFromSchemaAdvancedAndRedistribution(t *testing.T) {
 	require.NotNil(t, cfg.RouteRedistributionConfig)
 	require.Len(t, cfg.RouteRedistributionConfig.Rules, 1)
 	assert.Equal(t, []string{"PUBLIC", "TGW_STATIC_ROUTE"}, cfg.RouteRedistributionConfig.Rules[0].RouteRedistributionTypes)
+}
+
+// TestGetTGWBgpConfigFromSchemaOnlyIncludesChangedBlocks guards against
+// BZ#3742235's underlying cause: resourceNsxtPolicyTransitGatewayUpdate used to
+// always resend all three of bgp_config/advanced_config/redistribution_config
+// together whenever any single one of them changed, dragging along cached
+// values (including a possibly-invalid graceful restart timer) for blocks the
+// user never touched. NSX's PATCH .../routing/bgp is a documented partial
+// update ("only the provided fields are updated; omitted fields retain their
+// current values"), so Update now passes per-block include flags gated by
+// d.HasChange, and getTGWBgpConfigFromSchema must leave the excluded blocks'
+// fields nil (letting the VAPI binding omit them from the request) even when
+// they're present in ResourceData.
+func TestGetTGWBgpConfigFromSchemaOnlyIncludesChangedBlocks(t *testing.T) {
+	data := minimalTGWData()
+	data["bgp_config"] = minimalBgpConfigData()
+	data["advanced_config"] = []interface{}{
+		map[string]interface{}{"forwarding_up_timer": 10},
+	}
+	data["redistribution_config"] = []interface{}{
+		map[string]interface{}{
+			"rule": []interface{}{
+				map[string]interface{}{
+					"types":          []interface{}{"PUBLIC"},
+					"route_map_path": "",
+				},
+			},
+		},
+	}
+
+	res := resourceNsxtPolicyTransitGateway()
+	d := schema.TestResourceDataRaw(t, res.Schema, data)
+
+	// Simulate only redistribution_config having changed: bgp_config and
+	// advanced_config are present in ResourceData (as they would be for an
+	// already-provisioned TGW) but excluded via their include flags.
+	cfg := getTGWBgpConfigFromSchema(d, false, false, true)
+	require.NotNil(t, cfg)
+
+	assert.Nil(t, cfg.Ecmp, "bgp_config field must be omitted when bgp_config didn't change")
+	assert.Nil(t, cfg.Enabled, "bgp_config field must be omitted when bgp_config didn't change")
+	assert.Nil(t, cfg.LocalAsNum, "bgp_config field must be omitted when bgp_config didn't change")
+	assert.Nil(t, cfg.GracefulRestartConfig, "bgp_config field must be omitted when bgp_config didn't change")
+	assert.Nil(t, cfg.ForwardingUpTimer, "advanced_config field must be omitted when advanced_config didn't change")
+
+	require.NotNil(t, cfg.RouteRedistributionConfig)
+	require.Len(t, cfg.RouteRedistributionConfig.Rules, 1)
+	assert.Equal(t, []string{"PUBLIC"}, cfg.RouteRedistributionConfig.Rules[0].RouteRedistributionTypes)
 }
 
 // TestMockResourceNsxtPolicyTransitGatewayAdvancedAndRedistributionConfig


### PR DESCRIPTION
resourceNsxtPolicyTransitGatewayUpdate always rebuilt and resent the
whole TransitGatewayBgpRoutingConfig whenever any one of
bgp_config/advanced_config/redistribution_config changed, dragging
along cached values for the blocks the user wasn't touching -
including graceful restart timers NSX itself had never fully
populated (it omits graceful_restart_config.timer until BGP is
configured). Resending those as 0 violated NSX's own minimum-value
validation.

getTGWBgpConfigFromSchema now only reads the block(s) that actually
changed from Terraform state, leaving the rest nil rather than
resending a stale or synthetic value for something the user isn't
touching. For the blocks that didn't change, Update fetches the
TGW's current BgpRoutingConfig and copies those fields over
explicitly: live testing against NSX 9.2 (10.162.55.251,
10.161.5.96) showed that simply omitting them isn't safe on its own
- NSX's PATCH .../routing/bgp doesn't uniformly honor "omitted
fields retain their current value" as its own API spec claims. A
PATCH carrying bgp_config fields while omitting
route_redistribution_config cleared that config entirely instead of
preserving it, which is what the acceptance test below caught.
Explicitly resending NSX's own current values for unchanged blocks
avoids relying on that per-field PATCH behavior while still never
inventing a value NSX didn't already have.

The read-side graceful-restart default also now falls back
independently at each nesting level (mirroring the one place in this
codebase that already did this correctly,
setRouteControllerBgpConfigInSchema), sourced from the schema's own
declared default rather than a second literal.

Added TestAccResourceNsxtPolicyTransitGateway_redistributionConfigWithoutBgpConfig,
reproducing the original report: create a TGW with centralized_config
only, then configure redistribution_config alone without ever
touching bgp_config. Uses TGW_STATIC_ROUTE rather than PUBLIC since
NSX auto-populates a default PUBLIC redistribution rule on TGW
creation, and matching that default would produce no diff and never
exercise the Update path being tested. Also added unit tests for the
scoped-block and graceful-restart-default behavior. Verified against
both NSX managers with HTTP tracing that the PATCH body only ever
carries the fields for changed blocks plus NSX's live values for
unchanged ones.
