### PR TITLE
Fix project data source nil pointer panic on display name lookup

### DIFF
--- a/nsxt/data_source_nsxt_policy_project.go
+++ b/nsxt/data_source_nsxt_policy_project.go
@@ -98,6 +98,9 @@ func dataSourceNsxtPolicyProjectRead(d *schema.ResourceData, m interface{}) erro
 		var perfectMatch []model.Project
 		var prefixMatch []model.Project
 		for _, objInList := range objList.Results {
+			if objInList.DisplayName == nil {
+				continue
+			}
 			if strings.HasPrefix(*objInList.DisplayName, objName) {
 				prefixMatch = append(prefixMatch, objInList)
 			}


### PR DESCRIPTION
## Summary
- During display name lookups in the `nsxt_policy_project` data source, the provider lists all projects and matches them by display name. If any project in the retrieved list lacks a display name (the `DisplayName` pointer is nil), dereferencing it directly results in a nil pointer dereference panic, causing the provider plugin to crash.
- Address this by checking that the `DisplayName` pointer is not nil before dereferencing.

Scoped down from master's #2176: that PR also added a nil-check for the client object, guarding against a Global Manager code path where `cliProjectsClient` (a context-aware wrapper) returns nil for unsupported client types. This branch's `dataSourceNsxtPolicyProjectRead` uses a direct, always-Local client construction (`infra.NewProjectsClient(connector)`, no context/ClientType dispatch at all), so that scenario can't occur here — only the display-name nil-guard is applicable.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `golangci-lint run ./nsxt/` (0 issues)

Note: master's source PR added mock-based regression tests, which this branch has no framework for; the production fix is otherwise a direct, unmodified port of the applicable hunk.