### PR TITLE
VPC subnet property dns_server_preference should be computed

### DIFF
--- a/nsxt/resource_nsxt_vpc_subnet.go
+++ b/nsxt/resource_nsxt_vpc_subnet.go
@@ -292,6 +292,7 @@ var vpcSubnetSchema = map[string]*metadata.ExtendedSchema{
 						Schema: schema.Schema{
 							Type:         schema.TypeString,
 							ValidateFunc: validation.StringInSlice(dnsServerPreferenceValues, false),
+							Computed:     true,
 							Optional:     true,
 						},
 						Metadata: metadata.Metadata{


### PR DESCRIPTION
## Summary
- NSX assigns a value to this attribute and returns it when the API call doesn't specify it. Therefore this should be computed.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `golangci-lint run ./nsxt/` (0 issues)

Direct, unmodified port — no test files touched in the source PR.