### PR TITLE
Fix gateway interface realization data source on GM

### DIFF
--- a/docs/data-sources/policy_gateway_interface_realization.md
+++ b/docs/data-sources/policy_gateway_interface_realization.md
@@ -30,6 +30,32 @@ data "nsxt_policy_gateway_interface_realization" "info" {
 }
 ```
 
+## Example Usage - Global Manager
+
+```hcl
+data "nsxt_policy_site" "site" {
+  display_name = "site"
+}
+
+data "nsxt_policy_tier1_gateway" "tier1_gw" {
+  display_name = "tier1_gw"
+}
+
+resource "nsxt_policy_tier1_gateway_interface" "tier1_gw_if" {
+  display_name = "tier1_gw_if"
+  gateway_path = data.nsxt_policy_tier1_gateway.tier1_gw.path
+  segment_path = nsxt_policy_segment.segment1.path
+  subnets      = ["12.12.2.13/24"]
+  site_path    = data.nsxt_policy_site.site.path
+}
+
+data "nsxt_policy_gateway_interface_realization" "info" {
+  gateway_interface_path = nsxt_policy_tier1_gateway_interface.tier1_gw_if.path
+  site_path              = data.nsxt_policy_site.site.path
+  timeout                = 60
+}
+```
+
 ## Example Usage - Multi-Tenancy
 
 ```hcl
@@ -64,6 +90,7 @@ data "nsxt_policy_gateway_interface_realization" "info" {
 
 * `gateway_interface_path` - (Required) The policy path of the gateway interface.
 * `gateway_path` - (Deprecated) Use `gateway_interface_path` instead. Despite its name, this attribute expects the path of the gateway interface, not the gateway.
+* `site_path` - (Optional) The path of the site which the resource belongs to, this configuration is required for global manager only. `path` field of the existing `nsxt_policy_site` can be used here.
 * `id`  - (Optional) The ID of gateway interface.
 * `display_name` - (Optional) The display name of the resource. If neither ID nor display name are set, the realized gateway interface with IP addresses will be retrieved.
 * `delay` - (Optional) Delay (in seconds) before realization polling is started. Default is set to 1.

--- a/nsxt/data_source_nsxt_policy_gateway_interface_realization.go
+++ b/nsxt/data_source_nsxt_policy_gateway_interface_realization.go
@@ -37,6 +37,12 @@ func dataSourceNsxtPolicyGatewayInterfaceRealization() *schema.Resource {
 				ValidateFunc: validatePolicyPath(),
 				ExactlyOneOf: []string{"gateway_path", "gateway_interface_path"},
 			},
+			"site_path": {
+				Type:         schema.TypeString,
+				Description:  "Path of the site this resource belongs to. Required on Global Manager, since the realized entity is site-scoped there.",
+				Optional:     true,
+				ValidateFunc: validatePolicyPath(),
+			},
 			"display_name": {
 				Type:        schema.TypeString,
 				Description: "The display name of the gateway interface",
@@ -94,13 +100,25 @@ func dataSourceNsxtPolicyGatewayInterfaceRealizationRead(d *schema.ResourceData,
 	delay := d.Get("delay").(int)
 	timeout := d.Get("timeout").(int)
 
+	sitePath := d.Get("site_path").(string)
+	if !isPolicyGlobalManager(m) && sitePath != "" {
+		return globalManagerOnlyError()
+	}
+	if isPolicyGlobalManager(m) && sitePath == "" {
+		return attributeRequiredGlobalManagerError("site_path", "nsxt_policy_gateway_interface_realization")
+	}
+	var sitePathPtr *string
+	if sitePath != "" {
+		sitePathPtr = &sitePath
+	}
+
 	pendingStates := []string{"UNKNOWN", "UNREALIZED"}
 	targetStates := []string{"REALIZED", "ERROR"}
 	stateConf := &resource.StateChangeConf{
 		Pending: pendingStates,
 		Target:  targetStates,
 		Refresh: func() (interface{}, string, error) {
-			result, err := client.List(gatewayInterfacePath, nil)
+			result, err := client.List(gatewayInterfacePath, sitePathPtr)
 			if err != nil {
 				return result, "", err
 			}

--- a/nsxt/data_source_nsxt_policy_gateway_interface_realization_test.go
+++ b/nsxt/data_source_nsxt_policy_gateway_interface_realization_test.go
@@ -1,0 +1,62 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package nsxt
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+// site_path is required on Global Manager, since the realized entity lookup
+// is site-scoped there. Without it, GM's realized-entities API silently
+// returns no results and the data source times out (see bugzilla 3766849).
+func TestAccDataSourceNsxtPolicyGatewayInterfaceRealization_sitePathRequiredOnGM(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccOnlyGlobalManager(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccNsxtPolicyGatewayInterfaceRealizationMissingSitePathTemplate(),
+				ExpectError: regexp.MustCompile("requires site_path configuration for NSX Global Manager"),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceNsxtPolicyGatewayInterfaceRealization_sitePathNotAllowedOnLocalManager(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccOnlyLocalManager(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccNsxtPolicyGatewayInterfaceRealizationExtraSitePathTemplate(),
+				ExpectError: regexp.MustCompile("only supported with NSX Global Manager"),
+			},
+		},
+	})
+}
+
+func testAccNsxtPolicyGatewayInterfaceRealizationMissingSitePathTemplate() string {
+	return `
+data "nsxt_policy_gateway_interface_realization" "test" {
+  gateway_interface_path = "/global-infra/tier-0s/dummy/locale-services/dummy/interfaces/dummy"
+}`
+}
+
+func testAccNsxtPolicyGatewayInterfaceRealizationExtraSitePathTemplate() string {
+	return `
+data "nsxt_policy_gateway_interface_realization" "test" {
+  gateway_interface_path = "/infra/tier-0s/dummy/locale-services/dummy/interfaces/dummy"
+  site_path              = "/infra/sites/default"
+}`
+}

--- a/nsxt/resource_nsxt_policy_tier0_gateway_interface_test.go
+++ b/nsxt/resource_nsxt_policy_tier0_gateway_interface_test.go
@@ -53,6 +53,7 @@ func TestAccResourceNsxtPolicyTier0GatewayInterface_service(t *testing.T) {
 					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
 					resource.TestCheckResourceAttrSet(testResourceName, "locale_service_id"),
 					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+					resource.TestCheckResourceAttr("data.nsxt_policy_gateway_interface_realization.gw_realization", "state", "REALIZED"),
 				),
 			},
 			{
@@ -693,6 +694,7 @@ data "nsxt_policy_realization_info" "realization_info" {
 
 data "nsxt_policy_gateway_interface_realization" "gw_realization" {
   gateway_interface_path = nsxt_policy_tier0_gateway_interface.test.path
+  site_path              = data.nsxt_policy_site.test.path
 }`
 	}
 	return `


### PR DESCRIPTION
gateway_path required the interface path, not the gateway path, so it's deprecated in favor of gateway_interface_path. On Global Manager, realized-entities lookups also need a site_path, without which the data source silently returns no results and times out.