### PR TITLE
Fix bgp_config site_path drift after import on Global Manager

### DIFF
--- a/nsxt/resource_nsxt_policy_bgp_config.go
+++ b/nsxt/resource_nsxt_policy_bgp_config.go
@@ -14,6 +14,7 @@ import (
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_0s/locale_services"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 
+	tier0s "github.com/vmware/terraform-provider-nsxt/api/infra/tier_0s"
 	"github.com/vmware/terraform-provider-nsxt/nsxt/util"
 )
 
@@ -94,6 +95,26 @@ func resourceNsxtPolicyBgpConfigRead(d *schema.ResourceData, m interface{}) erro
 
 	for key, value := range data {
 		d.Set(key, value)
+	}
+
+	// gateway_path and site_path are not part of the BGP config object
+	// itself - they describe the parent Locale Service - and the Importer
+	// never sets site_path at all. Re-derive both from the Locale Service on
+	// every Read so a fresh import doesn't leave site_path empty, which
+	// would force a replace (site_path is ForceNew) on the next apply.
+	lsClient := tier0s.NewLocaleServicesClient(getSessionContext(d, m), connector)
+	if lsClient == nil {
+		return policyResourceNotSupportedError()
+	}
+	locSvc, err := lsClient.Get(gwID, serviceID)
+	if err != nil {
+		return handleReadError(d, "BGP Config", serviceID, err)
+	}
+	d.Set("gateway_path", getGatewayPathFromLocaleServicesPath(*locSvc.Path))
+	if isPolicyGlobalManager(m) && locSvc.EdgeClusterPath != nil {
+		d.Set("site_path", getSitePathFromEdgePath(*locSvc.EdgeClusterPath))
+	} else {
+		d.Set("site_path", "")
 	}
 
 	return nil

--- a/nsxt/resource_nsxt_policy_bgp_config_test.go
+++ b/nsxt/resource_nsxt_policy_bgp_config_test.go
@@ -82,6 +82,34 @@ func TestAccResourceNsxtPolicyBgpConfig_basic(t *testing.T) {
 	})
 }
 
+// Regression test: Read never re-derived gateway_path or site_path from the
+// parent Locale Service, and the Importer never set site_path at all. Since
+// site_path is ForceNew, a fresh import left it empty in state while config
+// still declared it, forcing a destroy-and-recreate on the very next plan.
+// ImportStateKind: ImportBlockWithID plans the import (via a native `import`
+// block) and fails unless the resulting plan is a no-op - the resource's own
+// `id` is a synthetic random UUID (regenerated on every import), so
+// ImportStateVerify can't be used here.
+func TestAccResourceNsxtPolicyBgpConfig_importBasic(t *testing.T) {
+	testResourceName := "nsxt_policy_bgp_config.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyBgpConfigTemplate(true),
+			},
+			{
+				ResourceName:      testResourceName,
+				ImportState:       true,
+				ImportStateKind:   resource.ImportBlockWithID,
+				ImportStateIdFunc: testAccResourceNsxtPolicyImportIDRetriever(testResourceName),
+			},
+		},
+	})
+}
+
 func TestAccResourceNsxtPolicyBgpConfig_minimalistic(t *testing.T) {
 	testResourceName := "nsxt_policy_bgp_config.test"
 


### PR DESCRIPTION
## Summary
- `gateway_path` and `site_path` describe the parent Locale Service, not the BGP config object itself, and Read never derived either of them — it only ever populated whatever the Importer set once at import time. The Importer itself never set `site_path` at all, so a fresh import left it empty while config still declared it. Since `site_path` is `ForceNew`, the next plan proposed destroying and recreating the resource instead of showing no changes.
- Fetch the parent Locale Service in Read and re-derive both paths from it on every read, mirroring the identical pattern already used by the sibling `nsxt_policy_gateway_redistribution_config` resource.
- Add import regression coverage using `ImportStateKind: ImportBlockWithID`, since this resource's `id` is a synthetic random UUID (regenerated on every import) that `ImportStateVerify` can't meaningfully compare.

Hand-adapted port of the equivalent master fix: master's version uses a unified `cliTier0LocaleServicesClient(sessionContext, connector)` wrapper (from an unported SDK-wrapper refactor); this branch instead reuses the existing `tier0s.NewLocaleServicesClient(getSessionContext(d, m), connector)` wrapper already used by the sibling `gateway_redistribution_config` resource, with the same LM/GM `site_path` derivation logic.

Touches the same file as #2246 (different functions — Read vs Update), should merge cleanly regardless of order.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `golangci-lint run ./nsxt/` (0 issues)
- [x] `go test ./nsxt/ -run TestAccResourceNsxtPolicyBgpConfig_importBasic -c` — compiles

Note: master's source PR added mock-based regression tests, which this branch has no framework for; the acceptance test coverage is otherwise a direct, unmodified port.