### PR TITLE
Fix three bugs in nsxt_edge_transport_node_rtep resource

### DIFF
--- a/docs/resources/edge_transport_node_rtep.md
+++ b/docs/resources/edge_transport_node_rtep.md
@@ -21,7 +21,7 @@ resource "nsxt_edge_transport_node_rtep" "test_rtep" {
 
   host_switch_name = "someSwitch"
   ip_assignment {
-    assigned_by_dhcp = true
+    static_ip_pool = "ip-pool-uuid"
   }
   named_teaming_policy = "tp123"
   rtep_vlan            = 500
@@ -35,7 +35,6 @@ The following arguments are supported:
 * `edge_id` - (Required) Edge ID to associate with remote tunnel endpoint.
 * `host_switch_name` - (Required) The host switch name to be used for the remote tunnel endpoint.
 * `ip_assignment` - (Required) - Specification for IPs to be used with host switch virtual tunnel endpoints. Should contain exactly one of the below:
-    * `assigned_by_dhcp` - (Optional) Enables DHCP assignment.
     * `static_ip` - (Optional) IP assignment specification for Static IP List.
         * `ip_addresses` - (Required) List of IPs for transport node host switch virtual tunnel endpoints.
         * `subnet_mask` - (Required) Subnet mask.

--- a/nsxt/resource_nsxt_edge_transport_node.go
+++ b/nsxt/resource_nsxt_edge_transport_node.go
@@ -767,6 +767,15 @@ func getIPAssignmentSchema(required bool) *schema.Schema {
 	}
 }
 
+func getIPAssignmentSchemaForRTEP() *schema.Schema {
+	s := getIPAssignmentSchema(false)
+	r := s.Elem.(*schema.Resource)
+	delete(r.Schema, "assigned_by_dhcp")
+	delete(r.Schema, "no_ipv4")
+	delete(r.Schema, "static_ip_mac")
+	return s
+}
+
 func getIPv6AssignmentSchema() *schema.Schema {
 	return &schema.Schema{
 		Type:        schema.TypeList,

--- a/nsxt/resource_nsxt_edge_transport_node_rtep.go
+++ b/nsxt/resource_nsxt_edge_transport_node_rtep.go
@@ -35,7 +35,7 @@ func resourceNsxtEdgeTransportNodeRTEP() *schema.Resource {
 				Description: "The host switch name to be used for the remote tunnel endpoint",
 				Required:    true,
 			},
-			"ip_assignment": getIPAssignmentSchema(true),
+			"ip_assignment": getIPAssignmentSchemaForRTEP(),
 			"named_teaming_policy": {
 				Type:        schema.TypeString,
 				Description: "The named teaming policy to be used by the remote tunnel endpoint",
@@ -97,7 +97,7 @@ func resourceNsxtEdgeTransportNodeRTEPRead(d *schema.ResourceData, m interface{}
 	connector := getPolicyConnector(m)
 	client := nsx.NewTransportNodesClient(connector)
 
-	id := d.Get("edge_id").(string)
+	id := d.Id()
 
 	obj, err := client.Get(id)
 	if err != nil {
@@ -108,6 +108,7 @@ func resourceNsxtEdgeTransportNodeRTEPRead(d *schema.ResourceData, m interface{}
 		return errors.NotFound{}
 	}
 
+	d.Set("edge_id", id)
 	d.Set("host_switch_name", obj.RemoteTunnelEndpoint.HostSwitchName)
 	ipAssignment, err := setIPAssignmentInSchema(obj.RemoteTunnelEndpoint.IpAssignmentSpec)
 	if err != nil {
@@ -124,7 +125,7 @@ func resourceNsxtEdgeTransportNodeRTEPUpdate(d *schema.ResourceData, m interface
 	connector := getPolicyConnector(m)
 	client := nsx.NewTransportNodesClient(connector)
 
-	id := d.Get("edge_id").(string)
+	id := d.Id()
 
 	obj, err := client.Get(id)
 	if err != nil {
@@ -145,10 +146,12 @@ func resourceNsxtEdgeTransportNodeRTEPUpdate(d *schema.ResourceData, m interface
 	}
 
 	rtep := model.TransportNodeRemoteTunnelEndpointConfig{
-		HostSwitchName:     &hostSwitchName,
-		IpAssignmentSpec:   ipAssignment,
-		NamedTeamingPolicy: &namedTeamingPolicy,
-		RtepVlan:           &rtepVlan,
+		HostSwitchName:   &hostSwitchName,
+		IpAssignmentSpec: ipAssignment,
+		RtepVlan:         &rtepVlan,
+	}
+	if namedTeamingPolicy != "" {
+		rtep.NamedTeamingPolicy = &namedTeamingPolicy
 	}
 	obj.RemoteTunnelEndpoint = &rtep
 	_, err = client.Update(id, obj, nil, nil, nil, nil, nil, nil, nil)
@@ -163,7 +166,7 @@ func resourceNsxtEdgeTransportNodeRTEPDelete(d *schema.ResourceData, m interface
 	connector := getPolicyConnector(m)
 	client := nsx.NewTransportNodesClient(connector)
 
-	id := d.Get("edge_id").(string)
+	id := d.Id()
 
 	obj, err := client.Get(id)
 	if err != nil {


### PR DESCRIPTION
## Summary
- **Issue 1** - Import by transport node UUID was broken: Read, Update and Delete all used `d.Get("edge_id")` to look up the edge, which is empty during terraform import (only `d.Id()` is populated at that point). Switch all three to `d.Id()`; add `d.Set("edge_id", id)` in Read so the attribute is written back to state after an import.
- **Issue 2** - Update sent an empty string pointer for `NamedTeamingPolicy` whenever the attribute was not set, causing NSX to reject the request with "uplink teaming policy name/s [] not specified". Apply the same non-empty guard that Create already had.
- **Issue 3** - DHCP and `no_ipv4` IP assignment types are not supported by the NSX RTEP API (a DHCP request triggers a server-side NPE, code 99). Add `getIPAssignmentSchemaForRTEP()` which strips those unsupported fields from the shared schema, so an unsupported assignment type is rejected at terraform plan time instead of reaching the API. Update docs accordingly.

**Dependency note:** `getIPAssignmentSchemaForRTEP()` calls `getIPAssignmentSchema(false)` (Optional), flipping this branch's `ip_assignment` field from its current `Required` to `Optional`. This isn't a regression introduced here — a separate, already-queued fix (upstream PR #1966, "Fixing the resource diff issue") adds `Computed: true` to `getIPAssignmentSchema`, and `Required` + `Computed` is an invalid schema combination, so upstream had already flipped this same field to `Optional` before this fix landed. When #1966 is ported to this branch, its hunk touching this specific line will be a no-op (already handled here); #1966's `Computed: true` addition to `getIPAssignmentSchema` itself is unaffected and still needs to land separately.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `golangci-lint run ./nsxt/` (0 issues)
- [x] `terrafmt diff ./docs --pattern '*.md'` (clean)
- [x] `markdownlint-cli2 docs/**/*.md` (0 issues)

Note: master's source PR added mock-based regression tests, which this branch has no framework for; the production fix is otherwise a direct, unmodified port aside from the noted schema-signature simplification.