### PR TITLE
Suppress ipsec_vpn_session psk drift after import

### DIFF
--- a/nsxt/resource_nsxt_policy_ipsec_vpn_session.go
+++ b/nsxt/resource_nsxt_policy_ipsec_vpn_session.go
@@ -122,10 +122,11 @@ func getIPSecVpnSessionCommon(isTransitGateway bool) map[string]*metadata.Extend
 		},
 		"psk": {
 			Schema: schema.Schema{
-				Type:        schema.TypeString,
-				Description: "IPSec Pre-shared key. Maximum length of this field is 128 characters.",
-				Optional:    true,
-				Sensitive:   true,
+				Type:             schema.TypeString,
+				Description:      "IPSec Pre-shared key. Maximum length of this field is 128 characters.",
+				Optional:         true,
+				Sensitive:        true,
+				DiffSuppressFunc: suppressIfEmptyPriorState,
 			},
 		},
 		"peer_id": {


### PR DESCRIPTION
## Summary
- NSX never returns the pre-shared key on GET, so terraform import leaves `psk` empty in state, causing a spurious diff/re-apply on every plan.
- Reuse the `suppressIfEmptyPriorState` DiffSuppressFunc already used for other write-only fields. `getIPSecVpnSessionCommon` is shared by `nsxt_policy_ipsec_vpn_session` and `nsxt_policy_transit_gateway_ipsec_vpn_session`, so this fixes both.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `golangci-lint run ./nsxt/` (0 issues)

Direct, unmodified port — no test files touched in the source PR.