### PR TITLE
Preserve redistribution config on T0 gw update if unset

### DIFF
--- a/nsxt/gateway_common.go
+++ b/nsxt/gateway_common.go
@@ -365,6 +365,13 @@ func initGatewayLocaleServices(context utl.SessionContext, d *schema.ResourceDat
 			// we need revision, and keep the HA vip config
 			serviceStruct.Revision = obj.Revision
 			serviceStruct.HaVipConfigs = obj.HaVipConfigs
+			// Preserve existing route redistribution config when not specified in the
+			// locale_service block (e.g. when managed by nsxt_policy_gateway_redistribution_config).
+			// Otherwise updating the T0 with locale_service (e.g. to set preferred_edge_paths)
+			// would overwrite and remove the redistribution config. See GitHub issue #1974.
+			if serviceStruct.RouteRedistributionConfig == nil && obj.RouteRedistributionConfig != nil {
+				serviceStruct.RouteRedistributionConfig = obj.RouteRedistributionConfig
+			}
 		}
 		dataValue, err := initChildLocaleService(&serviceStruct, false)
 		if err != nil {


### PR DESCRIPTION
## Summary
- Updating the T0 gateway with a `locale_service` block (e.g. to set `preferred_edge_paths`) would overwrite and remove any existing route redistribution config when the `locale_service` block itself doesn't specify one — such as when redistribution is managed separately via `nsxt_policy_gateway_redistribution_config`. Preserve the existing config in that case.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `golangci-lint run ./nsxt/` (0 issues)

Direct, unmodified port — no test files touched in the source PR.