### PR TITLE
Fix GRE tunnel create check, move test-only Exists helpers

### DIFF
--- a/nsxt/gateway_common.go
+++ b/nsxt/gateway_common.go
@@ -689,13 +689,3 @@ func getComputedGatewayIDSchema() *schema.Schema {
 		Computed:    true,
 	}
 }
-
-func policyTier0GetLocaleService(context utl.SessionContext, gwID string, localeServiceID string, connector client.Connector, isGlobalManager bool) *model.LocaleServices {
-	tier0LocaleservicesClient := cliTier0LocaleServicesClient(context, connector)
-	obj, err := tier0LocaleservicesClient.Get(gwID, localeServiceID)
-	if err != nil {
-		log.Printf("[DEBUG] Failed to get locale service %s for gateway %s: %s", gwID, localeServiceID, err)
-		return nil
-	}
-	return &obj
-}

--- a/nsxt/provider.go
+++ b/nsxt/provider.go
@@ -1351,22 +1351,6 @@ func getParentContext(d *schema.ResourceData, m interface{}, parentPath string) 
 	return getSessionContextHelper(d, m, parentPath)
 }
 
-func getSessionContextFromParentPath(m interface{}, parentPath string) tf_api.SessionContext {
-	var clientType tf_api.ClientType
-	projectID, vpcID := getContextDataFromParentPath(parentPath)
-	if projectID != "" {
-		clientType = tf_api.Multitenancy
-		if vpcID != "" {
-			clientType = tf_api.VPC
-		}
-	} else if isPolicyGlobalManager(m) {
-		clientType = tf_api.Global
-	} else {
-		clientType = tf_api.Local
-	}
-	return tf_api.SessionContext{ProjectID: projectID, VPCID: vpcID, ClientType: clientType, FromGlobal: false}
-}
-
 func getSessionContextHelper(d *schema.ResourceData, m interface{}, parentPath string) tf_api.SessionContext {
 	var clientType tf_api.ClientType
 	var projectID, vpcID string

--- a/nsxt/resource_nsxt_policy_firewall_exclude_list_member.go
+++ b/nsxt/resource_nsxt_policy_firewall_exclude_list_member.go
@@ -6,9 +6,7 @@ package nsxt
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
 	"github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
-	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 
 	"github.com/vmware/terraform-provider-nsxt/api/infra/settings/firewall/security"
@@ -43,25 +41,6 @@ func memberInList(member string, members []string) int {
 		}
 	}
 	return -1
-}
-
-func resourceNsxtPolicyFirewallExcludeListMemberExists(sessionContext utl.SessionContext, id string, connector client.Connector) (bool, error) {
-
-	client := cliExcludeListClient(sessionContext, connector)
-	if client == nil {
-		return false, policyResourceNotSupportedError()
-	}
-	obj, err := client.Get()
-	if isNotFoundError(err) {
-		return false, nil
-	} else if err != nil {
-		return false, err
-	}
-	if 0 <= memberInList(id, obj.Members) {
-		return true, nil
-	}
-
-	return false, nil
 }
 
 func resourceNsxtPolicyFirewallExcludeListMemberCreate(d *schema.ResourceData, m interface{}) error {

--- a/nsxt/resource_nsxt_policy_firewall_exclude_list_member_test.go
+++ b/nsxt/resource_nsxt_policy_firewall_exclude_list_member_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
 )
 
 func getGroupPrefix() string {
@@ -97,6 +99,25 @@ func TestAccResourceNsxtPolicyFirewallExcludeListMember_importBasic(t *testing.T
 	})
 }
 
+func testAccNsxtPolicyFirewallExcludeListMemberExistsOnNSX(sessionContext utl.SessionContext, id string, connector client.Connector) (bool, error) {
+
+	client := cliExcludeListClient(sessionContext, connector)
+	if client == nil {
+		return false, policyResourceNotSupportedError()
+	}
+	obj, err := client.Get()
+	if isNotFoundError(err) {
+		return false, nil
+	} else if err != nil {
+		return false, err
+	}
+	if 0 <= memberInList(id, obj.Members) {
+		return true, nil
+	}
+
+	return false, nil
+}
+
 func testAccNsxtPolicyFirewallExcludeListMemberExists(displayName string, resourceName string) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
 
@@ -112,7 +133,7 @@ func testAccNsxtPolicyFirewallExcludeListMemberExists(displayName string, resour
 			return fmt.Errorf("policy FirewallExcludeListMember resource ID not set in resources")
 		}
 
-		exists, err := resourceNsxtPolicyFirewallExcludeListMemberExists(testAccGetSessionContext(), resourceID, connector)
+		exists, err := testAccNsxtPolicyFirewallExcludeListMemberExistsOnNSX(testAccGetSessionContext(), resourceID, connector)
 		if err != nil {
 			return err
 		}
@@ -132,7 +153,7 @@ func testAccNsxtPolicyFirewallExcludeListMemberCheckDestroy(state *terraform.Sta
 			continue
 		}
 
-		exists, err := resourceNsxtPolicyFirewallExcludeListMemberExists(testAccGetSessionContext(), member, connector)
+		exists, err := testAccNsxtPolicyFirewallExcludeListMemberExistsOnNSX(testAccGetSessionContext(), member, connector)
 		if err != nil {
 			return err
 		}

--- a/nsxt/resource_nsxt_policy_gateway_community_list.go
+++ b/nsxt/resource_nsxt_policy_gateway_community_list.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	tier_0s "github.com/vmware/terraform-provider-nsxt/api/infra/tier_0s"
-	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 
 	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
@@ -47,27 +46,6 @@ func resourceNsxtPolicyGatewayCommunityList() *schema.Resource {
 			},
 		},
 	}
-}
-
-func resourceNsxtPolicyGatewayCommunityListExists(tier0Id string, id string, connector client.Connector, isGlobalManager bool) (bool, error) {
-	var err error
-	var sessionContext utl.SessionContext
-	if isGlobalManager {
-		sessionContext = utl.SessionContext{ClientType: utl.Global}
-	} else {
-		sessionContext = utl.SessionContext{ClientType: utl.Local}
-	}
-	client := cliCommunityListsClient(sessionContext, connector)
-	_, err = client.Get(tier0Id, id)
-	if err == nil {
-		return true, nil
-	}
-
-	if isNotFoundError(err) {
-		return false, nil
-	}
-
-	return false, logAPIError("Error retrieving resource", err)
 }
 
 func resourceNsxtPolicyGatewayCommunityListCreate(d *schema.ResourceData, m interface{}) error {

--- a/nsxt/resource_nsxt_policy_gateway_community_list_test.go
+++ b/nsxt/resource_nsxt_policy_gateway_community_list_test.go
@@ -10,6 +10,9 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
+
+	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
 )
 
 var accTestPolicyGatewayCommunityListCreateAttributes = map[string]string{
@@ -101,6 +104,27 @@ func TestAccResourceNsxtPolicyGatewayCommunityList_importBasic(t *testing.T) {
 	})
 }
 
