### PR TITLE
Fix nil pointer dereference in policy edge RTEP

### DIFF
--- a/nsxt/resource_nsxt_policy_edge_transport_node_rtep.go
+++ b/nsxt/resource_nsxt_policy_edge_transport_node_rtep.go
@@ -73,9 +73,9 @@ func setNsxtPolicyEdgeTransportNodeRTEP(d *schema.ResourceData, m interface{}, o
 	hswName := d.Get("host_switch_name").(string)
 	found := false
 
-	for i, hsw := range obj.SwitchSpec.Switches {
-		if *hsw.SwitchName == hswName {
-			{
+	if obj.SwitchSpec != nil {
+		for i, hsw := range obj.SwitchSpec.Switches {
+			if hsw.SwitchName != nil && *hsw.SwitchName == hswName {
 				found = true
 				if len(hsw.RemoteTunnelEndpoint) > 0 && op == "create" {
 					return fmt.Errorf("remote tunnel endpoint for Edge transport node %s already exists", tnPath)
@@ -146,9 +146,9 @@ func resourceNsxtPolicyEdgeTransportNodeRTEPRead(d *schema.ResourceData, m inter
 
 	hswName := d.Get("host_switch_name").(string)
 
-	for _, hsw := range obj.SwitchSpec.Switches {
-		if *hsw.SwitchName == hswName {
-			{
+	if obj.SwitchSpec != nil {
+		for _, hsw := range obj.SwitchSpec.Switches {
+			if hsw.SwitchName != nil && *hsw.SwitchName == hswName {
 				if len(hsw.RemoteTunnelEndpoint) == 0 {
 					return errors.NotFound{}
 				}

--- a/nsxt/utgomock_resource_nsxt_policy_edge_transport_node_rtep_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_edge_transport_node_rtep_test.go
@@ -129,6 +129,33 @@ func TestMockResourceNsxtPolicyEdgeTransportNodeRTEPCreate(t *testing.T) {
 		assert.Contains(t, err.Error(), "not found")
 	})
 
+	t.Run("Create_fails_when_SwitchSpec_is_nil", func(t *testing.T) {
+		mockETNSDK.EXPECT().Get(policyETNSiteID, policyETNEPID, policyETNID).Return(model.PolicyEdgeTransportNode{}, nil)
+
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalPolicyRTEPData())
+		m := newGoMockProviderClient()
+		err := resourceNsxtPolicyEdgeTransportNodeRTEPCreate(d, m)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("Create_fails_when_SwitchName_is_nil", func(t *testing.T) {
+		etn := model.PolicyEdgeTransportNode{
+			SwitchSpec: &model.PolicyEdgeTransportNodeSwitchSpec{
+				Switches: []model.PolicyEdgeTransportNodeSwitch{
+					{SwitchName: nil},
+				},
+			},
+		}
+		mockETNSDK.EXPECT().Get(policyETNSiteID, policyETNEPID, policyETNID).Return(etn, nil)
+
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalPolicyRTEPData())
+		m := newGoMockProviderClient()
+		err := resourceNsxtPolicyEdgeTransportNodeRTEPCreate(d, m)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
 	t.Run("Create_fails_when_Get_returns_error", func(t *testing.T) {
 		mockETNSDK.EXPECT().Get(policyETNSiteID, policyETNEPID, policyETNID).Return(model.PolicyEdgeTransportNode{}, vapiErrors.InternalServerError{})
 
@@ -176,6 +203,37 @@ func TestMockResourceNsxtPolicyEdgeTransportNodeRTEPRead(t *testing.T) {
 
 	t.Run("Read_fails_when_no_RTEP_on_switch", func(t *testing.T) {
 		mockETNSDK.EXPECT().Get(policyETNSiteID, policyETNEPID, policyETNID).Return(policyETNWithSwitch(rtepPolicySwitchName, false), nil)
+
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+			"edge_transport_node_path": rtepPolicyETNPath,
+			"host_switch_name":         rtepPolicySwitchName,
+		})
+		m := newGoMockProviderClient()
+		err := resourceNsxtPolicyEdgeTransportNodeRTEPRead(d, m)
+		require.Error(t, err)
+	})
+
+	t.Run("Read_fails_when_SwitchSpec_is_nil", func(t *testing.T) {
+		mockETNSDK.EXPECT().Get(policyETNSiteID, policyETNEPID, policyETNID).Return(model.PolicyEdgeTransportNode{}, nil)
+
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+			"edge_transport_node_path": rtepPolicyETNPath,
+			"host_switch_name":         rtepPolicySwitchName,
+		})
+		m := newGoMockProviderClient()
+		err := resourceNsxtPolicyEdgeTransportNodeRTEPRead(d, m)
+		require.Error(t, err)
+	})
+
+	t.Run("Read_fails_when_SwitchName_is_nil", func(t *testing.T) {
+		etn := model.PolicyEdgeTransportNode{
+			SwitchSpec: &model.PolicyEdgeTransportNodeSwitchSpec{
+				Switches: []model.PolicyEdgeTransportNodeSwitch{
+					{SwitchName: nil},
+				},
+			},
+		}
+		mockETNSDK.EXPECT().Get(policyETNSiteID, policyETNEPID, policyETNID).Return(etn, nil)
 
 		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
 			"edge_transport_node_path": rtepPolicyETNPath,


### PR DESCRIPTION
Add nil pointer checks for SwitchSpec and SwitchName when reading or setting RTEP configuration on PolicyEdgeTransportNode.

Without these checks, if an Edge transport node returns a nil SwitchSpec or a switch with a nil SwitchName from the NSX API, the provider crashes with a nil pointer dereference panic.