### PR TITLE
Fix nsxt_edge_transport_node perpetual drift

### DIFF
--- a/nsxt/resource_nsxt_edge_transport_node.go
+++ b/nsxt/resource_nsxt_edge_transport_node.go
@@ -183,7 +183,8 @@ func getEdgeNodeDeploymentConfigSchema() *schema.Schema {
 							"audit_username": {
 								Type:        schema.TypeString,
 								Optional:    true,
-								Description: "CLI \"audit\" username",
+								Computed:    true,
+								Description: "CLI \"audit\" username; if omitted, set from NSX after creation",
 							},
 							"cli_password": {
 								Type:        schema.TypeString,
@@ -449,16 +450,18 @@ func getStandardHostSwitchSchema(nodeType string) *schema.Schema {
 				},
 				"host_switch_profile": getHostSwitchProfileIDsSchema(),
 				"uplink_profile": {
-					Type:        schema.TypeString,
-					Description: "Host switch uplink profile",
-					Optional:    true,
-					Computed:    true,
+					Type:         schema.TypeString,
+					Description:  "Host switch uplink profile",
+					Optional:     true,
+					Computed:     true,
+					ValidateFunc: validatePolicyPath(),
 				},
 				"vtep_ha_profile": {
-					Type:        schema.TypeString,
-					Description: "Host switch high availability profile",
-					Optional:    true,
-					Computed:    true,
+					Type:         schema.TypeString,
+					Description:  "Host switch high availability profile",
+					Optional:     true,
+					Computed:     true,
+					ValidateFunc: validatePolicyPath(),
 				},
 				"ip_assignment":   getIPAssignmentSchema(false),
 				"ipv6_assignment": getIPv6AssignmentSchema(),
@@ -541,16 +544,18 @@ func getStandardHostSwitchSchema(nodeType string) *schema.Schema {
 									},
 									"host_switch_profile": getHostSwitchProfileIDsSchema(),
 									"uplink_profile": {
-										Type:        schema.TypeString,
-										Description: "Host switch uplink profile",
-										Optional:    true,
-										Computed:    true,
+										Type:         schema.TypeString,
+										Description:  "Host switch uplink profile",
+										Optional:     true,
+										Computed:     true,
+										ValidateFunc: validatePolicyPath(),
 									},
 									"vtep_ha_profile": {
-										Type:        schema.TypeString,
-										Description: "Host switch high availability profile",
-										Optional:    true,
-										Computed:    true,
+										Type:         schema.TypeString,
+										Description:  "Host switch high availability profile",
+										Optional:     true,
+										Computed:     true,
+										ValidateFunc: validatePolicyPath(),
 									},
 									"ip_assignment":   getIPAssignmentSchema(false),
 									"ipv6_assignment": getIPv6AssignmentSchema(),
@@ -601,8 +606,8 @@ func getTransportZoneEndpointSchema() *schema.Schema {
 				"transport_zone": {
 					Type:         schema.TypeString,
 					Required:     true,
-					Description:  "Unique ID identifying the transport zone for this endpoint",
-					ValidateFunc: validation.StringIsNotWhiteSpace,
+					Description:  "Policy path of the transport zone for this endpoint",
+					ValidateFunc: validatePolicyPath(),
 				},
 				"transport_zone_profiles": {
 					Type:        schema.TypeList,
@@ -649,10 +654,11 @@ func getUplinksSchema() *schema.Schema {
 func getHostSwitchProfileIDsSchema() *schema.Schema {
 	return &schema.Schema{
 		Type:        schema.TypeList,
-		Description: "Identifiers of host switch profiles to be associated with this host switch",
+		Description: "Policy paths of host switch profiles to be associated with this host switch",
 		Optional:    true,
 		Elem: &schema.Schema{
-			Type: schema.TypeString,
+			Type:         schema.TypeString,
+			ValidateFunc: validatePolicyPath(),
 		},
 		Computed:   true,
 		Deprecated: "use specific profiles instead",
@@ -932,6 +938,126 @@ func getTransportNodeFromSchema(d *schema.ResourceData, m interface{}) (*mpmodel
 	}
 
 	return &obj, nil
+}
+
+// etNodeShallowCopyMap returns a shallow copy of m.
+func etNodeShallowCopyMap(m map[string]interface{}) map[string]interface{} {
+	cp := make(map[string]interface{}, len(m))
+	for k, v := range m {
+		cp[k] = v
+	}
+	return cp
+}
+
+// etNodeStringVal returns the string value for key in m, or "" if absent/not string.
+func etNodeStringVal(m map[string]interface{}, key string) string {
+	v, _ := m[key].(string)
+	return v
+}
+
+// etNodeNestedList returns the []interface{} stored at key in m, or nil.
+func etNodeNestedList(m map[string]interface{}, key string) []interface{} {
+	v, _ := m[key].([]interface{})
+	return v
+}
+
+// etNodeNormalizeHostSwitchesInState restores policy-path representations for
+// standard_host_switch fields that the MP API returns as bare realization UUIDs.
+// It must be called after setHostSwitchSpecInSchema has stored the API values,
+// with priorSwitches being the state captured before that call.
+//
+// Because inputs are validated to be policy paths, any prior-state value that
+// is already a policy path is trusted and kept without an extra API lookup.
+func etNodeNormalizeHostSwitchesInState(d *schema.ResourceData, priorSwitches []interface{}) {
+	if len(priorSwitches) == 0 {
+		return
+	}
+	apiSwitches := d.Get("standard_host_switch").([]interface{})
+	if len(apiSwitches) != len(priorSwitches) {
+		return
+	}
+
+	modified := false
+	result := make([]interface{}, len(apiSwitches))
+	for i := range apiSwitches {
+		apiSw := apiSwitches[i].(map[string]interface{})
+		priorSw := priorSwitches[i].(map[string]interface{})
+		normalizedSw := etNodeShallowCopyMap(apiSw)
+
+		// For each string field: if the prior state already holds a policy path,
+		// keep it — the API always returns bare MP realization UUIDs for these.
+		for _, field := range []string{"uplink_profile", "vtep_ha_profile"} {
+			if prior := etNodeStringVal(priorSw, field); isPolicyPath(prior) {
+				normalizedSw[field] = prior
+				modified = true
+			}
+		}
+
+		// host_switch_profile (deprecated list of profile paths)
+		if etNodeNormalizeStringList(priorSw, normalizedSw, "host_switch_profile") {
+			modified = true
+		}
+
+		// transport_zone inside each transport_zone_endpoint
+		if etNodeNormalizeTZEndpoints(priorSw, normalizedSw) {
+			modified = true
+		}
+
+		result[i] = normalizedSw
+	}
+
+	if modified {
+		d.Set("standard_host_switch", result)
+	}
+}
+
+// etNodeNormalizeStringList replaces entries in newSw[field] with the
+// corresponding prior-state values when those are policy paths.
+func etNodeNormalizeStringList(priorSw, newSw map[string]interface{}, field string) bool {
+	priorList := etNodeNestedList(priorSw, field)
+	newList := etNodeNestedList(newSw, field)
+	if len(priorList) != len(newList) {
+		return false
+	}
+	modified := false
+	result := make([]interface{}, len(newList))
+	for j := range newList {
+		if prior, _ := priorList[j].(string); isPolicyPath(prior) {
+			result[j] = prior
+			modified = true
+		} else {
+			result[j] = newList[j]
+		}
+	}
+	if modified {
+		newSw[field] = result
+	}
+	return modified
+}
+
+// etNodeNormalizeTZEndpoints replaces transport_zone values in newSw's
+// transport_zone_endpoint list with prior-state policy paths where present.
+func etNodeNormalizeTZEndpoints(priorSw, newSw map[string]interface{}) bool {
+	priorEPs := etNodeNestedList(priorSw, "transport_zone_endpoint")
+	newEPs := etNodeNestedList(newSw, "transport_zone_endpoint")
+	if len(priorEPs) != len(newEPs) {
+		return false
+	}
+	modified := false
+	result := make([]interface{}, len(newEPs))
+	for j := range newEPs {
+		priorEP := priorEPs[j].(map[string]interface{})
+		newEP := etNodeShallowCopyMap(newEPs[j].(map[string]interface{}))
+		if prior := etNodeStringVal(priorEP, "transport_zone"); isPolicyPath(prior) {
+			newEP["transport_zone"] = prior
+			modified = true
+		}
+		result[j] = newEP
+	}
+	if modified {
+		newSw["transport_zone_endpoint"] = result
+	}
+	return modified
 }
 
 func resourceNsxtEdgeTransportNodeCreate(d *schema.ResourceData, m interface{}) error {
@@ -1682,11 +1808,16 @@ func resourceNsxtEdgeTransportNodeRead(d *schema.ResourceData, m interface{}) er
 	d.Set("node_id", obj.NodeId)
 	d.Set("failure_domain", obj.FailureDomainId)
 
+	// Capture prior state before setHostSwitchSpecInSchema overwrites it with
+	// bare MP realization UUIDs.  The normalization call below restores any
+	// policy-path values that were in use before the read.
+	priorSwitches := d.Get("standard_host_switch").([]interface{})
 	if obj.HostSwitchSpec != nil {
 		err = setHostSwitchSpecInSchema(d, obj.HostSwitchSpec, nodeTypeEdge)
 		if err != nil {
 			return handleReadError(d, "TransportNode", id, err)
 		}
+		etNodeNormalizeHostSwitchesInState(d, priorSwitches)
 	}
 
 	converter := bindings.NewTypeConverter()


### PR DESCRIPTION
## Summary
- The NSX MP API returns bare realization UUIDs for `uplink_profile`, `vtep_ha_profile`, `host_switch_profile` and `transport_zone`, while configuration uses policy paths. This caused a perpetual diff after every apply.
- NSX also silently injects a default `audit_username` ("audit") that was not present in configuration, causing a perpetual diff there too.
- Enforce policy paths via `ValidateFunc` on `uplink_profile`, `vtep_ha_profile`, `host_switch_profile` elements and `transport_zone`, making the prior state value for these fields a reliable policy path.
- In `resourceNsxtEdgeTransportNodeRead`, capture the prior state before `setHostSwitchSpecInSchema` overwrites it with API UUIDs, then restore any policy-path values via `etNodeNormalizeHostSwitchesInState`.
- Mark `audit_username` as `Optional`+`Computed` so Terraform accepts the NSX default value without showing a diff when the user omits the field.

This is a hand-port of the equivalent fix on master, adapted for this release branch (master's version also reverts an unported earlier fix attempt; this PR implements the final, corrected behavior directly against branch_3122's current schema).

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `golangci-lint run ./nsxt/` (0 issues)

No acceptance/unit test coverage is added, matching the corresponding fix on master, which also shipped without one.