### PR TITLE
fix(upgrade): validate upgrade_run_id in postcheck datasource and fix…

### DIFF
--- a/docs/data-sources/upgrade_postcheck.md
+++ b/docs/data-sources/upgrade_postcheck.md
@@ -1,12 +1,20 @@
 ---
-subcategory: "Beta"
-page_title: "NSXT: edge_upgrade_group"
-description: An Edge Upgrade Group data source.
+subcategory: "Upgrade"
+page_title: "NSXT: upgrade_postcheck"
+description: A data source to retrieve upgrade post-check results.
 ---
 
 # nsxt_upgrade_postcheck
 
-This data source provides information about Upgrade post-check results.
+This data source waits for upgrade post-checks to complete and reports any failures.
+
+The data source polls post-check execution status until all groups have finished running
+checks (i.e. none remain in `IN_PROGRESS` state). On success, no output is expected:
+`failed_group` will be empty when all post-checks passed. If any group fails or has
+warnings, it will be listed in `failed_group`.
+
+Post-checks are triggered by the `nsxt_upgrade_run` resource when `post_upgrade_check`
+is enabled in `edge_upgrade_setting` or `host_upgrade_setting`.
 
 ## Example Usage
 
@@ -20,14 +28,17 @@ data "nsxt_upgrade_postcheck" "pc" {
 ## Argument Reference
 
 * `upgrade_run_id` - (Required) The ID of corresponding `nsxt_upgrade_run` resource.
-* `type` - (Required) Component type of upgrade post-checks. Supported type: EDGE, HOST.
+* `type` - (Required) Component type of upgrade post-checks. Supported values: `EDGE`, `HOST`.
+* `timeout` - (Optional) Post-check status checks timeout in seconds. Default: 1800 seconds.
+* `interval` - (Optional) Interval to check post-check status in seconds. Default: 30 seconds.
+* `delay` - (Optional) Initial delay before starting post-check status checks in seconds. Default: 30 seconds.
 
 ## Attributes Reference
 
 In addition to arguments listed above, the following attributes are exported:
 
-* `failed_group` - (Computed) The description of the resource.
+* `failed_group` - Upgrade unit groups that failed post-checks. This list will be empty when all post-checks passed successfully.
     * `id` - ID of upgrade unit group.
     * `status` - Status of execution of upgrade post-checks.
     * `details` - Details about current execution of upgrade post-checks.
-    * `failure_count` - Total count of generated failures or warnings in last execution of upgrade post-checks      },
+    * `failure_count` - Total count of generated failures or warnings in last execution of upgrade post-checks.

--- a/nsxt/data_source_nsxt_upgrade_postcheck.go
+++ b/nsxt/data_source_nsxt_upgrade_postcheck.go
@@ -13,6 +13,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp/nsx/model"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp/nsx/upgrade/upgrade_unit_groups"
+
+	"github.com/vmware/terraform-provider-nsxt/nsxt/util"
 )
 
 var (
@@ -93,6 +95,11 @@ func dataSourceNsxtUpgradePostCheck() *schema.Resource {
 }
 
 func dataSourceNsxtUpgradePostCheckRead(d *schema.ResourceData, m interface{}) error {
+	upgradeRunID := d.Get("upgrade_run_id").(string)
+	if !util.VerifyVerifiableID(upgradeRunID, "nsxt_upgrade_run") {
+		return fmt.Errorf("value for upgrade_run_id is invalid: %s", upgradeRunID)
+	}
+
 	connector := getPolicyConnector(m)
 	aggregateInfoClient := upgrade_unit_groups.NewAggregateInfoClient(connector)
 	component := d.Get("type").(string)
@@ -156,5 +163,6 @@ func dataSourceNsxtUpgradePostCheckRead(d *schema.ResourceData, m interface{}) e
 		d.Set("failed_group", failedGroup)
 	}
 
+	d.SetId(fmt.Sprintf("%s/%s", upgradeRunID, component))
 	return nil
 }

--- a/nsxt/resource_nsxt_upgrade_run.go
+++ b/nsxt/resource_nsxt_upgrade_run.go
@@ -410,7 +410,7 @@ func resourceNsxtUpgradeRunCreate(d *schema.ResourceData, m interface{}) error {
 func upgradeRunCreateOrUpdate(d *schema.ResourceData, m interface{}) error {
 	id := d.Id()
 	if id == "" {
-		id = newUUID()
+		id = util.GetVerifiableID(newUUID(), "nsxt_upgrade_run")
 	}
 
 	// Validate that upgrade_prepare_id is actually from the nsxt_upgrade_prepare_ready data source


### PR DESCRIPTION
… docs (#2066)

- nsxt_upgrade_run now generates a verifiable ID (UUID + FNV hash tag "nsxt_upgrade_run") so it can be validated by consumers
- nsxt_upgrade_postcheck datasource validates upgrade_run_id against the verifiable ID scheme, mirroring how nsxt_upgrade_prepare_ready validates upgrade_prepare_ready_id
- datasource now calls d.SetId() so Terraform tracks state correctly
- docs: fix wrong subcategory/page_title/description, document timeout/ interval/delay args, clarify that failed_group is empty on success


(cherry picked from commit a1d65ee21f88deafe32d5f3cc06f3849014bcf6d)