### PR TITLE
Deprecate gateway_path, add gateway_interface_path

### DIFF
--- a/docs/data-sources/policy_gateway_interface_realization_info.md
+++ b/docs/data-sources/policy_gateway_interface_realization_info.md
@@ -17,10 +17,16 @@ data "nsxt_policy_tier1_gateway" "tier1_gw" {
   display_name = "tier1_gw"
 }
 
-data "nsxt_policy_gateway_interface_realization" "info" {
+resource "nsxt_policy_tier1_gateway_interface" "tier1_gw_if" {
+  display_name = "tier1_gw_if"
   gateway_path = data.nsxt_policy_tier1_gateway.tier1_gw.path
-  display_name = "pepsi-it_t1-t1_lrp"
-  timeout      = 60
+  segment_path = nsxt_policy_segment.segment1.path
+  subnets      = ["12.12.2.13/24"]
+}
+
+data "nsxt_policy_gateway_interface_realization" "info" {
+  gateway_interface_path = nsxt_policy_tier1_gateway_interface.tier1_gw_if.path
+  timeout                = 60
 }
 ```
 
@@ -35,19 +41,29 @@ data "nsxt_policy_tier1_gateway" "tier1_gw" {
   display_name = "tier1_gw"
 }
 
+resource "nsxt_policy_tier1_gateway_interface" "tier1_gw_if" {
+  context {
+    project_id = data.nsxt_policy_project.demoproj.id
+  }
+  display_name = "tier1_gw_if"
+  gateway_path = data.nsxt_policy_tier1_gateway.tier1_gw.path
+  segment_path = nsxt_policy_segment.segment1.path
+  subnets      = ["12.12.2.13/24"]
+}
+
 data "nsxt_policy_gateway_interface_realization" "info" {
   context {
     project_id = data.nsxt_policy_project.demoproj.id
   }
-  gateway_path = data.nsxt_policy_tier1_gateway.tier1_gw.path
-  display_name = "pepsi-it_t1-t1_lrp"
-  timeout      = 60
+  gateway_interface_path = nsxt_policy_tier1_gateway_interface.tier1_gw_if.path
+  timeout                = 60
 }
 ```
 
 ## Argument Reference
 
-* `gateway_path` - (Required) The policy path of the resource.
+* `gateway_interface_path` - (Required) The policy path of the gateway interface.
+* `gateway_path` - (Deprecated) Use `gateway_interface_path` instead. Despite its name, this attribute expects the path of the gateway interface, not the gateway.
 * `id`  - (Optional) The ID of gateway interface.
 * `display_name` - (Optional) The display name of the resource. If neither ID nor display name are set, the realized gateway interface with IP addresses will be retrieved.
 * `delay` - (Optional) Delay (in seconds) before realization polling is started. Default is set to 1.

--- a/nsxt/data_source_nsxt_policy_gateway_interface_realization.go
+++ b/nsxt/data_source_nsxt_policy_gateway_interface_realization.go
@@ -26,9 +26,18 @@ func dataSourceNsxtPolicyGatewayInterfaceRealization() *schema.Resource {
 			"context": getContextSchema(false, false, false),
 			"gateway_path": {
 				Type:         schema.TypeString,
-				Description:  "The path for the gateway",
-				Required:     true,
+				Description:  "The path for the gateway interface",
+				Optional:     true,
+				Deprecated:   "Use gateway_interface_path instead. Despite its name, this attribute expects the path of the gateway interface, not the gateway.",
 				ValidateFunc: validatePolicyPath(),
+				ExactlyOneOf: []string{"gateway_path", "gateway_interface_path"},
+			},
+			"gateway_interface_path": {
+				Type:         schema.TypeString,
+				Description:  "The path for the gateway interface",
+				Optional:     true,
+				ValidateFunc: validatePolicyPath(),
+				ExactlyOneOf: []string{"gateway_path", "gateway_interface_path"},
 			},
 			"display_name": {
 				Type:        schema.TypeString,
@@ -79,7 +88,10 @@ func dataSourceNsxtPolicyGatewayInterfaceRealizationRead(d *schema.ResourceData,
 	}
 
 	id := d.Get("id").(string)
-	gatewayPath := d.Get("gateway_path").(string)
+	gatewayInterfacePath := d.Get("gateway_interface_path").(string)
+	if gatewayInterfacePath == "" {
+		gatewayInterfacePath = d.Get("gateway_path").(string)
+	}
 	displayName := d.Get("display_name").(string)
 	delay := d.Get("delay").(int)
 	timeout := d.Get("timeout").(int)
@@ -90,7 +102,7 @@ func dataSourceNsxtPolicyGatewayInterfaceRealizationRead(d *schema.ResourceData,
 		Pending: pendingStates,
 		Target:  targetStates,
 		Refresh: func() (interface{}, string, error) {
-			result, err := client.List(gatewayPath, nil)
+			result, err := client.List(gatewayInterfacePath, nil)
 			if err != nil {
 				return result, "", err
 			}
@@ -160,7 +172,7 @@ func dataSourceNsxtPolicyGatewayInterfaceRealizationRead(d *schema.ResourceData,
 	}
 	_, err := stateConf.WaitForState()
 	if err != nil {
-		return fmt.Errorf("Failed to get gateway interface realization information for %s: %v", gatewayPath, err)
+		return fmt.Errorf("Failed to get gateway interface realization information for %s: %v", gatewayInterfacePath, err)
 	}
 	return nil
 }

--- a/nsxt/resource_nsxt_policy_tier0_gateway_interface_test.go
+++ b/nsxt/resource_nsxt_policy_tier0_gateway_interface_test.go
@@ -728,7 +728,7 @@ data "nsxt_policy_realization_info" "realization_info" {
 }
 
 data "nsxt_policy_gateway_interface_realization" "gw_realization" {
-  gateway_path = nsxt_policy_tier0_gateway_interface.test.path
+  gateway_interface_path = nsxt_policy_tier0_gateway_interface.test.path
 }`
 	}
 	return `
@@ -737,7 +737,7 @@ data "nsxt_policy_realization_info" "realization_info" {
 }
 
 data "nsxt_policy_gateway_interface_realization" "gw_realization" {
-  gateway_path = nsxt_policy_tier0_gateway_interface.test.path
+  gateway_interface_path = nsxt_policy_tier0_gateway_interface.test.path
 }`
 }
 


### PR DESCRIPTION
gateway_path in nsxt_policy_gateway_interface_realization actually required the interface path, not the gateway path, causing timeouts.