### PR TITLE
Mark span.zone_based_span as Computed

### DIFF
--- a/docs/resources/policy_transit_gateway.md
+++ b/docs/resources/policy_transit_gateway.md
@@ -42,7 +42,7 @@ The following arguments are supported:
 * `span` - (Optional) Span configuration. Note that one of `cluster_based_span` and `zone_based_span` is required. Available since NSX 9.1.0.
     * `cluster_based_span` - (Optional) Span based on vSphere Clusters.
         * `span_path` - (Required) Policy path of the network span object.
-    * `zone_based_span` - (Optional) Span based on zones.
+    * `zone_based_span` - (Optional, Computed) Span based on zones.
         * `zone_external_ids` - (Required) An array of Zone object's external IDs.
 
 ## Attributes Reference

--- a/nsxt/resource_nsxt_policy_transit_gateway.go
+++ b/nsxt/resource_nsxt_policy_transit_gateway.go
@@ -125,6 +125,7 @@ var transitGatewaySchema = map[string]*metadata.ExtendedSchema{
 							Type:     schema.TypeList,
 							MaxItems: 1,
 							Optional: true,
+							Computed: true,
 							Elem: &metadata.ExtendedResource{
 								Schema: map[string]*metadata.ExtendedSchema{
 									"zone_external_ids": {


### PR DESCRIPTION
## Summary
- `span.cluster_based_span` and `span.zone_based_span` are mutually exclusive nested blocks (governed by `ExactlyOneOf`), but only `cluster_based_span` was declared `Computed`. This asymmetry caused Terraform to fail to reconcile the server-returned `zone_based_span` value with state, showing a perpetual "add zone_based_span" diff on every re-apply.
- Add `Computed: true` to `zone_based_span` to match its sibling. Update docs to reflect `(Optional, Computed)`.

Scoped to just this fix: master's source PR bundled unrelated route_controller_bgp_neighbor test IP-address tweaks and a `testAccNsxtExtraCoverage` helper change, neither of which relate to this bug.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `golangci-lint run ./nsxt/` (0 issues)
- [x] `terrafmt diff ./docs --pattern '*.md'` (clean)
- [x] `markdownlint-cli2 docs/**/*.md` (0 issues)