### PR TITLE
Probe LDAP provider only when enabled (#2012)

### DIFF
--- a/nsxt/resource_nsxt_policy_ldap_identity_source.go
+++ b/nsxt/resource_nsxt_policy_ldap_identity_source.go
@@ -121,9 +121,10 @@ func resourceNsxtPolicyLdapIdentitySource() *schema.Resource {
 	}
 }
 
-func getLdapServersFromSchema(d *schema.ResourceData) []nsxModel.IdentitySourceLdapServer {
+func getLdapServersFromSchema(d *schema.ResourceData) ([]nsxModel.IdentitySourceLdapServer, bool) {
 	servers := d.Get("ldap_server").([]interface{})
 	serverList := make([]nsxModel.IdentitySourceLdapServer, 0)
+	isEnabled := false
 	for _, server := range servers {
 		data := server.(map[string]interface{})
 		bindIdentity := data["bind_identity"].(string)
@@ -141,9 +142,10 @@ func getLdapServersFromSchema(d *schema.ResourceData) []nsxModel.IdentitySourceL
 			UseStarttls:  &useStarttls,
 		}
 
+		isEnabled = enabled || isEnabled
 		serverList = append(serverList, elem)
 	}
-	return serverList
+	return serverList, isEnabled
 }
 
 // getLdapServerPasswordMap caches password of ldap servers for setting back to schema after read
@@ -207,7 +209,7 @@ func resourceNsxtPolicyLdapIdentitySourceProbeAndUpdate(d *schema.ResourceData, 
 	domainName := d.Get("domain_name").(string)
 	baseDn := d.Get("base_dn").(string)
 	altDomainNames := getStringListFromSchemaList(d, "alternative_domain_names")
-	ldapServers := getLdapServersFromSchema(d)
+	ldapServers, isEnabled := getLdapServersFromSchema(d)
 
 	var dataValue data.DataValue
 	var errs []error
@@ -242,26 +244,29 @@ func resourceNsxtPolicyLdapIdentitySourceProbeAndUpdate(d *schema.ResourceData, 
 	}
 	structValue := dataValue.(*data.StructValue)
 
-	log.Printf("[INFO] Probing LDAP Identity Source with ID %s", id)
-	probeResult, err := ldapClient.Probeidentitysource(structValue)
-	if err != nil {
-		return logAPIError("Error probing LDAP Identity Source", err)
-	}
-	for _, result := range probeResult.Results {
-		if result.Result != nil && *result.Result != nsxModel.IdentitySourceLdapServerProbeResult_RESULT_SUCCESS {
-			probeErrs := make([]string, 0)
-			for _, probeErr := range result.Errors {
-				if probeErr.ErrorType != nil {
-					probeErrs = append(probeErrs, *probeErr.ErrorType)
+	// Probe identity source only if it has any enabled servers
+	if isEnabled {
+		log.Printf("[INFO] Probing LDAP Identity Source with ID %s", id)
+		probeResult, err := ldapClient.Probeidentitysource(structValue)
+		if err != nil {
+			return logAPIError("Error probing LDAP Identity Source", err)
+		}
+		for _, result := range probeResult.Results {
+			if result.Result != nil && *result.Result != nsxModel.IdentitySourceLdapServerProbeResult_RESULT_SUCCESS {
+				probeErrs := make([]string, 0)
+				for _, probeErr := range result.Errors {
+					if probeErr.ErrorType != nil {
+						probeErrs = append(probeErrs, *probeErr.ErrorType)
+					}
 				}
+				return fmt.Errorf("LDAP Identity Source server %s probe failed with errors: %s",
+					*result.Url, strings.Join(probeErrs, ","))
 			}
-			return fmt.Errorf("LDAP Identity Source server %s probe failed with errors: %s",
-				*result.Url, strings.Join(probeErrs, ","))
 		}
 	}
 
 	log.Printf("[INFO] PUT LDAP Identity Source with ID %s", id)
-	if _, err = ldapClient.Update(id, structValue); err != nil {
+	if _, err := ldapClient.Update(id, structValue); err != nil {
 		return handleUpdateError(serverType, id, err)
 	}
 


### PR DESCRIPTION
The LDAP identity source resource is probing the LDAP provider for availability. Yet, when the servers are disabled, there is no point in doing so as there's nothing to be probed.


(cherry picked from commit e1a41a0a6a46180c89ae57bca50107eb9c1f35b6)