### PR TITLE
Fix route map perpetual drift due to mutually exclusive matches

### DIFF
--- a/docs/resources/policy_gateway_route_map.md
+++ b/docs/resources/policy_gateway_route_map.md
@@ -53,10 +53,10 @@ The following arguments are supported:
 * `gateway_path` - (Required) Policy path of relevant Tier0 Gateway.
 * `entry` - (Required) List of entries for the Route Map.
     * `action` - (Optional) Action for the route map entry, either `PERMIT` or `DENY`, with default being `PERMIT`.
-    * `community_list_match` - (Optional) List of Prefix List match criteria for route map. Cannot be configured together with `prefix_list_matches`. If configured together, `prefix_list_matches` will be ignored.
+    * `community_list_match` - (Optional) List of Prefix List match criteria for route map. Mutually exclusive with `prefix_list_matches`; specifying both on the same entry results in an error.
         * `criteria` - (Required) Community list path or a regular expression.
         * `match_operator` - (Required) Match operator for the criteria, one of `MATCH_ANY`, `MATCH_ALL`, `MATCH_EXACT`, `MATCH_COMMUNITY_REGEX`, `MATCH_LARGE_COMMUNITY_REGEX`. Only last two operators can be used together with regular expression criteria.
-    * `prefix_list_matches` - (Optional) List of policy paths for Prefix Lists configured on this Gateway. Cannot be configured together with `community_list_match`. If configured together, `prefix_list_matches` will be ignored.
+    * `prefix_list_matches` - (Optional) List of policy paths for Prefix Lists configured on this Gateway. Mutually exclusive with `community_list_match`; specifying both on the same entry results in an error.
     * `set` - (Optional) Set criteria for route map entry.
         * `as_path_prepend` - (Optional) Autonomous System (AS) path prepend to influence route selection.
         * `community` - (Optional) BGP regular or large community for matching routes.

--- a/docs/resources/policy_transit_gateway_route_map.md
+++ b/docs/resources/policy_transit_gateway_route_map.md
@@ -58,8 +58,8 @@ The following arguments are supported:
 * `nsx_id` - (Optional) The NSX ID of this resource. If set, this ID will be used to create the resource.
 * `entry` - (Required) Ordered list of route map entries. Each entry supports:
     * `action` - (Optional) Action for the entry. Accepted values: `PERMIT`, `DENY`. Defaults to `PERMIT`.
-    * `prefix_list_matches` - (Optional) Set of policy paths for prefix lists to match against.
-    * `community_list_match` - (Optional) List of BGP community match criteria. Each item supports:
+    * `prefix_list_matches` - (Optional) Set of policy paths for prefix lists to match against. Mutually exclusive with `community_list_match`.
+    * `community_list_match` - (Optional) List of BGP community match criteria. Mutually exclusive with `prefix_list_matches`. Each item supports:
         * `criteria` - (Required) Community list path or a regular expression.
         * `match_operator` - (Required) Match operator. Accepted values: `MATCH_ANY`, `MATCH_ALL`, `MATCH_EXACT`, `MATCH_COMMUNITY_REGEX`, `MATCH_LARGE_COMMUNITY_REGEX`.
     * `set` - (Optional) Set clause applied to matching routes (max 1 block):

