### PR TITLE
Fix zone_based_span empty-list drop/panic in getSpanFromSchema

### DIFF
--- a/nsxt/resource_nsxt_policy_transit_gateway.go
+++ b/nsxt/resource_nsxt_policy_transit_gateway.go
@@ -200,9 +200,13 @@ func getSpanFromSchema(iSpan interface{}) (*data.StructValue, error) {
 
 	// We're limiting to one span of any kind in the schema
 	span := iSpan.([]interface{})[0].(map[string]interface{})
-	if len(span["cluster_based_span"].([]interface{})) > 0 {
-		cbs := span["cluster_based_span"].([]interface{})[0].(map[string]interface{})
-		spanPath := cbs["span_path"].(string)
+	// Presence is determined by list length: when a nested block's contents
+	// stay at their zero value, the SDKv2 diff engine can reconstruct the
+	// single list element as a bare nil even though the block itself is
+	// present, so a direct type assertion on that element would panic.
+	if cbsList := span["cluster_based_span"].([]interface{}); len(cbsList) > 0 {
+		cbs, _ := cbsList[0].(map[string]interface{})
+		spanPath, _ := cbs["span_path"].(string)
 		clusterBasedSpan := model.ClusterBasedSpan{
 			SpanPath: &spanPath,
 			Type_:    model.BaseSpan_TYPE_CLUSTERBASEDSPAN,
@@ -213,9 +217,11 @@ func getSpanFromSchema(iSpan interface{}) (*data.StructValue, error) {
 		}
 		return dataValue.(*data.StructValue), nil
 	}
-	if len(span["zone_based_span"].([]interface{})) > 0 {
-		zbs := span["zone_based_span"].([]interface{})[0].(map[string]interface{})
-		zoneExternalIds := interfaceListToStringList(zbs["zone_external_ids"].([]interface{}))
+	if zbsList := span["zone_based_span"].([]interface{}); len(zbsList) > 0 {
+		var zoneExternalIds []string
+		if zbs, ok := zbsList[0].(map[string]interface{}); ok {
+			zoneExternalIds = interfaceListToStringList(zbs["zone_external_ids"].([]interface{}))
+		}
 		zoneBasedSpan := model.ZoneBasedSpan{
 			ZoneExternalIds: zoneExternalIds,
 			Type_:           model.BaseSpan_TYPE_ZONEBASEDSPAN,

--- a/nsxt/resource_nsxt_policy_transit_gateway_span_test.go
+++ b/nsxt/resource_nsxt_policy_transit_gateway_span_test.go
@@ -1,0 +1,43 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package nsxt
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetSpanFromSchemaZoneBasedEmptyZones guards against a regression where
+// span.zone_based_span with an explicitly empty zone_external_ids list was
+// dropped from the create/update payload entirely. The SDKv2 diff engine
+// emits no attribute entries for the nested block's contents when the list
+// stays at zero elements, so the reconstructed ResourceData can hand
+// getSpanFromSchema a zone_based_span element that is a bare nil instead of
+// a map. getSpanFromSchema must still recognize the block as present (via
+// the list length) and produce a ZoneBasedSpan rather than panicking or
+// silently dropping the span.
+func TestGetSpanFromSchemaZoneBasedEmptyZones(t *testing.T) {
+	span := []interface{}{
+		map[string]interface{}{
+			"cluster_based_span": []interface{}{},
+			"zone_based_span":    []interface{}{nil},
+		},
+	}
+
+	structVal, err := getSpanFromSchema(span)
+	require.NoError(t, err)
+	require.NotNil(t, structVal, "getSpanFromSchema must not drop a present-but-empty zone_based_span block")
+
+	out, err := setSpanFromSchema(structVal)
+	require.NoError(t, err)
+	require.NotNil(t, out)
+
+	spanList := out.([]interface{})
+	require.Len(t, spanList, 1)
+	spanMap := spanList[0].(map[string]interface{})
+	zbs := spanMap["zone_based_span"].([]interface{})
+	require.Len(t, zbs, 1)
+}


### PR DESCRIPTION
## Summary
- The SDKv2 diff engine emits no attribute entries for a nested list's contents when it stays at zero elements, so a present-but-empty `cluster_based_span`/`zone_based_span` block can reconstruct its single list element as a bare nil.
- Branch_3122's `getSpanFromSchema` already determined block presence via list length (unlike master's pre-fix version, which checked the reconstructed element map and could treat a present-but-empty block as absent) — but it still used an unchecked type assertion on that single element, which would panic instead of producing the (possibly empty) `ZoneBasedSpan`/`ClusterBasedSpan`.
- Tolerate a nil element by defaulting to an empty zone list / empty span path instead of panicking.

Adds a plain unit test (no mock framework needed) reproducing the exact nil-element shape and asserting `getSpanFromSchema` doesn't panic and still round-trips through `setSpanFromSchema` correctly.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `golangci-lint run ./nsxt/` (0 issues)
- [x] `go test ./nsxt/ -run TestGetSpanFromSchemaZoneBasedEmptyZones -v` — passes