### PR TITLE
Fix panic in getSpanFromSchema on nil span list element

### DIFF
--- a/nsxt/resource_nsxt_policy_transit_gateway.go
+++ b/nsxt/resource_nsxt_policy_transit_gateway.go
@@ -194,13 +194,20 @@ func resourceNsxtPolicyTransitGatewayExists(sessionContext utl.SessionContext, i
 }
 
 func getSpanFromSchema(iSpan interface{}) (*data.StructValue, error) {
-	if len(iSpan.([]interface{})) == 0 {
+	if iSpan == nil {
+		return nil, nil
+	}
+	spanList, ok := iSpan.([]interface{})
+	if !ok || len(spanList) == 0 || spanList[0] == nil {
 		return nil, nil
 	}
 	converter := bindings.NewTypeConverter()
 
 	// We're limiting to one span of any kind in the schema
-	span := iSpan.([]interface{})[0].(map[string]interface{})
+	span, ok := spanList[0].(map[string]interface{})
+	if !ok {
+		return nil, nil
+	}
 	// Presence is determined by list length: when a nested block's contents
 	// stay at their zero value, the SDKv2 diff engine can reconstruct the
 	// single list element as a bare nil even though the block itself is

--- a/nsxt/resource_nsxt_policy_transit_gateway_span_nil_test.go
+++ b/nsxt/resource_nsxt_policy_transit_gateway_span_nil_test.go
@@ -1,0 +1,31 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package nsxt
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetSpanFromSchemaNilSpan guards against a regression where the
+// Terraform SDK populates an optional "span" block that contains only
+// empty/default attributes with a single nil element rather than an empty
+// slice, or hands getSpanFromSchema a bare nil. Unchecked type assertions on
+// that element previously triggered a panic at apply time; getSpanFromSchema
+// must instead treat these shapes as "no span configured".
+func TestGetSpanFromSchemaNilSpan(t *testing.T) {
+	structVal, err := getSpanFromSchema(nil)
+	require.NoError(t, err)
+	require.Nil(t, structVal)
+
+	structVal, err = getSpanFromSchema([]interface{}{})
+	require.NoError(t, err)
+	require.Nil(t, structVal)
+
+	structVal, err = getSpanFromSchema([]interface{}{nil})
+	require.NoError(t, err)
+	require.Nil(t, structVal)
+}


### PR DESCRIPTION
## Summary
- The Terraform SDK populates optional blocks that contain only empty/default attributes with a single nil element rather than an empty slice, or can hand this function a bare nil. The previous code performed unchecked type assertions on that element, triggering a panic at apply time.
- Add nil/type guards on `iSpan` itself and its single list element, in addition to the existing length-based presence checks for `cluster_based_span` and `zone_based_span`.

This hardens the *outer* unwrapping level of `getSpanFromSchema`; #2250 (already open) separately hardens the *inner* per-block element extraction (`cluster_based_span`/`zone_based_span`'s own single element). Different lines in the same function — should merge cleanly regardless of order.

Adds a unit test covering the nil-span and nil-element shapes that previously panicked (master's source PR had no test).

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `golangci-lint run ./nsxt/` (0 issues)
- [x] `go test ./nsxt/ -run TestGetSpanFromSchemaNilSpan -v` — passes