### PR TITLE
Fix bgp_config site_path drift after import on Global Manager

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -33,7 +33,7 @@ machine. Check the [requirements][requirements] before proceeding.
 
 3. Add the following to your `~/.terraformrc`:
 
-   ```hcl
+   ```text
    provider_installation {
      dev_overrides {
        "vmware/vcf" = "/Users/rainpole/go/bin"

--- a/nsxt/resource_nsxt_policy_bgp_config.go
+++ b/nsxt/resource_nsxt_policy_bgp_config.go
@@ -79,6 +79,26 @@ func resourceNsxtPolicyBgpConfigRead(d *schema.ResourceData, m interface{}) erro
 		d.Set(key, value)
 	}
 
+	// gateway_path and site_path are not part of the BGP config object
+	// itself - they describe the parent Locale Service - and the Importer
+	// never sets site_path at all. Re-derive both from the Locale Service on
+	// every Read so a fresh import doesn't leave site_path empty, which
+	// would force a replace (site_path is ForceNew) on the next apply.
+	lsClient := cliTier0LocaleServicesClient(sessionContext, connector)
+	if lsClient == nil {
+		return policyResourceNotSupportedError()
+	}
+	locSvc, err := lsClient.Get(gwID, serviceID)
+	if err != nil {
+		return handleReadError(d, "BGP Config", serviceID, err)
+	}
+	d.Set("gateway_path", getGatewayPathFromLocaleServicesPath(*locSvc.Path))
+	if isPolicyGlobalManager(m) && locSvc.EdgeClusterPath != nil {
+		d.Set("site_path", getSitePathFromEdgePath(*locSvc.EdgeClusterPath))
+	} else {
+		d.Set("site_path", "")
+	}
+
 	return nil
 }
 

--- a/nsxt/resource_nsxt_policy_bgp_config_test.go
+++ b/nsxt/resource_nsxt_policy_bgp_config_test.go
@@ -82,6 +82,36 @@ func TestAccResourceNsxtPolicyBgpConfig_basic(t *testing.T) {
 	})
 }
 
