### PR TITLE
Suppress bgp_neighbor password drift after import

### DIFF
--- a/nsxt/resource_nsxt_policy_bgp_neighbor.go
+++ b/nsxt/resource_nsxt_policy_bgp_neighbor.go
@@ -124,11 +124,12 @@ func resourceNsxtPolicyBgpNeighbor() *schema.Resource {
 				ValidateFunc: validateSingleIP(),
 			},
 			"password": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Description:  "Password for BGP neighbor authentication",
-				ValidateFunc: validation.StringLenBetween(0, 32),
-				Sensitive:    true,
+				Type:             schema.TypeString,
+				Optional:         true,
+				Description:      "Password for BGP neighbor authentication",
+				ValidateFunc:     validation.StringLenBetween(0, 32),
+				Sensitive:        true,
+				DiffSuppressFunc: suppressIfEmptyPriorState,
 			},
 			"remote_as_num": {
 				Type:         schema.TypeString,


### PR DESCRIPTION
## Summary
- NSX never returns `password` on GET, so `terraform import` leaves it empty in state, causing a spurious diff/re-apply on every plan.
- Reuse the `suppressIfEmptyPriorState` DiffSuppressFunc already used by `nsxt_policy_virtual_network_appliance` for the same write-only field import issue.

Scoped port of the equivalent master fix: this branch has no `nsxt_policy_transit_gateway_bgp_neighbor` resource, so only the base `nsxt_policy_bgp_neighbor` hunk is included.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `golangci-lint run ./nsxt/` (0 issues)

Note: CI's `lint` job's `make tools` step is expected to fail on this branch until #2234 (Go version bump) merges into branch_3122 — unrelated to this change.