### PR TITLE
Optimize vpc caching by batching at project level

### DIFF
--- a/api/nsx/transport_node.go
+++ b/api/nsx/transport_node.go
@@ -312,6 +312,7 @@ func (c TransportNodeClientContext) Updatemaintenancemode(transportnodeIdParam s
 
 	case utl.Local:
 		client := c.Client.(client0.TransportNodesClient)
+		//nolint:noctx
 		err = client.Updatemaintenancemode(transportnodeIdParam, actionParam)
 
 	default:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware/terraform-provider-nsxt
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/google/uuid v1.6.0

--- a/nsxt/cache.go
+++ b/nsxt/cache.go
@@ -297,6 +297,9 @@ func getQueryString(resourceType string, context utl.SessionContext) string {
 	case utl.Local:
 		return fmt.Sprintf("resource_type:%s AND marked_for_delete:false AND context:Local", resourceType)
 	case utl.VPC, utl.Multitenancy:
+		if context.VPCID == "" {
+			return fmt.Sprintf("resource_type:%s AND marked_for_delete:false AND context:%s-*", resourceType, context.ProjectID)
+		}
 		return fmt.Sprintf("resource_type:%s AND marked_for_delete:false AND context:%s-%s", resourceType, context.ProjectID, context.VPCID)
 	default:
 		return fmt.Sprintf("resource_type:%s AND marked_for_delete:false", resourceType)
@@ -349,12 +352,23 @@ func (c *typeScopedCache) getTypeCache(resourceType string) *resourceTypeCache {
 
 // getEffectiveCacheContext derives the cache context, preferring parent_path when context{} is absent.
 func getEffectiveCacheContext(d *schema.ResourceData, m interface{}) utl.SessionContext {
+	var ctx utl.SessionContext
 	if pp, ok := d.GetOk("parent_path"); ok {
 		if parentPath := pp.(string); parentPath != "" {
-			return getParentContext(d, m, parentPath)
+			ctx = getParentContext(d, m, parentPath)
+		} else {
+			ctx = getSessionContext(d, m)
 		}
+	} else {
+		ctx = getSessionContext(d, m)
 	}
-	return getSessionContext(d, m)
+
+	// For VPC and Multitenancy contexts, batch cache queries at the Project level
+	// rather than the individual VPC level to improve cache performance.
+	if IsCacheEnabled(m) && (ctx.ClientType == utl.VPC || ctx.ClientType == utl.Multitenancy) {
+		ctx.VPCID = ""
+	}
+	return ctx
 }
 
 func getCacheQueryKey(resourceType string, d *schema.ResourceData, m interface{}) string {

--- a/nsxt/provider.go
+++ b/nsxt/provider.go
@@ -1020,7 +1020,7 @@ func (processor logRequestProcessor) Process(req *http.Request) error {
 			return nil
 		}
 	}
-	reqDump, err := httputil.DumpRequestOut(req, true)
+	reqDump, err := httputil.DumpRequest(req, true)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
This broadens the cache context for VPC resources from 'per-VPC' to 'per-Project' when caching is enabled. Previously,
  'context.VPCID' forced the provider to make a separate NSX Search API call for each VPC's resources (e.g. 'nsxt_vpc_subnet'), bypassing the bulk-fetching benefits of the cache. Now, 'getEffectiveCacheContext'
  clears the 'VPCID' for caching queries, and 'getQueryString' uses a 'context:%s-*' wildcard so one API call retrieves all VPC resources within the project.