### PR TITLE
Fix panic in policy segment port importer

### DIFF
--- a/nsxt/data_source_nsxt_policy_segment_port.go
+++ b/nsxt/data_source_nsxt_policy_segment_port.go
@@ -115,14 +115,11 @@ func dataSourceNsxtPolicySegmentPortRead(d *schema.ResourceData, m interface{}) 
 	if segmentPort.Attachment != nil && segmentPort.Attachment.Id != nil {
 		d.Set("vif_id", segmentPort.Attachment.Id)
 	}
-	d.Set("segment_path", getSegmentPathFromPortPath(*segmentPort.Path))
+	segmentPath, err := getPolicySegmentPathFromPortPath(*segmentPort.Path)
+	if err != nil {
+		return err
+	}
+	d.Set("segment_path", segmentPath)
 
 	return nil
-}
-
-func getSegmentPathFromPortPath(portPath string) string {
-	parts := strings.Split(portPath, "/")
-	parts = parts[:len(parts)-2]
-
-	return strings.Join(parts, "/")
 }

--- a/nsxt/data_source_nsxt_policy_segment_ports.go
+++ b/nsxt/data_source_nsxt_policy_segment_ports.go
@@ -145,7 +145,11 @@ func dataSourceNsxtPolicySegmentPortsRead(d *schema.ResourceData, m interface{})
 		}
 		if segmentPort.Path != nil {
 			item["path"] = *segmentPort.Path
-			item["segment_path"] = getSegmentPathFromPortPath(*segmentPort.Path)
+			segmentPath, err := getPolicySegmentPathFromPortPath(*segmentPort.Path)
+			if err != nil {
+				return err
+			}
+			item["segment_path"] = segmentPath
 		}
 		if segmentPort.Attachment != nil && segmentPort.Attachment.Id != nil {
 			item["vif_id"] = *segmentPort.Attachment.Id

--- a/nsxt/policy_utils.go
+++ b/nsxt/policy_utils.go
@@ -633,6 +633,8 @@ func nsxtPolicyPathResourceImporterHelper(d *schema.ResourceData, m interface{})
 		}
 		d.Set("context", []interface{}{ctxMap})
 		d.SetId(pathSegs[len(pathSegs)-1])
+	} else {
+		return nil, fmt.Errorf("invalid policy multitenancy path %s", importID)
 	}
 	return []*schema.ResourceData{d}, nil
 }

--- a/nsxt/policy_utils_importer_unit_test.go
+++ b/nsxt/policy_utils_importer_unit_test.go
@@ -61,3 +61,65 @@ func TestUnitNsxt_nsxtDomainResourceImporter(t *testing.T) {
 		assert.Equal(t, "mydomain", d.Get("domain"))
 	})
 }
+
+func policyResourceImporterTestResource() *schema.Resource {
+	return &schema.Resource{Schema: map[string]*schema.Schema{
+		"context": getContextSchemaExtended(true, false, true, true),
+	}}
+}
+
+func TestUnitNsxt_nsxtPolicyPathResourceImporterHelper(t *testing.T) {
+	res := policyResourceImporterTestResource()
+
+	t.Run("valid infra path sets resource id", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		d.SetId("/infra/segments/seg-1")
+		out, err := nsxtPolicyPathResourceImporterHelper(d, nil)
+		require.NoError(t, err)
+		require.Len(t, out, 1)
+		assert.Equal(t, "seg-1", d.Id())
+	})
+
+	t.Run("valid multitenancy path with project sets context and id", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		d.SetId("/orgs/default/projects/proj-1/infra/segments/seg-1")
+		out, err := nsxtPolicyPathResourceImporterHelper(d, nil)
+		require.NoError(t, err)
+		require.Len(t, out, 1)
+		assert.Equal(t, "seg-1", d.Id())
+		ctxList := d.Get("context").([]interface{})
+		require.Len(t, ctxList, 1)
+		ctx := ctxList[0].(map[string]interface{})
+		assert.Equal(t, "proj-1", ctx["project_id"])
+	})
+
+	t.Run("valid multitenancy path with project and vpc sets context and id", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		d.SetId("/orgs/default/projects/proj-1/vpcs/vpc-1/subnets/sub-1")
+		out, err := nsxtPolicyPathResourceImporterHelper(d, nil)
+		require.NoError(t, err)
+		require.Len(t, out, 1)
+		assert.Equal(t, "sub-1", d.Id())
+		ctxList := d.Get("context").([]interface{})
+		require.Len(t, ctxList, 1)
+		ctx := ctxList[0].(map[string]interface{})
+		assert.Equal(t, "proj-1", ctx["project_id"])
+		assert.Equal(t, "vpc-1", ctx["vpc_id"])
+	})
+
+	t.Run("malformed org path without projects keyword returns error", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		d.SetId("/orgs/default/proj/proj-1/infra/segments/seg-1/ports/port-123")
+		_, err := nsxtPolicyPathResourceImporterHelper(d, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid policy multitenancy path")
+	})
+
+	t.Run("short org path returns error", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		d.SetId("/orgs/default/infra")
+		_, err := nsxtPolicyPathResourceImporterHelper(d, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid policy multitenancy path")
+	})
+}

--- a/nsxt/resource_nsxt_policy_segment_port.go
+++ b/nsxt/resource_nsxt_policy_segment_port.go
@@ -1,8 +1,8 @@
 package nsxt
 
 import (
+	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -274,17 +274,22 @@ func resourceNsxtPolicySegmentPortDelete(d *schema.ResourceData, m interface{}) 
 	return nil
 }
 
