### PR TITLE
Fix drift on parent policy when a predefined sibling shares its path …

### DIFF
--- a/nsxt/policy_common.go
+++ b/nsxt/policy_common.go
@@ -359,6 +359,24 @@ func getPolicyGatewayPolicySchema(isVPC bool, withRule bool) map[string]*schema.
 	return secPolicy
 }
 
+// markParentPolicySharedFieldsComputed marks description/tag as Computed for
+// the nsxt_policy_parent_security_policy / nsxt_policy_parent_gateway_policy
+// resources. Those resources are commonly paired with a
+// nsxt_policy_predefined_security_policy / nsxt_policy_predefined_gateway_policy
+// resource pointed at the same underlying object via path, and that sibling
+// resource can PATCH description/tag independently. Without Computed, leaving
+// description/tag unset on the parent resource's own config causes its Read
+// to pick up the sibling's values and show them as spurious drift on the next
+// plan, since the parent's plan otherwise expects an unset field to mean
+// "empty". This does not affect resources where description/tag are declared
+// in the parent resource's own config, since an explicit value still takes
+// precedence over Computed.
+func markParentPolicySharedFieldsComputed(s map[string]*schema.Schema) map[string]*schema.Schema {
+	s["description"].Computed = true
+	s["tag"].Computed = true
+	return s
+}
+
 func getPolicyServiceEntrySchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"icmp_entry":        getIcmpEntrySchema(),

--- a/nsxt/resource_nsxt_policy_parent_gateway_policy.go
+++ b/nsxt/resource_nsxt_policy_parent_gateway_policy.go
@@ -16,7 +16,7 @@ func resourceNsxtPolicyParentGatewayPolicy() *schema.Resource {
 			State: nsxtDomainResourceImporter,
 		},
 
-		Schema: getPolicyGatewayPolicySchema(false, false),
+		Schema: markParentPolicySharedFieldsComputed(getPolicyGatewayPolicySchema(false, false)),
 	}
 }
 

--- a/nsxt/resource_nsxt_policy_parent_gateway_policy_test.go
+++ b/nsxt/resource_nsxt_policy_parent_gateway_policy_test.go
@@ -124,6 +124,53 @@ func TestAccResourceNsxtPolicyParentGatewayPolicy_importBasic_multitenancy(t *te
 	})
 }
 
+// TestAccResourceNsxtPolicyParentGatewayPolicy_predefinedSiblingNoDrift
+// reproduces Bugzilla 3761442: a nsxt_policy_predefined_gateway_policy
+// resource pointed at the same path as this parent resource can PATCH
+// description/tag on the shared underlying object. Since the parent
+// resource's own config never sets those fields, its next refresh must not
+// show drift wanting to null them back out.
+func TestAccResourceNsxtPolicyParentGatewayPolicy_predefinedSiblingNoDrift(t *testing.T) {
+	name := getAccTestResourceName()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyParentGatewayPolicyCheckDestroy(state, name)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyParentGatewayPolicyPredefinedSiblingTemplate(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("nsxt_policy_parent_gateway_policy.parent", "description", ""),
+					resource.TestCheckResourceAttr("nsxt_policy_parent_gateway_policy.parent", "tag.#", "0"),
+					resource.TestCheckResourceAttr("nsxt_policy_predefined_gateway_policy.predef", "description", "predefined description"),
+				),
+			},
+		},
+	})
+}
+
+func testAccNsxtPolicyParentGatewayPolicyPredefinedSiblingTemplate(name string) string {
+	return fmt.Sprintf(`
+resource "nsxt_policy_parent_gateway_policy" "parent" {
+  display_name    = "%s"
+  category        = "LocalGatewayRules"
+  sequence_number = 10
+}
+
+resource "nsxt_policy_predefined_gateway_policy" "predef" {
+  path        = nsxt_policy_parent_gateway_policy.parent.path
+  description = "predefined description"
+
+  tag {
+    scope = "color"
+    tag   = "orange"
+  }
+}`, name)
+}
+
 func testAccNsxtPolicyParentGatewayPolicyCheckDestroy(state *terraform.State, displayName string) error {
 	connector := getPolicyConnector(testAccProvider.Meta().(nsxtClients))
 	for _, rs := range state.RootModule().Resources {

--- a/nsxt/resource_nsxt_policy_parent_security_policy.go
+++ b/nsxt/resource_nsxt_policy_parent_security_policy.go
@@ -22,7 +22,7 @@ func resourceNsxtPolicyParentSecurityPolicy() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: nsxtDomainResourceImporter,
 		},
-		Schema: getPolicySecurityPolicySchema(false, true, false, false),
+		Schema: markParentPolicySharedFieldsComputed(getPolicySecurityPolicySchema(false, true, false, false)),
 	}
 }
 

