### PR TITLE
Fix route map perpetual drift from mutually exclusive matches

### DIFF
--- a/docs/resources/policy_gateway_route_map.md
+++ b/docs/resources/policy_gateway_route_map.md
@@ -53,10 +53,10 @@ The following arguments are supported:
 * `gateway_path` - (Required) Policy path of relevant Tier0 Gateway.
 * `entry` - (Required) List of entries for the Route Map.
     * `action` - (Optional) Action for the route map entry, either `PERMIT` or `DENY`, with default being `PERMIT`.
-    * `community_list_match` - (Optional) List of Prefix List match criteria for route map. Cannot be configured together with `prefix_list_matches`. If configured together, `prefix_list_matches` will be ignored.
+    * `community_list_match` - (Optional) List of Prefix List match criteria for route map. Mutually exclusive with `prefix_list_matches`; specifying both on the same entry results in an error.
         * `criteria` - (Required) Community list path or a regular expression.
         * `match_operator` - (Required) Match operator for the criteria, one of `MATCH_ANY`, `MATCH_ALL`, `MATCH_EXACT`, `MATCH_COMMUNITY_REGEX`, `MATCH_LARGE_COMMUNITY_REGEX`. Only last two operators can be used together with regular expression criteria.
-    * `prefix_list_matches` - (Optional) List of policy paths for Prefix Lists configured on this Gateway. Cannot be configured together with `community_list_match`. If configured together, `prefix_list_matches` will be ignored.
+    * `prefix_list_matches` - (Optional) List of policy paths for Prefix Lists configured on this Gateway. Mutually exclusive with `community_list_match`; specifying both on the same entry results in an error.
     * `set` - (Optional) Set criteria for route map entry.
         * `as_path_prepend` - (Optional) Autonomous System (AS) path prepend to influence route selection.
         * `community` - (Optional) BGP regular or large community for matching routes.

