### PR TITLE
Fix title in policy gateway interface doc

### DIFF
--- a/docs/data-sources/policy_gateway_interface_realization.md
+++ b/docs/data-sources/policy_gateway_interface_realization.md
@@ -4,7 +4,7 @@ page_title: "NSXT: policy_gateway_interface_realization"
 description: A gateway interface realization information.
 ---
 
-# nsxt_policy_gateway_interface_realization_info
+# nsxt_policy_gateway_interface_realization
 
 This data source provides information about the realization of a Tier0/Tier1 gateway interface resource on NSX manager. This data source will wait until realization is determined as either success or error. It is recommended to use this data source if further configuration depends on resource realization.
 


### PR DESCRIPTION
Correct the H1 heading in the policy gateway interface realization data source documentation to match the actual Terraform resource name ('nsxt_policy_gateway_interface_realization') instead of using an unnecessary '_info' suffix.

The filename and top-level heading previously contained '_info', which caused inconsistency with the data source name in HCL.