### PR TITLE
Fix GRE tunnel create check and Exists error handling

### DIFF
--- a/nsxt/resource_nsxt_policy_tier0_gateway_gre_tunnel.go
+++ b/nsxt/resource_nsxt_policy_tier0_gateway_gre_tunnel.go
@@ -233,19 +233,19 @@ func resourceNsxtPolicyTier0GatewayGRETunnelExists(id, localeServicePath string,
 	client := locale_services.NewTunnelsClient(connector)
 	_, err = client.Get(tier0id, localeSvcID, id)
 
+	if err == nil {
+		return true, nil
+	}
 	if isNotFoundError(err) {
 		return false, nil
 	}
-	return true, nil
+	return false, err
 }
 
 func resourceNsxtPolicyTier0GatewayGRETunnelCreate(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
 
 	id := d.Get("nsx_id").(string)
-	if id == "" {
-		id = newUUID()
-	}
 	localeServicePath := d.Get("locale_service_path").(string)
 	isT0, tier0id, localeSvcID, err := parseLocaleServicePolicyPath(localeServicePath)
 	if err != nil {
@@ -254,6 +254,19 @@ func resourceNsxtPolicyTier0GatewayGRETunnelCreate(d *schema.ResourceData, m int
 	if !isT0 {
 		return fmt.Errorf("locale service path %s is not associated with a tier0 router", localeServicePath)
 	}
+
+	if id == "" {
+		id = newUUID()
+	} else {
+		exists, err := resourceNsxtPolicyTier0GatewayGRETunnelExists(id, localeServicePath, connector, isPolicyGlobalManager(m))
+		if err != nil {
+			return handleCreateError("GreTunnel", id, err)
+		}
+		if exists {
+			return fmt.Errorf("GRE Tunnel with ID '%s' already exists", id)
+		}
+	}
+
 	client := locale_services.NewTunnelsClient(connector)
 
 	obj, err := tier0GatewayGRETunnelFromSchema(d)


### PR DESCRIPTION
## Summary
- `resourceNsxtPolicyTier0GatewayGRETunnelExists` returned `true, nil` for any non-not-found error, including real API failures.
- `Create` never checked for a colliding explicit `nsx_id` before issuing the Patch, silently overwriting an existing GRE tunnel instead of rejecting the create.
- Fix `Exists` to only report `true` when the `Get` succeeds, propagate real errors instead of misreporting them as existing, and have `Create` reject a colliding explicit `nsx_id` up front.

Hand-adapted port of the equivalent master fix: master's version of this file uses a different (SDK-wrapper-refactor) client-construction pattern not present on this branch, and the full source PR (#2207) bundled this fix with an unrelated 36-file "move test-only Exists helpers into `_test.go` files" refactor touching many resources absent from this branch (including several Transit-Gateway-routing-child resources). Only the isolated GRE tunnel logic fix is included here, rewritten against this branch's actual client-construction code.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `golangci-lint run ./nsxt/` (0 issues)

Note: CI's `lint` job's `make tools` step was previously expected to fail on PRs against this branch pending #2234's Go-version bump — that has since merged, so this should be unaffected.