### PR TITLE
Fix GM support gap in security policy data source and its test

### DIFF
--- a/nsxt/data_source_nsxt_policy_security_policy.go
+++ b/nsxt/data_source_nsxt_policy_security_policy.go
@@ -45,7 +45,6 @@ func dataSourceNsxtPolicySecurityPolicy() *schema.Resource {
 	}
 }
 
-// Local Manager Only
 func listSecurityPolicies(context utl.SessionContext, domain string, connector client.Connector) ([]model.SecurityPolicy, error) {
 	client := domains.NewSecurityPoliciesClient(context, connector)
 	if client == nil {
@@ -81,12 +80,12 @@ func dataSourceNsxtPolicySecurityPolicyRead(d *schema.ResourceData, m interface{
 	category := d.Get("category").(string)
 	domain := d.Get("domain").(string)
 	isDefault := d.Get("is_default").(bool)
+	context := getSessionContext(d, m)
 
 	objID := d.Get("id").(string)
 	objName := d.Get("display_name").(string)
 
 	var obj model.SecurityPolicy
-	context := getSessionContext(d, m)
 	if objID != "" {
 		// Get by id
 		client := domains.NewSecurityPoliciesClient(context, connector)

--- a/nsxt/resource_nsxt_policy_predefined_security_policy_test.go
+++ b/nsxt/resource_nsxt_policy_predefined_security_policy_test.go
@@ -64,6 +64,68 @@ func testAccResourceNsxtPolicyPredefinedSecurityPolicyBasic(t *testing.T, withCo
 	})
 }
 
+func TestAccResourceNsxtPolicyPredefinedSecurityPolicy_importBasic(t *testing.T) {
+	testAccResourceNsxtPolicyPredefinedSecurityPolicyImportBasic(t, func() {
+		testAccPreCheck(t)
+		testAccOnlyLocalManager(t)
+		testAccNSXVersion(t, "3.0.0")
+	})
+}
+
+func TestAccResourceNsxtPolicyPredefinedSecurityPolicy_importBasic_globalManager(t *testing.T) {
+	testAccResourceNsxtPolicyPredefinedSecurityPolicyImportBasic(t, func() {
+		testAccPreCheck(t)
+		testAccOnlyGlobalManager(t)
+	})
+}
+
+// testAccResourceNsxtPolicyPredefinedSecurityPolicyImportBasic provisions its
+// own Security Policy via nsxt_policy_parent_security_policy rather than
+// relying on a built-in default policy already existing: NSX does not
+// consistently auto-realize default category policies under GM domains
+// across versions (e.g. a fresh NSX 4.2.x Global Manager may have none at
+// all), so a self-created policy is the only environment-independent target.
+//
+// The predefined_security_policy block intentionally leaves description/tag
+// unset: those fields are also owned by nsxt_policy_parent_security_policy on
+// the same underlying object, and patching them here would fight the parent
+// resource for ownership and show up as drift on its own plan.
+func testAccResourceNsxtPolicyPredefinedSecurityPolicyImportBasic(t *testing.T, preCheck func()) {
+	testResourceName := "nsxt_policy_predefined_security_policy.test"
+	name := getAccTestResourceName()
+
+	// NOTE: This test cannot be parallel, as sibling tests in this file modify
+	// the same default policy and are not parallel either.
+	resource.Test(t, resource.TestCase{
+		PreCheck:  preCheck,
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyPredefinedSecurityPolicyImportBasicConfig(name),
+			},
+			{
+				ResourceName:      testResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccResourceNsxtPolicyImportIDRetriever(testResourceName),
+			},
+		},
+	})
+}
+
+func testAccNsxtPolicyPredefinedSecurityPolicyImportBasicConfig(name string) string {
+	return fmt.Sprintf(`
+resource "nsxt_policy_parent_security_policy" "parent" {
+  display_name = "%s"
+  domain       = "default"
+  category     = "Application"
+}
+
+resource "nsxt_policy_predefined_security_policy" "test" {
+  path = nsxt_policy_parent_security_policy.parent.path
+}`, name)
+}
+
 func TestAccResourceNsxtPolicyPredefinedSecurityPolicy_defaultRule(t *testing.T) {
 	testResourceName := "nsxt_policy_predefined_security_policy.test"
 	action1 := "DROP"


### PR DESCRIPTION
nsxt_policy_predefined_security_policy relies on the nsxt_policy_security_policy data source to look up a policy by category/is_default when no path is known. That lookup was gated by a stale "Local Manager Only" restriction, so it silently failed on Global Manager despite GM being a documented target. The underlying SecurityPoliciesClient already routes to the correct GM/LM client via SessionContext, so drop the restriction and let it run universally; verified directly against a live GM.

Also harden the resource's import acceptance test: rather than assuming a default category policy already exists (NSX does not consistently auto-realize these under GM domains across versions -- a fresh NSX 4.2.x GM had none at all), the test now provisions its own target policy via nsxt_policy_parent_security_policy, matching what the original bug report's own FVT test did. Verified against live GM environments on NSX 9.0.2 and 4.2.3, and against LM.