--- a/nsxt/resource_nsxt_policy_gateway_route_map.go
+++ b/nsxt/resource_nsxt_policy_gateway_route_map.go
@@ -70,7 +70,7 @@ func getPolicyRouteMapEntrySchema() *schema.Resource {
 			},
 			"community_list_match": {
 				Type:        schema.TypeList,
-				Description: "Prefix list match criteria for route map",
+				Description: "Community list match criteria for route map. Mutually exclusive with prefix_list_matches",
 				Optional:    true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -91,7 +91,7 @@ func getPolicyRouteMapEntrySchema() *schema.Resource {
 			"prefix_list_matches": {
 				Type:        schema.TypeSet,
 				Optional:    true,
-				Description: "List of paths for prefix lists for route map",
+				Description: "List of paths for prefix lists for route map. Mutually exclusive with community_list_match",
 				Elem:        getElemPolicyPathSchema(),
 			},
 			"set": {
@@ -162,7 +162,7 @@ func resourceNsxtPolicyGatewayRouteMapExists(tier0Id string, id string, connecto
 	return false, logAPIError("Error retrieving resource", err)
 }
 
-func policyGatewayRouteMapBuildEntry(d *schema.ResourceData, entryNo int, schemaEntry map[string]interface{}) model.RouteMapEntry {
+func policyGatewayRouteMapBuildEntry(d *schema.ResourceData, entryNo int, schemaEntry map[string]interface{}) (model.RouteMapEntry, error) {
 
 	action := schemaEntry["action"].(string)
 	obj := model.RouteMapEntry{
@@ -171,6 +171,10 @@ func policyGatewayRouteMapBuildEntry(d *schema.ResourceData, entryNo int, schema
 
 	commListMatches := schemaEntry["community_list_match"].([]interface{})
 	prefixListMatches := schemaEntry["prefix_list_matches"].(*schema.Set).List()
+
+	if len(commListMatches) > 0 && len(prefixListMatches) > 0 {
+		return obj, fmt.Errorf("entry %d: community_list_match and prefix_list_matches are mutually exclusive and cannot be used in the same route map entry", entryNo)
+	}
 
 	if len(commListMatches) > 0 {
 		var commCriteriaList []model.CommunityMatchCriteria
@@ -222,7 +226,7 @@ func policyGatewayRouteMapBuildEntry(d *schema.ResourceData, entryNo int, schema
 		obj.Set = &entrySet
 	}
 
-	return obj
+	return obj, nil
 }
 
 func resourceNsxtPolicyGatewayRouteMapPatch(gwID string, id string, d *schema.ResourceData, isGlobalManager bool, connector client.Connector) error {
@@ -233,7 +237,11 @@ func resourceNsxtPolicyGatewayRouteMapPatch(gwID string, id string, d *schema.Re
 	schemaEntries := d.Get("entry").([]interface{})
 	var entries []model.RouteMapEntry
 	for entryNo, entry := range schemaEntries {
-		entries = append(entries, policyGatewayRouteMapBuildEntry(d, entryNo, entry.(map[string]interface{})))
+		entryObj, err := policyGatewayRouteMapBuildEntry(d, entryNo, entry.(map[string]interface{}))
+		if err != nil {
+			return err
+		}
+		entries = append(entries, entryObj)
 	}
 
 	obj := model.Tier0RouteMap{

--- a/nsxt/resource_nsxt_policy_gateway_route_map_test.go
+++ b/nsxt/resource_nsxt_policy_gateway_route_map_test.go
@@ -6,6 +6,7 @@ package nsxt
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -110,6 +111,49 @@ func TestAccResourceNsxtPolicyGatewayRouteMap_importBasic(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestAccResourceNsxtPolicyGatewayRouteMap_mutuallyExclusiveMatches(t *testing.T) {
+	displayName := getAccTestResourceName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccNsxtPolicyGatewayRouteMapMutuallyExclusiveTemplate(displayName),
+				ExpectError: regexp.MustCompile(`community_list_match and prefix_list_matches are mutually exclusive`),
+			},
+		},
+	})
+}
+
+func testAccNsxtPolicyGatewayRouteMapMutuallyExclusiveTemplate(displayName string) string {
+	return testAccNsxtPolicyEdgeClusterReadTemplate(getEdgeClusterName()) +
+		testAccNsxtPolicyTier0WithEdgeClusterTemplate("test", false) + fmt.Sprintf(`
+resource "nsxt_policy_gateway_prefix_list" "test" {
+  display_name = "%s"
+  gateway_path = nsxt_policy_tier0_gateway.test.path
+
+  prefix {
+    action  = "PERMIT"
+    network = "4.4.0.0/20"
+  }
+}
+
+resource "nsxt_policy_gateway_route_map" "test" {
+  gateway_path = nsxt_policy_tier0_gateway.test.path
+  display_name = "%s"
+
+  entry {
+    action              = "PERMIT"
+    prefix_list_matches = [nsxt_policy_gateway_prefix_list.test.path]
+    community_list_match {
+      criteria       = "11:22"
+      match_operator = "MATCH_COMMUNITY_REGEX"
+    }
+  }
+}`, displayName, displayName)
 }
 
 func testAccNsxtPolicyGatewayRouteMapExists(displayName string, resourceName string) resource.TestCheckFunc {


### PR DESCRIPTION
## Summary
- Route map entries silently dropped `prefix_list_matches` when `community_list_match` was also set, since NSX treats the two as mutually exclusive per entry. The dropped value was never sent to NSX, so every subsequent read/plan showed drift.
- Reject the invalid combination with a clear error at apply time instead of silently discarding data.

Scoped port of the equivalent master fix: this branch has no `nsxt_policy_transit_gateway_route_map` resource, so only the `nsxt_policy_gateway_route_map` (Tier0/Tier1) hunk is included.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `golangci-lint run ./nsxt/` (0 issues)
- [x] New acceptance test `TestAccResourceNsxtPolicyGatewayRouteMap_mutuallyExclusiveMatches` compiles (`go test -c`)

Note: CI's `lint` job's `make tools` step is expected to fail on this branch until #2234 (Go version bump) merges into branch_3122 — unrelated to this change.