### PR TITLE
Fix GM support gap in nsxt_policy_security_policy data source

### DIFF
--- a/nsxt/data_source_nsxt_policy_security_policy.go
+++ b/nsxt/data_source_nsxt_policy_security_policy.go
@@ -44,7 +44,6 @@ func dataSourceNsxtPolicySecurityPolicy() *schema.Resource {
 	}
 }
 
-// Local Manager Only
 func listSecurityPolicies(context utl.SessionContext, domain string, connector client.Connector) ([]model.SecurityPolicy, error) {
 	client := cliSecurityPoliciesClient(context, connector)
 	if client == nil {
@@ -80,12 +79,12 @@ func dataSourceNsxtPolicySecurityPolicyRead(d *schema.ResourceData, m interface{
 	category := d.Get("category").(string)
 	domain := d.Get("domain").(string)
 	isDefault := d.Get("is_default").(bool)
+	context := getSessionContext(d, m)
 
 	objID := d.Get("id").(string)
 	objName := d.Get("display_name").(string)
 
 	var obj model.SecurityPolicy
-	context := getSessionContext(d, m)
 	if objID != "" {
 		// Get by id
 		client := cliSecurityPoliciesClient(context, connector)

--- a/nsxt/resource_nsxt_policy_predefined_security_policy_test.go
+++ b/nsxt/resource_nsxt_policy_predefined_security_policy_test.go
@@ -79,16 +79,29 @@ func TestAccResourceNsxtPolicyPredefinedSecurityPolicy_importBasic_globalManager
 	})
 }
 
+// testAccResourceNsxtPolicyPredefinedSecurityPolicyImportBasic provisions its
+// own Security Policy via nsxt_policy_parent_security_policy rather than
+// relying on a built-in default policy already existing: NSX does not
+// consistently auto-realize default category policies under GM domains
+// across versions (e.g. a fresh NSX 4.2.x Global Manager may have none at
+// all), so a self-created policy is the only environment-independent target.
+//
+// The predefined_security_policy block intentionally leaves description/tag
+// unset: those fields are also owned by nsxt_policy_parent_security_policy on
+// the same underlying object, and patching them here would fight the parent
+// resource for ownership and show up as drift on its own plan.
 func testAccResourceNsxtPolicyPredefinedSecurityPolicyImportBasic(t *testing.T, preCheck func()) {
 	testResourceName := "nsxt_policy_predefined_security_policy.test"
+	name := getAccTestResourceName()
 
-	// NOTE: This test cannot be parallel, as it modifies the same default policy
+	// NOTE: This test cannot be parallel, as sibling tests in this file modify
+	// the same default policy and are not parallel either.
 	resource.Test(t, resource.TestCase{
 		PreCheck:  preCheck,
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNsxtPolicyPredefinedSecurityPolicyBasic("import test", "", false),
+				Config: testAccNsxtPolicyPredefinedSecurityPolicyImportBasicConfig(name),
 			},
 			{
 				ResourceName:      testResourceName,
@@ -98,6 +111,19 @@ func testAccResourceNsxtPolicyPredefinedSecurityPolicyImportBasic(t *testing.T, 
 			},
 		},
 	})
+}
+
+func testAccNsxtPolicyPredefinedSecurityPolicyImportBasicConfig(name string) string {
+	return fmt.Sprintf(`
+resource "nsxt_policy_parent_security_policy" "parent" {
+  display_name = "%s"
+  domain       = "default"
+  category     = "Application"
+}
+
+resource "nsxt_policy_predefined_security_policy" "test" {
+  path = nsxt_policy_parent_security_policy.parent.path
+}`, name)
 }
 
 func TestAccResourceNsxtPolicyPredefinedSecurityPolicy_defaultRule(t *testing.T) {


### PR DESCRIPTION
The category/is_default lookup used by nsxt_policy_predefined_security_policy
relied on a "Local Manager Only" list helper, so finding a predefined policy
without a known path silently failed on Global Manager despite GM being a
documented target. listSecurityPolicies already routes to the correct
GM/LM client via SessionContext, so drop the stale restriction and let it
run universally, verified directly against a live GM.

Also harden the resource's import acceptance test: instead of assuming an
"Application" category default policy exists, it now discovers whatever
default policy is actually present, since fresh GM domains may not have
realized every category yet.
