### PR TITLE
Accept segment path for edge transport node network IDs

### DIFF
--- a/nsxt/resource_nsxt_policy_edge_transport_node.go
+++ b/nsxt/resource_nsxt_policy_edge_transport_node.go
@@ -503,7 +503,7 @@ func resourceNsxtPolicyEdgeTransportNode() *schema.Resource {
 							Type:         schema.TypeString,
 							Required:     true,
 							Description:  "Portgroup, logical switch identifier or segment path for management network connectivity",
-							ValidateFunc: validateID(),
+							ValidateFunc: validateIDOrPolicyPath(),
 						},
 					},
 				},
@@ -526,7 +526,7 @@ func resourceNsxtPolicyEdgeTransportNode() *schema.Resource {
 										Type:         schema.TypeString,
 										Optional:     true,
 										Description:  "A portgroup, logical switch identifier or segment path for datapath connectivity",
-										ValidateFunc: validateID(),
+										ValidateFunc: validateIDOrPolicyPath(),
 									},
 									"device_name": {
 										Type:        schema.TypeString,

--- a/nsxt/validators.go
+++ b/nsxt/validators.go
@@ -401,6 +401,22 @@ func validateID() schema.SchemaValidateFunc {
 	}
 }
 
+func validateIDOrPolicyPath() schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (s []string, es []error) {
+		v, ok := i.(string)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be string", k))
+			return
+		}
+
+		if !isValidID(v) && !isPolicyPath(v) {
+			es = append(es, fmt.Errorf("expected %s to be a valid ID or policy path, got: %s", k, v))
+		}
+
+		return
+	}
+}
+
 func validateSHA256Thumbprint() schema.SchemaValidateFunc {
 	return func(i interface{}, k string) (warnings []string, errors []error) {
 		v, ok := i.(string)

--- a/nsxt/validators_table_test.go
+++ b/nsxt/validators_table_test.go
@@ -501,6 +501,14 @@ func TestUnitNsxt_validatePolicyPathAndIDAndProjectID(t *testing.T) {
 	_, es = vid("bad/id", "k")
 	assert.NotEmpty(t, es)
 
+	vidp := validateIDOrPolicyPath()
+	_, es = vidp("ok-id", "k")
+	assert.Empty(t, es)
+	_, es = vidp("/infra/segments/seg1", "k")
+	assert.Empty(t, es)
+	_, es = vidp("/badpath", "k")
+	assert.NotEmpty(t, es)
+
 	vpdef := validateProjectID(true)
 	_, es = vpdef("default", "k")
 	assert.Empty(t, es)


### PR DESCRIPTION
datapath_network_id and management network_id are documented to accept a segment path, but validateID() rejected any value containing a slash, so a valid path always failed validation.