### PR TITLE
Fix nsx_id client type resolution in getOrGenerateIDWithParent

### DIFF
--- a/nsxt/policy_utils.go
+++ b/nsxt/policy_utils.go
@@ -86,7 +86,7 @@ func getOrGenerateIDWithParent(d *schema.ResourceData, m interface{}, presenceCh
 
 	parentPath := d.Get("parent_path").(string)
 
-	exists, err := presenceChecker(getSessionContext(d, m), parentPath, id, connector)
+	exists, err := presenceChecker(getParentContext(d, m, parentPath), parentPath, id, connector)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## Summary
- `getOrGenerateIDWithParent` passed `getSessionContext(d, m)` to the presence-checker, which derives the client type from the schema context block. Resources that carry context in `parent_path` instead have no context block, so clientType resolved to Local and the Multitenancy-only client factory returned nil, producing "unsupported client type". The bug only triggered when `nsx_id` was explicitly set (the existence check is skipped when `nsx_id` is absent).
- Pass `getParentContext(d, m, parentPath)` instead of `getSessionContext`, so the correct Multitenancy context is derived from `parent_path`.
- Affects all callers of `getOrGenerateIDWithParent` on this branch: `route_controller_bgp_neighbor`, `route_controller_interface`, `vpc_attachment`, `vpc_dhcp_v4_static_binding_config`, `vpc_nat_rule`, and the `transit_gateway` attachment/ipsec_vpn/nat_rule/static_route resources.

Scoped port of the equivalent master fix: this branch has no Transit Gateway BGP-routing-child resources (`prefix_list`/`route_map`/`community_list`/`bfd_peer`), so only the shared one-line `policy_utils.go` fix is included — the new TGW routing-child importer helper, its unit test, and the four TGW routing-child resource/test files from the original PR are all out of scope here.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `golangci-lint run ./nsxt/` (0 issues)

Note: CI's `lint` job's `make tools` step is expected to fail on this branch until #2234 (Go version bump) merges into branch_3122 — unrelated to this change.