+func testAccNsxtPolicyGatewayCommunityListExistsOnNSX(tier0Id string, id string, connector client.Connector, isGlobalManager bool) (bool, error) {
+	var err error
+	var sessionContext utl.SessionContext
+	if isGlobalManager {
+		sessionContext = utl.SessionContext{ClientType: utl.Global}
+	} else {
+		sessionContext = utl.SessionContext{ClientType: utl.Local}
+	}
+	client := cliCommunityListsClient(sessionContext, connector)
+	_, err = client.Get(tier0Id, id)
+	if err == nil {
+		return true, nil
+	}
+
+	if isNotFoundError(err) {
+		return false, nil
+	}
+
+	return false, logAPIError("Error retrieving resource", err)
+}
+
 func testAccNsxtPolicyGatewayCommunityListExists(displayName string, resourceName string) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
 
@@ -118,7 +142,7 @@ func testAccNsxtPolicyGatewayCommunityListExists(displayName string, resourceNam
 		gwPath := rs.Primary.Attributes["gateway_path"]
 		_, gwID := parseGatewayPolicyPath(gwPath)
 
-		exists, err := resourceNsxtPolicyGatewayCommunityListExists(gwID, resourceID, connector, testAccIsGlobalManager())
+		exists, err := testAccNsxtPolicyGatewayCommunityListExistsOnNSX(gwID, resourceID, connector, testAccIsGlobalManager())
 		if err != nil {
 			return err
 		}
@@ -142,7 +166,7 @@ func testAccNsxtPolicyGatewayCommunityListCheckDestroy(state *terraform.State, d
 		gwPath := rs.Primary.Attributes["gateway_path"]
 		_, gwID := parseGatewayPolicyPath(gwPath)
 
-		exists, err := resourceNsxtPolicyGatewayCommunityListExists(gwID, resourceID, connector, testAccIsGlobalManager())
+		exists, err := testAccNsxtPolicyGatewayCommunityListExistsOnNSX(gwID, resourceID, connector, testAccIsGlobalManager())
 		if err != nil {
 			return err
 		}

--- a/nsxt/resource_nsxt_policy_gateway_redistribution_config_test.go
+++ b/nsxt/resource_nsxt_policy_gateway_redistribution_config_test.go
@@ -143,7 +143,7 @@ func testAccNsxtPolicyTier0CheckRedistributionExists(resourceName string) resour
 
 		testAccNsxtPolicyGatewayRedistributionLocaleService = rs.Primary.Attributes["locale_service_id"]
 		testAccNsxtPolicyGatewayRedistributionGatewayID = rs.Primary.Attributes["gateway_id"]
-		localeService := policyTier0GetLocaleService(testAccGetSessionContext(), testAccNsxtPolicyGatewayRedistributionGatewayID, testAccNsxtPolicyGatewayRedistributionLocaleService, connector, testAccIsGlobalManager())
+		localeService := testAccPolicyTier0GetLocaleService(testAccGetSessionContext(), testAccNsxtPolicyGatewayRedistributionGatewayID, testAccNsxtPolicyGatewayRedistributionLocaleService, connector)
 		if localeService == nil {
 			return fmt.Errorf("Error while retrieving Locale Service %s for Gateway %s", testAccNsxtPolicyGatewayRedistributionLocaleService, testAccNsxtPolicyGatewayRedistributionGatewayID)
 		}
@@ -170,7 +170,7 @@ func testAccNsxtPolicyTier0CheckNoRedistribution(tier0Name string) resource.Test
 
 		connector := getPolicyConnector(testAccProvider.Meta().(nsxtClients))
 
-		localeService := policyTier0GetLocaleService(testAccGetSessionContext(), testAccNsxtPolicyGatewayRedistributionGatewayID, testAccNsxtPolicyGatewayRedistributionLocaleService, connector, testAccIsGlobalManager())
+		localeService := testAccPolicyTier0GetLocaleService(testAccGetSessionContext(), testAccNsxtPolicyGatewayRedistributionGatewayID, testAccNsxtPolicyGatewayRedistributionLocaleService, connector)
 		if localeService == nil {
 			return fmt.Errorf("Error while retrieving Locale Service %s for Gateway %s", testAccNsxtPolicyGatewayRedistributionLocaleService, testAccNsxtPolicyGatewayRedistributionGatewayID)
 		}

--- a/nsxt/resource_nsxt_policy_gateway_route_map.go
+++ b/nsxt/resource_nsxt_policy_gateway_route_map.go
@@ -180,27 +180,6 @@ func setRouteMapEntriesInSchema(d *schema.ResourceData, entries []model.RouteMap
 	d.Set("entry", entryList)
 }
 
-func resourceNsxtPolicyGatewayRouteMapExists(tier0Id string, id string, connector client.Connector, isGlobalManager bool) (bool, error) {
-	var err error
-	var sessionContext utl.SessionContext
-	if isGlobalManager {
-		sessionContext = utl.SessionContext{ClientType: utl.Global}
-	} else {
-		sessionContext = utl.SessionContext{ClientType: utl.Local}
-	}
-	client := cliRouteMapsClient(sessionContext, connector)
-	_, err = client.Get(tier0Id, id)
-	if err == nil {
-		return true, nil
-	}
-
-	if isNotFoundError(err) {
-		return false, nil
-	}
-
-	return false, logAPIError("Error retrieving resource", err)
-}
-
 func policyGatewayRouteMapBuildEntry(d *schema.ResourceData, entryNo int, schemaEntry map[string]interface{}) model.RouteMapEntry {
 
 	action := schemaEntry["action"].(string)

--- a/nsxt/resource_nsxt_policy_gateway_route_map_test.go
+++ b/nsxt/resource_nsxt_policy_gateway_route_map_test.go
@@ -10,6 +10,9 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
+
+	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
 )
 
 // NOTE - to save test suite running time, this test also covers the data source
@@ -112,6 +115,27 @@ func TestAccResourceNsxtPolicyGatewayRouteMap_importBasic(t *testing.T) {
 	})
 }
 
+func testAccNsxtPolicyGatewayRouteMapExistsOnNSX(tier0Id string, id string, connector client.Connector, isGlobalManager bool) (bool, error) {
+	var err error
+	var sessionContext utl.SessionContext
+	if isGlobalManager {
+		sessionContext = utl.SessionContext{ClientType: utl.Global}
+	} else {
+		sessionContext = utl.SessionContext{ClientType: utl.Local}
+	}
+	client := cliRouteMapsClient(sessionContext, connector)
+	_, err = client.Get(tier0Id, id)
+	if err == nil {
+		return true, nil
+	}
+
+	if isNotFoundError(err) {
+		return false, nil
+	}
+
+	return false, logAPIError("Error retrieving resource", err)
+}
+
 func testAccNsxtPolicyGatewayRouteMapExists(displayName string, resourceName string) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
 
