### PR TITLE
Fix false failures in nsxt_policy_project acceptance tests without TF_ACC

### DIFF
--- a/nsxt/resource_nsxt_policy_project_test.go
+++ b/nsxt/resource_nsxt_policy_project_test.go
@@ -35,6 +35,9 @@ var accTestPolicyProjectUpdateAttributes = map[string]string{
 }
 
 func getExpectedSiteInfoCount(t *testing.T) string {
+	if os.Getenv(resource.EnvTfAcc) == "" {
+		return "0"
+	}
 	if util.NsxVersion == "" {
 		connector, err := testAccGetPolicyConnector()
 		if err != nil {


### PR DESCRIPTION
## Summary
- getExpectedSiteInfoCount (used by several nsxt_policy_project acceptance tests) opened a real NSX policy connector to determine NSX version before resource.ParallelTest ran its own TF_ACC skip check. Without TF_ACC set (or without network access to an NSX manager), this caused the test to be reported FAILED instead of SKIPPED.
- Added an explicit TF_ACC guard (using resource.EnvTfAcc, the same constant the SDK uses internally) so the function short-circuits and returns "0" when acceptance tests are not enabled, matching the SDK's own skip behavior.

## Test plan
- [x] go build ./...
- [x] golangci-lint run ./nsxt/ - 0 issues
- [x] go test ./... - all tests now pass; TestAccResourceNsxtPolicyProject_900basic/910basic/920basic/420basic now correctly SKIP instead of FAIL when TF_ACC is unset

🤖 Generated with [Claude Code](https://claude.com/claude-code)