### PR TITLE
Prevent index panic in policy path importer (#2101)

### DIFF
--- a/nsxt/policy_utils.go
+++ b/nsxt/policy_utils.go
@@ -514,7 +514,7 @@ func nsxtPolicyPathResourceImporterHelper(d *schema.ResourceData, m interface{})
 		// assigned into the context as well
 		ctxMap := make(map[string]interface{})
 		ctxMap["project_id"] = pathSegs[4]
-		if len(pathSegs) > 5 && pathSegs[5] == "vpcs" {
+		if len(pathSegs) > 6 && pathSegs[5] == "vpcs" {
 			ctxMap["vpc_id"] = pathSegs[6]
 		}
 		d.Set("context", []interface{}{ctxMap})


### PR DESCRIPTION
The policy resource importer helper in policy_utils.go relied on strict hardcoded slice indices (e.g. index 6) when splitting user-provided import ID paths.

When a user attempts to import an 'nsxt_policy_static_route' with a truncated or invalid ID path format, the provider crashes with an out of bounds index panic: "runtime error: index out of range [6] with length 6".

(cherry picked from commit 60a9d0e22fd6c843f0e0e049a1c74e46ab2f095d)