### PR TITLE
Guard against nil entries in inter-VRF routing block iterators (#2081)

### DIFF
--- a/nsxt/resource_nsxt_policy_tier0_inter_vrf_routing.go
+++ b/nsxt/resource_nsxt_policy_tier0_inter_vrf_routing.go
@@ -155,6 +155,9 @@ func getPolicyInterVRFRoutingFromSchema(d *schema.ResourceData) model.PolicyInte
 	bpgRouteLeakingList := d.Get("bgp_route_leaking")
 	if bpgRouteLeakingList != nil {
 		for _, brl := range bpgRouteLeakingList.([]interface{}) {
+			if brl == nil {
+				continue
+			}
 			brlMap := brl.(map[string]interface{})
 			addressFamily := brlMap["address_family"].(string)
 			var inFilter []string
@@ -177,6 +180,9 @@ func getPolicyInterVRFRoutingFromSchema(d *schema.ResourceData) model.PolicyInte
 	staticRouteAdvert := d.Get("static_route_advertisement")
 	if staticRouteAdvert != nil {
 		for _, sAdvert := range staticRouteAdvert.([]interface{}) {
+			if sAdvert == nil {
+				continue
+			}
 			// Should be one as list has MaxItems = 1
 			sAdvertMap := sAdvert.(map[string]interface{})
 
@@ -184,6 +190,9 @@ func getPolicyInterVRFRoutingFromSchema(d *schema.ResourceData) model.PolicyInte
 			advertRulesList := sAdvertMap["advertisement_rule"]
 			if advertRulesList != nil {
 				for _, advRule := range advertRulesList.([]interface{}) {
+					if advRule == nil {
+						continue
+					}
 					advRuleMap := advRule.(map[string]interface{})
 					action := advRuleMap["action"].(string)
 					name := advRuleMap["name"].(string)


### PR DESCRIPTION
Null block elements emitted by Terraform (e.g. empty dynamic blocks) caused a panic in getPolicyInterVRFRoutingFromSchema during Update because the unchecked type assertion brl.(map[string]interface{}) crashed when the slice contained a nil interface value. Add nil-continue guards before every such assertion in the bgp_route_leaking, static_route_advertisement, and advertisement_rule loops.

(cherry picked from commit f3b860b28c30df2686fa6e2088a9034f86ee6712)