### PR TITLE
Suppress site connection info password drift

### DIFF
--- a/nsxt/resource_nsxt_policy_site.go
+++ b/nsxt/resource_nsxt_policy_site.go
@@ -84,10 +84,11 @@ func getConnectionInfoSchema() *schema.Schema {
 					Description: "Fully Qualified Domain Name of the Management Node",
 				},
 				"password": {
-					Type:        schema.TypeString,
-					Optional:    true,
-					Sensitive:   true,
-					Description: "Password",
+					Type:             schema.TypeString,
+					Optional:         true,
+					Sensitive:        true,
+					Description:      "Password",
+					DiffSuppressFunc: suppressIfEmptyPriorState,
 				},
 				"site_uuid": {
 					Type:        schema.TypeString,


### PR DESCRIPTION
## Summary
- The NSX-T API does not return site node connection passwords in its responses. During read operations, the empty password returned from the API overrides the existing password in the schema, causing Terraform to detect drift and prompt for a perpetual update.
- Address this by adding the `suppressIfEmptyPriorState` DiffSuppressFunc to the password field in the connection info schema. This suppresses spurious diffs when the password is empty in the state (such as after an import) while still allowing users to update the password in their configuration.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `golangci-lint run ./nsxt/` (0 issues)

Note: master's source PR added mock-based regression tests, which this branch has no framework for; the production fix is otherwise a direct, unmodified port.