### PR TITLE
Suppress bgp_neighbor password drift after import

### DIFF
--- a/nsxt/resource_nsxt_policy_bgp_neighbor.go
+++ b/nsxt/resource_nsxt_policy_bgp_neighbor.go
@@ -125,11 +125,12 @@ func resourceNsxtPolicyBgpNeighbor() *schema.Resource {
 				ValidateFunc: validateSingleIP(),
 			},
 			"password": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Description:  "Password for BGP neighbor authentication",
-				ValidateFunc: validation.StringLenBetween(0, 32),
-				Sensitive:    true,
+				Type:             schema.TypeString,
+				Optional:         true,
+				Description:      "Password for BGP neighbor authentication",
+				ValidateFunc:     validation.StringLenBetween(0, 32),
+				Sensitive:        true,
+				DiffSuppressFunc: suppressIfEmptyPriorState,
 			},
 			"remote_as_num": {
 				Type:         schema.TypeString,

--- a/nsxt/resource_nsxt_policy_transit_gateway_bgp_neighbor.go
+++ b/nsxt/resource_nsxt_policy_transit_gateway_bgp_neighbor.go
@@ -107,11 +107,12 @@ func resourceNsxtPolicyTransitGatewayBgpNeighbor() *schema.Resource {
 				ValidateFunc: validateSingleIP(),
 			},
 			"password": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Description:  "Password for BGP neighbor authentication",
-				ValidateFunc: validation.StringLenBetween(0, 32),
-				Sensitive:    true,
+				Type:             schema.TypeString,
+				Optional:         true,
+				Description:      "Password for BGP neighbor authentication",
+				ValidateFunc:     validation.StringLenBetween(0, 32),
+				Sensitive:        true,
+				DiffSuppressFunc: suppressIfEmptyPriorState,
 			},
 			"remote_as_num": {
 				Type:         schema.TypeString,


### PR DESCRIPTION
NSX never returns password on GET, so terraform import leaves it empty in state, causing a spurious diff/re-apply on every plan. Reuse the suppressIfEmptyPriorState DiffSuppressFunc already used by nsxt_policy_virtual_network_appliance and
nsxt_policy_route_controller_bgp_neighbor for the same write-only field import issue. Also fixes the identical unfixed pattern in nsxt_policy_transit_gateway_bgp_neighbor.