### PR TITLE
Fix nil pointer dereference in policy edge RTEP

### DIFF
--- a/nsxt/resource_nsxt_policy_edge_transport_node_rtep.go
+++ b/nsxt/resource_nsxt_policy_edge_transport_node_rtep.go
@@ -73,9 +73,9 @@ func setNsxtPolicyEdgeTransportNodeRTEP(d *schema.ResourceData, m interface{}, o
 	hswName := d.Get("host_switch_name").(string)
 	found := false
 
-	for i, hsw := range obj.SwitchSpec.Switches {
-		if *hsw.SwitchName == hswName {
-			{
+	if obj.SwitchSpec != nil {
+		for i, hsw := range obj.SwitchSpec.Switches {
+			if hsw.SwitchName != nil && *hsw.SwitchName == hswName {
 				found = true
 				if len(hsw.RemoteTunnelEndpoint) > 0 && op == "create" {
 					return fmt.Errorf("remote tunnel endpoint for Edge transport node %s already exists", tnPath)
@@ -145,9 +145,9 @@ func resourceNsxtPolicyEdgeTransportNodeRTEPRead(d *schema.ResourceData, m inter
 
 	hswName := d.Get("host_switch_name").(string)
 
-	for _, hsw := range obj.SwitchSpec.Switches {
-		if *hsw.SwitchName == hswName {
-			{
+	if obj.SwitchSpec != nil {
+		for _, hsw := range obj.SwitchSpec.Switches {
+			if hsw.SwitchName != nil && *hsw.SwitchName == hswName {
 				if len(hsw.RemoteTunnelEndpoint) == 0 {
 					return errors.NotFound{}
 				}


### PR DESCRIPTION
## Summary
- Add nil pointer checks for `SwitchSpec` and `SwitchName` when reading or setting RTEP configuration on `PolicyEdgeTransportNode`.
- Without these checks, if an Edge transport node returns a nil `SwitchSpec` or a switch with a nil `SwitchName` from the NSX API, the provider crashes with a nil pointer dereference panic.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `golangci-lint run ./nsxt/` (0 issues)

Note: master's source PR added mock-based regression tests, which this branch has no framework for; the production fix is otherwise a direct, unmodified port.