### PR TITLE
Expose unique_id/realization_id on policy_edge_node data source

### DIFF
--- a/docs/data-sources/policy_edge_node.md
+++ b/docs/data-sources/policy_edge_node.md
@@ -30,9 +30,18 @@ data "nsxt_policy_edge_node" "node1" {
 * `display_name` - (Optional) The Display Name prefix of the edge node to retrieve.
 * `member_index` - (Optional) Member index of the node in edge cluster.
 
+~> **NOTE:** `id` behaves inconsistently on this data source. As an input, it is used to locate the edge
+node. However, once the edge node is found, NSX reports back an `id` that is actually the node's
+`member_index` within the edge cluster rather than a stable, globally unique identifier. If you set `id`
+to look up a specific edge node, do not rely on the resulting `id` attribute value for anything other
+than the lookup - use `path`, `unique_id` or `realization_id` instead to reference this resource
+unambiguously elsewhere in your configuration.
+
 ## Attributes Reference
 
 In addition to arguments listed above, the following attributes are exported:
 
 * `description` - The description of the resource.
 * `path` - The NSX path of the policy resource.
+* `unique_id` - A unique identifier assigned by the system for this edge node.
+* `realization_id` - The ID used to realize this edge node.

--- a/nsxt/data_source_nsxt_policy_edge_node.go
+++ b/nsxt/data_source_nsxt_policy_edge_node.go
@@ -33,10 +33,25 @@ func dataSourceNsxtPolicyEdgeNode() *schema.Resource {
 				Optional:     true,
 				ValidateFunc: validation.IntAtLeast(0),
 			},
-			"id":           getDataSourceIDSchema(),
+			"id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "The ID of the edge node to retrieve. Note: after the edge node is located, this attribute is overwritten with the value NSX reports as the node's id, which is actually its member index within the edge cluster rather than a stable unique identifier. Use path, unique_id or realization_id to reference this resource unambiguously.",
+			},
 			"display_name": getDataSourceDisplayNameSchema(),
 			"description":  getDataSourceDescriptionSchema(),
 			"path":         getPathSchema(),
+			"unique_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "A unique identifier assigned by the system",
+			},
+			"realization_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "ID used to realize the entity",
+			},
 		},
 	}
 }
@@ -65,6 +80,8 @@ func dataSourceNsxtPolicyEdgeNodeRead(d *schema.ResourceData, m interface{}) err
 		}
 		policyEdgeNode := dataValue.(model.PolicyEdgeNode)
 		d.Set("member_index", policyEdgeNode.MemberIndex)
+		d.Set("unique_id", policyEdgeNode.UniqueId)
+		d.Set("realization_id", policyEdgeNode.RealizationId)
 		return nil
 	}
 
@@ -133,5 +150,7 @@ func dataSourceNsxtPolicyEdgeNodeRead(d *schema.ResourceData, m interface{}) err
 	d.Set("display_name", obj.DisplayName)
 	d.Set("description", obj.Description)
 	d.Set("path", obj.Path)
+	d.Set("unique_id", obj.UniqueId)
+	d.Set("realization_id", obj.RealizationId)
 	return nil
 }

--- a/nsxt/data_source_nsxt_policy_edge_node_test.go
+++ b/nsxt/data_source_nsxt_policy_edge_node_test.go
@@ -27,6 +27,8 @@ func TestAccDataSourceNsxtPolicyEdgeNode_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(testResourceName, "display_name"),
 					resource.TestCheckResourceAttr(testResourceName, "member_index", "0"),
 					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "unique_id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "realization_id"),
 				),
 			},
 		},

