### PR TITLE
Add documentation for missing data sources

### DIFF
--- a/docs/data-sources/manager_cluster_node.md
+++ b/docs/data-sources/manager_cluster_node.md
@@ -1,0 +1,29 @@
+---
+subcategory: "Fabric"
+page_title: "NSXT: manager_cluster_node"
+description: A NSX manager cluster node data source.
+---
+
+# nsxt_manager_cluster_node
+
+This data source provides information about a specific NSX manager cluster node.
+
+## Example Usage
+
+```hcl
+data "nsxt_manager_cluster_node" "node1" {
+  display_name = "nsx-manager-node1"
+}
+```
+
+## Argument Reference
+
+* `id` - (Optional) Unique ID of the manager cluster node to retrieve.
+* `display_name` - (Optional) Display name prefix of the manager cluster node to retrieve.
+
+## Attributes Reference
+
+In addition to arguments listed above, the following attributes are exported:
+
+* `description` - Description of this resource.
+* `appliance_mgmt_listen_address` - The IP and port for the appliance management API service on this node.

--- a/docs/data-sources/policy_gateway_prefix_list.md
+++ b/docs/data-sources/policy_gateway_prefix_list.md
@@ -1,0 +1,37 @@
+---
+subcategory: "Gateways and Routing"
+page_title: "NSXT: policy_gateway_prefix_list"
+description: Policy Gateway Prefix List data source.
+---
+
+# nsxt_policy_gateway_prefix_list
+
+This data source provides information about a policy Gateway Prefix List configured on NSX.
+
+This data source is applicable to NSX Global Manager and NSX Policy Manager.
+
+## Example Usage
+
+```hcl
+data "nsxt_policy_tier0_gateway" "gw1" {
+  display_name = "gw1"
+}
+
+data "nsxt_policy_gateway_prefix_list" "prefix_list1" {
+  gateway_path = data.nsxt_policy_tier0_gateway.gw1.path
+  display_name = "t0_prefix_list"
+}
+```
+
+## Argument Reference
+
+* `id` - (Optional) The ID of the Gateway Prefix List to retrieve.
+* `display_name` - (Optional) The Display Name prefix of the Gateway Prefix List to retrieve.
+* `gateway_path` - (Optional) Policy path of the Gateway where the Prefix List is configured.
+
+## Attributes Reference
+
+In addition to arguments listed above, the following attributes are exported:
+
+* `description` - The description of the resource.
+* `path` - The NSX path of the policy resource.

--- a/docs/data-sources/policy_gateway_route_map.md
+++ b/docs/data-sources/policy_gateway_route_map.md
@@ -1,0 +1,37 @@
+---
+subcategory: "Gateways and Routing"
+page_title: "NSXT: policy_gateway_route_map"
+description: Policy Gateway Route Map data source.
+---
+
+# nsxt_policy_gateway_route_map
+
+This data source provides information about a policy Gateway Route Map configured on NSX.
+
+This data source is applicable to NSX Global Manager, NSX Policy Manager and VMC.
+
+## Example Usage
+
+```hcl
+data "nsxt_policy_tier0_gateway" "gw1" {
+  display_name = "gw1"
+}
+
+data "nsxt_policy_gateway_route_map" "route_map1" {
+  gateway_path = data.nsxt_policy_tier0_gateway.gw1.path
+  display_name = "test"
+}
+```
+
+## Argument Reference
+
+* `id` - (Optional) The ID of the Gateway Route Map to retrieve.
+* `display_name` - (Optional) The Display Name prefix of the Gateway Route Map to retrieve.
+* `gateway_path` - (Optional) Policy path of the Gateway where the Route Map is configured.
+
+## Attributes Reference
+
+In addition to arguments listed above, the following attributes are exported:
+
+* `description` - The description of the resource.
+* `path` - The NSX path of the policy resource.

--- a/docs/data-sources/provider_info.md
+++ b/docs/data-sources/provider_info.md
@@ -1,0 +1,20 @@
+---
+subcategory: "Manager"
+page_title: "NSXT: provider_info"
+description: A NSX-T provider information data source.
+---
+
+# nsxt_provider_info
+
+This data source provides build and version information about the installed NSX-T Terraform provider.
+
+## Example Usage
+
+```hcl
+data "nsxt_provider_info" "info" {}
+```
+
+## Attributes Reference
+
+* `commit` - Latest commit hash of the provider build.
+* `date` - Date and time when the provider was compiled.


### PR DESCRIPTION
Add missing documentation files for four registered data sources:
- manager_cluster_node
- policy_gateway_prefix_list
- policy_gateway_route_map
- provider_info

These data sources are registered in nsxt/provider.go but lacked corresponding documentation under docs/data-sources/. Adding these files ensures complete provider documentation coverage and satisfies documentation linting requirements.