### PR TITLE
Add Computed to ip_assignment and cpu_config to fix diff issue

### DIFF
--- a/nsxt/resource_nsxt_edge_transport_node.go
+++ b/nsxt/resource_nsxt_edge_transport_node.go
@@ -492,6 +492,7 @@ func getStandardHostSwitchSchema(nodeType string) *schema.Schema {
 				Type:        schema.TypeList,
 				Description: "Enhanced Networking Stack enabled HostSwitch CPU configuration",
 				Optional:    true,
+				Computed:    true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"num_lcores": {
@@ -689,6 +690,7 @@ func getIPAssignmentSchema(required bool) *schema.Schema {
 		MaxItems:    1,
 		Required:    required,
 		Optional:    !required,
+		Computed:    true,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"assigned_by_dhcp": {


### PR DESCRIPTION
## Summary
- Sub-config objects were not set into schema in the read operation, causing NSX-populated defaults for the enhanced-networking-stack `cpu_config` block and for `ip_assignment` to perpetually plan back to empty on every apply.
- Mark both `TypeList` blocks `Computed` so Terraform accepts the server-populated values when the user has not explicitly set them.

**Depends on / sequencing note:** the only caller passing `getIPAssignmentSchema(true)` (`nsxt_edge_transport_node_rtep`) is fixed separately in #2244, which flips it to `Optional` via a new `getIPAssignmentSchemaForRTEP()` wrapper — required, since `Required` + `Computed` is an invalid schema combination. This PR deliberately does **not** touch that line to avoid a merge conflict with #2244 regardless of which merges first; verified no other caller in this codebase (or on master) passes `true` to `getIPAssignmentSchema`, so once both PRs are in, no invalid schema combination remains.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `golangci-lint run ./nsxt/` (0 issues)