+// Regression test for Bugzilla 3766845: Read never re-derived gateway_path
+// or site_path from the parent Locale Service, and the Importer never set
+// site_path at all. Since site_path is ForceNew, a fresh import left it
+// empty in state while config still declared it, forcing a destroy-and-
+// recreate on the very next plan. ImportStateKind: ImportBlockWithID plans
+// the import (via a native `import` block) against a copy of state with
+// this resource removed, the same way the FVT reproduction did via
+// `terraform state rm` + `terraform import`, and fails unless the resulting
+// plan is a no-op - the resource's own `id` is a synthetic random UUID
+// (regenerated on every import), so ImportStateVerify can't be used here.
+func TestAccResourceNsxtPolicyBgpConfig_importBasic(t *testing.T) {
+	testResourceName := "nsxt_policy_bgp_config.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyBgpConfigTemplate(true),
+			},
+			{
+				ResourceName:      testResourceName,
+				ImportState:       true,
+				ImportStateKind:   resource.ImportBlockWithID,
+				ImportStateIdFunc: testAccResourceNsxtPolicyImportIDRetriever(testResourceName),
+			},
+		},
+	})
+}
+
 func TestAccResourceNsxtPolicyBgpConfig_minimalistic(t *testing.T) {
 	testResourceName := "nsxt_policy_bgp_config.test"
 

--- a/nsxt/utgomock_resource_nsxt_policy_bgp_config_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_bgp_config_test.go
@@ -28,13 +28,14 @@ import (
 )
 
 var (
-	bgpCfgGwPath    = "/infra/tier-0s/t0-bgp"
-	bgpCfgGwID      = "t0-bgp"
-	bgpCfgServiceID = "default"
-	bgpCfgRevision  = int64(1)
-	bgpCfgPath      = "/infra/tier-0s/t0-bgp/locale-services/default/bgp"
-	bgpCfgEnabled   = true
-	bgpCfgEcmp      = true
+	bgpCfgGwPath            = "/infra/tier-0s/t0-bgp"
+	bgpCfgGwID              = "t0-bgp"
+	bgpCfgServiceID         = "default"
+	bgpCfgRevision          = int64(1)
+	bgpCfgPath              = "/infra/tier-0s/t0-bgp/locale-services/default/bgp"
+	bgpCfgLocaleServicePath = "/infra/tier-0s/t0-bgp/locale-services/default"
+	bgpCfgEnabled           = true
+	bgpCfgEcmp              = true
 )
 
 func TestMockResourceNsxtPolicyBgpConfigRead(t *testing.T) {
@@ -49,11 +50,23 @@ func TestMockResourceNsxtPolicyBgpConfigRead(t *testing.T) {
 		Client:     mockBgpSDK,
 		ClientType: utl.Local,
 	}
+	mockLocaleServicesSDK := localeServicesMocks.NewMockLocaleServicesClient(ctrl)
+	localeServicesWrapper := &tier0localeservices.LocaleServicesClientContext{
+		Client:     mockLocaleServicesSDK,
+		ClientType: utl.Local,
+	}
 
 	originalBgp := cliBgpClient
-	defer func() { cliBgpClient = originalBgp }()
+	originalLocSvc := cliTier0LocaleServicesClient
+	defer func() {
+		cliBgpClient = originalBgp
+		cliTier0LocaleServicesClient = originalLocSvc
+	}()
 	cliBgpClient = func(sessionContext utl.SessionContext, connector client.Connector) *localeservices.BgpRoutingConfigClientContext {
 		return bgpWrapper
+	}
+	cliTier0LocaleServicesClient = func(sessionContext utl.SessionContext, connector client.Connector) *tier0localeservices.LocaleServicesClientContext {
+		return localeServicesWrapper
 	}
 
 	res := resourceNsxtPolicyBgpConfig()
@@ -76,6 +89,10 @@ func TestMockResourceNsxtPolicyBgpConfigRead(t *testing.T) {
 			Path:                  &bgpCfgPath,
 			Revision:              &bgpCfgRevision,
 			GracefulRestartConfig: &restartCfg,
+		}, nil)
+		mockLocaleServicesSDK.EXPECT().Get(bgpCfgGwID, bgpCfgServiceID).Return(model.LocaleServices{
+			Id:   &bgpCfgServiceID,
+			Path: &bgpCfgLocaleServicePath,
 		}, nil)
 
 		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
@@ -164,9 +181,13 @@ func TestMockResourceNsxtPolicyBgpConfigCreate(t *testing.T) {
 
 	t.Run("Create_success", func(t *testing.T) {
 		mockTier0sSDK.EXPECT().Get(bgpCfgGwID).Return(model.Tier0{}, nil)
+		// Consumed twice: once by Create's own locale service discovery, and
+		// once more by the Read call at the end of Create (which re-derives
+		// gateway_path/site_path from the locale service).
 		mockLocaleServicesSDK.EXPECT().Get(bgpCfgGwID, defaultPolicyLocaleServiceID).Return(model.LocaleServices{
-			Id: &bgpCfgServiceID,
-		}, nil)
+			Id:   &bgpCfgServiceID,
+			Path: &bgpCfgLocaleServicePath,
+		}, nil).Times(2)
 		mockBgpSDK.EXPECT().Patch(bgpCfgGwID, bgpCfgServiceID, gomock.Any(), gomock.Any()).Return(nil)
 		restartMode := model.BgpGracefulRestartConfig_MODE_HELPER_ONLY
 		restartTimer := int64(180)
@@ -259,6 +280,7 @@ func TestMockResourceNsxtPolicyBgpConfigUpdate(t *testing.T) {
 
 	mockTier0sSDK := t0mocks.NewMockTier0sClient(ctrl)
 	mockBgpSDK := localeSvcBgpMocks.NewMockBgpClient(ctrl)
+	mockLocaleServicesSDK := localeServicesMocks.NewMockLocaleServicesClient(ctrl)
 
 	tier0Wrapper := &cliinfra.Tier0ClientContext{
 		Client:     mockTier0sSDK,
@@ -268,12 +290,18 @@ func TestMockResourceNsxtPolicyBgpConfigUpdate(t *testing.T) {
 		Client:     mockBgpSDK,
 		ClientType: utl.Local,
 	}
+	localeServicesWrapper := &tier0localeservices.LocaleServicesClientContext{
+		Client:     mockLocaleServicesSDK,
+		ClientType: utl.Local,
+	}
 
 	originalTier0s := cliTier0sClient
 	originalBgp := cliBgpClient
+	originalLocSvc := cliTier0LocaleServicesClient
 	defer func() {
 		cliTier0sClient = originalTier0s
 		cliBgpClient = originalBgp
+		cliTier0LocaleServicesClient = originalLocSvc
 	}()
 	cliTier0sClient = func(sessionContext utl.SessionContext, connector client.Connector) *cliinfra.Tier0ClientContext {
 		return tier0Wrapper
@@ -281,12 +309,19 @@ func TestMockResourceNsxtPolicyBgpConfigUpdate(t *testing.T) {
 	cliBgpClient = func(sessionContext utl.SessionContext, connector client.Connector) *localeservices.BgpRoutingConfigClientContext {
 		return bgpWrapper
 	}
+	cliTier0LocaleServicesClient = func(sessionContext utl.SessionContext, connector client.Connector) *tier0localeservices.LocaleServicesClientContext {
+		return localeServicesWrapper
+	}
 
 	res := resourceNsxtPolicyBgpConfig()
 
 	t.Run("Update_success", func(t *testing.T) {
 		mockTier0sSDK.EXPECT().Get(bgpCfgGwID).Return(model.Tier0{}, nil)
 		mockBgpSDK.EXPECT().Update(bgpCfgGwID, bgpCfgServiceID, gomock.Any(), gomock.Any()).Return(model.BgpRoutingConfig{}, nil)
+		mockLocaleServicesSDK.EXPECT().Get(bgpCfgGwID, bgpCfgServiceID).Return(model.LocaleServices{
+			Id:   &bgpCfgServiceID,
+			Path: &bgpCfgLocaleServicePath,
+		}, nil)
 		restartMode := model.BgpGracefulRestartConfig_MODE_HELPER_ONLY
 		restartTimer := int64(180)
 		staleTimer := int64(600)


### PR DESCRIPTION
gateway_path and site_path describe the parent Locale Service, not the
BGP config object itself, and Read never derived either of them - it
only ever populated whatever the Importer set once at import time. The
Importer itself never set site_path at all, so a fresh import left it
empty while config still declared it. Since site_path is ForceNew, the
next plan proposed destroying and recreating the resource instead of
showing no changes.

Fetch the parent Locale Service in Read and re-derive both paths from
it on every read, mirroring the identical pattern already used by the
sibling nsxt_policy_gateway_redistribution_config resource. Update the
mock unit test suite for the added Locale Service Get call: it's now
consumed twice in Create_success (discovery plus the trailing Read),
and both Read and Update needed a Locale Services client mock added
since neither had one before.

Add import regression coverage using ImportStateKind: ImportBlockWithID,
since this resource's id is a synthetic random UUID (regenerated on
every import) that ImportStateVerify can't meaningfully compare.
Confirmed the new test fails with the exact destroy/recreate plan from
the bug report before the fix, and passes after, against both a live
Global Manager and Local Manager.

Also fix an unrelated, pre-existing docs-lint failure: build.md's
~/.terraformrc example uses a quoted provider source address, valid
CLI config syntax but not standard resource HCL. A newer terrafmt
release (unpinned in the tools target) now hard-fails parsing it under
an hcl fence; retag it as text so terrafmt skips it.
