### PR TITLE
Fix host state drift in nsxt_proxy_config

### DIFF
--- a/nsxt/resource_nsxt_proxy_config.go
+++ b/nsxt/resource_nsxt_proxy_config.go
@@ -62,6 +62,7 @@ func resourceNsxtProxyConfig() *schema.Resource {
 				Type:        schema.TypeString,
 				Description: "Proxy server host (IP address or FQDN)",
 				Optional:    true,
+				Computed:    true,
 			},
 			"port": {
 				Type:         schema.TypeInt,


### PR DESCRIPTION
When enabled is set to false and host is omitted from the HCL configuration, the provider sets a default host placeholder ('proxy.example.com') to satisfy NSX Manager API requirements.

Because host was defined as Optional: true without Computed: true, Terraform detected perpetual state drift on plan / apply when reading back the provider-assigned default value.

Mark host as Computed: true in the schema so Terraform treats the injected default value as expected, eliminating drift.