@@ -129,7 +153,7 @@ func testAccNsxtPolicyGatewayRouteMapExists(displayName string, resourceName str
 		gwPath := rs.Primary.Attributes["gateway_path"]
 		_, gwID := parseGatewayPolicyPath(gwPath)
 
-		exists, err := resourceNsxtPolicyGatewayRouteMapExists(gwID, resourceID, connector, testAccIsGlobalManager())
+		exists, err := testAccNsxtPolicyGatewayRouteMapExistsOnNSX(gwID, resourceID, connector, testAccIsGlobalManager())
 		if err != nil {
 			return err
 		}
@@ -153,7 +177,7 @@ func testAccNsxtPolicyGatewayRouteMapCheckDestroy(state *terraform.State, displa
 		gwPath := rs.Primary.Attributes["gateway_path"]
 		_, gwID := parseGatewayPolicyPath(gwPath)
 
-		exists, err := resourceNsxtPolicyGatewayRouteMapExists(gwID, resourceID, connector, testAccIsGlobalManager())
+		exists, err := testAccNsxtPolicyGatewayRouteMapExistsOnNSX(gwID, resourceID, connector, testAccIsGlobalManager())
 		if err != nil {
 			return err
 		}

--- a/nsxt/resource_nsxt_policy_idps_cluster_config.go
+++ b/nsxt/resource_nsxt_policy_idps_cluster_config.go
@@ -9,11 +9,8 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/settings/firewall/security/intrusion_services"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
-
-	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
 )
 
 func resourceNsxtPolicyIdpsClusterConfig() *schema.Resource {
@@ -63,24 +60,6 @@ func resourceNsxtPolicyIdpsClusterConfig() *schema.Resource {
 			},
 		},
 	}
-}
-
-func resourceNsxtPolicyIdpsClusterConfigExists(sessionContext utl.SessionContext, id string, connector client.Connector) (bool, error) {
-	client := intrusion_services.NewClusterConfigsClient(connector)
-	if client == nil {
-		return false, policyResourceNotSupportedError()
-	}
-
-	_, err := client.Get(id, nil)
-	if err == nil {
-		return true, nil
-	}
-
-	if isNotFoundError(err) {
-		return false, nil
-	}
-
-	return false, logAPIError("Error retrieving IDPS Cluster Config", err)
 }
 
 func buildIdsClusterConfig(d *schema.ResourceData, id string) model.IdsClusterConfig {

--- a/nsxt/resource_nsxt_policy_idps_cluster_config_test.go
+++ b/nsxt/resource_nsxt_policy_idps_cluster_config_test.go
@@ -10,7 +10,10 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/settings/firewall/security/intrusion_services"
+
+	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
 )
 
 func getTestComputeCollectionName() string {
@@ -200,6 +203,24 @@ func TestAccResourceNsxtPolicyIdpsClusterConfig_importBasicLegacy(t *testing.T) 
 	})
 }
 
+func testAccNsxtPolicyIdpsClusterConfigExistsOnNSX(sessionContext utl.SessionContext, id string, connector client.Connector) (bool, error) {
+	client := intrusion_services.NewClusterConfigsClient(connector)
+	if client == nil {
+		return false, policyResourceNotSupportedError()
+	}
+
+	_, err := client.Get(id, nil)
+	if err == nil {
+		return true, nil
+	}
+
+	if isNotFoundError(err) {
+		return false, nil
+	}
+
+	return false, logAPIError("Error retrieving IDPS Cluster Config", err)
+}
+
 func testAccNsxtPolicyIdpsClusterConfigExists(displayName string, resourceName string) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
 
@@ -215,7 +236,7 @@ func testAccNsxtPolicyIdpsClusterConfigExists(displayName string, resourceName s
 			return fmt.Errorf("Policy IdpsClusterConfig resource ID not set in resources")
 		}
 
-		exists, err := resourceNsxtPolicyIdpsClusterConfigExists(testAccGetSessionContext(), resourceID, connector)
+		exists, err := testAccNsxtPolicyIdpsClusterConfigExistsOnNSX(testAccGetSessionContext(), resourceID, connector)
 		if err != nil {
 			return err
 		}

--- a/nsxt/resource_nsxt_policy_idps_signature_version.go
+++ b/nsxt/resource_nsxt_policy_idps_signature_version.go
@@ -9,10 +9,7 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/settings/firewall/security/intrusion_services"
-
-	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
 )
 
 // NOTE: IDS Signature Versions are system-managed resources in NSX.
@@ -89,20 +86,6 @@ func resourceNsxtPolicyIdpsSignatureVersion() *schema.Resource {
 			},
 		},
 	}
-}
-
-func resourceNsxtPolicyIdpsSignatureVersionExists(sessionContext utl.SessionContext, id string, connector client.Connector) (bool, error) {
-	client := intrusion_services.NewSignatureVersionsClient(connector)
-	_, err := client.Get(id)
-	if err == nil {
-		return true, nil
-	}
-
-	if isNotFoundError(err) {
-		return false, nil
-	}
-
-	return false, logAPIError("Error retrieving IDS Signature Version", err)
 }
 
 func resourceNsxtPolicyIdpsSignatureVersionCreate(d *schema.ResourceData, m interface{}) error {

--- a/nsxt/resource_nsxt_policy_idps_signature_version_test.go
+++ b/nsxt/resource_nsxt_policy_idps_signature_version_test.go
@@ -10,6 +10,10 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/settings/firewall/security/intrusion_services"
+
+	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
 )
 
 // NOTE: IDS Signature Versions are system-managed resources.
@@ -83,6 +87,20 @@ func TestAccResourceNsxtPolicyIdpsSignatureVersion_makeActive(t *testing.T) {
 	})
 }
 
+func testAccNsxtPolicyIdpsSignatureVersionExistsOnNSX(sessionContext utl.SessionContext, id string, connector client.Connector) (bool, error) {
+	client := intrusion_services.NewSignatureVersionsClient(connector)
+	_, err := client.Get(id)
+	if err == nil {
+		return true, nil
+	}
+
+	if isNotFoundError(err) {
+		return false, nil
+	}
+
+	return false, logAPIError("Error retrieving IDS Signature Version", err)
+}
+
 func testAccNsxtPolicyIdpsSignatureVersionExists(resourceName string) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
 		connector := getPolicyConnector(testAccProvider.Meta().(nsxtClients))
@@ -97,7 +115,7 @@ func testAccNsxtPolicyIdpsSignatureVersionExists(resourceName string) resource.T
 			return fmt.Errorf("Policy IDS Signature Version resource ID not set in resources")
 		}
 
-		exists, err := resourceNsxtPolicyIdpsSignatureVersionExists(testAccGetSessionContext(), resourceID, connector)
+		exists, err := testAccNsxtPolicyIdpsSignatureVersionExistsOnNSX(testAccGetSessionContext(), resourceID, connector)
 		if err != nil {
 			return err
 		}

--- a/nsxt/resource_nsxt_policy_ipsec_vpn_local_endpoint.go
+++ b/nsxt/resource_nsxt_policy_ipsec_vpn_local_endpoint.go
@@ -230,36 +230,6 @@ func (c *localEndpointClient) Delete(connector client.Connector, id string) erro
 	return client.Delete(c.gwID, c.serviceID, id)
 }
 
