### PR TITLE
Fix undeclared site reference in GM segment attribute test

### DIFF
--- a/nsxt/data_source_nsxt_policy_segment_test.go
+++ b/nsxt/data_source_nsxt_policy_segment_test.go
@@ -146,7 +146,7 @@ data "nsxt_policy_segment" "test" {
 }
 
 func testAccNsxtPolicySegmentWithAttributesTemplate(tzName string, name string) string {
-	return testAccNSXPolicyTransportZoneReadTemplate(tzName, false, false) + fmt.Sprintf(`
+	return testAccNSXPolicyTransportZoneReadTemplate(tzName, false, true) + fmt.Sprintf(`
 resource "nsxt_policy_tier1_gateway" "test" {
   display_name = "%s-t1"
 }


### PR DESCRIPTION
testAccNsxtPolicySegmentWithAttributesTemplate passed addSite=false, so on Global Manager the transport zone template referenced data.nsxt_policy_site.test without declaring it. Regression from #2216.