### PR TITLE
Fix index out of range panic for short segment paths (#2078)

### DIFF
--- a/nsxt/segment_port_common.go
+++ b/nsxt/segment_port_common.go
@@ -405,7 +405,7 @@ func getSegmentPort(segmentPath, segmentPortId string, context utl.SessionContex
 
 func isT1Segment(segmentPath string) bool {
 	pathSplit := strings.Split(segmentPath, "/")
-	if len(pathSplit) >= 3 && pathSplit[len(pathSplit)-4] == "tier-1s" {
+	if len(pathSplit) >= 4 && pathSplit[len(pathSplit)-4] == "tier-1s" {
 		return true
 	}
 	return false
@@ -418,7 +418,7 @@ func getSegmentIdFromSegPath(segPortPath string) string {
 
 func getT1IdFromSegPath(segPortPath string) string {
 	pathSplit := strings.Split(segPortPath, "/")
-	if len(pathSplit) >= 3 && pathSplit[len(pathSplit)-4] == "tier-1s" {
+	if len(pathSplit) >= 4 && pathSplit[len(pathSplit)-4] == "tier-1s" {
 		return pathSplit[len(pathSplit)-3]
 	}
 	return ""


### PR DESCRIPTION
isT1Segment() and getT1IdFromSegPath() accessed pathSplit[len-4] while only guarding with `len >= 3`. When segment_path contains exactly three tokens (e.g. "a/b/c"), len-4 evaluates to -1 and Go panics with "index out of range [-1]" instead of returning a graceful error.

Raise the minimum length guard to >= 4 in both functions so the index is always in bounds. A valid T1 segment path has the form /infra/tier-1s/{id}/segments/{id} (six tokens), so the existing happy-path behaviour is unchanged.

(cherry picked from commit 10eb67e940a91d4b222d95b5927ed2d14e1c9280)