### PR TITLE
Fix flaky TestAccDataSourceNsxtPolicyTags_basic

### DIFF
--- a/nsxt/data_source_nsxt_policy_tags_test.go
+++ b/nsxt/data_source_nsxt_policy_tags_test.go
@@ -8,9 +8,18 @@ import (
 	"fmt"
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
+
+// The nsxt_policy_tags data source reads from a backend tag aggregation
+// index that is synced asynchronously from realized objects (e.g. segments).
+// Reading it in the same apply as the object that owns the tag is racy, since
+// the sync may not have completed yet. Creating the segment in its own step
+// with a settle delay before reading the tags avoids that race.
+const testAccNSXPolicyTagsSyncDelay = 10 * time.Second
 
 func TestAccDataSourceNsxtPolicyTags_basic(t *testing.T) {
 	tagName := "testTag"
@@ -26,6 +35,16 @@ func TestAccDataSourceNsxtPolicyTags_basic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
+				Config: testAccNSXPolicyTagsCreateTemplate(tagName, emptyScopeTag, transportZone),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("nsxt_policy_segment.segment1", "path"),
+					func(_ *terraform.State) error {
+						time.Sleep(testAccNSXPolicyTagsSyncDelay)
+						return nil
+					},
+				),
+			},
+			{
 				Config: testAccNSXPolicyTagsReadTemplate(tagName, emptyScopeTag, transportZone),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckOutput("nsxt_tags", tagName),
@@ -35,6 +54,28 @@ func TestAccDataSourceNsxtPolicyTags_basic(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testAccNSXPolicyTagsCreateTemplate(tagName string, emptyScopeTag string, transportZone string) string {
+	return fmt.Sprintf(`
+resource "nsxt_policy_segment" "segment1" {
+  display_name        = "segment1"
+  description         = "Terraform provisioned Segment"
+  transport_zone_path = data.nsxt_policy_transport_zone.overlay_transport_zone.path
+  tag {
+    scope = "scope-test"
+    tag   = "%s"
+  }
+  tag {
+    tag = "%s"
+  }
+
+}
+
+data "nsxt_policy_transport_zone" "overlay_transport_zone" {
+  display_name = "%s"
+}
+`, tagName, emptyScopeTag, transportZone)
 }
 
 func testAccNSXPolicyTagsReadTemplate(tagName string, emptyScopeTag string, transportZone string) string {


### PR DESCRIPTION
nsxt_policy_tags reads from a backend tag aggregation index that is synced asynchronously from realized objects, not from the segment's own realized state. Reading it in the same apply that creates the tagged segment races that sync: depends_on only waits for the segment to realize, not for the aggregation index to catch up, so items occasionally comes back empty and the items[0] output errors with "Invalid index".

Retrying/polling inside the data source was rejected: a data source can't tell "not synced yet" apart from "no tags with this scope exist", so it would have to block until timeout on every legitimate empty result. Since resource+data-source-in-one-apply isn't a supported pattern here, fix the test instead: create the segment in its own step with a settle delay, then read the tags data sources in a second step, mirroring the existing sleep-based workaround for backend eventual consistency in resource_nsxt_edge_cluster_test.go.