### PR TITLE
Fix drift and update failures for adopted edge transport nodes

### DIFF
--- a/nsxt/resource_nsxt_policy_edge_transport_node.go
+++ b/nsxt/resource_nsxt_policy_edge_transport_node.go
@@ -473,6 +473,13 @@ func resourceNsxtPolicyEdgeTransportNode() *schema.Resource {
 				Default:      model.PolicyEdgeTransportNode_FORM_FACTOR_MEDIUM,
 				Optional:     true,
 				ValidateFunc: validation.StringInSlice(policyEdgeNodeFormFactorValues, false),
+				// form_factor conflicts with node_id, so it can never be set in
+				// config for an adopted (pre-existing) node. Without this, the
+				// schema Default would still apply and perpetually plan to force
+				// the adopted node's real form factor back to the default value.
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return d.Get("node_id").(string) != ""
+				},
 			},
 			"hostname": {
 				Type:        schema.TypeString,
@@ -1584,6 +1591,12 @@ func resourceNsxtPolicyEdgeTransportNodeRead(d *schema.ResourceData, m interface
 		return handleReadError(d, "EdgeTransportNode", id, err)
 	}
 
+	// advanced_configuration, credentials and management_interface all
+	// conflict with node_id, so an adopted (pre-existing) node's config never
+	// declares them. Populating them from the API anyway would show up as
+	// permanent, spurious drift wanting to null them back out on every plan.
+	adopted := d.Get("node_id").(string) != ""
+
 	d.Set("site_path", sitePath)
 	d.Set("enforcement_point", epID)
 	d.Set("display_name", obj.DisplayName)
@@ -1592,23 +1605,27 @@ func resourceNsxtPolicyEdgeTransportNodeRead(d *schema.ResourceData, m interface
 	d.Set("nsx_id", id)
 	d.Set("path", obj.Path)
 	d.Set("revision", obj.Revision)
-	d.Set("advanced_configuration", setPolicyKeyValueListForSchema(obj.AdvancedConfiguration))
+	if !adopted {
+		d.Set("advanced_configuration", setPolicyKeyValueListForSchema(obj.AdvancedConfiguration))
+	}
 
 	err = setApplianceConfigInSchema(d, obj.ApplianceConfig)
 	if err != nil {
 		return handleReadError(d, "EdgeTransportNode", id, err)
 	}
 
-	err = setCredentialsInSchema(d, obj.Credentials)
-	if err != nil {
-		return handleReadError(d, "EdgeTransportNode", id, err)
+	if !adopted {
+		err = setCredentialsInSchema(d, obj.Credentials)
+		if err != nil {
+			return handleReadError(d, "EdgeTransportNode", id, err)
+		}
 	}
 
 	d.Set("failure_domain_path", obj.FailureDomainPath)
 	d.Set("form_factor", obj.FormFactor)
 	d.Set("hostname", obj.Hostname)
 
-	if obj.ManagementInterface != nil {
+	if !adopted && obj.ManagementInterface != nil {
 		mgtInterface := make(map[string]interface{})
 		mgtInterface["ip_assignment"], err = setPolicyIPAssignmentsInSchema(obj.ManagementInterface.IpAssignmentSpecs)
 		if err != nil {
@@ -1722,7 +1739,18 @@ func resourceNsxtPolicyEdgeTransportNodeUpdate(d *schema.ResourceData, m interfa
 	}
 
 	log.Printf("[INFO] Updating PolicyEdgeTransportNode with ID %s", id)
-	err = policyEdgeTransportNodePatch(siteID, epID, id, d, m)
+	if d.Get("node_id").(string) != "" {
+		// This node was adopted via node_id: management_interface, credentials,
+		// form_factor, vm_deployment_config and advanced_configuration all
+		// conflict with node_id and are never present in config, so building
+		// the request body from config alone (policyEdgeTransportNodePatch)
+		// would send an empty management_interface, which NSX rejects as
+		// missing required fields. Use the same GET-then-merge patch Create
+		// uses for adoption instead.
+		err = policyEdgeTransportNodePredeployedPatch(siteID, epID, id, d, m)
+	} else {
+		err = policyEdgeTransportNodePatch(siteID, epID, id, d, m)
+	}
 	if err != nil {
 		return handleUpdateError("PolicyEdgeTransportNode", id, err)
 	}

--- a/nsxt/utgomock_resource_nsxt_policy_edge_transport_node_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_edge_transport_node_test.go
@@ -180,6 +180,19 @@ func TestMockResourceNsxtPolicyEdgeTransportNodeCreate(t *testing.T) {
 	})
 }
 
+// policyETNAdoptedAPIResponse mirrors policyETNAPIResponse but also
+// populates fields that conflict with node_id (credentials,
+// management_interface), simulating what NSX reports for a pre-existing
+// (adopted) edge node.
+func policyETNAdoptedAPIResponse() model.PolicyEdgeTransportNode {
+	obj := policyETNAPIResponse()
+	cliUsername := "admin"
+	obj.Credentials = &model.PolicyEdgeTransportNodeCredential{CliUsername: &cliUsername}
+	networkID := "some-network-id"
+	obj.ManagementInterface = &model.PolicyEdgeTransportManagementInterface{NetworkId: &networkID}
+	return obj
+}
+
 func TestMockResourceNsxtPolicyEdgeTransportNodeRead(t *testing.T) {
 	util.NsxVersion = "3.2.0"
 	defer func() { util.NsxVersion = "" }()
@@ -216,6 +229,28 @@ func TestMockResourceNsxtPolicyEdgeTransportNodeRead(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, policyETNName, d.Get("display_name"))
 		assert.Equal(t, policyETNHostname, d.Get("hostname"))
+	})
+
+	// Bugzilla 3762385: an adopted (node_id) node's config can never declare
+	// credentials or management_interface (they ConflictsWith node_id), so
+	// Read must not populate them even when NSX reports real values for
+	// them - otherwise every plan shows spurious drift wanting to remove them.
+	t.Run("Read_skips_conflicting_fields_for_adopted_node", func(t *testing.T) {
+		mockETNSDK.EXPECT().Get(policyETNSiteID, policyETNEPID, policyETNID).Return(policyETNAdoptedAPIResponse(), nil)
+
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+			"node_id":           policyETNID,
+			"site_path":         policyETNSitePath,
+			"enforcement_point": policyETNEPID,
+			"hostname":          policyETNHostname,
+			"switch":            minimalPolicyETNSwitchData(),
+		})
+		d.SetId(policyETNID)
+		m := newGoMockProviderClient()
+		err := resourceNsxtPolicyEdgeTransportNodeRead(d, m)
+		require.NoError(t, err)
+		assert.Empty(t, d.Get("credentials").([]interface{}), "credentials must stay unset for an adopted node")
+		assert.Empty(t, d.Get("management_interface").([]interface{}), "management_interface must stay unset for an adopted node")
 	})
 
 	t.Run("Read_clears_id_when_not_found", func(t *testing.T) {
@@ -262,6 +297,31 @@ func TestMockResourceNsxtPolicyEdgeTransportNodeUpdate(t *testing.T) {
 
 		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
 			"display_name":      policyETNName,
+			"hostname":          policyETNHostname,
+			"site_path":         policyETNSitePath,
+			"enforcement_point": policyETNEPID,
+			"switch":            minimalPolicyETNSwitchData(),
+		})
+		d.SetId(policyETNID)
+		m := newGoMockProviderClient()
+		err := resourceNsxtPolicyEdgeTransportNodeUpdate(d, m)
+		require.NoError(t, err)
+	})
+
+	// Bugzilla 3762385: updating an adopted (node_id) node must go through
+	// the GET-then-merge patch (like Create does for adoption), not the
+	// build-from-config patch, since config can never carry
+	// management_interface/credentials/form_factor for such a node - sending
+	// them empty makes NSX reject the request as missing required fields.
+	t.Run("Update_adopted_node_merges_via_predeployed_patch", func(t *testing.T) {
+		gomock.InOrder(
+			mockETNSDK.EXPECT().Get(policyETNSiteID, policyETNEPID, policyETNID).Return(policyETNAdoptedAPIResponse(), nil),
+			mockETNSDK.EXPECT().Patch(policyETNSiteID, policyETNEPID, policyETNID, gomock.Any()).Return(nil),
+		)
+		mockETNSDK.EXPECT().Get(policyETNSiteID, policyETNEPID, policyETNID).Return(policyETNAdoptedAPIResponse(), nil)
+
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+			"node_id":           policyETNID,
 			"hostname":          policyETNHostname,
 			"site_path":         policyETNSitePath,
 			"enforcement_point": policyETNEPID,


### PR DESCRIPTION
node_id-adoption ConflictsWith advanced_configuration, credentials, form_factor and management_interface, so config for an adopted node never sets them. Read still populated all of them unconditionally from the API, showing permanent spurious drift on every plan; form_factor additionally carries a static schema Default that would keep re-asserting itself even with Read fixed, so it needs a DiffSuppressFunc instead.

More seriously, Update always rebuilt the request body from config via policyEdgeTransportNodePatch, same as a freshly created node. For an adopted node that sends an empty management_interface, which NSX rejects as missing required fields on any update - including one only triggered by the spurious drift above. Route Update through the same GET-then-merge policyEdgeTransportNodePredeployedPatch that Create already uses for adoption.

Add mock-based regression coverage for both fixes; confirmed both new tests fail against the pre-fix code and pass after.