### PR TITLE
cache optimisation 

### DIFF
--- a/nsxt/cache.go
+++ b/nsxt/cache.go
@@ -19,6 +19,12 @@ import (
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 )
 
+// resourceTypeCache holds every populated search bucket for one NSX resource type. The
+// outer data map is keyed by the query string (see getCacheQueryKey) that produced a given
+// bucket — the same resource type can have more than one bucket if it's queried under
+// different tag filters or provider configs. The inner map is that bucket's contents,
+// keyed by whatever CacheKeyForResourceID/data-source id was used to look objects up
+// (see converListToMapByType for how an object ends up under multiple keys).
 type resourceTypeCache struct {
 	mu       sync.RWMutex
 	data     map[string]map[string]*data.StructValue // key: query, key: resource ID
@@ -26,6 +32,10 @@ type resourceTypeCache struct {
 	cacheMis atomic.Int64
 }
 
+// typeScopedCache is the process-wide root: one resourceTypeCache per NSX resource type
+// (see gcache). Its own mutex only protects the byTyp map itself (creating/looking up a
+// type's cache); it is never held while a search runs or a bucket is read, so looking up
+// one resource type never blocks concurrent access to another.
 type typeScopedCache struct {
 	mu    sync.RWMutex
 	byTyp map[string]*resourceTypeCache
@@ -35,11 +45,19 @@ type typeScopedCache struct {
 // queries (resource_type:<value>). Values must match NSX Search's resource_type
 // field exactly, including casing, and must not be changed here.
 const (
-	resourceTypeConnectivityPolicy                             = "ConnectivityPolicy"
-	resourceTypeDhcpV4StaticBindingConfig                      = "DhcpV4StaticBindingConfig"
-	resourceTypeDhcpV6StaticBindingConfig                      = "DhcpV6StaticBindingConfig"
-	resourceTypeGatewayPolicy                                  = "gatewaypolicy"
-	resourceTypeGroup                                          = "Group"
+	resourceTypeConnectivityPolicy        = "ConnectivityPolicy"
+	resourceTypeDhcpV4StaticBindingConfig = "DhcpV4StaticBindingConfig"
+	resourceTypeDhcpV6StaticBindingConfig = "DhcpV6StaticBindingConfig"
+	// resourceTypeGatewayPolicy is shared by the Tier-0/Tier-1 gateway policy resource and the
+	// VPC gateway policy resource: both cache under this one bucket. Same sharing applies to
+	// resourceTypeStaticRoutes and resourceTypeDhcpV4StaticBindingConfig below. Keep these
+	// path-indexed (see shouldIndexByPath) since the VPC-scoped side of each pair can collide
+	// on short id once its cache bucket is project-wide-shared.
+	resourceTypeGatewayPolicy = "gatewaypolicy"
+	resourceTypeGroup         = "Group"
+	// resourceTypeVPCGroup is a distinct NSX Search resource_type ("group", lowercase) from
+	// resourceTypeGroup ("Group") above — VPC-scoped groups and Tier-0/Tier-1-scoped groups are
+	// never in the same bucket, unlike the shared types noted above.
 	resourceTypeVPCGroup                                       = "group"
 	resourceTypeIpAddressAllocation                            = "IpAddressAllocation"
 	resourceTypeIpAddressPool                                  = "IpAddressPool"
@@ -82,12 +100,30 @@ var postWriteByKey sync.Map // string -> struct{}
 // errCacheUseBackendDirect indicates the cache bucket exists but the ID is missing, so use direct GET.
 var errCacheUseBackendDirect = errors.New("nsxt cache: use direct API read")
 
+// cacheLogEvent defers a log message describing bulk-populate work until after the caller
+// releases tc.mu, so exclusive-lock hold time and contention on log's internal mutex don't
+// grow with the number of DEBUG/WARNING lines a populate call produces.
+type cacheLogEvent struct {
+	level string // "DEBUG" or "WARNING"
+	msg   string
+}
+
+func logCacheEvents(events []cacheLogEvent) {
+	for _, e := range events {
+		log.Printf("[%s] %s", e.level, e.msg) //nolint:gosec
+	}
+}
+
 // compositeCacheEntry defines a parent type with an extra child search and merge step.
 type compositeCacheEntry struct {
 	childSearchType string
 	merge           func(parents, children []*data.StructValue) ([]*data.StructValue, error)
 }
 
+// compositeCacheRegistry lists resource types whose NSX Search result doesn't already embed
+// everything the Terraform schema needs: GatewayPolicy/SecurityPolicy objects come back from
+// Search without their Rules, so a second search for the child rule type is required, and the
+// two result sets have to be merged (by parent path) before the combined object can be cached.
 var compositeCacheRegistry = map[string]compositeCacheEntry{
 	resourceTypeGatewayPolicy: {
 		childSearchType: resourceTypeRule,
@@ -220,7 +256,8 @@ func shouldIndexByPath(resourceType string) bool {
 	switch resourceType {
 	case resourceTypePolicyNatRule, resourceTypeSegmentPort, resourceTypeIpAddressPoolStaticSubnet, resourceTypeIpAddressPoolBlockSubnet, resourceTypeService,
 		resourceTypeVpc, resourceTypeVpcAttachment, resourceTypeVpcConnectivityProfile, resourceTypeVpcIpAddressAllocation, resourceTypeVpcServiceProfile,
-		resourceTypeVpcSubnet, resourceTypeTransitGateway, resourceTypeTransitGatewayAttachment, resourceTypeProjectIpAddressAllocation, resourceTypePolicyVpcNatRule:
+		resourceTypeVpcSubnet, resourceTypeTransitGateway, resourceTypeTransitGatewayAttachment, resourceTypeProjectIpAddressAllocation, resourceTypePolicyVpcNatRule,
+		resourceTypeVPCGroup, resourceTypeGatewayPolicy, resourceTypeStaticRoutes, resourceTypeDhcpV4StaticBindingConfig:
 		return true
 	default:
 		return false
@@ -355,20 +392,21 @@ func (c *resourceTypeCache) getQueryResult(query string, resourceID string) (*da
 	return nil, fmt.Errorf("element is not found")
 }
 
-func (c *resourceTypeCache) writeCache(query string, resourceType string, d *schema.ResourceData, m interface{}, connector client.Connector) error {
+func (c *resourceTypeCache) writeCache(query string, resourceType string, d *schema.ResourceData, m interface{}, connector client.Connector) ([]cacheLogEvent, error) {
 	if _, ok := c.data[query]; ok {
-		log.Printf("[DEBUG] Cache skip bulk refill for resourceType=%s query=%q (bucket already present)", resourceType, query) //nolint:gosec
-		return nil
+		return []cacheLogEvent{{"DEBUG", fmt.Sprintf("Cache skip bulk refill for resourceType=%s query=%q (bucket already present)", resourceType, query)}}, nil
 	}
 	runID := m.(nsxtClients).CommonConfig.contextID
-	log.Printf("[DEBUG] Cache miss: populating cache for resourceType=%s query=%q", resourceType, query) //nolint:gosec
-	err := c.getListOfPolicyResources(query, d, m, connector, getEffectiveCacheContext(d, m), resourceType, runID)
-	if err != nil {
-		return err
-	}
-	return nil
+	events := []cacheLogEvent{{"DEBUG", fmt.Sprintf("Cache miss: populating cache for resourceType=%s query=%q", resourceType, query)}}
+	childEvents, err := c.getListOfPolicyResources(query, d, m, connector, getEffectiveCacheContext(d, m), resourceType, runID)
+	events = append(events, childEvents...)
+	return events, err
 }
 
+// getTypeCache returns (creating if needed) the resourceTypeCache for resourceType. Held only
+// long enough to read or insert the map entry, so this never serializes callers working with
+// different resource types, and never blocks on a search/populate happening under the returned
+// resourceTypeCache's own (separate) mutex.
 func (c *typeScopedCache) getTypeCache(resourceType string) *resourceTypeCache {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -390,6 +428,11 @@ func getEffectiveCacheContext(d *schema.ResourceData, m interface{}) utl.Session
 	return getSessionContext(d, m)
 }
 
+// getCacheQueryKey returns the string that selects which bucket in resourceTypeCache.data a
+// resource read hits. Two reads share a bucket (and its search results) only when this key is
+// identical, so anything that should force a distinct search — the resource's own tag filter,
+// the run's context_id, the manager host — is folded in here rather than compared separately
+// after the fact.
 func getCacheQueryKey(resourceType string, d *schema.ResourceData, m interface{}) string {
 	clients := m.(nsxtClients)
 	context := getEffectiveCacheContext(d, m)
@@ -426,57 +469,64 @@ func (c *typeScopedCache) readCache(resourceID string, resourceType string, d *s
 	}
 
 	// Slow path: take exclusive lock to populate the bucket, then double-check.
+	// All logging below is accumulated into populateEvents and flushed by the deferred
+	// logCacheEvents call, which is registered before (and therefore, by defer's LIFO
+	// order, runs after) tc.mu.Unlock — so no log.Printf in this path ever executes while
+	// tc.mu is held, regardless of which return point is taken.
+	var populateEvents []cacheLogEvent
+	defer func() { logCacheEvents(populateEvents) }()
 	tc.mu.Lock()
+	defer tc.mu.Unlock()
 	val, qerr = tc.getQueryResult(query, resourceID)
 	if val != nil {
-		tc.mu.Unlock()
 		hit := tc.cacheHit.Add(1)
-		log.Printf("[DEBUG] Cache hit: resourceType=%s id=%s query=%q (hit=%d miss=%d)", resourceType, resourceID, query, hit, tc.cacheMis.Load()) //nolint:gosec
+		populateEvents = append(populateEvents, cacheLogEvent{"DEBUG", fmt.Sprintf("Cache hit: resourceType=%s id=%s query=%q (hit=%d miss=%d)", resourceType, resourceID, query, hit, tc.cacheMis.Load())})
 		return val, nil
 	}
 	if errors.Is(qerr, errCacheUseBackendDirect) {
-		tc.mu.Unlock()
 		miss := tc.cacheMis.Add(1)
-		log.Printf("[DEBUG] Cache lookup miss: resourceType=%s id=%s query=%q (hit=%d miss=%d)", resourceType, resourceID, query, tc.cacheHit.Load(), miss) //nolint:gosec
+		populateEvents = append(populateEvents, cacheLogEvent{"DEBUG", fmt.Sprintf("Cache lookup miss: resourceType=%s id=%s query=%q (hit=%d miss=%d)", resourceType, resourceID, query, tc.cacheHit.Load(), miss)})
 		return nil, errCacheUseBackendDirect
 	}
 	miss := tc.cacheMis.Add(1)
-	err := tc.writeCache(query, resourceType, d, m, connector)
+	var err error
+	var writeCacheEvents []cacheLogEvent
+	writeCacheEvents, err = tc.writeCache(query, resourceType, d, m, connector)
+	populateEvents = append(populateEvents, writeCacheEvents...)
 	if err != nil {
-		tc.mu.Unlock()
-		log.Printf("[DEBUG] Cache lookup miss: resourceType=%s id=%s query=%q (hit=%d miss=%d)", resourceType, resourceID, query, tc.cacheHit.Load(), miss) //nolint:gosec
+		populateEvents = append(populateEvents, cacheLogEvent{"DEBUG", fmt.Sprintf("Cache lookup miss: resourceType=%s id=%s query=%q (hit=%d miss=%d)", resourceType, resourceID, query, tc.cacheHit.Load(), miss)})
 		return nil, err
 	}
 	val, _ = tc.getQueryResult(query, resourceID)
-	tc.mu.Unlock()
-	log.Printf("[DEBUG] Cache lookup miss: resourceType=%s id=%s query=%q (hit=%d miss=%d)", resourceType, resourceID, query, tc.cacheHit.Load(), miss) //nolint:gosec
+	populateEvents = append(populateEvents, cacheLogEvent{"DEBUG", fmt.Sprintf("Cache lookup miss: resourceType=%s id=%s query=%q (hit=%d miss=%d)", resourceType, resourceID, query, tc.cacheHit.Load(), miss)})
 	if val != nil {
 		return val, nil
 	}
 	return nil, errCacheUseBackendDirect
 }
 
-func (c *resourceTypeCache) getListOfPolicyResources(query string, d *schema.ResourceData, m interface{}, connector client.Connector, context utl.SessionContext, resourceType string, runID string) error {
+func (c *resourceTypeCache) getListOfPolicyResources(query string, d *schema.ResourceData, m interface{}, connector client.Connector, context utl.SessionContext, resourceType string, runID string) ([]cacheLogEvent, error) {
+	var events []cacheLogEvent
 	context = projectScopedSearchContext(context)
 	additionalQuery := buildTagQuery(d, runID, m)
-	log.Printf("[DEBUG] Cache search query: resourceType=%s query=%q additionalQuery=%q", resourceType, query, additionalQuery) //nolint:gosec
+	events = append(events, cacheLogEvent{"DEBUG", fmt.Sprintf("Cache search query: resourceType=%s query=%q additionalQuery=%q", resourceType, query, additionalQuery)})
 	resultList, err := listPolicyResources(connector, context, resourceType, &additionalQuery)
-	log.Printf("[DEBUG] Cache search results: resourceType=%s query=%q additionalQuery=%q results=%d", resourceType, query, additionalQuery, len(resultList)) //nolint:gosec
+	events = append(events, cacheLogEvent{"DEBUG", fmt.Sprintf("Cache search results: resourceType=%s query=%q additionalQuery=%q results=%d", resourceType, query, additionalQuery, len(resultList))})
 	if err != nil && len(resultList) == 0 {
-		return fmt.Errorf("error listing resource %s %w", resourceType, err)
+		return events, fmt.Errorf("error listing resource %s %w", resourceType, err)
 	}
 	if err != nil {
-		log.Printf("[WARNING] Partial search results for resourceType=%s query=%q: %d parent results before error: %v", resourceType, query, len(resultList), err) //nolint:gosec
+		events = append(events, cacheLogEvent{"WARNING", fmt.Sprintf("Partial search results for resourceType=%s query=%q: %d parent results before error: %v", resourceType, query, len(resultList), err)})
 	}
 
 	entry, composite := compositeCacheRegistry[resourceType]
 	if !composite {
 		tmp := converListToMapByType(resultList, resourceType)
 		if tmp == nil {
-			return fmt.Errorf("error converting resources to cache map for resource type %s", resourceType)
+			return events, fmt.Errorf("error converting resources to cache map for resource type %s", resourceType)
 		}
 		c.data[query] = tmp
-		return nil
+		return events, nil
 	}
 
 	// Child rules may be untagged, so try provider-managed tags first and then fall back to no tag filter.
@@ -488,31 +538,31 @@ func (c *resourceTypeCache) getListOfPolicyResources(query string, d *schema.Res
 	}
 	childList, childErr := listPolicyResources(connector, context, entry.childSearchType, childAdditional)
 	if childErr != nil && len(childList) == 0 {
-		return fmt.Errorf("error listing composite child resource %s for parent %s: %w", entry.childSearchType, resourceType, childErr)
+		return events, fmt.Errorf("error listing composite child resource %s for parent %s: %w", entry.childSearchType, resourceType, childErr)
 	}
 	if childErr != nil {
-		log.Printf("[WARNING] Partial child search for resourceType=%s childType=%s query=%q: %d results before error: %v", resourceType, entry.childSearchType, query, len(childList), childErr) //nolint:gosec
+		events = append(events, cacheLogEvent{"WARNING", fmt.Sprintf("Partial child search for resourceType=%s childType=%s query=%q: %d results before error: %v", resourceType, entry.childSearchType, query, len(childList), childErr)})
 	}
 	if childAdditional != nil && len(resultList) > 0 && len(childList) == 0 {
 		childList, childErr = listPolicyResources(connector, context, entry.childSearchType, nil)
 		if childErr != nil && len(childList) == 0 {
-			return fmt.Errorf("error listing composite child resource %s for parent %s: %w", entry.childSearchType, resourceType, childErr)
+			return events, fmt.Errorf("error listing composite child resource %s for parent %s: %w", entry.childSearchType, resourceType, childErr)
 		}
 		if childErr != nil {
-			log.Printf("[WARNING] Partial child search (fallback) for resourceType=%s childType=%s query=%q: %d results before error: %v", resourceType, entry.childSearchType, query, len(childList), childErr) //nolint:gosec
+			events = append(events, cacheLogEvent{"WARNING", fmt.Sprintf("Partial child search (fallback) for resourceType=%s childType=%s query=%q: %d results before error: %v", resourceType, entry.childSearchType, query, len(childList), childErr)})
 		}
 	}
 
 	mergedSVs, err := entry.merge(resultList, childList)
 	if err != nil {
-		return err
+		return events, err
 	}
 	tmp := converListToMapByType(mergedSVs, resourceType)
 	if tmp == nil {
-		return fmt.Errorf("error converting merged resources to cache map for resource type %s", resourceType)
+		return events, fmt.Errorf("error converting merged resources to cache map for resource type %s", resourceType)
 	}
 	c.data[query] = tmp
-	return nil
+	return events, nil
 }
 
 // convertCachedValue converts a raw cache value to the typed model, strips provider-managed tags,
@@ -571,6 +621,13 @@ func reflectStringField(obj interface{}, fieldName string) *string {
 // through to the regular (uncached) read path in all of those cases.
 func cacheAwareDataSourceReadByID[T any](d *schema.ResourceData, m interface{}, connector client.Connector, objID string, resourceType string, bindingType bindings.BindingType) (*T, bool) {
 	if objID == "" || !IsCacheEnabled(m) {
+		return nil, false
+	}
+	if shouldIndexByPath(resourceType) && !strings.Contains(objID, "/") {
+		// The cache bucket for this type is populated/keyed by path (see shouldIndexByPath),
+		// but objID here is a short user-supplied id, which is only unique within its own
+		// VPC/project, not across the shared project-wide bucket. Fall through to a live,
+		// correctly-scoped read instead of risking a cross-VPC id collision.
 		return nil, false
 	}
 	if _, ok := postWriteByKey.LoadAndDelete(postWriteKey(resourceType, objID)); ok {
@@ -760,6 +817,14 @@ func mergeSecurityPolicyCacheSearchResults(parents, children []*data.StructValue
 	return modelsToStructValues(merged, model.SecurityPolicyBindingType())
 }
 
+// CacheAwareResourceRead is the standard read path for a policy resource's Read function: try
+// the shared search-backed cache first, and fall back to backendRead (a direct GET) on a cache
+// miss, a conversion failure, cache being disabled, or the resource having just been written by
+// this run (postWriteBypass — avoids reading a search snapshot that predates the write). resourceID
+// must be the same key used by the corresponding MarkPostWriteAndInvalidateCacheForResourceType
+// call for this resource (use CacheKeyForResourceID to guarantee that for path-indexed types).
+// Returns (object, cacheUsed, cacheAttempted, error): callers generally only need the object and
+// error; cacheUsed/cacheAttempted exist for tests and diagnostics.
 func CacheAwareResourceRead[T any](d *schema.ResourceData, m interface{}, connector client.Connector, resourceID string, resourceType string, bindingType bindings.BindingType, backendRead func() (*T, error), patchFunc func(obj *T) error) (*T, bool, bool, error) {
 	cacheAttempted := false
 	postWriteBypass := false

--- a/nsxt/cache.go
+++ b/nsxt/cache.go
@@ -111,6 +111,12 @@ const (
 
 var invalidNSXTCacheModeWarn sync.Map // raw env value -> struct{}; log once per distinct invalid value
 
+// sharedTypeConverter is reused across all cache conversions: bindings.TypeConverter is a
+// stateless, field-less struct (all conversion state lives in per-call visitors), so a single
+// instance is safe to share across goroutines and avoids an allocation on every cached
+// object read/write at 100+ resource scale.
+var sharedTypeConverter = bindings.NewTypeConverter()
+
 func postWriteKey(resourceType, resourceID string) string {
 	return resourceType + "::" + resourceID
 }
@@ -203,9 +209,18 @@ func CacheKeyForResourceID(resourceType string, d *schema.ResourceData) string {
 	return d.Id()
 }
 
+// VPC-scoped resource types are path-indexed because their short NSX id (often
+// user-chosen via nsx_id) is only guaranteed unique within its own VPC, not project-wide,
+// while the cache populate search/bucket for utl.VPC/utl.Multitenancy contexts is now
+// shared across all VPCs in a project (see projectScopedSearchContext). Path is unique
+// project/system-wide, so keying by path avoids one VPC's resource shadowing another's.
+// Known gap: data source cache reads (cacheAwareDataSourceReadByID) key off a short
+// user-supplied id with no path available, so they remain exposed to this collision.
 func shouldIndexByPath(resourceType string) bool {
 	switch resourceType {
-	case resourceTypePolicyNatRule, resourceTypeSegmentPort, resourceTypeIpAddressPoolStaticSubnet, resourceTypeIpAddressPoolBlockSubnet, resourceTypeService:
+	case resourceTypePolicyNatRule, resourceTypeSegmentPort, resourceTypeIpAddressPoolStaticSubnet, resourceTypeIpAddressPoolBlockSubnet, resourceTypeService,
+		resourceTypeVpc, resourceTypeVpcAttachment, resourceTypeVpcConnectivityProfile, resourceTypeVpcIpAddressAllocation, resourceTypeVpcServiceProfile,
+		resourceTypeVpcSubnet, resourceTypeTransitGateway, resourceTypeTransitGatewayAttachment, resourceTypeProjectIpAddressAllocation, resourceTypePolicyVpcNatRule:
 		return true
 	default:
 		return false
@@ -246,17 +261,17 @@ func getStructValueStringField(obj *data.StructValue, field string) (string, boo
 }
 
 func converListToMapByType(list []*data.StructValue, resourceType string) map[string]*data.StructValue {
-	converter := bindings.NewTypeConverter()
 	ret := make(map[string]*data.StructValue)
 	for _, obj := range list {
-		dataValue, errors := converter.ConvertToGolang(obj, model.PolicyConfigResourceBindingType())
+		dataValue, errors := sharedTypeConverter.ConvertToGolang(obj, model.PolicyConfigResourceBindingType())
 		if len(errors) > 0 {
 			return nil
 		}
 		resource := dataValue.(model.PolicyConfigResource)
 
 		// Primary indexing via PolicyConfigResource conversion.
-		if resource.Id != nil {
+		idIndexed := resource.Id != nil
+		if idIndexed {
 			id := *resource.Id
 			indexCacheMapKey(ret, id, obj)
 			// Index both raw and extracted policy IDs when Search returns a full path.
@@ -264,24 +279,32 @@ func converListToMapByType(list []*data.StructValue, resourceType string) map[st
 				indexCacheMapKey(ret, getPolicyIDFromPath(id), obj)
 			}
 		}
-		if resource.DisplayName != nil {
+		displayNameIndexed := resource.DisplayName != nil
+		if displayNameIndexed {
 			indexCacheMapKey(ret, *resource.DisplayName, obj)
 		}
-		if shouldIndexByPath(resourceType) && resource.Path != nil {
+		indexByPath := shouldIndexByPath(resourceType)
+		pathIndexed := indexByPath && resource.Path != nil
+		if pathIndexed {
 			indexCacheMapKey(ret, *resource.Path, obj)
 		}
 
-		// Also index from raw StructValue fields to cover cases where SDK conversion loses fields.
-		if id, ok := getStructValueStringField(obj, "id"); ok {
-			indexCacheMapKey(ret, id, obj)
-			if strings.Contains(id, "/") {
-				indexCacheMapKey(ret, getPolicyIDFromPath(id), obj)
+		// Fall back to raw StructValue fields only when the typed conversion above didn't
+		// already index that field, to cover cases where SDK conversion loses fields.
+		if !idIndexed {
+			if id, ok := getStructValueStringField(obj, "id"); ok {
+				indexCacheMapKey(ret, id, obj)
+				if strings.Contains(id, "/") {
+					indexCacheMapKey(ret, getPolicyIDFromPath(id), obj)
+				}
 			}
 		}
-		if dn, ok := getStructValueStringField(obj, "display_name"); ok {
-			indexCacheMapKey(ret, dn, obj)
+		if !displayNameIndexed {
+			if dn, ok := getStructValueStringField(obj, "display_name"); ok {
+				indexCacheMapKey(ret, dn, obj)
+			}
 		}
-		if shouldIndexByPath(resourceType) {
+		if indexByPath && !pathIndexed {
 			if p, ok := getStructValueStringField(obj, "path"); ok {
 				indexCacheMapKey(ret, p, obj)
 			}
@@ -297,25 +320,35 @@ func getQueryString(resourceType string, context utl.SessionContext) string {
 	case utl.Local:
 		return fmt.Sprintf("resource_type:%s AND marked_for_delete:false AND context:Local", resourceType)
 	case utl.VPC, utl.Multitenancy:
-		return fmt.Sprintf("resource_type:%s AND marked_for_delete:false AND context:%s-%s", resourceType, context.ProjectID, context.VPCID)
+		// Scoped to the project only (VPCID intentionally omitted): NSX policy paths/IDs are
+		// unique across VPCs within a project, and searchMultitenancyResources already searches
+		// the whole project in one call when VPCID is empty. Narrowing the cache bucket to a
+		// single VPC here caused a fresh bucket (and full search) per VPC, which regressed cache
+		// mode below no-cache performance when a run touches many VPCs (e.g. 100 VpcAttachments
+		// across 100 VPCs).
+		return fmt.Sprintf("resource_type:%s AND marked_for_delete:false AND context:%s", resourceType, context.ProjectID)
 	default:
 		return fmt.Sprintf("resource_type:%s AND marked_for_delete:false", resourceType)
 	}
 }
 
+// projectScopedSearchContext strips VPCID from a VPC/Multitenancy context so the cache
+// populate search covers the whole project in one call instead of one call per VPC. Only
+// the search/query scope is widened; the resource lookup within the populated bucket still
+// keys by resourceID, which remains unique within the project.
+func projectScopedSearchContext(context utl.SessionContext) utl.SessionContext {
+	if context.ClientType == utl.VPC || context.ClientType == utl.Multitenancy {
+		context.VPCID = ""
+	}
+	return context
+}
+
 func (c *resourceTypeCache) getQueryResult(query string, resourceID string) (*data.StructValue, error) {
 	if inner, ok := c.data[query]; ok {
+		// converListToMapByType indexes every object under its raw "id" field (in addition to
+		// the typed id) at populate time, so a miss here means no O(n) scan can find it either.
 		if v := inner[resourceID]; v != nil {
 			return v, nil
-		}
-		// As a safety net, scan the bucket for a matching raw "id" field.
-		for _, v := range inner {
-			if v == nil {
-				continue
-			}
-			if id, ok := getStructValueStringField(v, "id"); ok && id == resourceID {
-				return v, nil
-			}
 		}
 		return nil, errCacheUseBackendDirect
 	}
@@ -380,41 +413,43 @@ func (c *typeScopedCache) readCache(resourceID string, resourceType string, d *s
 	// Fast path: read lock allows concurrent hits without blocking each other.
 	tc.mu.RLock()
 	val, qerr := tc.getQueryResult(query, resourceID)
+	tc.mu.RUnlock()
 	if val != nil {
 		hit := tc.cacheHit.Add(1)
 		log.Printf("[DEBUG] Cache hit: resourceType=%s id=%s query=%q (hit=%d miss=%d)", resourceType, resourceID, query, hit, tc.cacheMis.Load()) //nolint:gosec
-		tc.mu.RUnlock()
 		return val, nil
 	}
 	if errors.Is(qerr, errCacheUseBackendDirect) {
 		miss := tc.cacheMis.Add(1)
 		log.Printf("[DEBUG] Cache lookup miss: resourceType=%s id=%s query=%q (hit=%d miss=%d)", resourceType, resourceID, query, tc.cacheHit.Load(), miss) //nolint:gosec
-		tc.mu.RUnlock()
 		return nil, errCacheUseBackendDirect
 	}
-	tc.mu.RUnlock()
 
 	// Slow path: take exclusive lock to populate the bucket, then double-check.
 	tc.mu.Lock()
-	defer tc.mu.Unlock()
 	val, qerr = tc.getQueryResult(query, resourceID)
 	if val != nil {
+		tc.mu.Unlock()
 		hit := tc.cacheHit.Add(1)
 		log.Printf("[DEBUG] Cache hit: resourceType=%s id=%s query=%q (hit=%d miss=%d)", resourceType, resourceID, query, hit, tc.cacheMis.Load()) //nolint:gosec
 		return val, nil
 	}
 	if errors.Is(qerr, errCacheUseBackendDirect) {
+		tc.mu.Unlock()
 		miss := tc.cacheMis.Add(1)
 		log.Printf("[DEBUG] Cache lookup miss: resourceType=%s id=%s query=%q (hit=%d miss=%d)", resourceType, resourceID, query, tc.cacheHit.Load(), miss) //nolint:gosec
 		return nil, errCacheUseBackendDirect
 	}
 	miss := tc.cacheMis.Add(1)
-	log.Printf("[DEBUG] Cache lookup miss: resourceType=%s id=%s query=%q (hit=%d miss=%d)", resourceType, resourceID, query, tc.cacheHit.Load(), miss) //nolint:gosec
 	err := tc.writeCache(query, resourceType, d, m, connector)
 	if err != nil {
+		tc.mu.Unlock()
+		log.Printf("[DEBUG] Cache lookup miss: resourceType=%s id=%s query=%q (hit=%d miss=%d)", resourceType, resourceID, query, tc.cacheHit.Load(), miss) //nolint:gosec
 		return nil, err
 	}
 	val, _ = tc.getQueryResult(query, resourceID)
+	tc.mu.Unlock()
+	log.Printf("[DEBUG] Cache lookup miss: resourceType=%s id=%s query=%q (hit=%d miss=%d)", resourceType, resourceID, query, tc.cacheHit.Load(), miss) //nolint:gosec
 	if val != nil {
 		return val, nil
 	}
@@ -422,6 +457,7 @@ func (c *typeScopedCache) readCache(resourceID string, resourceType string, d *s
 }
 
 func (c *resourceTypeCache) getListOfPolicyResources(query string, d *schema.ResourceData, m interface{}, connector client.Connector, context utl.SessionContext, resourceType string, runID string) error {
+	context = projectScopedSearchContext(context)
 	additionalQuery := buildTagQuery(d, runID, m)
 	log.Printf("[DEBUG] Cache search query: resourceType=%s query=%q additionalQuery=%q", resourceType, query, additionalQuery) //nolint:gosec
 	resultList, err := listPolicyResources(connector, context, resourceType, &additionalQuery)
@@ -486,8 +522,7 @@ func convertCachedValue[T any](val interface{}, resourceType, resourceID string,
 	if !ok {
 		return nil, false
 	}
-	converter := bindings.NewTypeConverter()
-	goVal, convErrs := converter.ConvertToGolang(sv, bindingType)
+	goVal, convErrs := sharedTypeConverter.ConvertToGolang(sv, bindingType)
 	if len(convErrs) > 0 {
 		log.Printf("[WARNING] Cache: conversion failed for resourceType=%s id=%s (%v); discarding cached value", resourceType, resourceID, convErrs[0]) //nolint:gosec
 		return nil, false
@@ -586,10 +621,9 @@ func TryCacheRead[T any](d *schema.ResourceData, m interface{}, connector client
 }
 
 func structValuesToModels[T any](list []*data.StructValue, bt bindings.BindingType) ([]T, error) {
-	converter := bindings.NewTypeConverter()
 	out := make([]T, 0, len(list))
 	for _, obj := range list {
-		dataValue, errors := converter.ConvertToGolang(obj, bt)
+		dataValue, errors := sharedTypeConverter.ConvertToGolang(obj, bt)
 		if len(errors) > 0 {
 			var zero T
 			return nil, fmt.Errorf("converting %T for cache: %w", zero, errors[0])
@@ -604,10 +638,9 @@ func structValuesToModels[T any](list []*data.StructValue, bt bindings.BindingTy
 }
 
 func modelsToStructValues[T any](models []T, bt bindings.BindingType) ([]*data.StructValue, error) {
-	converter := bindings.NewTypeConverter()
 	out := make([]*data.StructValue, 0, len(models))
 	for i := range models {
-		dataValue, errors := converter.ConvertToVapi(models[i], bt)
+		dataValue, errors := sharedTypeConverter.ConvertToVapi(models[i], bt)
 		if len(errors) > 0 {
 			var zero T
 			return nil, fmt.Errorf("converting %T to struct value: %w", zero, errors[0])
@@ -622,10 +655,9 @@ func modelsToStructValues[T any](models []T, bt bindings.BindingType) ([]*data.S
 }
 
 func structValuesToRules(list []*data.StructValue) []model.Rule {
-	converter := bindings.NewTypeConverter()
 	out := make([]model.Rule, 0, len(list))
 	for _, obj := range list {
-		dataValue, errors := converter.ConvertToGolang(obj, model.RuleBindingType())
+		dataValue, errors := sharedTypeConverter.ConvertToGolang(obj, model.RuleBindingType())
 		if len(errors) > 0 {
 			continue
 		}

--- a/nsxt/cache.go
+++ b/nsxt/cache.go
@@ -661,7 +661,10 @@ func cacheAwareDataSourceReadByID[T any](d *schema.ResourceData, m interface{}, 
 func TryCacheRead[T any](d *schema.ResourceData, m interface{}, connector client.Connector, resourceID string, resourceType string, bindingType bindings.BindingType) (*T, bool, bool, error) {
 	cacheUsed := false
 	cacheAttempted := false
-	if isRefreshPhase(d) && IsCacheEnabled(m) {
+	// See the matching comment in CacheAwareResourceRead: skip the cache attempt entirely when
+	// resourceID is a short id for a path-indexed type, since the shared bucket is keyed by path.
+	shortIDBypass := shouldIndexByPath(resourceType) && !strings.Contains(resourceID, "/")
+	if isRefreshPhase(d) && IsCacheEnabled(m) && !shortIDBypass {
 		if _, ok := postWriteByKey.LoadAndDelete(postWriteKey(resourceType, resourceID)); ok {
 			// Bypass cache after a write for this resource instance (one-shot).
 			return nil, cacheUsed, true, nil
@@ -828,8 +831,16 @@ func mergeSecurityPolicyCacheSearchResults(parents, children []*data.StructValue
 func CacheAwareResourceRead[T any](d *schema.ResourceData, m interface{}, connector client.Connector, resourceID string, resourceType string, bindingType bindings.BindingType, backendRead func() (*T, error), patchFunc func(obj *T) error) (*T, bool, bool, error) {
 	cacheAttempted := false
 	postWriteBypass := false
+	// shortIDBypass is true when resourceID is a short id (not yet the path CacheKeyForResourceID
+	// would prefer) for a path-indexed type: path isn't set on d during Create-then-Read (it's
+	// only populated by this same Read once it has the live object), and importers set only the
+	// id via d.SetId without setting path. The shared bucket for this type is keyed by path; a
+	// short-id lookup here would hit whichever object converListToMapByType indexed first under
+	// that colliding short id, which may belong to a different VPC. Skip the cache attempt
+	// entirely — backendRead is always correctly scoped by the caller's own session context.
+	shortIDBypass := shouldIndexByPath(resourceType) && !strings.Contains(resourceID, "/")
 
-	if isRefreshPhase(d) && IsCacheEnabled(m) {
+	if isRefreshPhase(d) && IsCacheEnabled(m) && !shortIDBypass {
 		if _, ok := postWriteByKey.LoadAndDelete(postWriteKey(resourceType, resourceID)); ok {
 			// Ensure read-your-writes semantics: bypass cache once right after a write.
 			// Search-backed cache may be briefly stale immediately after a write.

--- a/nsxt/cache_test.go
+++ b/nsxt/cache_test.go
@@ -567,3 +567,113 @@ func TestCacheAwareDataSourceReadByIDBypassesCacheForShortIDOnPathIndexedTypes(t
 		}
 	})
 }
+
+func TestCacheAwareResourceReadBypassesCacheForShortIDOnPathIndexedTypes(t *testing.T) {
+	// CacheAwareResourceRead's resourceID is a short id (not yet path) during the Create-then-Read
+	// sequence (path isn't set on d until the Read populates it from the live object) and after
+	// terraform import (importers call d.SetId(shortID) without setting path). Without this bypass,
+	// such a call falls through to gcache.readCache keyed by the short id against the shared
+	// project-wide bucket, which can return a different VPC's same-short-id object.
+	rSchema := map[string]*schema.Schema{
+		"path": getPathSchema(),
+	}
+	m := nsxtClients{CommonConfig: commonProviderConfig{CacheMode: "config_scope"}}
+
+	t.Run("short-id-on-path-indexed-type-bypasses-cache-and-calls-backendRead", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, rSchema, map[string]interface{}{})
+		d.SetId("subnet1")
+		backendReadCalled := false
+		obj, cacheUsed, cacheAttempted, err := CacheAwareResourceRead[model.VpcSubnet](
+			d, m, nil, "subnet1", resourceTypeVpcSubnet, model.VpcSubnetBindingType(),
+			func() (*model.VpcSubnet, error) {
+				backendReadCalled = true
+				return &model.VpcSubnet{Id: strPtr("subnet1")}, nil
+			},
+			func(*model.VpcSubnet) error { return nil },
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !backendReadCalled {
+			t.Fatal("expected backendRead to be called when bypassing cache for a short id on a path-indexed type")
+		}
+		if cacheUsed {
+			t.Fatal("expected cacheUsed=false when bypassing cache")
+		}
+		if cacheAttempted {
+			t.Fatal("expected cacheAttempted=false: the short-id bypass should skip the cache attempt entirely, not count as a failed attempt")
+		}
+		if obj == nil || obj.Id == nil || *obj.Id != "subnet1" {
+			t.Fatalf("expected backendRead's object to be returned, got %+v", obj)
+		}
+	})
+
+	t.Run("full-path-on-path-indexed-type-not-bypassed-by-this-check", func(t *testing.T) {
+		path := "/orgs/o/projects/p/vpcs/vpcA/subnets/subnet1"
+		d := schema.TestResourceDataRaw(t, rSchema, map[string]interface{}{"path": path})
+		d.SetId(path)
+		if _, ok := postWriteByKey.LoadAndDelete(postWriteKey(resourceTypeVpcSubnet, path)); ok {
+			t.Fatal("test setup: unexpected post-write marker present")
+		}
+		postWriteByKey.Store(postWriteKey(resourceTypeVpcSubnet, path), struct{}{})
+		_, cacheUsed, cacheAttempted, err := CacheAwareResourceRead[model.VpcSubnet](
+			d, m, nil, path, resourceTypeVpcSubnet, model.VpcSubnetBindingType(),
+			func() (*model.VpcSubnet, error) { return &model.VpcSubnet{Id: strPtr("subnet1")}, nil },
+			func(*model.VpcSubnet) error { return nil },
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cacheUsed {
+			t.Fatal("expected cacheUsed=false (post-write bypass path, not a cache hit)")
+		}
+		if !cacheAttempted {
+			t.Fatal("expected cacheAttempted=true, proving control reached the postWriteByKey check rather than the short-id bypass")
+		}
+	})
+}
+
+func TestTryCacheReadBypassesCacheForShortIDOnPathIndexedTypes(t *testing.T) {
+	rSchema := map[string]*schema.Schema{
+		"path": getPathSchema(),
+	}
+	m := nsxtClients{CommonConfig: commonProviderConfig{CacheMode: "config_scope"}}
+
+	t.Run("short-id-on-path-indexed-type-bypasses-cache", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, rSchema, map[string]interface{}{})
+		d.SetId("subnet1")
+		obj, cacheUsed, cacheAttempted, err := TryCacheRead[model.VpcSubnet](d, m, nil, "subnet1", resourceTypeVpcSubnet, model.VpcSubnetBindingType())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if obj != nil {
+			t.Fatalf("expected nil object on bypass, got %+v", obj)
+		}
+		if cacheUsed {
+			t.Fatal("expected cacheUsed=false when bypassing cache")
+		}
+		if cacheAttempted {
+			t.Fatal("expected cacheAttempted=false: the short-id bypass should skip the cache attempt entirely")
+		}
+	})
+
+	t.Run("full-path-on-path-indexed-type-not-bypassed-by-this-check", func(t *testing.T) {
+		path := "/orgs/o/projects/p/vpcs/vpcA/subnets/subnet1"
+		d := schema.TestResourceDataRaw(t, rSchema, map[string]interface{}{"path": path})
+		d.SetId(path)
+		if _, ok := postWriteByKey.LoadAndDelete(postWriteKey(resourceTypeVpcSubnet, path)); ok {
+			t.Fatal("test setup: unexpected post-write marker present")
+		}
+		postWriteByKey.Store(postWriteKey(resourceTypeVpcSubnet, path), struct{}{})
+		_, cacheUsed, cacheAttempted, err := TryCacheRead[model.VpcSubnet](d, m, nil, path, resourceTypeVpcSubnet, model.VpcSubnetBindingType())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cacheUsed {
+			t.Fatal("expected cacheUsed=false (post-write bypass path, not a cache hit)")
+		}
+		if !cacheAttempted {
+			t.Fatal("expected cacheAttempted=true, proving control reached the postWriteByKey check rather than the short-id bypass")
+		}
+	})
+}

--- a/nsxt/cache_test.go
+++ b/nsxt/cache_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 )
 
@@ -388,6 +389,93 @@ func TestAttachRulesByParentPathGatewayPolicy(t *testing.T) {
 			t.Fatalf("expected no policies, got %d", len(got))
 		}
 	})
+}
+
+func TestGetQueryStringVPCScopedToProjectNotVPC(t *testing.T) {
+	// VPCID must be omitted from the cache bucket key: NSX policy paths/IDs are unique
+	// within a project across all VPCs, and narrowing the key (and the underlying search)
+	// to a single VPC caused a fresh cache bucket per VPC, regressing cache mode below
+	// no-cache performance for VPC-scoped resource types touching many VPCs.
+	for _, clientType := range []utl.ClientType{utl.VPC, utl.Multitenancy} {
+		context := utl.SessionContext{ClientType: clientType, ProjectID: "proj-1", VPCID: "vpc-1"}
+		got := getQueryString(resourceTypeVpcAttachment, context)
+		if strings.Contains(got, "vpc-1") {
+			t.Fatalf("clientType=%v: query %q must not be scoped to a specific VPCID", clientType, got)
+		}
+		if !strings.Contains(got, "proj-1") {
+			t.Fatalf("clientType=%v: query %q must still be scoped to the project", got, got)
+		}
+
+		otherVPC := context
+		otherVPC.VPCID = "vpc-2"
+		if got2 := getQueryString(resourceTypeVpcAttachment, otherVPC); got2 != got {
+			t.Fatalf("clientType=%v: query must be identical across VPCs in the same project so the cache bucket is shared; got %q vs %q", clientType, got, got2)
+		}
+	}
+}
+
+func TestProjectScopedSearchContextStripsVPCID(t *testing.T) {
+	for _, clientType := range []utl.ClientType{utl.VPC, utl.Multitenancy} {
+		in := utl.SessionContext{ClientType: clientType, ProjectID: "proj-1", VPCID: "vpc-1"}
+		out := projectScopedSearchContext(in)
+		if out.VPCID != "" {
+			t.Fatalf("clientType=%v: expected VPCID stripped, got %q", clientType, out.VPCID)
+		}
+		if out.ProjectID != "proj-1" {
+			t.Fatalf("clientType=%v: ProjectID must be preserved, got %q", clientType, out.ProjectID)
+		}
+	}
+
+	// Non-VPC-scoped contexts must be returned unchanged.
+	local := utl.SessionContext{ClientType: utl.Local, ProjectID: "", VPCID: ""}
+	if got := projectScopedSearchContext(local); got != local {
+		t.Fatalf("Local context should be unchanged, got %+v", got)
+	}
+}
+
+func TestShouldIndexByPathForVPCScopedTypes(t *testing.T) {
+	// VPC-scoped types must key by path, not short id: NSX ids for these types (often
+	// user-chosen via nsx_id) are only guaranteed unique within their own VPC, but the cache
+	// populate search/bucket for these types is now shared across all VPCs in a project.
+	vpcScopedTypes := []string{
+		resourceTypeVpc, resourceTypeVpcAttachment, resourceTypeVpcConnectivityProfile,
+		resourceTypeVpcIpAddressAllocation, resourceTypeVpcServiceProfile, resourceTypeVpcSubnet,
+		resourceTypeTransitGateway, resourceTypeTransitGatewayAttachment,
+		resourceTypeProjectIpAddressAllocation, resourceTypePolicyVpcNatRule,
+	}
+	for _, rt := range vpcScopedTypes {
+		if !shouldIndexByPath(rt) {
+			t.Errorf("shouldIndexByPath(%q) = false, want true", rt)
+		}
+	}
+}
+
+func TestConverListToMapByTypeVpcScopedResourcesIndexedByPath(t *testing.T) {
+	// Two different VPCs in the same project can legitimately have a VpcSubnet with the same
+	// user-chosen short id (getOrGenerateID2 only checks uniqueness within the current VPC).
+	// Since the cache bucket for VPC-scoped types is now shared project-wide, both objects
+	// land in the same map; this test confirms each remains independently retrievable via its
+	// distinct (project/system-unique) path, even though they share a colliding short id.
+	pathA := "/orgs/o/projects/p/vpcs/vpcA/subnets/subnet1"
+	pathB := "/orgs/o/projects/p/vpcs/vpcB/subnets/subnet1"
+	subnetA := model.VpcSubnet{Id: strPtr("subnet1"), DisplayName: strPtr("subnet1-a"), Path: strPtr(pathA)}
+	subnetB := model.VpcSubnet{Id: strPtr("subnet1"), DisplayName: strPtr("subnet1-b"), Path: strPtr(pathB)}
+
+	svs, err := modelsToStructValues([]model.VpcSubnet{subnetA, subnetB}, model.VpcSubnetBindingType())
+	if err != nil {
+		t.Fatalf("modelsToStructValues: %v", err)
+	}
+
+	got := converListToMapByType(svs, resourceTypeVpcSubnet)
+	if got == nil {
+		t.Fatal("converListToMapByType returned nil")
+	}
+	if got[pathA] == nil {
+		t.Errorf("VPC A's subnet not retrievable by its path %q", pathA)
+	}
+	if got[pathB] == nil {
+		t.Errorf("VPC B's subnet not retrievable by its path %q", pathB)
+	}
 }
 
 func TestErrCacheUseBackendDirect(t *testing.T) {

--- a/nsxt/cache_test.go
+++ b/nsxt/cache_test.go
@@ -442,6 +442,12 @@ func TestShouldIndexByPathForVPCScopedTypes(t *testing.T) {
 		resourceTypeVpcIpAddressAllocation, resourceTypeVpcServiceProfile, resourceTypeVpcSubnet,
 		resourceTypeTransitGateway, resourceTypeTransitGatewayAttachment,
 		resourceTypeProjectIpAddressAllocation, resourceTypePolicyVpcNatRule,
+		// Also reachable via CacheAwareResourceRead under a VPC-scoped SessionContext
+		// (resource_nsxt_vpc_group.go, resource_nsxt_vpc_gateway_policy.go,
+		// resource_nsxt_vpc_static_routes.go, resource_nsxt_vpc_dhcp_v4_static_binding_config.go),
+		// so they need the same path-indexing safety even though some are shared with
+		// non-VPC-scoped sibling resources (GatewayPolicy, StaticRoutes, DhcpV4StaticBindingConfig).
+		resourceTypeVPCGroup, resourceTypeGatewayPolicy, resourceTypeStaticRoutes, resourceTypeDhcpV4StaticBindingConfig,
 	}
 	for _, rt := range vpcScopedTypes {
 		if !shouldIndexByPath(rt) {
@@ -522,6 +528,42 @@ func TestReflectStringField(t *testing.T) {
 	t.Run("nil-obj-returns-nil", func(t *testing.T) {
 		if got := reflectStringField(nil, "DisplayName"); got != nil {
 			t.Fatalf("expected nil, got %v", got)
+		}
+	})
+}
+
+func TestCacheAwareDataSourceReadByIDBypassesCacheForShortIDOnPathIndexedTypes(t *testing.T) {
+	dsSchema := map[string]*schema.Schema{
+		"id":           getDataSourceIDSchema(),
+		"display_name": getDataSourceExtendedDisplayNameSchema(),
+		"description":  getDataSourceDescriptionSchema(),
+		"path":         getPathSchema(),
+	}
+	m := nsxtClients{CommonConfig: commonProviderConfig{CacheMode: "config_scope"}}
+
+	t.Run("short-id-on-path-indexed-type-bypasses-cache", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, dsSchema, map[string]interface{}{"id": "subnet1"})
+		_, ok := cacheAwareDataSourceReadByID[model.VpcSubnet](d, m, nil, "subnet1", resourceTypeVpcSubnet, model.VpcSubnetBindingType())
+		if ok {
+			t.Fatal("expected cache bypass (ok=false) for a short id on a path-indexed resource type")
+		}
+		if d.Id() != "" {
+			t.Fatalf("expected d.Id() to be untouched on bypass, got %q", d.Id())
+		}
+	})
+
+	t.Run("full-path-on-path-indexed-type-not-bypassed-by-this-check", func(t *testing.T) {
+		// A full path contains "/", so the new short-id bypass must not trigger; this proves
+		// the check is specific to short (non-path) ids, not to shouldIndexByPath types broadly.
+		path := "/orgs/o/projects/p/vpcs/vpcA/subnets/subnet1"
+		d := schema.TestResourceDataRaw(t, dsSchema, map[string]interface{}{"id": path})
+		if _, ok := postWriteByKey.LoadAndDelete(postWriteKey(resourceTypeVpcSubnet, path)); ok {
+			t.Fatal("test setup: unexpected post-write marker present")
+		}
+		postWriteByKey.Store(postWriteKey(resourceTypeVpcSubnet, path), struct{}{})
+		_, ok := cacheAwareDataSourceReadByID[model.VpcSubnet](d, m, nil, path, resourceTypeVpcSubnet, model.VpcSubnetBindingType())
+		if ok {
+			t.Fatal("expected ok=false (post-write bypass), proving control reached the postWriteByKey check rather than the short-id bypass")
 		}
 	})
 }

--- a/nsxt/resource_nsxt_policy_dhcp_v4_static_binding.go
+++ b/nsxt/resource_nsxt_policy_dhcp_v4_static_binding.go
@@ -265,7 +265,7 @@ func resourceNsxtPolicyDhcpV4StaticBindingCreate(d *schema.ResourceData, m inter
 
 	d.SetId(id)
 	d.Set("nsx_id", id)
-	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeDhcpV4StaticBindingConfig, d.Id(), m)
+	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeDhcpV4StaticBindingConfig, CacheKeyForResourceID(resourceTypeDhcpV4StaticBindingConfig, d), m)
 
 	return resourceNsxtPolicyDhcpV4StaticBindingRead(d, m)
 }
@@ -293,7 +293,7 @@ func resourceNsxtPolicyDhcpV4StaticBindingRead(d *schema.ResourceData, m interfa
 		d,
 		m,
 		connector,
-		id,
+		CacheKeyForResourceID(resourceTypeDhcpV4StaticBindingConfig, d),
 		resourceTypeDhcpV4StaticBindingConfig,
 		model.DhcpV4StaticBindingConfigBindingType(),
 		func() (*model.DhcpV4StaticBindingConfig, error) {
@@ -395,7 +395,7 @@ func resourceNsxtPolicyDhcpV4StaticBindingUpdate(d *schema.ResourceData, m inter
 	if err != nil {
 		return handleUpdateError("DhcpV4 Static Binding Config", id, err)
 	}
-	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeDhcpV4StaticBindingConfig, d.Id(), m)
+	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeDhcpV4StaticBindingConfig, CacheKeyForResourceID(resourceTypeDhcpV4StaticBindingConfig, d), m)
 
 	return resourceNsxtPolicyDhcpV4StaticBindingRead(d, m)
 }
@@ -430,7 +430,7 @@ func resourceNsxtPolicyDhcpStaticBindingDelete(d *schema.ResourceData, m interfa
 	if err != nil {
 		return handleDeleteError("Dhcp Static Binding Config", id, err)
 	}
-	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeDhcpV4StaticBindingConfig, id, m)
+	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeDhcpV4StaticBindingConfig, CacheKeyForResourceID(resourceTypeDhcpV4StaticBindingConfig, d), m)
 	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeDhcpV6StaticBindingConfig, id, m)
 
 	return nil

--- a/nsxt/resource_nsxt_policy_gateway_policy.go
+++ b/nsxt/resource_nsxt_policy_gateway_policy.go
@@ -214,7 +214,7 @@ func resourceNsxtPolicyGatewayPolicyGeneralCreate(d *schema.ResourceData, m inte
 
 	d.SetId(id)
 	d.Set("nsx_id", id)
-	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeGatewayPolicy, d.Id(), m)
+	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeGatewayPolicy, CacheKeyForResourceID(resourceTypeGatewayPolicy, d), m)
 
 	return resourceNsxtPolicyGatewayPolicyGeneralRead(d, m, withRule)
 }
@@ -235,7 +235,7 @@ func resourceNsxtPolicyGatewayPolicyGeneralRead(d *schema.ResourceData, m interf
 			d,
 			m,
 			connector,
-			id,
+			CacheKeyForResourceID(resourceTypeGatewayPolicy, d),
 			resourceTypeGatewayPolicy,
 			model.GatewayPolicyBindingType(),
 			func() (*model.GatewayPolicy, error) {
@@ -298,7 +298,7 @@ func resourceNsxtPolicyGatewayPolicyGeneralUpdate(d *schema.ResourceData, m inte
 	if err != nil {
 		return handleUpdateError("Gateway Policy", id, err)
 	}
-	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeGatewayPolicy, d.Id(), m)
+	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeGatewayPolicy, CacheKeyForResourceID(resourceTypeGatewayPolicy, d), m)
 	return resourceNsxtPolicyGatewayPolicyGeneralRead(d, m, withRule)
 }
 
@@ -317,7 +317,7 @@ func resourceNsxtPolicyGatewayPolicyDelete(d *schema.ResourceData, m interface{}
 	if err != nil {
 		return handleDeleteError("Gateway Policy", id, err)
 	}
-	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeGatewayPolicy, d.Id(), m)
+	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeGatewayPolicy, CacheKeyForResourceID(resourceTypeGatewayPolicy, d), m)
 
 	return nil
 }

--- a/nsxt/resource_nsxt_policy_gateway_policy_rule.go
+++ b/nsxt/resource_nsxt_policy_gateway_policy_rule.go
@@ -63,7 +63,7 @@ func resourceNsxtPolicyGatewayPolicyRuleCreate(d *schema.ResourceData, m interfa
 		return handleCreateError("GatewayPolicyRule", fmt.Sprintf("%s/%s", policyPath, ruleName), err)
 	}
 
-	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeGatewayPolicy, policyID, m)
+	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeGatewayPolicy, policyPath, m)
 
 	d.SetId(id)
 
@@ -124,7 +124,7 @@ func resourceNsxtPolicyGatewayPolicyRuleRead(d *schema.ResourceData, m interface
 			d,
 			m,
 			connector,
-			policyID,
+			policyPath,
 			resourceTypeGatewayPolicy,
 			model.GatewayPolicyBindingType(),
 		)
@@ -173,7 +173,7 @@ func resourceNsxtPolicyGatewayPolicyRuleUpdate(d *schema.ResourceData, m interfa
 		return handleUpdateError("GatewayPolicyRule", fmt.Sprintf("%s/%s", policyPath, id), err)
 	}
 
-	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeGatewayPolicy, policyID, m)
+	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeGatewayPolicy, policyPath, m)
 
 	return resourceNsxtPolicyGatewayPolicyRuleRead(d, m)
 }
@@ -197,7 +197,7 @@ func resourceNsxtPolicyGatewayPolicyRuleDelete(d *schema.ResourceData, m interfa
 	}
 	err := client.Delete(domain, policyID, id)
 	if err == nil {
-		MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeGatewayPolicy, policyID, m)
+		MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeGatewayPolicy, policyPath, m)
 	}
 	return err
 }

--- a/nsxt/resource_nsxt_policy_group.go
+++ b/nsxt/resource_nsxt_policy_group.go
@@ -832,6 +832,17 @@ func resourceNsxtPolicyGroupCreate(d *schema.ResourceData, m interface{}) error 
 	return resourceNsxtPolicyGroupGeneralCreate(d, m, true)
 }
 
+// groupCacheResourceType returns the cache bucket for a Group resource: withDomain=true is the
+// non-VPC (Tier-0/Tier-1-scoped) resourceNsxtPolicyGroup* caller, withDomain=false is the
+// VPC-scoped resourceNsxtVPCGroup* caller. Keeping this as the single source of truth avoids
+// the General* functions below hardcoding resourceTypeGroup regardless of caller.
+func groupCacheResourceType(withDomain bool) string {
+	if withDomain {
+		return resourceTypeGroup
+	}
+	return resourceTypeVPCGroup
+}
+
 func resourceNsxtPolicyGroupGeneralCreate(d *schema.ResourceData, m interface{}, withDomain bool) error {
 	connector := getPolicyConnector(m)
 
@@ -911,7 +922,8 @@ func resourceNsxtPolicyGroupGeneralCreate(d *schema.ResourceData, m interface{},
 
 	d.SetId(id)
 	d.Set("nsx_id", id)
-	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeGroup, d.Id(), m)
+	resourceType := groupCacheResourceType(withDomain)
+	MarkPostWriteAndInvalidateCacheForResourceType(resourceType, CacheKeyForResourceID(resourceType, d), m)
 	return resourceNsxtPolicyGroupGeneralRead(d, m, withDomain)
 }
 
@@ -936,12 +948,13 @@ func resourceNsxtPolicyGroupGeneralRead(d *schema.ResourceData, m interface{}, w
 	var obj *model.Group
 	var err error
 	if isCacheEnabledForRead(d, m) {
+		resourceType := groupCacheResourceType(withDomain)
 		obj, _, _, err = CacheAwareResourceRead[model.Group](
 			d,
 			m,
 			connector,
-			id,
-			resourceTypeGroup,
+			CacheKeyForResourceID(resourceType, d),
+			resourceType,
 			model.GroupBindingType(),
 			func() (*model.Group, error) {
 				readObj, readErr := client.Get(domainName, id)
@@ -1084,7 +1097,8 @@ func resourceNsxtPolicyGroupGeneralUpdate(d *schema.ResourceData, m interface{},
 	if err != nil {
 		return handleUpdateError("Group", id, err)
 	}
-	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeGroup, d.Id(), m)
+	resourceType := groupCacheResourceType(withDomain)
+	MarkPostWriteAndInvalidateCacheForResourceType(resourceType, CacheKeyForResourceID(resourceType, d), m)
 	return resourceNsxtPolicyGroupGeneralRead(d, m, withDomain)
 }
 
@@ -1118,7 +1132,8 @@ func resourceNsxtPolicyGroupGeneralDelete(d *schema.ResourceData, m interface{},
 	if err != nil {
 		return handleDeleteError("Group", id, err)
 	}
-	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeGroup, id, m)
+	resourceType := groupCacheResourceType(withDomain)
+	MarkPostWriteAndInvalidateCacheForResourceType(resourceType, CacheKeyForResourceID(resourceType, d), m)
 
 	return nil
 }

--- a/nsxt/resource_nsxt_policy_group_test.go
+++ b/nsxt/resource_nsxt_policy_group_test.go
@@ -2008,3 +2008,12 @@ resource "nsxt_policy_group" "test" {
 }
 `, testAccNsxtProjectContext(), os.Getenv("NSXT_VPC_ID"), name)
 }
+
+func TestGroupCacheResourceType(t *testing.T) {
+	if got := groupCacheResourceType(true); got != resourceTypeGroup {
+		t.Errorf("groupCacheResourceType(true) = %q, want %q (non-VPC Group cache bucket)", got, resourceTypeGroup)
+	}
+	if got := groupCacheResourceType(false); got != resourceTypeVPCGroup {
+		t.Errorf("groupCacheResourceType(false) = %q, want %q (VPC Group cache bucket)", got, resourceTypeVPCGroup)
+	}
+}

--- a/nsxt/resource_nsxt_policy_project_ip_address_allocation.go
+++ b/nsxt/resource_nsxt_policy_project_ip_address_allocation.go
@@ -134,7 +134,7 @@ func resourceNsxtPolicyProjectIpAddressAllocationCreate(d *schema.ResourceData, 
 	}
 	d.SetId(id)
 	d.Set("nsx_id", id)
-	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeProjectIpAddressAllocation, d.Id(), m)
+	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeProjectIpAddressAllocation, CacheKeyForResourceID(resourceTypeProjectIpAddressAllocation, d), m)
 
 	return resourceNsxtPolicyProjectIpAddressAllocationRead(d, m)
 }
@@ -157,7 +157,7 @@ func resourceNsxtPolicyProjectIpAddressAllocationRead(d *schema.ResourceData, m 
 			d,
 			m,
 			connector,
-			id,
+			CacheKeyForResourceID(resourceTypeProjectIpAddressAllocation, d),
 			resourceTypeProjectIpAddressAllocation,
 			model.ProjectIpAddressAllocationBindingType(),
 			func() (*model.ProjectIpAddressAllocation, error) {
@@ -232,7 +232,7 @@ func resourceNsxtPolicyProjectIpAddressAllocationUpdate(d *schema.ResourceData, 
 		d.Partial(true)
 		return handleUpdateError("ProjectIpAddressAllocation", id, err)
 	}
-	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeProjectIpAddressAllocation, d.Id(), m)
+	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeProjectIpAddressAllocation, CacheKeyForResourceID(resourceTypeProjectIpAddressAllocation, d), m)
 
 	return resourceNsxtPolicyProjectIpAddressAllocationRead(d, m)
 }
@@ -253,7 +253,7 @@ func resourceNsxtPolicyProjectIpAddressAllocationDelete(d *schema.ResourceData, 
 	if err != nil {
 		return handleDeleteError("ProjectIpAddressAllocation", id, err)
 	}
-	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeProjectIpAddressAllocation, id, m)
+	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeProjectIpAddressAllocation, CacheKeyForResourceID(resourceTypeProjectIpAddressAllocation, d), m)
 
 	return nil
 }

--- a/nsxt/resource_nsxt_policy_static_route.go
+++ b/nsxt/resource_nsxt_policy_static_route.go
@@ -202,7 +202,7 @@ func resourceNsxtPolicyStaticRouteCreate(d *schema.ResourceData, m interface{}) 
 
 	d.SetId(id)
 	d.Set("nsx_id", id)
-	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeStaticRoutes, d.Id(), m)
+	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeStaticRoutes, CacheKeyForResourceID(resourceTypeStaticRoutes, d), m)
 
 	return resourceNsxtPolicyStaticRouteRead(d, m)
 }
@@ -232,7 +232,7 @@ func resourceNsxtPolicyStaticRouteRead(d *schema.ResourceData, m interface{}) er
 			d,
 			m,
 			connector,
-			id,
+			CacheKeyForResourceID(resourceTypeStaticRoutes, d),
 			resourceTypeStaticRoutes,
 			model.StaticRoutesBindingType(),
 			func() (*model.StaticRoutes, error) {
@@ -357,7 +357,7 @@ func resourceNsxtPolicyStaticRouteUpdate(d *schema.ResourceData, m interface{}) 
 
 	d.SetId(id)
 	d.Set("nsx_id", id)
-	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeStaticRoutes, d.Id(), m)
+	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeStaticRoutes, CacheKeyForResourceID(resourceTypeStaticRoutes, d), m)
 
 	return resourceNsxtPolicyStaticRouteRead(d, m)
 }
@@ -382,7 +382,7 @@ func resourceNsxtPolicyStaticRouteDelete(d *schema.ResourceData, m interface{}) 
 	if err != nil {
 		return handleDeleteError("Static Route", id, err)
 	}
-	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeStaticRoutes, id, m)
+	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeStaticRoutes, CacheKeyForResourceID(resourceTypeStaticRoutes, d), m)
 
 	return nil
 }

--- a/nsxt/resource_nsxt_policy_transit_gateway.go
+++ b/nsxt/resource_nsxt_policy_transit_gateway.go
@@ -787,7 +787,7 @@ func resourceNsxtPolicyTransitGatewayCreate(d *schema.ResourceData, m interface{
 
 	d.SetId(id)
 	d.Set("nsx_id", id)
-	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeTransitGateway, d.Id(), m)
+	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeTransitGateway, CacheKeyForResourceID(resourceTypeTransitGateway, d), m)
 
 	return resourceNsxtPolicyTransitGatewayRead(d, m)
 }
@@ -810,7 +810,7 @@ func resourceNsxtPolicyTransitGatewayRead(d *schema.ResourceData, m interface{})
 			d,
 			m,
 			connector,
-			id,
+			CacheKeyForResourceID(resourceTypeTransitGateway, d),
 			resourceTypeTransitGateway,
 			model.TransitGatewayBindingType(),
 			func() (*model.TransitGateway, error) {
@@ -1067,7 +1067,7 @@ func resourceNsxtPolicyTransitGatewayUpdate(d *schema.ResourceData, m interface{
 		}
 	}
 
-	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeTransitGateway, d.Id(), m)
+	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeTransitGateway, CacheKeyForResourceID(resourceTypeTransitGateway, d), m)
 	return resourceNsxtPolicyTransitGatewayRead(d, m)
 }
 
@@ -1097,6 +1097,6 @@ func resourceNsxtPolicyTransitGatewayDelete(d *schema.ResourceData, m interface{
 	if err := orgRootClient.Patch(orgRoot, nil); err != nil {
 		return handleDeleteError("TransitGateway", id, err)
 	}
-	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeTransitGateway, id, m)
+	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeTransitGateway, CacheKeyForResourceID(resourceTypeTransitGateway, d), m)
 	return nil
 }

--- a/nsxt/resource_nsxt_policy_transit_gateway_attachment.go
+++ b/nsxt/resource_nsxt_policy_transit_gateway_attachment.go
@@ -205,7 +205,7 @@ func resourceNsxtPolicyTransitGatewayAttachmentCreate(d *schema.ResourceData, m 
 	}
 	d.SetId(id)
 	d.Set("nsx_id", id)
-	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeTransitGatewayAttachment, d.Id(), m)
+	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeTransitGatewayAttachment, CacheKeyForResourceID(resourceTypeTransitGatewayAttachment, d), m)
 
 	return resourceNsxtPolicyTransitGatewayAttachmentRead(d, m)
 }
@@ -235,7 +235,7 @@ func resourceNsxtPolicyTransitGatewayAttachmentRead(d *schema.ResourceData, m in
 			d,
 			m,
 			connector,
-			id,
+			CacheKeyForResourceID(resourceTypeTransitGatewayAttachment, d),
 			resourceTypeTransitGatewayAttachment,
 			model.TransitGatewayAttachmentBindingType(),
 			func() (*model.TransitGatewayAttachment, error) {
@@ -317,7 +317,7 @@ func resourceNsxtPolicyTransitGatewayAttachmentUpdate(d *schema.ResourceData, m 
 	if err != nil {
 		return handleUpdateError("TransitGatewayAttachment", id, err)
 	}
-	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeTransitGatewayAttachment, d.Id(), m)
+	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeTransitGatewayAttachment, CacheKeyForResourceID(resourceTypeTransitGatewayAttachment, d), m)
 
 	return resourceNsxtPolicyTransitGatewayAttachmentRead(d, m)
 }
@@ -345,7 +345,7 @@ func resourceNsxtPolicyTransitGatewayAttachmentDelete(d *schema.ResourceData, m 
 	if err != nil {
 		return handleDeleteError("TransitGatewayAttachment", id, err)
 	}
-	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeTransitGatewayAttachment, id, m)
+	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeTransitGatewayAttachment, CacheKeyForResourceID(resourceTypeTransitGatewayAttachment, d), m)
 
 	return nil
 }

--- a/nsxt/resource_nsxt_vpc.go
+++ b/nsxt/resource_nsxt_vpc.go
@@ -229,7 +229,7 @@ func resourceNsxtVpcCreate(d *schema.ResourceData, m interface{}) error {
 	d.SetId(id)
 	d.Set("nsx_id", id)
 
-	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeVpc, d.Id(), m)
+	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeVpc, CacheKeyForResourceID(resourceTypeVpc, d), m)
 	return resourceNsxtVpcRead(d, m)
 }
 
@@ -248,7 +248,7 @@ func resourceNsxtVpcRead(d *schema.ResourceData, m interface{}) error {
 			d,
 			m,
 			connector,
-			id,
+			CacheKeyForResourceID(resourceTypeVpc, d),
 			resourceTypeVpc,
 			model.VpcBindingType(),
 			func() (*model.Vpc, error) {
@@ -332,7 +332,7 @@ func resourceNsxtVpcUpdate(d *schema.ResourceData, m interface{}) error {
 		return handleUpdateError("Vpc", id, err)
 	}
 
-	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeVpc, d.Id(), m)
+	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeVpc, CacheKeyForResourceID(resourceTypeVpc, d), m)
 	return resourceNsxtVpcRead(d, m)
 }
 
@@ -352,7 +352,7 @@ func resourceNsxtVpcDelete(d *schema.ResourceData, m interface{}) error {
 	if err != nil {
 		return handleDeleteError("Vpc", id, err)
 	}
-	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeVpc, id, m)
+	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeVpc, CacheKeyForResourceID(resourceTypeVpc, d), m)
 
 	return nil
 }

--- a/nsxt/resource_nsxt_vpc_attachment.go
+++ b/nsxt/resource_nsxt_vpc_attachment.go
@@ -118,7 +118,7 @@ func resourceNsxtVpcAttachmentCreate(d *schema.ResourceData, m interface{}) erro
 	d.SetId(id)
 	d.Set("nsx_id", id)
 
-	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeVpcAttachment, d.Id(), m)
+	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeVpcAttachment, CacheKeyForResourceID(resourceTypeVpcAttachment, d), m)
 	return resourceNsxtVpcAttachmentRead(d, m)
 }
 
@@ -145,7 +145,7 @@ func resourceNsxtVpcAttachmentRead(d *schema.ResourceData, m interface{}) error 
 			d,
 			m,
 			connector,
-			id,
+			CacheKeyForResourceID(resourceTypeVpcAttachment, d),
 			resourceTypeVpcAttachment,
 			model.VpcAttachmentBindingType(),
 			func() (*model.VpcAttachment, error) {
@@ -221,7 +221,7 @@ func resourceNsxtVpcAttachmentUpdate(d *schema.ResourceData, m interface{}) erro
 		return handleUpdateError("VpcAttachment", id, err)
 	}
 
-	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeVpcAttachment, d.Id(), m)
+	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeVpcAttachment, CacheKeyForResourceID(resourceTypeVpcAttachment, d), m)
 	return resourceNsxtVpcAttachmentRead(d, m)
 }
 
@@ -246,7 +246,7 @@ func resourceNsxtVpcAttachmentDelete(d *schema.ResourceData, m interface{}) erro
 	if err != nil {
 		return handleDeleteError("VpcAttachment", id, err)
 	}
-	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeVpcAttachment, id, m)
+	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeVpcAttachment, CacheKeyForResourceID(resourceTypeVpcAttachment, d), m)
 
 	return nil
 }

--- a/nsxt/resource_nsxt_vpc_connectivity_profile.go
+++ b/nsxt/resource_nsxt_vpc_connectivity_profile.go
@@ -295,7 +295,7 @@ func resourceNsxtVpcConnectivityProfileCreate(d *schema.ResourceData, m interfac
 	d.SetId(id)
 	d.Set("nsx_id", id)
 
-	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeVpcConnectivityProfile, d.Id(), m)
+	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeVpcConnectivityProfile, CacheKeyForResourceID(resourceTypeVpcConnectivityProfile, d), m)
 	return resourceNsxtVpcConnectivityProfileRead(d, m)
 }
 
@@ -313,7 +313,7 @@ func resourceNsxtVpcConnectivityProfileRead(d *schema.ResourceData, m interface{
 			d,
 			m,
 			connector,
-			id,
+			CacheKeyForResourceID(resourceTypeVpcConnectivityProfile, d),
 			resourceTypeVpcConnectivityProfile,
 			model.VpcConnectivityProfileBindingType(),
 			func() (*model.VpcConnectivityProfile, error) {
@@ -399,7 +399,7 @@ func resourceNsxtVpcConnectivityProfileUpdate(d *schema.ResourceData, m interfac
 		return handleUpdateError("VpcConnectivityProfile", id, err)
 	}
 
-	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeVpcConnectivityProfile, d.Id(), m)
+	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeVpcConnectivityProfile, CacheKeyForResourceID(resourceTypeVpcConnectivityProfile, d), m)
 	return resourceNsxtVpcConnectivityProfileRead(d, m)
 }
 
@@ -419,7 +419,7 @@ func resourceNsxtVpcConnectivityProfileDelete(d *schema.ResourceData, m interfac
 	if err != nil {
 		return handleDeleteError("VpcConnectivityProfile", id, err)
 	}
-	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeVpcConnectivityProfile, id, m)
+	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeVpcConnectivityProfile, CacheKeyForResourceID(resourceTypeVpcConnectivityProfile, d), m)
 
 	return nil
 }

--- a/nsxt/resource_nsxt_vpc_dhcp_v4_static_binding_config.go
+++ b/nsxt/resource_nsxt_vpc_dhcp_v4_static_binding_config.go
@@ -282,7 +282,7 @@ func resourceNsxtVpcSubnetDhcpV4StaticBindingConfigCreate(d *schema.ResourceData
 	d.SetId(id)
 	d.Set("nsx_id", id)
 
-	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeDhcpV4StaticBindingConfig, d.Id(), m)
+	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeDhcpV4StaticBindingConfig, CacheKeyForResourceID(resourceTypeDhcpV4StaticBindingConfig, d), m)
 	return resourceNsxtVpcSubnetDhcpV4StaticBindingConfigRead(d, m)
 }
 
@@ -308,7 +308,7 @@ func resourceNsxtVpcSubnetDhcpV4StaticBindingConfigRead(d *schema.ResourceData, 
 			d,
 			m,
 			connector,
-			id,
+			CacheKeyForResourceID(resourceTypeDhcpV4StaticBindingConfig, d),
 			resourceTypeDhcpV4StaticBindingConfig,
 			model.DhcpV4StaticBindingConfigBindingType(),
 			func() (*model.DhcpV4StaticBindingConfig, error) {
@@ -420,7 +420,7 @@ func resourceNsxtVpcSubnetDhcpV4StaticBindingConfigUpdate(d *schema.ResourceData
 		return handleUpdateError("DhcpV4StaticBindingConfig", id, err)
 	}
 
-	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeDhcpV4StaticBindingConfig, d.Id(), m)
+	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeDhcpV4StaticBindingConfig, CacheKeyForResourceID(resourceTypeDhcpV4StaticBindingConfig, d), m)
 	return resourceNsxtVpcSubnetDhcpV4StaticBindingConfigRead(d, m)
 }
 
@@ -444,7 +444,7 @@ func resourceNsxtVpcSubnetDhcpV4StaticBindingConfigDelete(d *schema.ResourceData
 	if err != nil {
 		return handleDeleteError("DhcpV4StaticBindingConfig", id, err)
 	}
-	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeDhcpV4StaticBindingConfig, id, m)
+	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeDhcpV4StaticBindingConfig, CacheKeyForResourceID(resourceTypeDhcpV4StaticBindingConfig, d), m)
 
 	return nil
 }

--- a/nsxt/resource_nsxt_vpc_gateway_policy.go
+++ b/nsxt/resource_nsxt_vpc_gateway_policy.go
@@ -55,7 +55,7 @@ func resourceNsxtVPCGatewayPolicyCreate(d *schema.ResourceData, m interface{}) e
 	d.SetId(id)
 	d.Set("nsx_id", id)
 
-	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeGatewayPolicy, d.Id(), m)
+	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeGatewayPolicy, CacheKeyForResourceID(resourceTypeGatewayPolicy, d), m)
 	return resourceNsxtVPCGatewayPolicyRead(d, m)
 }
 
@@ -73,7 +73,7 @@ func resourceNsxtVPCGatewayPolicyRead(d *schema.ResourceData, m interface{}) err
 			d,
 			m,
 			connector,
-			id,
+			CacheKeyForResourceID(resourceTypeGatewayPolicy, d),
 			resourceTypeGatewayPolicy,
 			model.GatewayPolicyBindingType(),
 			func() (*model.GatewayPolicy, error) {
@@ -133,7 +133,7 @@ func resourceNsxtVPCGatewayPolicyUpdate(d *schema.ResourceData, m interface{}) e
 		return handleUpdateError("VPC Gateway Policy", id, err)
 	}
 
-	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeGatewayPolicy, d.Id(), m)
+	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeGatewayPolicy, CacheKeyForResourceID(resourceTypeGatewayPolicy, d), m)
 	return resourceNsxtVPCGatewayPolicyRead(d, m)
 }
 
@@ -149,7 +149,7 @@ func resourceNsxtVPCGatewayPolicyDelete(d *schema.ResourceData, m interface{}) e
 	if err != nil {
 		return handleDeleteError("VPC Gateway Policy", id, err)
 	}
-	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeGatewayPolicy, id, m)
+	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeGatewayPolicy, CacheKeyForResourceID(resourceTypeGatewayPolicy, d), m)
 
 	return nil
 }

--- a/nsxt/resource_nsxt_vpc_group.go
+++ b/nsxt/resource_nsxt_vpc_group.go
@@ -35,11 +35,9 @@ func resourceNsxtVPCGroupCreate(d *schema.ResourceData, m interface{}) error {
 	if isConfigScopedCacheMode(m) {
 		_ = d.Set("tag", initPolicyTagsSet(getPolicyTagsWithProviderManagedDefaults(d, m)))
 	}
-	if err := resourceNsxtPolicyGroupGeneralCreate(d, m, false); err != nil {
-		return err
-	}
-	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeVPCGroup, d.Id(), m)
-	return nil
+	// resourceNsxtPolicyGroupGeneralCreate already marks/invalidates resourceTypeVPCGroup
+	// internally via groupCacheResourceType(false) — no separate call needed here.
+	return resourceNsxtPolicyGroupGeneralCreate(d, m, false)
 }
 
 func resourceNsxtVPCGroupRead(d *schema.ResourceData, m interface{}) error {
@@ -59,7 +57,7 @@ func resourceNsxtVPCGroupRead(d *schema.ResourceData, m interface{}) error {
 		d,
 		m,
 		connector,
-		id,
+		CacheKeyForResourceID(resourceTypeVPCGroup, d),
 		resourceTypeVPCGroup,
 		model.GroupBindingType(),
 		func() (*model.Group, error) {
@@ -122,17 +120,13 @@ func resourceNsxtVPCGroupUpdate(d *schema.ResourceData, m interface{}) error {
 	if isConfigScopedCacheMode(m) {
 		_ = d.Set("tag", initPolicyTagsSet(getPolicyTagsWithProviderManagedDefaults(d, m)))
 	}
-	if err := resourceNsxtPolicyGroupGeneralUpdate(d, m, false); err != nil {
-		return err
-	}
-	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeVPCGroup, d.Id(), m)
-	return nil
+	// resourceNsxtPolicyGroupGeneralUpdate already marks/invalidates resourceTypeVPCGroup
+	// internally via groupCacheResourceType(false) — no separate call needed here.
+	return resourceNsxtPolicyGroupGeneralUpdate(d, m, false)
 }
 
 func resourceNsxtVPCGroupDelete(d *schema.ResourceData, m interface{}) error {
-	if err := resourceNsxtPolicyGroupGeneralDelete(d, m, false); err != nil {
-		return err
-	}
-	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeVPCGroup, d.Id(), m)
-	return nil
+	// resourceNsxtPolicyGroupGeneralDelete already marks/invalidates resourceTypeVPCGroup
+	// internally via groupCacheResourceType(false) — no separate call needed here.
+	return resourceNsxtPolicyGroupGeneralDelete(d, m, false)
 }

--- a/nsxt/resource_nsxt_vpc_ip_address_allocation.go
+++ b/nsxt/resource_nsxt_vpc_ip_address_allocation.go
@@ -172,7 +172,7 @@ func resourceNsxtVpcIpAddressAllocationCreate(d *schema.ResourceData, m interfac
 	d.SetId(id)
 	d.Set("nsx_id", id)
 
-	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeVpcIpAddressAllocation, d.Id(), m)
+	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeVpcIpAddressAllocation, CacheKeyForResourceID(resourceTypeVpcIpAddressAllocation, d), m)
 	return resourceNsxtVpcIpAddressAllocationRead(d, m)
 }
 
@@ -190,7 +190,7 @@ func resourceNsxtVpcIpAddressAllocationRead(d *schema.ResourceData, m interface{
 			d,
 			m,
 			connector,
-			id,
+			CacheKeyForResourceID(resourceTypeVpcIpAddressAllocation, d),
 			resourceTypeVpcIpAddressAllocation,
 			model.VpcIpAddressAllocationBindingType(),
 			func() (*model.VpcIpAddressAllocation, error) {
@@ -273,7 +273,7 @@ func resourceNsxtVpcIpAddressAllocationUpdate(d *schema.ResourceData, m interfac
 		return handleUpdateError("VpcIpAddressAllocation", id, err)
 	}
 
-	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeVpcIpAddressAllocation, d.Id(), m)
+	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeVpcIpAddressAllocation, CacheKeyForResourceID(resourceTypeVpcIpAddressAllocation, d), m)
 	return resourceNsxtVpcIpAddressAllocationRead(d, m)
 }
 
@@ -293,7 +293,7 @@ func resourceNsxtVpcIpAddressAllocationDelete(d *schema.ResourceData, m interfac
 	if err != nil {
 		return handleDeleteError("VpcIpAddressAllocation", id, err)
 	}
-	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeVpcIpAddressAllocation, id, m)
+	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeVpcIpAddressAllocation, CacheKeyForResourceID(resourceTypeVpcIpAddressAllocation, d), m)
 
 	return nil
 }

--- a/nsxt/resource_nsxt_vpc_nat_rule.go
+++ b/nsxt/resource_nsxt_vpc_nat_rule.go
@@ -271,7 +271,7 @@ func resourceNsxtPolicyVpcNatRuleRead(d *schema.ResourceData, m interface{}) err
 			d,
 			m,
 			connector,
-			id,
+			CacheKeyForResourceID(resourceTypePolicyVpcNatRule, d),
 			resourceTypePolicyVpcNatRule,
 			model.PolicyVpcNatRuleBindingType(),
 			func() (*model.PolicyVpcNatRule, error) {

--- a/nsxt/resource_nsxt_vpc_service_profile.go
+++ b/nsxt/resource_nsxt_vpc_service_profile.go
@@ -625,7 +625,7 @@ func resourceNsxtVpcServiceProfileCreate(d *schema.ResourceData, m interface{}) 
 	d.SetId(id)
 	d.Set("nsx_id", id)
 
-	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeVpcServiceProfile, d.Id(), m)
+	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeVpcServiceProfile, CacheKeyForResourceID(resourceTypeVpcServiceProfile, d), m)
 	return resourceNsxtVpcServiceProfileRead(d, m)
 }
 
@@ -643,7 +643,7 @@ func resourceNsxtVpcServiceProfileRead(d *schema.ResourceData, m interface{}) er
 			d,
 			m,
 			connector,
-			id,
+			CacheKeyForResourceID(resourceTypeVpcServiceProfile, d),
 			resourceTypeVpcServiceProfile,
 			model.VpcServiceProfileBindingType(),
 			func() (*model.VpcServiceProfile, error) {
@@ -735,7 +735,7 @@ func resourceNsxtVpcServiceProfileUpdate(d *schema.ResourceData, m interface{}) 
 		return handleUpdateError("VpcServiceProfile", id, err)
 	}
 
-	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeVpcServiceProfile, d.Id(), m)
+	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeVpcServiceProfile, CacheKeyForResourceID(resourceTypeVpcServiceProfile, d), m)
 	return resourceNsxtVpcServiceProfileRead(d, m)
 }
 
@@ -755,7 +755,7 @@ func resourceNsxtVpcServiceProfileDelete(d *schema.ResourceData, m interface{}) 
 	if err != nil {
 		return handleDeleteError("VpcServiceProfile", id, err)
 	}
-	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeVpcServiceProfile, id, m)
+	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeVpcServiceProfile, CacheKeyForResourceID(resourceTypeVpcServiceProfile, d), m)
 
 	return nil
 }

--- a/nsxt/resource_nsxt_vpc_static_routes.go
+++ b/nsxt/resource_nsxt_vpc_static_routes.go
@@ -148,7 +148,7 @@ func resourceNsxtVpcStaticRoutesCreate(d *schema.ResourceData, m interface{}) er
 	d.SetId(id)
 	d.Set("nsx_id", id)
 
-	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeStaticRoutes, d.Id(), m)
+	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeStaticRoutes, CacheKeyForResourceID(resourceTypeStaticRoutes, d), m)
 	return resourceNsxtVpcStaticRoutesRead(d, m)
 }
 
@@ -166,7 +166,7 @@ func resourceNsxtVpcStaticRoutesRead(d *schema.ResourceData, m interface{}) erro
 			d,
 			m,
 			connector,
-			id,
+			CacheKeyForResourceID(resourceTypeStaticRoutes, d),
 			resourceTypeStaticRoutes,
 			model.StaticRoutesBindingType(),
 			func() (*model.StaticRoutes, error) {
@@ -249,7 +249,7 @@ func resourceNsxtVpcStaticRoutesUpdate(d *schema.ResourceData, m interface{}) er
 		return handleUpdateError("StaticRoutes", id, err)
 	}
 
-	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeStaticRoutes, d.Id(), m)
+	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeStaticRoutes, CacheKeyForResourceID(resourceTypeStaticRoutes, d), m)
 	return resourceNsxtVpcStaticRoutesRead(d, m)
 }
 
@@ -269,7 +269,7 @@ func resourceNsxtVpcStaticRoutesDelete(d *schema.ResourceData, m interface{}) er
 	if err != nil {
 		return handleDeleteError("StaticRoutes", id, err)
 	}
-	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeStaticRoutes, id, m)
+	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeStaticRoutes, CacheKeyForResourceID(resourceTypeStaticRoutes, d), m)
 
 	return nil
 }

--- a/nsxt/resource_nsxt_vpc_subnet.go
+++ b/nsxt/resource_nsxt_vpc_subnet.go
@@ -685,7 +685,7 @@ func resourceNsxtVpcSubnetCreate(d *schema.ResourceData, m interface{}) error {
 	d.SetId(id)
 	d.Set("nsx_id", id)
 
-	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeVpcSubnet, d.Id(), m)
+	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeVpcSubnet, CacheKeyForResourceID(resourceTypeVpcSubnet, d), m)
 	return resourceNsxtVpcSubnetRead(d, m)
 }
 
@@ -884,7 +884,7 @@ func resourceNsxtVpcSubnetRead(d *schema.ResourceData, m interface{}) error {
 			d,
 			m,
 			connector,
-			id,
+			CacheKeyForResourceID(resourceTypeVpcSubnet, d),
 			resourceTypeVpcSubnet,
 			model.VpcSubnetBindingType(),
 			func() (*model.VpcSubnet, error) {
@@ -993,7 +993,7 @@ func resourceNsxtVpcSubnetUpdate(d *schema.ResourceData, m interface{}) error {
 		return handleUpdateError("VpcSubnet", id, err)
 	}
 
-	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeVpcSubnet, d.Id(), m)
+	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeVpcSubnet, CacheKeyForResourceID(resourceTypeVpcSubnet, d), m)
 	return resourceNsxtVpcSubnetRead(d, m)
 }
 
@@ -1043,7 +1043,7 @@ func resourceNsxtVpcSubnetDelete(d *schema.ResourceData, m interface{}) error {
 	if err != nil {
 		return handleDeleteError("VpcSubnet", id, err)
 	}
-	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeVpcSubnet, id, m)
+	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeVpcSubnet, CacheKeyForResourceID(resourceTypeVpcSubnet, d), m)
 
 	return nil
 }


### PR DESCRIPTION
How the cache is optimized

- **The core problem this branch solves**: for VPC-scoped resources (VpcAttachment, VpcSubnet, Group, GatewayPolicy, StaticRoutes, DHCP bindings, etc.), the cache used to run one NSX Search per VPC. A Terraform config touching 100 VPCs meant 100 separate searches — each populating its own tiny cache bucket — which made "cache mode" slower than no caching at all.

- **The fix (getQueryString + projectScopedSearchContext in cache.go)**: for any VPC/Multitenancy-scoped resource, the cache bucket key drops the VPC ID and keeps only the project ID. One search now covers every VPC in a project, populating one shared bucket that all 100 VPCs' resources read from. This is the actual performance win — search count drops from O(VPCs) to O(1) per project per resource type.

- **The correctness cost of that optimization, and how it's paid down**: widening the bucket to project scope means two different VPCs' resources can now land in the same map. NSX short ids (nsx_id) are only guaranteed unique within a VPC, not across a project — so two VPCs could each have a resource named subnet1, and naively keying the shared bucket by short id would let one VPC's data silently mask the other's. The fix: 14 resource types that can be VPC-scoped are now indexed and looked up by path instead of short id (path is project/system-unique), via shouldIndexByPath + a new CacheKeyForResourceID helper that every CRUD call site and data source was migrated to use.

**Everything else in the diff is either infrastructure for that path-keying migration, or bugs found while doing it**:

-cache_test.go — new tests proving the query-scoping and path-indexing behavior

- The 10+ resource_nsxt_*.go one-liner diffs — switching each type's cache calls from raw id to CacheKeyForResourceID

- resource_nsxt_policy_group.go, resource_nsxt_policy_gateway_policy.go, resource_nsxt_policy_static_route.go, resource_nsxt_policy_dhcp_v4_static_binding.go, resource_nsxt_policy_gateway_policy_rule.go — fixes for call sites that were missed in that migration (shared Create/Read/Update/Delete functions hardcoding the wrong bucket, or a rule resource referencing its parent by the wrong key)

- Mutex/logging changes in cache.go — unrelated hardening (panic-safety, moving log calls outside the lock) picked up along the way

Net effect: cache mode should now do roughly 1 search per resource type per project, instead of 1 per VPC, without the path-keying migration reintroducing a correctness regression for the sake of that speed.