--- a/nsxt/resource_nsxt_policy_gateway_route_map.go
+++ b/nsxt/resource_nsxt_policy_gateway_route_map.go
@@ -72,7 +72,7 @@ func getPolicyRouteMapEntrySchema() *schema.Resource {
 			},
 			"community_list_match": {
 				Type:        schema.TypeList,
-				Description: "Prefix list match criteria for route map",
+				Description: "Community list match criteria for route map. Mutually exclusive with prefix_list_matches",
 				Optional:    true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -93,7 +93,7 @@ func getPolicyRouteMapEntrySchema() *schema.Resource {
 			"prefix_list_matches": {
 				Type:        schema.TypeSet,
 				Optional:    true,
-				Description: "List of paths for prefix lists for route map",
+				Description: "List of paths for prefix lists for route map. Mutually exclusive with community_list_match",
 				Elem:        getElemPolicyPathSchema(),
 			},
 			"set": {
@@ -180,7 +180,7 @@ func setRouteMapEntriesInSchema(d *schema.ResourceData, entries []model.RouteMap
 	d.Set("entry", entryList)
 }
 
-func policyGatewayRouteMapBuildEntry(d *schema.ResourceData, entryNo int, schemaEntry map[string]interface{}) model.RouteMapEntry {
+func policyGatewayRouteMapBuildEntry(d *schema.ResourceData, entryNo int, schemaEntry map[string]interface{}) (model.RouteMapEntry, error) {
 
 	action := schemaEntry["action"].(string)
 	obj := model.RouteMapEntry{
@@ -189,6 +189,10 @@ func policyGatewayRouteMapBuildEntry(d *schema.ResourceData, entryNo int, schema
 
 	commListMatches := schemaEntry["community_list_match"].([]interface{})
 	prefixListMatches := schemaEntry["prefix_list_matches"].(*schema.Set).List()
+
+	if len(commListMatches) > 0 && len(prefixListMatches) > 0 {
+		return obj, fmt.Errorf("entry %d: community_list_match and prefix_list_matches are mutually exclusive and cannot be used in the same route map entry", entryNo)
+	}
 
 	if len(commListMatches) > 0 {
 		var commCriteriaList []model.CommunityMatchCriteria
@@ -239,7 +243,7 @@ func policyGatewayRouteMapBuildEntry(d *schema.ResourceData, entryNo int, schema
 		obj.Set = &entrySet
 	}
 
-	return obj
+	return obj, nil
 }
 
 func resourceNsxtPolicyGatewayRouteMapPatch(gwID string, id string, d *schema.ResourceData, isGlobalManager bool, connector client.Connector) error {
@@ -250,7 +254,11 @@ func resourceNsxtPolicyGatewayRouteMapPatch(gwID string, id string, d *schema.Re
 	schemaEntries := d.Get("entry").([]interface{})
 	var entries []model.RouteMapEntry
 	for entryNo, entry := range schemaEntries {
-		entries = append(entries, policyGatewayRouteMapBuildEntry(d, entryNo, entry.(map[string]interface{})))
+		entryObj, err := policyGatewayRouteMapBuildEntry(d, entryNo, entry.(map[string]interface{}))
+		if err != nil {
+			return err
+		}
+		entries = append(entries, entryObj)
 	}
 
 	obj := model.Tier0RouteMap{

--- a/nsxt/resource_nsxt_policy_gateway_route_map_test.go
+++ b/nsxt/resource_nsxt_policy_gateway_route_map_test.go
@@ -6,6 +6,7 @@ package nsxt
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -113,6 +114,49 @@ func TestAccResourceNsxtPolicyGatewayRouteMap_importBasic(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestAccResourceNsxtPolicyGatewayRouteMap_mutuallyExclusiveMatches(t *testing.T) {
+	displayName := getAccTestResourceName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccNsxtPolicyGatewayRouteMapMutuallyExclusiveTemplate(displayName),
+				ExpectError: regexp.MustCompile(`community_list_match and prefix_list_matches are mutually exclusive`),
+			},
+		},
+	})
+}
+
+func testAccNsxtPolicyGatewayRouteMapMutuallyExclusiveTemplate(displayName string) string {
+	return testAccNsxtPolicyEdgeClusterReadTemplate(getEdgeClusterName()) +
+		testAccNsxtPolicyTier0WithEdgeClusterTemplate("test", false) + fmt.Sprintf(`
+resource "nsxt_policy_gateway_prefix_list" "test" {
+  display_name = "%s"
+  gateway_path = nsxt_policy_tier0_gateway.test.path
+
+  prefix {
+    action  = "PERMIT"
+    network = "4.4.0.0/20"
+  }
+}
+
+resource "nsxt_policy_gateway_route_map" "test" {
+  gateway_path = nsxt_policy_tier0_gateway.test.path
+  display_name = "%s"
+
+  entry {
+    action              = "PERMIT"
+    prefix_list_matches = [nsxt_policy_gateway_prefix_list.test.path]
+    community_list_match {
+      criteria       = "11:22"
+      match_operator = "MATCH_COMMUNITY_REGEX"
+    }
+  }
+}`, displayName, displayName)
 }
 
 func testAccNsxtPolicyGatewayRouteMapExistsOnNSX(tier0Id string, id string, connector client.Connector, isGlobalManager bool) (bool, error) {

--- a/nsxt/resource_nsxt_policy_transit_gateway_route_map.go
+++ b/nsxt/resource_nsxt_policy_transit_gateway_route_map.go
@@ -64,7 +64,7 @@ func resourceNsxtPolicyTransitGatewayRouteMapExists(sessionContext utl.SessionCo
 	return false, logAPIError("Error retrieving TransitGatewayRouteMap", err)
 }
 
-func tgwRouteMapBuildObj(d *schema.ResourceData, id string) model.TransitGatewayRouteMap {
+func tgwRouteMapBuildObj(d *schema.ResourceData, id string) (model.TransitGatewayRouteMap, error) {
 	displayName := d.Get("display_name").(string)
 	description := d.Get("description").(string)
 	tags := getPolicyTagsFromSchema(d)
@@ -72,7 +72,11 @@ func tgwRouteMapBuildObj(d *schema.ResourceData, id string) model.TransitGateway
 	schemaEntries := d.Get("entry").([]interface{})
 	var entries []model.RouteMapEntry
 	for entryNo, entry := range schemaEntries {
-		entries = append(entries, policyGatewayRouteMapBuildEntry(d, entryNo, entry.(map[string]interface{})))
+		entryObj, err := policyGatewayRouteMapBuildEntry(d, entryNo, entry.(map[string]interface{}))
+		if err != nil {
+			return model.TransitGatewayRouteMap{}, err
+		}
+		entries = append(entries, entryObj)
 	}
 
 	return model.TransitGatewayRouteMap{
@@ -81,7 +85,7 @@ func tgwRouteMapBuildObj(d *schema.ResourceData, id string) model.TransitGateway
 		Description: &description,
 		Tags:        tags,
 		Entries:     entries,
-	}
+	}, nil
 }
 
 func resourceNsxtPolicyTransitGatewayRouteMapCreate(d *schema.ResourceData, m interface{}) error {
@@ -97,7 +101,10 @@ func resourceNsxtPolicyTransitGatewayRouteMapCreate(d *schema.ResourceData, m in
 		return pathErr
 	}
 
-	obj := tgwRouteMapBuildObj(d, id)
+	obj, err := tgwRouteMapBuildObj(d, id)
+	if err != nil {
+		return err
+	}
 
 	log.Printf("[INFO] Creating TransitGatewayRouteMap with ID %s", id)
 	sessionContext := getParentContext(d, m, parentPath)
@@ -163,7 +170,10 @@ func resourceNsxtPolicyTransitGatewayRouteMapUpdate(d *schema.ResourceData, m in
 		return pathErr
 	}
 
-	obj := tgwRouteMapBuildObj(d, id)
+	obj, err := tgwRouteMapBuildObj(d, id)
+	if err != nil {
+		return err
+	}
 	revision := int64(d.Get("revision").(int))
 	obj.Revision = &revision
 

--- a/nsxt/resource_nsxt_policy_transit_gateway_route_map_test.go
+++ b/nsxt/resource_nsxt_policy_transit_gateway_route_map_test.go
@@ -6,6 +6,7 @@ package nsxt
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -102,6 +103,52 @@ func TestAccResourceNsxtPolicyTransitGatewayRouteMap_importBasic(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestAccResourceNsxtPolicyTransitGatewayRouteMap_mutuallyExclusiveMatches(t *testing.T) {
+	prereqName := getAccTestResourceName()
+	displayName := getAccTestResourceName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccOnlyLocalManager(t)
+			testAccNSXVersion(t, "9.2.0")
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccNsxtPolicyTransitGatewayRouteMapMutuallyExclusiveTemplate(prereqName, displayName),
+				ExpectError: regexp.MustCompile(`community_list_match and prefix_list_matches are mutually exclusive`),
+			},
+		},
+	})
+}
+
+func testAccNsxtPolicyTransitGatewayRouteMapMutuallyExclusiveTemplate(prereqName string, displayName string) string {
+	return testAccNsxtPolicyTransitGatewayRouteMapPrerequisites(prereqName) + fmt.Sprintf(`
+resource "nsxt_policy_transit_gateway_prefix_list" "test" {
+  display_name = "%s-pl"
+  parent_path  = nsxt_policy_transit_gateway.test.path
+  prefix {
+    action  = "PERMIT"
+    network = "10.10.0.0/16"
+  }
+}
+
+resource "nsxt_policy_transit_gateway_route_map" "test" {
+  parent_path  = nsxt_policy_transit_gateway.test.path
+  display_name = "%s"
+
+  entry {
+    action              = "PERMIT"
+    prefix_list_matches = [nsxt_policy_transit_gateway_prefix_list.test.path]
+    community_list_match {
+      criteria       = "11:22"
+      match_operator = "MATCH_COMMUNITY_REGEX"
+    }
+  }
+}`, displayName, displayName)
 }
 
 func testAccNsxtPolicyTransitGatewayRouteMapExists(displayName string, resourceName string) resource.TestCheckFunc {

--- a/nsxt/utgomock_resource_nsxt_policy_gateway_route_map_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_gateway_route_map_test.go
@@ -121,6 +121,33 @@ func TestMockResourceNsxtPolicyGatewayRouteMapCreate(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "Tier0")
 	})
+
+	t.Run("Create fails when prefix_list_matches and community_list_match are both set", func(t *testing.T) {
+		notFoundErr := vapiErrors.NotFound{}
+		mockSDK.EXPECT().Get(routeMapGwID, routeMapID).Return(nsxModel.Tier0RouteMap{}, notFoundErr)
+
+		data := minimalRouteMapData()
+		data["entry"] = []interface{}{
+			map[string]interface{}{
+				"action":              routeMapEntryAction,
+				"prefix_list_matches": []interface{}{"/infra/tier-0s/t0-rm-gw-1/prefix-lists/pl-1"},
+				"community_list_match": []interface{}{
+					map[string]interface{}{
+						"criteria":       "11:22",
+						"match_operator": nsxModel.CommunityMatchCriteria_MATCH_OPERATOR_ANY,
+					},
+				},
+				"set": []interface{}{},
+			},
+		}
+
+		res := resourceNsxtPolicyGatewayRouteMap()
+		d := schema.TestResourceDataRaw(t, res.Schema, data)
+
+		err := resourceNsxtPolicyGatewayRouteMapCreate(d, newGoMockProviderClient())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "mutually exclusive")
+	})
 }
 
 func TestMockResourceNsxtPolicyGatewayRouteMapRead(t *testing.T) {

--- a/nsxt/utgomock_resource_nsxt_policy_transit_gateway_route_map_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_transit_gateway_route_map_test.go
@@ -117,6 +117,33 @@ func TestMockResourceNsxtPolicyTransitGatewayRouteMapCreate(t *testing.T) {
 		err := resourceNsxtPolicyTransitGatewayRouteMapCreate(d, newGoMockProviderClient())
 		require.Error(t, err)
 	})
+
+	t.Run("Create fails when prefix_list_matches and community_list_match are both set", func(t *testing.T) {
+		notFoundErr := vapiErrors.NotFound{}
+		mockSDK.EXPECT().Get(tgwRMOrgID, tgwRMProjectID, tgwRMTGWID, tgwRMID).Return(nsxModel.TransitGatewayRouteMap{}, notFoundErr)
+
+		data := minimalTGWRouteMapData()
+		data["entry"] = []interface{}{
+			map[string]interface{}{
+				"action":              tgwRMAction,
+				"prefix_list_matches": []interface{}{tgwRMPrefixPath},
+				"community_list_match": []interface{}{
+					map[string]interface{}{
+						"criteria":       "11:22",
+						"match_operator": nsxModel.CommunityMatchCriteria_MATCH_OPERATOR_ANY,
+					},
+				},
+				"set": []interface{}{},
+			},
+		}
+
+		res := resourceNsxtPolicyTransitGatewayRouteMap()
+		d := schema.TestResourceDataRaw(t, res.Schema, data)
+
+		err := resourceNsxtPolicyTransitGatewayRouteMapCreate(d, newGoMockProviderClient())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "mutually exclusive")
+	})
 }
 
 func TestMockResourceNsxtPolicyTransitGatewayRouteMapRead(t *testing.T) {


### PR DESCRIPTION
Route map entries silently dropped prefix_list_matches when community_list_match was also set, since NSX treats the two as mutually exclusive per entry. The dropped value was never sent to NSX, so every subsequent read/plan showed drift.

Reject the invalid combination with a clear error at apply time instead of silently discarding data, for both nsxt_policy_gateway_route_map and
nsxt_policy_transit_gateway_route_map, which share this entry-building code.

Added unit tests covering the new validation error, and acceptance tests asserting the error is raised against a live NSX manager.

Verified against a live NSX 9.2.0 manager: the invalid combination now fails fast on apply, and a corrected config creates cleanly with no drift on re-apply.

AI-Tool-Used: Claude Code
AI-Tool-Use-Level: high
AI-Code-Category: production