### PR TITLE
Fix acknowledgment of non-ackable upgrade precheck warnings (#2126)

### DIFF
--- a/nsxt/resource_nsxt_upgrade_precheck_acknowledge.go
+++ b/nsxt/resource_nsxt_upgrade_precheck_acknowledge.go
@@ -119,7 +119,11 @@ func acknowledgePrecheckWarnings(m interface{}, precheckIDs []string) error {
 	}
 	var warns []string
 	for _, warn := range precheckWarnings {
-		warns = append(warns, *warn.Id)
+		// Only append warnings that actually need acknowledgment and are not already acknowledged.
+		// If NeedsAck is nil (e.g. for backward compatibility or in tests), we default to true.
+		if (warn.NeedsAck == nil || *warn.NeedsAck) && (warn.Acked == nil || !*warn.Acked) {
+			warns = append(warns, *warn.Id)
+		}
 	}
 
 	client := upgrade.NewPreUpgradeChecksClient(connector)
@@ -127,11 +131,19 @@ func acknowledgePrecheckWarnings(m interface{}, precheckIDs []string) error {
 		if slices.Contains(warns, precheckID) {
 			err := client.Acknowledge(precheckID)
 			if err != nil {
-				msg := fmt.Sprintf("Failed to acknowledge precheck warning with ID %s", precheckID)
-				return logAPIError(msg, err)
+				errStr := err.Error()
+				// If the warning does not need acknowledgment or is already acknowledged,
+				// the NSX API might return error code 30976 (Invalid pre-check id provided).
+				// We ignore this error and log it, since the precheck is already in the desired state.
+				if strings.Contains(errStr, "30976") || strings.Contains(errStr, "Invalid pre-check id provided") {
+					log.Printf("[INFO] Ignoring error acknowledging precheck warning %s: %s", precheckID, errStr)
+				} else {
+					msg := fmt.Sprintf("Failed to acknowledge precheck warning with ID %s", precheckID)
+					return logAPIError(msg, err)
+				}
 			}
 		} else {
-			log.Printf("[INFO] Precheck warning with ID %s has not been triggered by NSX", precheckID)
+			log.Printf("[INFO] Precheck warning with ID %s has not been triggered by NSX, or doesn't need acknowledgment", precheckID)
 		}
 	}
 	return nil


### PR DESCRIPTION
Skip acknowledgment of upgrade precheck warnings when needs_ack is false.

The Upgrade Coordinator returns CannotAcknowledgeException (code 30976) when trying to acknowledge prechecks that do not require acknowledgment. Precheck warnings like edgeNodeAlarmCheckCheck (which are informational warnings with needs_ack set to false) can be collected and requested for acknowledgment, but there is no need to ack them.

Update acknowledgePrecheckWarnings to filter out warnings where needs_ack is false or has already been acknowledged, preventing unnecessary and invalid API calls. Additionally, handle and gracefully ignore any 30976 error code returned by the NSX API in case the precheck's state changed.


(cherry picked from commit 32ec818c07f847fc0c1e19fdbd1a15a2619149a4)