-func resourceNsxtPolicyIPSecVpnLocalEndpointExistsOnService(id string, connector client.Connector, servicePath string) (bool, error) {
-	// Used by acceptance tests and create flow; infer multitenancy from servicePath when applicable.
-	sessionContext := utl.SessionContext{ClientType: utl.Local}
-	if strings.HasPrefix(servicePath, "/orgs/") {
-		projectID := extractProjectIDFromPolicyPath(servicePath)
-		if projectID != "" {
-			sessionContext.ClientType = utl.Multitenancy
-			sessionContext.ProjectID = projectID
-		}
-	}
-	client, err := newLocalEndpointClient(servicePath, sessionContext)
-	if err != nil {
-		return false, err
-	}
-	_, err = client.Get(connector, id)
-	if err == nil {
-		return true, nil
-	}
-
-	if isNotFoundError(err) {
-		return false, nil
-	}
-
-	if _, codeErr := getInvalidRequestErrorCode(err); codeErr == nil {
-		return false, nil
-	}
-
-	return false, logAPIError("Error retrieving resource", err)
-}
-
 func ipSecVpnLocalEndpointInitStruct(d *schema.ResourceData) model.IPSecVpnLocalEndpoint {
 	displayName := d.Get("display_name").(string)
 	description := d.Get("description").(string)

--- a/nsxt/resource_nsxt_policy_ipsec_vpn_local_endpoint_test.go
+++ b/nsxt/resource_nsxt_policy_ipsec_vpn_local_endpoint_test.go
@@ -6,10 +6,14 @@ package nsxt
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
+
+	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
 )
 
 var accTestPolicyIPSecVpnLocalEndpointCreateAttributes = map[string]string{
@@ -182,6 +186,35 @@ func testAccResourceNsxtPolicyIPSecVpnLocalEndpointImport(t *testing.T, withCont
 	})
 }
 
+func testAccNsxtPolicyIPSecVpnLocalEndpointExistsOnNSXService(id string, connector client.Connector, servicePath string) (bool, error) {
+	sessionContext := utl.SessionContext{ClientType: utl.Local}
+	if strings.HasPrefix(servicePath, "/orgs/") {
+		projectID := extractProjectIDFromPolicyPath(servicePath)
+		if projectID != "" {
+			sessionContext.ClientType = utl.Multitenancy
+			sessionContext.ProjectID = projectID
+		}
+	}
+	client, err := newLocalEndpointClient(servicePath, sessionContext)
+	if err != nil {
+		return false, err
+	}
+	_, err = client.Get(connector, id)
+	if err == nil {
+		return true, nil
+	}
+
+	if isNotFoundError(err) {
+		return false, nil
+	}
+
+	if _, codeErr := getInvalidRequestErrorCode(err); codeErr == nil {
+		return false, nil
+	}
+
+	return false, logAPIError("Error retrieving resource", err)
+}
+
 func testAccNsxtPolicyIPSecVpnLocalEndpointExists(displayName string, resourceName string) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
 
