### PR TITLE
Fix stale revision on concurrent BGP config update

### DIFF
--- a/nsxt/resource_nsxt_policy_bgp_config.go
+++ b/nsxt/resource_nsxt_policy_bgp_config.go
@@ -235,7 +235,6 @@ func resourceNsxtPolicyBgpConfigCreate(d *schema.ResourceData, m interface{}) er
 func resourceNsxtPolicyBgpConfigUpdate(d *schema.ResourceData, m interface{}) error {
 	connector := getPolicyConnector(m)
 
-	revision := int64(d.Get("revision").(int))
 	gwPath := d.Get("gateway_path").(string)
 	_, gwID := parseGatewayPolicyPath(gwPath)
 	serviceID := d.Get("locale_service_id").(string)
@@ -250,22 +249,44 @@ func resourceNsxtPolicyBgpConfigUpdate(d *schema.ResourceData, m interface{}) er
 		return handleUpdateError("BgpRoutingConfig", gwID, err)
 	}
 
-	obj.Revision = &revision
-	if isPolicyGlobalManager(m) {
-		gmObj, convErr := convertModelBindingType(obj, model.BgpRoutingConfigBindingType(), gm_model.BgpRoutingConfigBindingType())
-		if convErr != nil {
-			return convErr
-		}
-		gmRoutingConfig := gmObj.(gm_model.BgpRoutingConfig)
+	// The BGP config object is a singleton child of the Tier0 gateway's locale
+	// service, and nsxt_policy_tier0_gateway's own inline bgp_config block can
+	// update that same object. When both resources change in the same apply,
+	// the revision cached in this resource's state can already be stale by the
+	// time this Update runs, so re-fetch the current revision immediately
+	// before each write attempt and retry on conflict.
+	doUpdate := func() error {
+		if isPolicyGlobalManager(m) {
+			client := gm_locale_services.NewBgpClient(connector)
+			current, getErr := client.Get(gwID, serviceID)
+			if getErr != nil {
+				return getErr
+			}
 
-		client := gm_locale_services.NewBgpClient(connector)
-		_, err = client.Update(gwID, serviceID, gmRoutingConfig, nil)
-	} else {
+			gmObj, convErr := convertModelBindingType(obj, model.BgpRoutingConfigBindingType(), gm_model.BgpRoutingConfigBindingType())
+			if convErr != nil {
+				return convErr
+			}
+			gmRoutingConfig := gmObj.(gm_model.BgpRoutingConfig)
+			gmRoutingConfig.Revision = current.Revision
+
+			_, updateErr := client.Update(gwID, serviceID, gmRoutingConfig, nil)
+			return updateErr
+		}
+
 		client := locale_services.NewBgpClient(connector)
-		_, err = client.Update(gwID, serviceID, *obj, nil)
+		current, getErr := client.Get(gwID, serviceID)
+		if getErr != nil {
+			return getErr
+		}
+		obj.Revision = current.Revision
+
+		_, updateErr := client.Update(gwID, serviceID, *obj, nil)
+		return updateErr
 	}
 
-	if err != nil {
+	commonProviderConfig := getCommonProviderConfig(m)
+	if err := retryUponPreconditionFailed(doUpdate, commonProviderConfig.MaxRetries); err != nil {
 		return handleUpdateError("BgpRoutingConfig", gwID, err)
 	}
 


### PR DESCRIPTION
## Summary
- `nsxt_policy_bgp_config`'s Update used the revision cached in Terraform state, which goes stale when `nsxt_policy_tier0_gateway`'s own inline `bgp_config` block updates the same underlying object in the same apply.
- Fetch the current revision immediately before each write and retry on conflict, matching the pattern already used by `gateway_redistribution_config` and `tier0_gateway_ha_vip_config`.

Hand-adapted port of the equivalent master fix: master's version of this file uses a unified `cliBgpClient(sessionContext, connector)` wrapper (from an unported SDK-wrapper refactor) that doesn't exist on this branch. This branch still branches explicitly on `isPolicyGlobalManager(m)` between `locale_services.NewBgpClient` and `gm_locale_services.NewBgpClient`, so the fetch-fresh-revision-and-retry fix is applied to both paths directly.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `golangci-lint run ./nsxt/` (0 issues)

Note: master's source PR added mock-based regression tests, which this branch has no framework for; the production fix logic is otherwise equivalent.