--- a/nsxt/resource_nsxt_policy_parent_security_policy_test.go
+++ b/nsxt/resource_nsxt_policy_parent_security_policy_test.go
@@ -119,6 +119,54 @@ func TestAccResourceNsxtPolicyParentSecurityPolicy_importBasic_multitenancy(t *t
 	})
 }
 
+// TestAccResourceNsxtPolicyParentSecurityPolicy_predefinedSiblingNoDrift
+// reproduces Bugzilla 3761445: a nsxt_policy_predefined_security_policy
+// resource pointed at the same path as this parent resource can PATCH
+// description/tag on the shared underlying object. Since the parent
+// resource's own config never sets those fields, its next refresh must not
+// show drift wanting to null them back out.
+func TestAccResourceNsxtPolicyParentSecurityPolicy_predefinedSiblingNoDrift(t *testing.T) {
+	name := getAccTestResourceName()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyParentSecurityPolicyCheckDestroy(state, name)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyParentSecurityPolicyPredefinedSiblingTemplate(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("nsxt_policy_parent_security_policy.parent", "description", ""),
+					resource.TestCheckResourceAttr("nsxt_policy_parent_security_policy.parent", "tag.#", "0"),
+					resource.TestCheckResourceAttr("nsxt_policy_predefined_security_policy.predef", "description", "predefined description"),
+				),
+			},
+		},
+	})
+}
+
+func testAccNsxtPolicyParentSecurityPolicyPredefinedSiblingTemplate(name string) string {
+	return fmt.Sprintf(`
+resource "nsxt_policy_parent_security_policy" "parent" {
+  display_name    = "%s"
+  domain          = "default"
+  category        = "Application"
+  sequence_number = 10
+}
+
+resource "nsxt_policy_predefined_security_policy" "predef" {
+  path        = nsxt_policy_parent_security_policy.parent.path
+  description = "predefined description"
+
+  tag {
+    scope = "color"
+    tag   = "orange"
+  }
+}`, name)
+}
+
 func testAccNsxtPolicyParentSecurityPolicyCheckDestroy(state *terraform.State, displayName string) error {
 	connector := getPolicyConnector(testAccProvider.Meta().(nsxtClients))
 	for _, rs := range state.RootModule().Resources {


### PR DESCRIPTION
…(#2195)

nsxt_policy_parent_security_policy and nsxt_policy_parent_gateway_policy expose description/tag as Optional but not Computed, and their Read unconditionally syncs both from the live object. When a nsxt_policy_predefined_security_policy / nsxt_policy_predefined_gateway_policy resource targets the same object via path and sets description/tag itself, the parent resource's own config never declared those fields, so the next plan treats them as drift and proposes nulling them back out.

Mark description/tag Computed on these two parent resources only, so an unconfigured value adopts whatever the API returns instead of forcing empty. An explicit value on the parent resource's own config still takes precedence, so normal drift detection is unaffected.

Add regression coverage reproducing the exact FVT scenario for both resources, verified failing before the fix and passing after, against a live NSX 4.2.3 Global Manager.


(cherry picked from commit 3434c49810b6bf80c1542aa040a0e7ad0f55c72e)