@@ -195,7 +228,7 @@ func testAccNsxtPolicyIPSecVpnLocalEndpointExists(displayName string, resourceNa
 		resourceID := rs.Primary.Attributes["id"]
 		servicePath := rs.Primary.Attributes["service_path"]
 
-		exists, err := resourceNsxtPolicyIPSecVpnLocalEndpointExistsOnService(resourceID, connector, servicePath)
+		exists, err := testAccNsxtPolicyIPSecVpnLocalEndpointExistsOnNSXService(resourceID, connector, servicePath)
 		if err != nil {
 			return err
 		}
@@ -217,7 +250,7 @@ func testAccNsxtPolicyIPSecVpnLocalEndpointCheckDestroy(state *terraform.State, 
 
 		resourceID := rs.Primary.Attributes["id"]
 		servicePath := rs.Primary.Attributes["service_path"]
-		exists, err := resourceNsxtPolicyIPSecVpnLocalEndpointExistsOnService(resourceID, connector, servicePath)
+		exists, err := testAccNsxtPolicyIPSecVpnLocalEndpointExistsOnNSXService(resourceID, connector, servicePath)
 		if err != nil {
 			return err
 		}

--- a/nsxt/resource_nsxt_policy_ipsec_vpn_service_test.go
+++ b/nsxt/resource_nsxt_policy_ipsec_vpn_service_test.go
@@ -369,7 +369,7 @@ func testAccNsxtPolicyIPSecVpnServiceExists(displayName string, resourceName str
 		if parentPath == "" {
 			parentPath = localeServicePath
 		}
-		sessionContext := getSessionContextFromParentPath(testAccProvider.Meta(), parentPath)
+		sessionContext := testAccGetSessionContextFromParentPath(testAccProvider.Meta(), parentPath)
 		isT0, gwID, localeServiceID, err := parseLocaleServicePolicyPath(localeServicePath)
 		if localeServiceID == "" {
 			isT0, gwID = parseGatewayPolicyPath(gatewayPath)
@@ -401,7 +401,7 @@ func testAccNsxtPolicyIPSecVpnServiceCheckDestroy(state *terraform.State, displa
 		if parentPath == "" {
 			parentPath = localeServicePath
 		}
-		sessionContext := getSessionContextFromParentPath(testAccProvider.Meta(), parentPath)
+		sessionContext := testAccGetSessionContextFromParentPath(testAccProvider.Meta(), parentPath)
 		isT0, gwID, localeServiceID, err := parseLocaleServicePolicyPath(localeServicePath)
 		if localeServiceID == "" {
 			isT0, gwID = parseGatewayPolicyPath(gatewayPath)

--- a/nsxt/resource_nsxt_policy_ipsec_vpn_session_test.go
+++ b/nsxt/resource_nsxt_policy_ipsec_vpn_session_test.go
@@ -733,7 +733,7 @@ func testAccNsxtPolicyIPSecVpnSessionExists(displayName string, resourceName str
 		if resourceID == "" {
 			return fmt.Errorf("Policy IPSecVpnSession resource ID not set in resources")
 		}
-		sessionContext := getSessionContextFromParentPath(testAccProvider.Meta(), servicePath)
+		sessionContext := testAccGetSessionContextFromParentPath(testAccProvider.Meta(), servicePath)
 		exists, err := resourceNsxtPolicyIPSecVpnSessionExists(servicePath, resourceID, connector, sessionContext)
 		if err != nil {
 			return err
@@ -756,7 +756,7 @@ func testAccNsxtPolicyIPSecVpnSessionCheckDestroy(state *terraform.State, displa
 
 		resourceID := rs.Primary.Attributes["id"]
 		servicePath := rs.Primary.Attributes["service_path"]
-		sessionContext := getSessionContextFromParentPath(testAccProvider.Meta(), servicePath)
+		sessionContext := testAccGetSessionContextFromParentPath(testAccProvider.Meta(), servicePath)
 		exists, err := resourceNsxtPolicyIPSecVpnSessionExists(servicePath, resourceID, connector, sessionContext)
 		if err != nil {
 			return err

--- a/nsxt/resource_nsxt_policy_ospf_area.go
+++ b/nsxt/resource_nsxt_policy_ospf_area.go
@@ -11,10 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/vmware/terraform-provider-nsxt/api/infra/tier_0s/locale_services/ospf"
-	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
-
-	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
 )
 
 var cliOspfAreasClient = ospf.NewAreasClient
@@ -83,21 +80,6 @@ func resourceNsxtPolicyOspfArea() *schema.Resource {
 			},
 		},
 	}
-}
-
-func resourceNsxtPolicyOspfAreaExists(gwID string, localeServiceID string, areaID string, isGlobalManager bool, connector client.Connector) (bool, error) {
-	sessionContext := utl.SessionContext{ClientType: utl.Local}
-	client := cliOspfAreasClient(sessionContext, connector)
-	_, err := client.Get(gwID, localeServiceID, areaID)
-	if err == nil {
-		return true, nil
-	}
-
-	if isNotFoundError(err) {
-		return false, nil
-	}
-
-	return false, logAPIError("Error retrieving resource", err)
 }
 
 func parseOspfConfigPath(path string) (string, string) {

--- a/nsxt/resource_nsxt_policy_ospf_area_test.go
+++ b/nsxt/resource_nsxt_policy_ospf_area_test.go
@@ -10,6 +10,9 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
+
+	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
 )
 
 var accTestPolicyOspfAreaCreateAttributes = map[string]string{
@@ -158,6 +161,21 @@ func testAccNSXPolicyOspfAreaImporterGetIDs(s *terraform.State) (string, error) 
 	return fmt.Sprintf("%s/%s/%s", gwID, serviceID, resourceID), nil
 }
 
+func testAccNsxtPolicyOspfAreaExistsOnNSX(gwID string, localeServiceID string, areaID string, isGlobalManager bool, connector client.Connector) (bool, error) {
+	sessionContext := utl.SessionContext{ClientType: utl.Local}
+	client := cliOspfAreasClient(sessionContext, connector)
+	_, err := client.Get(gwID, localeServiceID, areaID)
+	if err == nil {
+		return true, nil
+	}
+
+	if isNotFoundError(err) {
+		return false, nil
+	}
+
+	return false, logAPIError("Error retrieving resource", err)
+}
+
 func testAccNsxtPolicyOspfAreaExists(resourceName string) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
 
@@ -176,7 +194,7 @@ func testAccNsxtPolicyOspfAreaExists(resourceName string) resource.TestCheckFunc
 		ospfPath := rs.Primary.Attributes["ospf_path"]
 		gwID, serviceID := parseOspfConfigPath(ospfPath)
 
-		exists, err := resourceNsxtPolicyOspfAreaExists(gwID, serviceID, resourceID, testAccIsGlobalManager(), connector)
+		exists, err := testAccNsxtPolicyOspfAreaExistsOnNSX(gwID, serviceID, resourceID, testAccIsGlobalManager(), connector)
 		if err != nil {
 			return err
 		}
@@ -199,7 +217,7 @@ func testAccNsxtPolicyOspfAreaCheckDestroy(state *terraform.State, displayName s
 		resourceID := rs.Primary.Attributes["id"]
 		ospfPath := rs.Primary.Attributes["ospf_path"]
 		gwID, serviceID := parseOspfConfigPath(ospfPath)
-		exists, err := resourceNsxtPolicyOspfAreaExists(gwID, serviceID, resourceID, testAccIsGlobalManager(), connector)
+		exists, err := testAccNsxtPolicyOspfAreaExistsOnNSX(gwID, serviceID, resourceID, testAccIsGlobalManager(), connector)
 		if err != nil {
 			return err
 		}

--- a/nsxt/resource_nsxt_policy_tier0_gateway_gre_tunnel.go
+++ b/nsxt/resource_nsxt_policy_tier0_gateway_gre_tunnel.go
@@ -239,19 +239,19 @@ func resourceNsxtPolicyTier0GatewayGRETunnelExists(id, localeServicePath string,
 	client := cliTunnelsClient(sessionContext, connector)
 	_, err = client.Get(tier0id, localeSvcID, id)
 
+	if err == nil {
+		return true, nil
+	}
 	if isNotFoundError(err) {
 		return false, nil
 	}
-	return true, nil
+	return false, err
 }
 
 func resourceNsxtPolicyTier0GatewayGRETunnelCreate(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
 
 	id := d.Get("nsx_id").(string)
-	if id == "" {
-		id = newUUID()
-	}
 	localeServicePath := d.Get("locale_service_path").(string)
 	isT0, tier0id, localeSvcID, err := parseLocaleServicePolicyPath(localeServicePath)
 	if err != nil {
@@ -260,6 +260,19 @@ func resourceNsxtPolicyTier0GatewayGRETunnelCreate(d *schema.ResourceData, m int
 	if !isT0 {
 		return fmt.Errorf("locale service path %s is not associated with a tier0 router", localeServicePath)
 	}
+
+	if id == "" {
+		id = newUUID()
+	} else {
+		exists, err := resourceNsxtPolicyTier0GatewayGRETunnelExists(id, localeServicePath, connector, isPolicyGlobalManager(m))
+		if err != nil {
+			return err
+		}
+		if exists {
+			return fmt.Errorf("GRE Tunnel with ID '%s' already exists", id)
+		}
+	}
+
 	sessionContext := utl.SessionContext{ClientType: utl.Local}
 	client := cliTunnelsClient(sessionContext, connector)
 

--- a/nsxt/resource_nsxt_policy_tier0_gateway_ha_vip_config_test.go
+++ b/nsxt/resource_nsxt_policy_tier0_gateway_ha_vip_config_test.go
@@ -170,7 +170,7 @@ func testAccNsxtPolicyTier0HAVipConfigExists(resourceName string) resource.TestC
 
 		localeServiceID := rs.Primary.Attributes["locale_service_id"]
 		gwID := rs.Primary.Attributes["tier0_id"]
-		localeService := policyTier0GetLocaleService(testAccGetSessionContext(), gwID, localeServiceID, connector, testAccIsGlobalManager())
+		localeService := testAccPolicyTier0GetLocaleService(testAccGetSessionContext(), gwID, localeServiceID, connector)
 		if localeService == nil {
 			return fmt.Errorf("Error while retrieving Locale Service %s for Gateway %s", localeServiceID, gwID)
 		}

--- a/nsxt/resource_nsxt_policy_transit_gateway_attachment_test.go
+++ b/nsxt/resource_nsxt_policy_transit_gateway_attachment_test.go
@@ -112,7 +112,7 @@ func testAccNsxtPolicyTransitGatewayAttachmentExists(displayName string, resourc
 		}
 
 		parentPath := rs.Primary.Attributes["parent_path"]
-		exists, err := resourceNsxtPolicyTransitGatewayAttachmentExists(getSessionContextFromParentPath(testAccProvider.Meta(), parentPath), parentPath, resourceID, connector)
+		exists, err := resourceNsxtPolicyTransitGatewayAttachmentExists(testAccGetSessionContextFromParentPath(testAccProvider.Meta(), parentPath), parentPath, resourceID, connector)
 		if err != nil {
 			return err
 		}
@@ -134,7 +134,7 @@ func testAccNsxtPolicyTransitGatewayAttachmentCheckDestroy(state *terraform.Stat
 
 		resourceID := rs.Primary.Attributes["id"]
 		parentPath := rs.Primary.Attributes["parent_path"]
-		exists, err := resourceNsxtPolicyTransitGatewayAttachmentExists(getSessionContextFromParentPath(testAccProvider.Meta(), parentPath), parentPath, resourceID, connector)
+		exists, err := resourceNsxtPolicyTransitGatewayAttachmentExists(testAccGetSessionContextFromParentPath(testAccProvider.Meta(), parentPath), parentPath, resourceID, connector)
 		if err != nil {
 			return err
 		}

--- a/nsxt/resource_nsxt_policy_transit_gateway_bfd_peer_test.go
+++ b/nsxt/resource_nsxt_policy_transit_gateway_bfd_peer_test.go
@@ -106,7 +106,7 @@ func testAccNsxtPolicyTransitGatewayBfdPeerExists(displayName string, resourceNa
 		}
 
 		parentPath := rs.Primary.Attributes["parent_path"]
-		sessionContext := getSessionContextFromParentPath(testAccProvider.Meta(), parentPath)
+		sessionContext := testAccGetSessionContextFromParentPath(testAccProvider.Meta(), parentPath)
 		exists, err := resourceNsxtPolicyTransitGatewayBfdPeerExists(sessionContext, parentPath, resourceID, connector)
 		if err != nil {
 			return err
@@ -127,7 +127,7 @@ func testAccNsxtPolicyTransitGatewayBfdPeerCheckDestroy(state *terraform.State, 
 		}
 		resourceID := rs.Primary.Attributes["id"]
 		parentPath := rs.Primary.Attributes["parent_path"]
-		sessionContext := getSessionContextFromParentPath(testAccProvider.Meta(), parentPath)
+		sessionContext := testAccGetSessionContextFromParentPath(testAccProvider.Meta(), parentPath)
 		exists, err := resourceNsxtPolicyTransitGatewayBfdPeerExists(sessionContext, parentPath, resourceID, connector)
 		if err != nil {
 			return err

--- a/nsxt/resource_nsxt_policy_transit_gateway_community_list_test.go
+++ b/nsxt/resource_nsxt_policy_transit_gateway_community_list_test.go
@@ -126,7 +126,7 @@ func testAccNsxtPolicyTransitGatewayCommunityListExists(displayName string, reso
 		}
 
 		parentPath := rs.Primary.Attributes["parent_path"]
-		sessionContext := getSessionContextFromParentPath(testAccProvider.Meta(), parentPath)
+		sessionContext := testAccGetSessionContextFromParentPath(testAccProvider.Meta(), parentPath)
 		exists, err := resourceNsxtPolicyTransitGatewayCommunityListExists(sessionContext, parentPath, resourceID, connector)
 		if err != nil {
 			return err
@@ -147,7 +147,7 @@ func testAccNsxtPolicyTransitGatewayCommunityListCheckDestroy(state *terraform.S
 		}
 		resourceID := rs.Primary.Attributes["id"]
 		parentPath := rs.Primary.Attributes["parent_path"]
-		sessionContext := getSessionContextFromParentPath(testAccProvider.Meta(), parentPath)
+		sessionContext := testAccGetSessionContextFromParentPath(testAccProvider.Meta(), parentPath)
 		exists, err := resourceNsxtPolicyTransitGatewayCommunityListExists(sessionContext, parentPath, resourceID, connector)
 		if err != nil {
 			return err

--- a/nsxt/resource_nsxt_policy_transit_gateway_ipsec_vpn_local_endpoint_test.go
+++ b/nsxt/resource_nsxt_policy_transit_gateway_ipsec_vpn_local_endpoint_test.go
@@ -127,7 +127,7 @@ func testAccNsxtPolicyTGWIPSecVpnLocalEndpointExists(displayName string, resourc
 			return fmt.Errorf("Policy TransitGatewayIPSecVpnLocalEndpoint resource ID not set in resources")
 		}
 		parentPath := rs.Primary.Attributes["parent_path"]
-		exists, err := resourceNsxtPolicyTGWIPSecVpnLocalEndpointExists(getSessionContextFromParentPath(testAccProvider.Meta(), parentPath), parentPath, resourceID, connector)
+		exists, err := resourceNsxtPolicyTGWIPSecVpnLocalEndpointExists(testAccGetSessionContextFromParentPath(testAccProvider.Meta(), parentPath), parentPath, resourceID, connector)
 		if err != nil {
 			return err
 		}
@@ -149,7 +149,7 @@ func testAccNsxtPolicyTGWIPSecVpnLocalEndpointCheckDestroy(state *terraform.Stat
 
 		resourceID := rs.Primary.Attributes["id"]
 		parentPath := rs.Primary.Attributes["parent_path"]
-		exists, err := resourceNsxtPolicyTGWIPSecVpnLocalEndpointExists(getSessionContextFromParentPath(testAccProvider.Meta(), parentPath), parentPath, resourceID, connector)
+		exists, err := resourceNsxtPolicyTGWIPSecVpnLocalEndpointExists(testAccGetSessionContextFromParentPath(testAccProvider.Meta(), parentPath), parentPath, resourceID, connector)
 		if err != nil {
 			return err
 		}

--- a/nsxt/resource_nsxt_policy_transit_gateway_ipsec_vpn_service_test.go
+++ b/nsxt/resource_nsxt_policy_transit_gateway_ipsec_vpn_service_test.go
@@ -143,7 +143,7 @@ func testAccNsxtPolicyTGWIPSecVpnServicesExists(displayName string, resourceName
 			return fmt.Errorf("Policy TransitGatewayIPSecVpnServices resource ID not set in resources")
 		}
 		parentPath := rs.Primary.Attributes["parent_path"]
-		exists, err := resourceNsxtPolicyTGWIPSecVpnServicesExists(getSessionContextFromParentPath(testAccProvider.Meta(), parentPath), parentPath, resourceID, connector)
+		exists, err := resourceNsxtPolicyTGWIPSecVpnServicesExists(testAccGetSessionContextFromParentPath(testAccProvider.Meta(), parentPath), parentPath, resourceID, connector)
 		if err != nil {
 			return err
 		}
@@ -165,7 +165,7 @@ func testAccNsxtPolicyTGWIPSecVpnServicesCheckDestroy(state *terraform.State, di
 
 		resourceID := rs.Primary.Attributes["id"]
 		parentPath := rs.Primary.Attributes["parent_path"]
-		exists, err := resourceNsxtPolicyTGWIPSecVpnServicesExists(getSessionContextFromParentPath(testAccProvider.Meta(), parentPath), parentPath, resourceID, connector)
+		exists, err := resourceNsxtPolicyTGWIPSecVpnServicesExists(testAccGetSessionContextFromParentPath(testAccProvider.Meta(), parentPath), parentPath, resourceID, connector)
 		if err != nil {
 			return err
 		}

--- a/nsxt/resource_nsxt_policy_transit_gateway_ipsec_vpn_session_test.go
+++ b/nsxt/resource_nsxt_policy_transit_gateway_ipsec_vpn_session_test.go
@@ -465,7 +465,7 @@ func testAccNsxtPolicyTGWIPSecVpnSessionExists(displayName string, resourceName 
 			return fmt.Errorf("Policy TGWIPSecVpnSession resource ID not set in resources")
 		}
 		parentPath := rs.Primary.Attributes["parent_path"]
-		exists, err := resourceNsxtPolicyTGWIPSecVpnSessionExists(getSessionContextFromParentPath(testAccProvider.Meta(), parentPath), parentPath, resourceID, connector)
+		exists, err := resourceNsxtPolicyTGWIPSecVpnSessionExists(testAccGetSessionContextFromParentPath(testAccProvider.Meta(), parentPath), parentPath, resourceID, connector)
 		if err != nil {
 			return err
 		}
@@ -487,7 +487,7 @@ func testAccNsxtPolicyTGWIPSecVpnSessionCheckDestroy(state *terraform.State, dis
 
 		resourceID := rs.Primary.Attributes["id"]
 		parentPath := rs.Primary.Attributes["parent_path"]
-		exists, err := resourceNsxtPolicyTGWIPSecVpnSessionExists(getSessionContextFromParentPath(testAccProvider.Meta(), parentPath), parentPath, resourceID, connector)
+		exists, err := resourceNsxtPolicyTGWIPSecVpnSessionExists(testAccGetSessionContextFromParentPath(testAccProvider.Meta(), parentPath), parentPath, resourceID, connector)
 		if err != nil {
 			return err
 		}

--- a/nsxt/resource_nsxt_policy_transit_gateway_nat_rule_test.go
+++ b/nsxt/resource_nsxt_policy_transit_gateway_nat_rule_test.go
@@ -216,7 +216,7 @@ func testAccNsxtTransitGatewayNatRuleExists(displayName string, resourceName str
 
 		parentPath := rs.Primary.Attributes["parent_path"]
 
-		exists, err := resourceNsxtPolicyTransitGatewayNatRuleExists(getSessionContextFromParentPath(testAccProvider.Meta(), parentPath), parentPath, resourceID, connector)
+		exists, err := resourceNsxtPolicyTransitGatewayNatRuleExists(testAccGetSessionContextFromParentPath(testAccProvider.Meta(), parentPath), parentPath, resourceID, connector)
 		if err != nil {
 			return err
 		}
@@ -239,7 +239,7 @@ func testAccNsxtTransitGatewayNatRuleCheckDestroy(state *terraform.State, displa
 		resourceID := rs.Primary.Attributes["id"]
 		parentPath := rs.Primary.Attributes["parent_path"]
 
-		exists, err := resourceNsxtPolicyTransitGatewayNatRuleExists(getSessionContextFromParentPath(testAccProvider.Meta(), parentPath), parentPath, resourceID, connector)
+		exists, err := resourceNsxtPolicyTransitGatewayNatRuleExists(testAccGetSessionContextFromParentPath(testAccProvider.Meta(), parentPath), parentPath, resourceID, connector)
 		if err != nil {
 			return err
 		}

--- a/nsxt/resource_nsxt_policy_transit_gateway_prefix_list_test.go
+++ b/nsxt/resource_nsxt_policy_transit_gateway_prefix_list_test.go
@@ -166,7 +166,7 @@ func testAccNsxtPolicyTransitGatewayPrefixListExists(displayName string, resourc
 		}
 
 		parentPath := rs.Primary.Attributes["parent_path"]
-		sessionContext := getSessionContextFromParentPath(testAccProvider.Meta(), parentPath)
+		sessionContext := testAccGetSessionContextFromParentPath(testAccProvider.Meta(), parentPath)
 		exists, err := resourceNsxtPolicyTransitGatewayPrefixListExists(sessionContext, parentPath, resourceID, connector)
 		if err != nil {
 			return err
@@ -187,7 +187,7 @@ func testAccNsxtPolicyTransitGatewayPrefixListCheckDestroy(state *terraform.Stat
 		}
 		resourceID := rs.Primary.Attributes["id"]
 		parentPath := rs.Primary.Attributes["parent_path"]
-		sessionContext := getSessionContextFromParentPath(testAccProvider.Meta(), parentPath)
+		sessionContext := testAccGetSessionContextFromParentPath(testAccProvider.Meta(), parentPath)
 		exists, err := resourceNsxtPolicyTransitGatewayPrefixListExists(sessionContext, parentPath, resourceID, connector)
 		if err != nil {
 			return err

--- a/nsxt/resource_nsxt_policy_transit_gateway_route_map_test.go
+++ b/nsxt/resource_nsxt_policy_transit_gateway_route_map_test.go
@@ -119,7 +119,7 @@ func testAccNsxtPolicyTransitGatewayRouteMapExists(displayName string, resourceN
 		}
 
 		parentPath := rs.Primary.Attributes["parent_path"]
-		sessionContext := getSessionContextFromParentPath(testAccProvider.Meta(), parentPath)
+		sessionContext := testAccGetSessionContextFromParentPath(testAccProvider.Meta(), parentPath)
 		exists, err := resourceNsxtPolicyTransitGatewayRouteMapExists(sessionContext, parentPath, resourceID, connector)
 		if err != nil {
 			return err
@@ -140,7 +140,7 @@ func testAccNsxtPolicyTransitGatewayRouteMapCheckDestroy(state *terraform.State,
 		}
 		resourceID := rs.Primary.Attributes["id"]
 		parentPath := rs.Primary.Attributes["parent_path"]
-		sessionContext := getSessionContextFromParentPath(testAccProvider.Meta(), parentPath)
+		sessionContext := testAccGetSessionContextFromParentPath(testAccProvider.Meta(), parentPath)
 		exists, err := resourceNsxtPolicyTransitGatewayRouteMapExists(sessionContext, parentPath, resourceID, connector)
 		if err != nil {
 			return err

--- a/nsxt/resource_nsxt_policy_transit_gateway_static_route_test.go
+++ b/nsxt/resource_nsxt_policy_transit_gateway_static_route_test.go
@@ -135,7 +135,7 @@ func testAccNsxtPolicyTransitGatewayStaticRouteExists(displayName string, resour
 			return fmt.Errorf("Policy ransitGatewayStaticRoute resource ID not set in resources")
 		}
 		parentPath := rs.Primary.Attributes["parent_path"]
-		sessionContext := getSessionContextFromParentPath(testAccProvider.Meta(), parentPath)
+		sessionContext := testAccGetSessionContextFromParentPath(testAccProvider.Meta(), parentPath)
 		exists, err := resourceNsxtPolicyTransitGatewayStaticRouteExists(sessionContext, parentPath, resourceID, connector)
 		if err != nil {
 			return err
@@ -157,7 +157,7 @@ func testAccNsxtPolicyTransitGatewayStaticRouteCheckDestroy(state *terraform.Sta
 		}
 		resourceID := rs.Primary.Attributes["id"]
 		parentPath := rs.Primary.Attributes["parent_path"]
-		sessionContext := getSessionContextFromParentPath(testAccProvider.Meta(), parentPath)
+		sessionContext := testAccGetSessionContextFromParentPath(testAccProvider.Meta(), parentPath)
 		exists, err := resourceNsxtPolicyTransitGatewayStaticRouteExists(sessionContext, parentPath, resourceID, connector)
 		if err != nil {
 			return err

--- a/nsxt/resource_nsxt_vpc_dhcp_v4_static_binding_config_test.go
+++ b/nsxt/resource_nsxt_vpc_dhcp_v4_static_binding_config_test.go
@@ -287,7 +287,7 @@ func testAccNsxtVpcSubnetDhcpV4StaticBindingConfigExists(displayName string, res
 
 		parentPath := rs.Primary.Attributes["parent_path"]
 
-		exists, err := resourceNsxtVpcSubnetDhcpV4StaticBindingConfigExists(getSessionContextFromParentPath(testAccProvider.Meta(), parentPath), parentPath, resourceID, connector)
+		exists, err := resourceNsxtVpcSubnetDhcpV4StaticBindingConfigExists(testAccGetSessionContextFromParentPath(testAccProvider.Meta(), parentPath), parentPath, resourceID, connector)
 		if err != nil {
 			return err
 		}
@@ -310,7 +310,7 @@ func testAccNsxtVpcSubnetDhcpV4StaticBindingConfigCheckDestroy(state *terraform.
 		resourceID := rs.Primary.Attributes["id"]
 		parentPath := rs.Primary.Attributes["parent_path"]
 
-		exists, err := resourceNsxtVpcSubnetDhcpV4StaticBindingConfigExists(getSessionContextFromParentPath(testAccProvider.Meta(), parentPath), parentPath, resourceID, connector)
+		exists, err := resourceNsxtVpcSubnetDhcpV4StaticBindingConfigExists(testAccGetSessionContextFromParentPath(testAccProvider.Meta(), parentPath), parentPath, resourceID, connector)
 		if err != nil {
 			return err
 		}

--- a/nsxt/resource_nsxt_vpc_dhcp_v6_static_binding_config_test.go
+++ b/nsxt/resource_nsxt_vpc_dhcp_v6_static_binding_config_test.go
@@ -168,7 +168,7 @@ func testAccNsxtVpcSubnetDhcpV6StaticBindingConfigExists(displayName string, res
 
 		parentPath := rs.Primary.Attributes["parent_path"]
 
-		exists, err := resourceNsxtVpcSubnetDhcpV6StaticBindingConfigExists(getSessionContextFromParentPath(testAccProvider.Meta(), parentPath), parentPath, resourceID, connector)
+		exists, err := resourceNsxtVpcSubnetDhcpV6StaticBindingConfigExists(testAccGetSessionContextFromParentPath(testAccProvider.Meta(), parentPath), parentPath, resourceID, connector)
 		if err != nil {
 			return err
 		}
@@ -191,7 +191,7 @@ func testAccNsxtVpcSubnetDhcpV6StaticBindingConfigCheckDestroy(state *terraform.
 		resourceID := rs.Primary.Attributes["id"]
 		parentPath := rs.Primary.Attributes["parent_path"]
 
-		exists, err := resourceNsxtVpcSubnetDhcpV6StaticBindingConfigExists(getSessionContextFromParentPath(testAccProvider.Meta(), parentPath), parentPath, resourceID, connector)
+		exists, err := resourceNsxtVpcSubnetDhcpV6StaticBindingConfigExists(testAccGetSessionContextFromParentPath(testAccProvider.Meta(), parentPath), parentPath, resourceID, connector)
 		if err != nil {
 			return err
 		}

--- a/nsxt/resource_nsxt_vpc_nat_rule_test.go
+++ b/nsxt/resource_nsxt_vpc_nat_rule_test.go
@@ -199,7 +199,7 @@ func testAccNsxtVpcNatRuleExists(displayName string, resourceName string) resour
 
 		parentPath := rs.Primary.Attributes["parent_path"]
 
-		exists, err := resourceNsxtPolicyVpcNatRuleExists(getSessionContextFromParentPath(testAccProvider.Meta(), parentPath), parentPath, resourceID, connector)
+		exists, err := resourceNsxtPolicyVpcNatRuleExists(testAccGetSessionContextFromParentPath(testAccProvider.Meta(), parentPath), parentPath, resourceID, connector)
 		if err != nil {
 			return err
 		}
@@ -222,7 +222,7 @@ func testAccNsxtVpcNatRuleCheckDestroy(state *terraform.State, displayName strin
 		resourceID := rs.Primary.Attributes["id"]
 		parentPath := rs.Primary.Attributes["parent_path"]
 
-		exists, err := resourceNsxtPolicyVpcNatRuleExists(getSessionContextFromParentPath(testAccProvider.Meta(), parentPath), parentPath, resourceID, connector)
+		exists, err := resourceNsxtPolicyVpcNatRuleExists(testAccGetSessionContextFromParentPath(testAccProvider.Meta(), parentPath), parentPath, resourceID, connector)
 		if err != nil {
 			return err
 		}

--- a/nsxt/utgomock_resource_nsxt_policy_tier0_gateway_gre_tunnel_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_tier0_gateway_gre_tunnel_test.go
@@ -115,6 +115,7 @@ func TestMockResourceNsxtPolicyTier0GatewayGRETunnelCreate(t *testing.T) {
 
 	t.Run("Create success", func(t *testing.T) {
 		gomock.InOrder(
+			mockSDK.EXPECT().Get(greTunnelTier0ID, greTunnelLocSvcID, greTunnelID).Return(nil, vapiErrors.NotFound{}),
 			mockSDK.EXPECT().Patch(greTunnelTier0ID, greTunnelLocSvcID, greTunnelID, gomock.Any()).Return(nil),
 			mockSDK.EXPECT().Get(greTunnelTier0ID, greTunnelLocSvcID, greTunnelID).Return(greTunnelStructValue(t), nil),
 		)

--- a/nsxt/utils_test.go
+++ b/nsxt/utils_test.go
@@ -344,6 +344,32 @@ func testAccGetMultitenancyContext() tf_api.SessionContext {
 	return tf_api.SessionContext{ProjectID: projectID, ClientType: tf_api.Multitenancy}
 }
 
+func testAccPolicyTier0GetLocaleService(context tf_api.SessionContext, gwID string, localeServiceID string, connector client.Connector) *model.LocaleServices {
+	tier0LocaleservicesClient := cliTier0LocaleServicesClient(context, connector)
+	obj, err := tier0LocaleservicesClient.Get(gwID, localeServiceID)
+	if err != nil {
+		log.Printf("[DEBUG] Failed to get locale service %s for gateway %s: %s", gwID, localeServiceID, err)
+		return nil
+	}
+	return &obj
+}
+
+func testAccGetSessionContextFromParentPath(m interface{}, parentPath string) tf_api.SessionContext {
+	var clientType tf_api.ClientType
+	projectID, vpcID := getContextDataFromParentPath(parentPath)
+	if projectID != "" {
+		clientType = tf_api.Multitenancy
+		if vpcID != "" {
+			clientType = tf_api.VPC
+		}
+	} else if isPolicyGlobalManager(m) {
+		clientType = tf_api.Global
+	} else {
+		clientType = tf_api.Local
+	}
+	return tf_api.SessionContext{ProjectID: projectID, VPCID: vpcID, ClientType: clientType, FromGlobal: false}
+}
+
 func testAccIsGlobalManager2() tf_api.ClientType {
 	if testAccIsVPC() {
 		return tf_api.VPC


### PR DESCRIPTION
GRE Tunnel Create now rejects a colliding nsx_id and propagates API errors instead of misreporting them as existing. The other flagged Exists/helper functions were only used by acceptance tests, so they were relocated into their _test.go files and renamed to avoid confusion with production helpers.