### PR TITLE
Fail when a user specifies a transport_zone_path for a project-based …

### DIFF
--- a/docs/resources/policy_segment.md
+++ b/docs/resources/policy_segment.md
@@ -94,7 +94,7 @@ The following arguments are supported:
 * `domain_name`- (Optional) DNS domain names.
 * `overlay_id` - (Optional) Overlay connectivity ID for this Segment.
 * `vlan_ids` - (Optional) List of VLAN IDs or ranges. Specifying vlan ids can be useful for overlay segments, f.e. for EVPN.
-* `transport_zone_path` - (Optional) Policy path to the Overlay transport zone. This property is required for NSX Local Manager, and should not be specified for NSX Global Manager, where NSX will automatically assign default transport zone on each site.
+* `transport_zone_path` - (Optional) Policy path to the Overlay transport zone. This property is required for NSX Local Manager, and should not be specified for NSX Global Manager or for multitenancy use cases, where NSX will automatically assign default transport zone on each site.
 * `dhcp_config_path` - (Optional) Policy path to DHCP server or relay configuration to use for subnets configured on this segment. This attribute is supported with NSX 3.0.0 onwards.
 * `subnet` - (Optional) Subnet configuration block.
     * `cidr` - (Required) Gateway IP address CIDR. This argument can not be changed if DHCP is enabled for the subnet.

--- a/docs/resources/policy_vlan_segment.md
+++ b/docs/resources/policy_vlan_segment.md
@@ -107,7 +107,7 @@ The following arguments are supported:
 * `ignore_tags` - (Optional) A list of tag scopes that provider should ignore, more specifically, it should not detect drift when tags with such scope are present on NSX, and it should not overwrite them when applying its own tags. This feature is useful for external network with VCD scenario.
 * `nsx_id` - (Optional) The NSX ID of this resource. If set, this ID will be used to create the resource.
 * `domain_name`- (Optional) DNS domain names.
-* `transport_zone_path` - (Optional) Policy path to the VLAN backed transport zone. This property is required for NSX Local Manager, and should not be specified for NSX Global Manager, where NSX will automatically assign default transport zone on each site.
+* `transport_zone_path` - (Optional) Policy path to the Overlay transport zone. This property is required for NSX Local Manager, and should not be specified for NSX Global Manager or for multitenancy use cases, where NSX will automatically assign default transport zone on each site.
 * `vlan_ids` - (Optional) List of VLAN IDs or VLAN ranges.
 * `dhcp_config_path` - (Optional) Policy path to DHCP server or relay configuration to use for subnets configured on this segment. This attribute is supported with NSX 3.0.0 onwards.
 * `subnet` - (Optional) Subnet configuration block.

--- a/nsxt/segment_common.go
+++ b/nsxt/segment_common.go
@@ -718,6 +718,11 @@ func policySegmentResourceToInfraStruct(context utl.SessionContext, id string, d
 
 	if (tzPath == "") && context.ClientType == utl.Local && !isFixed {
 		return model.Infra{}, fmt.Errorf("transport_zone_path needs to be specified for infra segment on local manager")
+	} else if tzPath != "" && context.ClientType == utl.Multitenancy && d.HasChange("transport_zone_path") {
+		// For multitenancy segments, the TZ can only be the default TZ. The provider cannot validate that the specified segment
+		// is the default one - since the user might not have the permissions to lookup the TZ (if the user is a project admin
+		// for example. And since NSX populates this attribute, validate that the value which was set by NSX isn't modified here.
+		return model.Infra{}, fmt.Errorf("transport_zone_path cannot be specified for project based segments")
 	}
 
 	obj := model.Segment{


### PR DESCRIPTION
…segment (#1962)

For project-based segments, NSX will always use the default transport zone. So when a transport_zone is explicitly specified for a segment which belongs to a project, NSX ignores it.
The provider should fail here, so the user will know that the config hasn't been applied instead of having a permadiff here.