### PR TITLE
Accept policy path on import for IPSec VPN DPD/IKE/tunnel profiles

### DIFF
--- a/docs/resources/policy_ipsec_vpn_dpd_profile.md
+++ b/docs/resources/policy_ipsec_vpn_dpd_profile.md
@@ -55,3 +55,9 @@ terraform import nsxt_policy_ipsec_vpn_dpd_profile.test UUID
 ```
 
 The above command imports IPSec VPN DPD Profile named `test` with the NSX ID `UUID`.
+
+For example:
+
+```shell
+terraform import nsxt_policy_ipsec_vpn_dpd_profile.test /infra/ipsec-vpn-dpd-profiles/my-dpd-profile
+```

--- a/docs/resources/policy_ipsec_vpn_ike_profile.md
+++ b/docs/resources/policy_ipsec_vpn_ike_profile.md
@@ -56,3 +56,9 @@ terraform import nsxt_policy_ipsec_vpn_ike_profile.test UUID
 ```
 
 The above command imports IPSec VPN IKE Profile named `test` with the NSX ID `UUID`.
+
+For example:
+
+```shell
+terraform import nsxt_policy_ipsec_vpn_ike_profile.test /infra/ipsec-vpn-ike-profiles/my-ike-profile
+```

--- a/docs/resources/policy_ipsec_vpn_tunnel_profile.md
+++ b/docs/resources/policy_ipsec_vpn_tunnel_profile.md
@@ -58,3 +58,9 @@ terraform import nsxt_policy_ipsec_vpn_tunnel_profile.test UUID
 ```
 
 The above command imports IPSec VPN IKE Profile named `test` with the NSX ID `UUID`.
+
+For example:
+
+```shell
+terraform import nsxt_policy_ipsec_vpn_tunnel_profile.test /infra/ipsec-vpn-tunnel-profiles/my-tunnel-profile
+```

--- a/nsxt/resource_nsxt_policy_ipsec_vpn_dpd_profile.go
+++ b/nsxt/resource_nsxt_policy_ipsec_vpn_dpd_profile.go
@@ -15,6 +15,8 @@ import (
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 )
 
+var dpdProfilePathExample = "/infra/ipsec-vpn-dpd-profiles/[profile]"
+
 var iPSecVpnDpdProfileDpdProbeModeValues = []string{
 	model.IPSecVpnDpdProfile_DPD_PROBE_MODE_ON_DEMAND,
 	model.IPSecVpnDpdProfile_DPD_PROBE_MODE_PERIODIC,
@@ -27,7 +29,7 @@ func resourceNsxtPolicyIPSecVpnDpdProfile() *schema.Resource {
 		Update: resourceNsxtPolicyIPSecVpnDpdProfileUpdate,
 		Delete: resourceNsxtPolicyIPSecVpnDpdProfileDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			State: getPolicyPathOrIDResourceImporter(dpdProfilePathExample),
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_policy_ipsec_vpn_ike_profile.go
+++ b/nsxt/resource_nsxt_policy_ipsec_vpn_ike_profile.go
@@ -15,6 +15,8 @@ import (
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 )
 
+var ikeProfilePathExample = "/infra/ipsec-vpn-ike-profiles/[profile]"
+
 var iPSecVpnIkeProfileDhGroupsValues = []string{
 	model.IPSecVpnIkeProfile_DH_GROUPS_GROUP2,
 	model.IPSecVpnIkeProfile_DH_GROUPS_GROUP5,
@@ -54,7 +56,7 @@ func resourceNsxtPolicyIPSecVpnIkeProfile() *schema.Resource {
 		Update: resourceNsxtPolicyIPSecVpnIkeProfileUpdate,
 		Delete: resourceNsxtPolicyIPSecVpnIkeProfileDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			State: getPolicyPathOrIDResourceImporter(ikeProfilePathExample),
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/nsxt/resource_nsxt_policy_ipsec_vpn_tunnel_profile.go
+++ b/nsxt/resource_nsxt_policy_ipsec_vpn_tunnel_profile.go
@@ -15,6 +15,8 @@ import (
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 )
 
+var tunnelProfilePathExample = "/infra/ipsec-vpn-tunnel-profiles/[profile]"
+
 var ipSecVpnTunnelProfileDfPolicyValues = []string{
 	model.IPSecVpnTunnelProfile_DF_POLICY_COPY,
 	model.IPSecVpnTunnelProfile_DF_POLICY_CLEAR,
@@ -57,7 +59,7 @@ func resourceNsxtPolicyIPSecVpnTunnelProfile() *schema.Resource {
 		Update: resourceNsxtPolicyIPSecVpnTunnelProfileUpdate,
 		Delete: resourceNsxtPolicyIPSecVpnTunnelProfileDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			State: getPolicyPathOrIDResourceImporter(tunnelProfilePathExample),
 		},
 
 		Schema: map[string]*schema.Schema{


### PR DESCRIPTION
## Summary
- `nsxt_policy_ipsec_vpn_dpd_profile`, `_ike_profile`, and `_tunnel_profile` used `schema.ImportStatePassthrough`, so importing with a full policy path (rather than a bare NSX ID) set the resource ID to the literal path string, which does not match what Read expects and breaks the subsequent lookup.
- Switch to `getPolicyPathOrIDResourceImporter`, which accepts either a bare ID or a full policy path and extracts the ID correctly from either form.

This is a scoped-down port of master's `1f34297b` ("Fix project context loss on import for IPSec VPN service, session, local endpoint, ike profile resources and add dedicated L2 VPN session importer"). That commit's core intent — fixing project/multitenancy context loss on import via `extractProjectIDFromPolicyPath`/`getContextSchema` for `ipsec_vpn_service`/`_session`/`_local_endpoint`/`l2_vpn_session` — depends on multitenancy support for IPSec VPN resources (added upstream by a separate, unported PR, #1978) that doesn't exist on this branch at all; those resources have no `context` schema field and no project-scoping logic whatsoever here, so that part of the fix is not applicable.

The DPD/IKE/tunnel profile importer switch is independently valid and doesn't depend on multitenancy, so it's included here on its own. Deliberately uses a plain (non-multitenancy) path example in the importer's error messages and docs, since advertising multitenancy-path support would be misleading — this branch's Read logic has no project-context awareness for these resources.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `golangci-lint run ./nsxt/` (0 issues)
- [x] `terrafmt diff ./docs --pattern '*.md'` (clean)
- [x] `markdownlint-cli2 docs/**/*.md` (0 issues)