### PR TITLE
Only set policy edge VM host_id when non-empty

### DIFF
--- a/nsxt/resource_nsxt_policy_edge_transport_node.go
+++ b/nsxt/resource_nsxt_policy_edge_transport_node.go
@@ -1169,7 +1169,6 @@ func getVMDeploymentConfigFromSchema(iVmDeploymentCfg interface{}) (*data.Struct
 		vmDeploymentCfg := model.PolicyVsphereDeploymentConfig{
 			ComputeId:              &computeId,
 			EdgeHostAffinityConfig: edgeHostAffinityConfig,
-			HostId:                 &hostID,
 			ReservationInfo:        reservationInfo,
 			StorageId:              &storageID,
 			VcId:                   &vcID,
@@ -1177,6 +1176,9 @@ func getVMDeploymentConfigFromSchema(iVmDeploymentCfg interface{}) (*data.Struct
 		}
 		if computeFolderId != "" {
 			vmDeploymentCfg.ComputeFolderId = &computeFolderId
+		}
+		if hostID != "" {
+			vmDeploymentCfg.HostId = &hostID
 		}
 		converter := bindings.NewTypeConverter()
 		dataValue, errs := converter.ConvertToVapi(vmDeploymentCfg, model.PolicyVsphereDeploymentConfigBindingType())

--- a/nsxt/resource_nsxt_policy_edge_transport_node_vm_deployment_config_test.go
+++ b/nsxt/resource_nsxt_policy_edge_transport_node_vm_deployment_config_test.go
@@ -1,0 +1,50 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package nsxt
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnitNsxt_getVMDeploymentConfigFromSchema_hostIdOmitted(t *testing.T) {
+	cfg := []interface{}{
+		map[string]interface{}{
+			"compute_manager_id": "vc1",
+			"compute_id":         "cluster1",
+			"storage_id":         "datastore1",
+			"compute_folder_id":  "",
+			"host_id":            "",
+		},
+	}
+	out, err := getVMDeploymentConfigFromSchema(cfg)
+	require.NoError(t, err)
+	require.NotNil(t, out)
+	optHostID, err := out.Optional("host_id")
+	require.NoError(t, err)
+	require.False(t, optHostID.IsSet())
+}
+
+func TestUnitNsxt_getVMDeploymentConfigFromSchema_hostIdSet(t *testing.T) {
+	cfg := []interface{}{
+		map[string]interface{}{
+			"compute_manager_id": "vc1",
+			"compute_id":         "cluster1",
+			"storage_id":         "datastore1",
+			"compute_folder_id":  "",
+			"host_id":            "host-1",
+		},
+	}
+	out, err := getVMDeploymentConfigFromSchema(cfg)
+	require.NoError(t, err)
+	require.NotNil(t, out)
+	optHostID, err := out.Optional("host_id")
+	require.NoError(t, err)
+	require.True(t, optHostID.IsSet())
+	hostID, err := optHostID.StringValue()
+	require.NoError(t, err)
+	require.Equal(t, "host-1", hostID)
+}


### PR DESCRIPTION
## Summary
- `nsxt_policy_edge_transport_node` always sent `"host_id": ""` in the `vm_deployment_config` payload when `host_id` was left unconfigured, because `getVMDeploymentConfigFromSchema()` unconditionally set `HostId` to a pointer to the (possibly empty) string. NSX then runs its VLAN-segment accessibility validation against an empty host context and creation/update fails with error 16031, even though the same segments work fine when `host_id` is set explicitly or when deployed via the UI.
- Guard the assignment the same way `compute_folder_id` is already guarded, and the same way this was previously fixed for the non-policy `nsxt_edge_transport_node` resource.
- Adds a unit test pinning `getVMDeploymentConfigFromSchema()`'s behavior: `host_id` must stay unset in the vAPI payload when not configured, and must be set when provided. The existing acceptance test `TestAccResourceNsxtPolicyEdgeTransportNode_basic` already configures `vm_deployment_config` without `host_id`, so it already exercises this path end-to-end and needs no changes.

Note: master's version of this new unit test is gated behind a `//go:build unittest` tag, but this branch's `make test` target doesn't pass `-tags unittest` anywhere, which would make the test silently never run. Dropped the tag here so it runs under the normal `go test ./nsxt/` invocation.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `golangci-lint run ./nsxt/` (0 issues)
- [x] `go test ./nsxt/ -run TestUnitNsxt_getVMDeploymentConfigFromSchema -v` — both new tests pass