-func getSegmentPortPathOrIDResourceImporter(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
-	var policyPath = d.Id()
-	var segmentPath string
-	policyPathSegs := strings.Split(policyPath, "/")
-	segmentPath = strings.Join(policyPathSegs[:len(policyPathSegs)-2], "/")
+var segmentPortPathExample = getMultitenancyPathExample("/infra/segments/[segment]/ports/[port]")
 
-	d.Set("segment_path", segmentPath)
+func getSegmentPortPathOrIDResourceImporter(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	importID := d.Id()
 	rd, err := nsxtPolicyPathResourceImporterHelper(d, m)
-	if err != nil {
+	if errors.Is(err, ErrNotAPolicyPath) || errors.Is(err, ErrUnexpectedPolicyPath) {
+		return nil, fmt.Errorf("Invalid policy path %s; expected format: %s", importID, segmentPortPathExample)
+	} else if err != nil {
 		return nil, err
 	}
-	d.SetId(policyPathSegs[len(policyPathSegs)-1])
+
+	segmentPath, err := getPolicySegmentPathFromPortPath(importID)
+	if err != nil {
+		return nil, fmt.Errorf("Invalid policy path %s; expected format: %s", importID, segmentPortPathExample)
+	}
+
+	d.Set("segment_path", segmentPath)
 	return rd, nil
 }

--- a/nsxt/segment_port_common.go
+++ b/nsxt/segment_port_common.go
@@ -465,9 +465,11 @@ func nsxtPolicySegmentPortProfilesRead(d *schema.ResourceData, m interface{}) er
 	if segmentPathValue, ok := d.GetOk("segment_path"); ok {
 		segmentPath = segmentPathValue.(string)
 	} else if segmentPortPathValue, ok := d.GetOk("segment_port_path"); ok {
-		segmentPortPath := segmentPortPathValue.(string)
-		pathParts := strings.Split(segmentPortPath, "/")
-		segmentPath = strings.Join(pathParts[:len(pathParts)-2], "/")
+		var err error
+		segmentPath, err = getPolicySegmentPathFromPortPath(segmentPortPathValue.(string))
+		if err != nil {
+			return err
+		}
 	} else {
 		return fmt.Errorf("neither segment_path nor segment_port_path found in resource data")
 	}

--- a/nsxt/utgomock_resource_nsxt_policy_segment_port_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_segment_port_test.go
@@ -433,3 +433,63 @@ func TestMockGetT1IdFromSegPath(t *testing.T) {
 		})
 	}
 }
+
+func TestMockSegmentPortImporter(t *testing.T) {
+	res := resourceNsxtPolicySegmentPort()
+
+	t.Run("Import with invalid ID (not policy path) returns error without panic", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		d.SetId("port-123")
+		rd, err := getSegmentPortPathOrIDResourceImporter(d, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Invalid policy path port-123")
+		assert.Nil(t, rd)
+	})
+
+	t.Run("Import with empty ID returns error without panic", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		d.SetId("")
+		rd, err := getSegmentPortPathOrIDResourceImporter(d, nil)
+		require.Error(t, err)
+		assert.Nil(t, rd)
+	})
+
+	t.Run("Import with segment path (missing /ports/) returns error without panic", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		d.SetId("/infra/segments/seg-1")
+		rd, err := getSegmentPortPathOrIDResourceImporter(d, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Invalid policy path /infra/segments/seg-1")
+		assert.Nil(t, rd)
+	})
+
+	t.Run("Import with valid infra segment port path succeeds", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		d.SetId("/infra/segments/seg-1/ports/port-123")
+		rd, err := getSegmentPortPathOrIDResourceImporter(d, nil)
+		require.NoError(t, err)
+		require.NotNil(t, rd)
+		assert.Equal(t, "port-123", d.Id())
+		assert.Equal(t, "/infra/segments/seg-1", d.Get("segment_path"))
+	})
+
+	t.Run("Import with valid tier-1 segment port path succeeds", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		d.SetId("/infra/tier-1s/t1-1/segments/seg-1/ports/port-123")
+		rd, err := getSegmentPortPathOrIDResourceImporter(d, nil)
+		require.NoError(t, err)
+		require.NotNil(t, rd)
+		assert.Equal(t, "port-123", d.Id())
+		assert.Equal(t, "/infra/tier-1s/t1-1/segments/seg-1", d.Get("segment_path"))
+	})
+
+	t.Run("Import with valid multitenancy segment port path succeeds", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		d.SetId("/orgs/default/projects/proj-1/infra/segments/seg-1/ports/port-123")
+		rd, err := getSegmentPortPathOrIDResourceImporter(d, nil)
+		require.NoError(t, err)
+		require.NotNil(t, rd)
+		assert.Equal(t, "port-123", d.Id())
+		assert.Equal(t, "/orgs/default/projects/proj-1/infra/segments/seg-1", d.Get("segment_path"))
+	})
+}


### PR DESCRIPTION
Importing a policy segment port using an invalid identifier or a bare ID (such as "port-123") caused the provider to panic with "runtime error: slice bounds out of range [:-1]". The importer performed unchecked slicing on path segments assuming at least two slash separators existed.

Validate the import identifier via the standard policy path helper and return an informative error message when given an invalid path format. Also use safe path delimiter parsing to extract parent segment paths across data sources and helpers.