--- a/nsxt/utgomock_data_source_nsxt_policy_edge_node_test.go
+++ b/nsxt/utgomock_data_source_nsxt_policy_edge_node_test.go
@@ -1,0 +1,133 @@
+//go:build unittest
+
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package nsxt
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/bindings"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/data"
+	vapiProtocolClient "github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+	"go.uber.org/mock/gomock"
+
+	edge_clusters "github.com/vmware/terraform-provider-nsxt/api/infra/sites/enforcement_points/edge_clusters"
+	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
+	edgenodemocks "github.com/vmware/terraform-provider-nsxt/mocks/infra/sites/enforcement_points/edge_clusters"
+	"github.com/vmware/terraform-provider-nsxt/nsxt/util"
+)
+
+func setupEdgeNodeDataSourceMock(t *testing.T, ctrl *gomock.Controller) (*edgenodemocks.MockEdgeNodesClient, func()) {
+	t.Helper()
+	mockSDK := edgenodemocks.NewMockEdgeNodesClient(ctrl)
+	wrapper := &edge_clusters.PolicyEdgeNodeClientContext{
+		Client:     mockSDK,
+		ClientType: utl.Local,
+	}
+	orig := cliEdgeNodesClient
+	cliEdgeNodesClient = func(_ utl.SessionContext, _ vapiProtocolClient.Connector) *edge_clusters.PolicyEdgeNodeClientContext {
+		return wrapper
+	}
+	return mockSDK, func() { cliEdgeNodesClient = orig }
+}
+
+// TestMockDataSourceNsxtPolicyEdgeNodeReadLocalManager exercises the legacy
+// (pre-3.2.0, Local Manager) code path and verifies unique_id/realization_id
+// are surfaced from the SDK model.
+func TestMockDataSourceNsxtPolicyEdgeNodeReadLocalManager(t *testing.T) {
+	util.NsxVersion = "3.0.0"
+	defer func() { util.NsxVersion = "" }()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupEdgeNodeDataSourceMock(t, ctrl)
+	defer restore()
+	m := newGoMockProviderClient()
+	ep := getPolicyEnforcementPoint(m)
+
+	edgeClusterPath := "/infra/sites/default/enforcement-points/default/edge-clusters/cluster1"
+	nodeID := "node-1"
+	memberIndex := int64(0)
+	uniqueID := "unique-node-1"
+	realizationID := "realization-node-1"
+
+	t.Run("by id exposes unique_id and realization_id", func(t *testing.T) {
+		mockSDK.EXPECT().Get(defaultSite, ep, "cluster1", nodeID).Return(model.PolicyEdgeNode{
+			Id:            &nodeID,
+			DisplayName:   &nodeID,
+			MemberIndex:   &memberIndex,
+			UniqueId:      &uniqueID,
+			RealizationId: &realizationID,
+		}, nil)
+
+		ds := dataSourceNsxtPolicyEdgeNode()
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{
+			"edge_cluster_path": edgeClusterPath,
+			"id":                nodeID,
+		})
+
+		err := dataSourceNsxtPolicyEdgeNodeRead(d, m)
+		require.NoError(t, err)
+		assert.Equal(t, nodeID, d.Id())
+		assert.Equal(t, uniqueID, d.Get("unique_id"))
+		assert.Equal(t, realizationID, d.Get("realization_id"))
+	})
+}
+
+// TestMockDataSourceNsxtPolicyEdgeNodeReadSearchPath exercises the modern
+// (GM / NSX >= 3.2.0) search-based code path. It also documents the known
+// "id" misbehavior: the value supplied as input (an nsx_id) is not what ends
+// up in the id attribute - NSX reports back its own id for the resource,
+// which in practice is the node's member index.
+func TestMockDataSourceNsxtPolicyEdgeNodeReadSearchPath(t *testing.T) {
+	util.NsxVersion = "3.2.0"
+	defer func() { util.NsxVersion = "" }()
+
+	resourceType := "PolicyEdgeNode"
+	inputNsxID := "edge-transport-node-uuid"
+	returnedID := "0" // NSX reports the member index as this resource's id
+	displayName := "edge-node-2"
+	memberIndex := int64(0)
+	uniqueID := "unique-node-2"
+	realizationID := "realization-node-2"
+
+	converter := bindings.NewTypeConverter()
+	val, errs := converter.ConvertToVapi(model.PolicyEdgeNode{
+		Id:            &returnedID,
+		DisplayName:   &displayName,
+		ResourceType:  &resourceType,
+		MemberIndex:   &memberIndex,
+		UniqueId:      &uniqueID,
+		RealizationId: &realizationID,
+	}, model.PolicyEdgeNodeBindingType())
+	require.Empty(t, errs)
+	sv := val.(*data.StructValue)
+
+	stub := &seqQueryListClient{responses: []model.SearchResponse{{
+		Results:     []*data.StructValue{sv},
+		ResultCount: i64(1),
+	}}}
+	defer setupCliQueryClientStub(t, stub)()
+
+	ds := dataSourceNsxtPolicyEdgeNode()
+	d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{
+		"edge_cluster_path": "/infra/sites/default/enforcement-points/default/edge-clusters/cluster1",
+		"id":                inputNsxID,
+	})
+
+	m := newGoMockProviderClient()
+	err := dataSourceNsxtPolicyEdgeNodeRead(d, m)
+	require.NoError(t, err)
+
+	assert.Equal(t, returnedID, d.Id())
+	assert.NotEqual(t, inputNsxID, d.Id())
+	assert.Equal(t, uniqueID, d.Get("unique_id"))
+	assert.Equal(t, realizationID, d.Get("realization_id"))
+}


### PR DESCRIPTION
Document the pre-existing id misbehavior and add unit/acceptance test coverage for the new attributes.