### PR TITLE
Address a bug with floodProtectionProfileBindingModelToSchema (#2040)

### DIFF
--- a/nsxt/resource_nsxt_policy_distributed_flood_protection_profile_binding.go
+++ b/nsxt/resource_nsxt_policy_distributed_flood_protection_profile_binding.go
@@ -152,9 +152,17 @@ func resourceNsxtPolicyDistributedFloodProtectionProfileBindingRead(d *schema.Re
 		return handleReadError(d, "FloodProtectionProfileBinding", id, err)
 	}
 
-	floodProtectionProfileBindingModelToSchema(d, *binding.DisplayName, *binding.Description, id, *binding.Path, *binding.ProfilePath, *binding.SequenceNumber, binding.Tags, *binding.Revision)
+	floodProtectionProfileBindingModelToSchema(d, binding.DisplayName, binding.Description, id, binding.Path, binding.ProfilePath, int64PtrOrZero(binding.SequenceNumber), binding.Tags, binding.Revision)
 
 	return nil
+}
+
+func int64PtrOrZero(p *int64) *int64 {
+	if p != nil {
+		return p
+	}
+	z := int64(0)
+	return &z
 }
 
 func resourceNsxtPolicyDistributedFloodProtectionProfileBindingUpdate(d *schema.ResourceData, m interface{}) error {

--- a/nsxt/resource_nsxt_policy_gateway_flood_protection_profile_binding.go
+++ b/nsxt/resource_nsxt_policy_gateway_flood_protection_profile_binding.go
@@ -225,11 +225,12 @@ func resourceNsxtPolicyGatewayFloodProtectionProfileBindingRead(d *schema.Resour
 		return handleReadError(d, "GatewayFloodProtectionProfileBinding", id, err)
 	}
 
-	floodProtectionProfileBindingModelToSchema(d, *binding.DisplayName, *binding.Description, id, *binding.Path, *binding.ProfilePath, -1, binding.Tags, *binding.Revision)
+	floodProtectionProfileBindingModelToSchema(d, binding.DisplayName, binding.Description, id, binding.Path, binding.ProfilePath, nil, binding.Tags, binding.Revision)
 	return nil
 }
 
-func floodProtectionProfileBindingModelToSchema(d *schema.ResourceData, displayName, description, nsxID, path, profilePath string, seqNum int64, tags []model.Tag, revision int64) {
+// seqNum is set only for the distributed binding; pass nil for gateway (no sequence_number attribute).
+func floodProtectionProfileBindingModelToSchema(d *schema.ResourceData, displayName, description *string, nsxID string, path, profilePath *string, seqNum *int64, tags []model.Tag, revision *int64) {
 	d.Set("display_name", displayName)
 	d.Set("description", description)
 	setPolicyTagsInSchema(d, tags)
@@ -238,7 +239,7 @@ func floodProtectionProfileBindingModelToSchema(d *schema.ResourceData, displayN
 	d.Set("revision", revision)
 
 	d.Set("profile_path", profilePath)
-	if seqNum != -1 {
+	if seqNum != nil {
 		d.Set("sequence_number", seqNum)
 	}
 }


### PR DESCRIPTION
When null values are returned from NSX, function causes a null pointer exception.

(cherry picked from commit 3209ea64256298a027132323ebcd9688c368e5d4)