### PR TITLE
Fix segment advanced_config not surviving terraform import

### DIFF
--- a/nsxt/resource_nsxt_policy_segment_test.go
+++ b/nsxt/resource_nsxt_policy_segment_test.go
@@ -59,6 +59,44 @@ func TestAccResourceNsxtPolicySegment_basicImport_multitenancy(t *testing.T) {
 	})
 }
 
+// Regression test: advanced_config must survive a terraform import.
+// The Read function used to only write advanced_config back into state when
+// the local config already had a non-empty value, so a fresh import (which
+// starts with no local config) could never populate it. ImportStateVerify
+// below fails if the imported state doesn't exactly match the pre-import
+// state, so this would have caught that regression.
+func TestAccResourceNsxtPolicySegment_advancedConfigImport(t *testing.T) {
+	name := getAccTestResourceName()
+	tzName := getOverlayTransportZoneName()
+	testResourceName := "nsxt_policy_segment.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicySegmentCheckDestroy(state, name)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicySegmentAdvancedConfigImportTemplate(tzName, name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicySegmentExists(testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "advanced_config.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "advanced_config.0.connectivity", "ON"),
+					resource.TestCheckResourceAttr(testResourceName, "advanced_config.0.local_egress", "false"),
+					resource.TestCheckResourceAttr(testResourceName, "advanced_config.0.urpf_mode", "NONE"),
+					resource.TestCheckResourceAttr(testResourceName, "advanced_config.0.multicast", "false"),
+				),
+			},
+			{
+				ResourceName:      testResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccResourceNsxtPolicySegment_basicUpdate(t *testing.T) {
 	name := getAccTestResourceName()
 	updatedName := getAccTestResourceName()
@@ -240,7 +278,7 @@ func testAccResourceNsxtPolicySegmentNoTransportZone(t *testing.T, withContext b
 					resource.TestCheckResourceAttr(testResourceName, "overlay_id", "1011"),
 					resource.TestCheckResourceAttr(testResourceName, "vlan_ids.#", "0"),
 					resource.TestCheckResourceAttr(testResourceName, "tag.#", "0"),
-					resource.TestCheckResourceAttr(testResourceName, "advanced_config.#", "0"),
+					resource.TestCheckResourceAttr(testResourceName, "advanced_config.#", "1"),
 				),
 			},
 			{
@@ -255,7 +293,7 @@ func testAccResourceNsxtPolicySegmentNoTransportZone(t *testing.T, withContext b
 					resource.TestCheckResourceAttr(testResourceName, "overlay_id", "1011"),
 					resource.TestCheckResourceAttr(testResourceName, "vlan_ids.#", "0"),
 					resource.TestCheckResourceAttr(testResourceName, "tag.#", "0"),
-					resource.TestCheckResourceAttr(testResourceName, "advanced_config.#", "0"),
+					resource.TestCheckResourceAttr(testResourceName, "advanced_config.#", "1"),
 				),
 			},
 		},
@@ -616,6 +654,28 @@ resource "nsxt_policy_segment" "test" {
   }
 }
 `, context, name, tzSetting)
+}
+
+func testAccNsxtPolicySegmentAdvancedConfigImportTemplate(tzName string, name string) string {
+	return testAccNsxtPolicySegmentDeps(tzName, false) + fmt.Sprintf(`
+resource "nsxt_policy_segment" "test" {
+  display_name        = "%s"
+  description          = "Acceptance Test"
+  connectivity_path    = nsxt_policy_tier1_gateway.tier1ForSegments.path
+  transport_zone_path  = data.nsxt_policy_transport_zone.test.path
+
+  subnet {
+    cidr = "12.12.2.1/24"
+  }
+
+  advanced_config {
+    connectivity = "ON"
+    local_egress = false
+    urpf_mode    = "NONE"
+    multicast    = false
+  }
+}
+`, name)
 }
 
 func testAccNsxtPolicySegmentBasicTemplate(tzName string, name string) string {

--- a/nsxt/resource_nsxt_policy_vlan_segment_test.go
+++ b/nsxt/resource_nsxt_policy_vlan_segment_test.go
@@ -180,7 +180,7 @@ func TestAccResourceNsxtPolicyVlanSegment_noTransportZone(t *testing.T) {
 					resource.TestCheckResourceAttr(testResourceName, "domain_name", "tftest.org"),
 					resource.TestCheckResourceAttr(testResourceName, "vlan_ids.#", "1"),
 					resource.TestCheckResourceAttr(testResourceName, "tag.#", "0"),
-					resource.TestCheckResourceAttr(testResourceName, "advanced_config.#", "0"),
+					resource.TestCheckResourceAttr(testResourceName, "advanced_config.#", "1"),
 				),
 			},
 			{
@@ -194,7 +194,7 @@ func TestAccResourceNsxtPolicyVlanSegment_noTransportZone(t *testing.T) {
 					resource.TestCheckResourceAttr(testResourceName, "domain_name", "tftest.org"),
 					resource.TestCheckResourceAttr(testResourceName, "vlan_ids.#", "1"),
 					resource.TestCheckResourceAttr(testResourceName, "tag.#", "0"),
-					resource.TestCheckResourceAttr(testResourceName, "advanced_config.#", "0"),
+					resource.TestCheckResourceAttr(testResourceName, "advanced_config.#", "1"),
 				),
 			},
 		},

--- a/nsxt/segment_common.go
+++ b/nsxt/segment_common.go
@@ -288,6 +288,7 @@ func getPolicyCommonSegmentSchema(vlanRequired bool, isFixed bool) map[string]*s
 			Description: "Advanced segment configuration",
 			Elem:        getPolicySegmentAdvancedConfigurationSchema(),
 			Optional:    true,
+			Computed:    true,
 			MaxItems:    1,
 		},
 		"connectivity_path": {
@@ -1409,10 +1410,7 @@ func nsxtPolicySegmentRead(d *schema.ResourceData, m interface{}, isVlan bool, i
 		// This is a list with 1 element
 		var advConfigList []map[string]interface{}
 		advConfigList = append(advConfigList, advConfig)
-		userConfig := d.Get("advanced_config").([]interface{})
-		if len(userConfig) > 0 {
-			d.Set("advanced_config", advConfigList)
-		}
+		d.Set("advanced_config", advConfigList)
 	}
 
 	if obj.L2Extension != nil {


### PR DESCRIPTION
The Read function only wrote advanced_config back into state when the local config already had a non-empty value, so a fresh terraform import (which starts with no local config) could never populate it, causing permanent drift on the next apply. Mark advanced_config as Computed so an unconfigured block doesn't create a phantom diff for existing users, and always populate it from the API response.

Update the two acceptance tests that asserted advanced_config.# == 0 for a segment with no advanced_config configured, since the API returns a populated (default) AdvancedConfig object for every segment regardless of whether the user configures the block.