### PR TITLE
Only set policy edge VM host_id when non-empty

### DIFF
--- a/nsxt/resource_nsxt_policy_edge_transport_node.go
+++ b/nsxt/resource_nsxt_policy_edge_transport_node.go
@@ -1201,7 +1201,6 @@ func getVMDeploymentConfigFromSchema(iVmDeploymentCfg interface{}) (*data.Struct
 		vmDeploymentCfg := model.PolicyVsphereDeploymentConfig{
 			ComputeId:              &computeId,
 			EdgeHostAffinityConfig: edgeHostAffinityConfig,
-			HostId:                 &hostID,
 			ReservationInfo:        reservationInfo,
 			StorageId:              &storageID,
 			VcId:                   &vcID,
@@ -1209,6 +1208,9 @@ func getVMDeploymentConfigFromSchema(iVmDeploymentCfg interface{}) (*data.Struct
 		}
 		if computeFolderId != "" {
 			vmDeploymentCfg.ComputeFolderId = &computeFolderId
+		}
+		if hostID != "" {
+			vmDeploymentCfg.HostId = &hostID
 		}
 		converter := bindings.NewTypeConverter()
 		dataValue, errs := converter.ConvertToVapi(vmDeploymentCfg, model.PolicyVsphereDeploymentConfigBindingType())

--- a/nsxt/resource_nsxt_policy_edge_transport_node_vm_deployment_config_test.go
+++ b/nsxt/resource_nsxt_policy_edge_transport_node_vm_deployment_config_test.go
@@ -1,0 +1,52 @@
+//go:build unittest
+
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package nsxt
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnitNsxt_getVMDeploymentConfigFromSchema_hostIdOmitted(t *testing.T) {
+	cfg := []interface{}{
+		map[string]interface{}{
+			"compute_manager_id": "vc1",
+			"compute_id":         "cluster1",
+			"storage_id":         "datastore1",
+			"compute_folder_id":  "",
+			"host_id":            "",
+		},
+	}
+	out, err := getVMDeploymentConfigFromSchema(cfg)
+	require.NoError(t, err)
+	require.NotNil(t, out)
+	optHostID, err := out.Optional("host_id")
+	require.NoError(t, err)
+	require.False(t, optHostID.IsSet())
+}
+
+func TestUnitNsxt_getVMDeploymentConfigFromSchema_hostIdSet(t *testing.T) {
+	cfg := []interface{}{
+		map[string]interface{}{
+			"compute_manager_id": "vc1",
+			"compute_id":         "cluster1",
+			"storage_id":         "datastore1",
+			"compute_folder_id":  "",
+			"host_id":            "host-1",
+		},
+	}
+	out, err := getVMDeploymentConfigFromSchema(cfg)
+	require.NoError(t, err)
+	require.NotNil(t, out)
+	optHostID, err := out.Optional("host_id")
+	require.NoError(t, err)
+	require.True(t, optHostID.IsSet())
+	hostID, err := optHostID.StringValue()
+	require.NoError(t, err)
+	require.Equal(t, "host-1", hostID)
+}

--- a/nsxt/utgomock_gateway_common_locale_service_test.go
+++ b/nsxt/utgomock_gateway_common_locale_service_test.go
@@ -232,7 +232,7 @@ func TestMockNsxtPolicyTier0GetLocaleService(t *testing.T) {
 		lsID := "ls-1"
 		mockSDK.EXPECT().Get("gw1", "ls-1").Return(model.LocaleServices{Id: &lsID}, nil)
 
-		out := policyTier0GetLocaleService(ctx, "gw1", "ls-1", nil, false)
+		out := testAccPolicyTier0GetLocaleService(ctx, "gw1", "ls-1", nil)
 		require.NotNil(t, out)
 		assert.Equal(t, "ls-1", *out.Id)
 	})
@@ -245,7 +245,7 @@ func TestMockNsxtPolicyTier0GetLocaleService(t *testing.T) {
 
 		mockSDK.EXPECT().Get("gw1", "ls-1").Return(model.LocaleServices{}, assertErr("not found"))
 
-		out := policyTier0GetLocaleService(ctx, "gw1", "ls-1", nil, false)
+		out := testAccPolicyTier0GetLocaleService(ctx, "gw1", "ls-1", nil)
 		assert.Nil(t, out)
 	})
 }

--- a/nsxt/utgomock_provider_test.go
+++ b/nsxt/utgomock_provider_test.go
@@ -375,24 +375,24 @@ func TestUnitNsxt_getGlobalPolicyEnforcementPointPath(t *testing.T) {
 
 func TestUnitNsxt_getSessionContextFromParentPath(t *testing.T) {
 	t.Run("multitenancy project path", func(t *testing.T) {
-		ctx := getSessionContextFromParentPath(nsxtClients{}, "/orgs/default/projects/proj1/groups/g1")
+		ctx := testAccGetSessionContextFromParentPath(nsxtClients{}, "/orgs/default/projects/proj1/groups/g1")
 		assert.EqualValues(t, tf_api.Multitenancy, ctx.ClientType)
 		assert.Equal(t, "proj1", ctx.ProjectID)
 	})
 
 	t.Run("VPC path", func(t *testing.T) {
-		ctx := getSessionContextFromParentPath(nsxtClients{}, "/orgs/default/projects/proj1/vpcs/vpc1/subnets/s1")
+		ctx := testAccGetSessionContextFromParentPath(nsxtClients{}, "/orgs/default/projects/proj1/vpcs/vpc1/subnets/s1")
 		assert.EqualValues(t, tf_api.VPC, ctx.ClientType)
 		assert.Equal(t, "vpc1", ctx.VPCID)
 	})
 
 	t.Run("global manager path falls back to Global", func(t *testing.T) {
-		ctx := getSessionContextFromParentPath(nsxtClients{PolicyGlobalManager: true}, "/infra/domains/default/groups/g1")
+		ctx := testAccGetSessionContextFromParentPath(nsxtClients{PolicyGlobalManager: true}, "/infra/domains/default/groups/g1")
 		assert.EqualValues(t, tf_api.Global, ctx.ClientType)
 	})
 
 	t.Run("local manager path falls back to Local", func(t *testing.T) {
-		ctx := getSessionContextFromParentPath(nsxtClients{}, "/infra/domains/default/groups/g1")
+		ctx := testAccGetSessionContextFromParentPath(nsxtClients{}, "/infra/domains/default/groups/g1")
 		assert.EqualValues(t, tf_api.Local, ctx.ClientType)
 	})
 }


### PR DESCRIPTION
nsxt_policy_edge_transport_node always sent "host_id": "" in the vm_deployment_config payload when host_id was left unconfigured, because getVMDeploymentConfigFromSchema() unconditionally set HostId to a pointer to the (possibly empty) string. NSX then runs its VLAN-segment accessibility validation against an empty host context and creation/update fails with error 16031, even though the same segments work fine when host_id is set explicitly or when deployed via the UI.

Guard the assignment the same way compute_folder_id is already guarded, and the same way this was previously fixed for the non-policy nsxt_edge_transport_node resource (see #1053): only set HostId when the value is non-empty.

Add a unit test pinning getVMDeploymentConfigFromSchema()'s behavior: host_id must stay unset in the vAPI payload when not configured, and must be set when provided. The existing acceptance test TestAccResourceNsxtPolicyEdgeTransportNode_basic already configures vm_deployment_config without host_id, so it already exercises this path end-to-end and needs no changes.

Fixes: #2201