### PR TITLE
Fix nsxt_policy_ipsec_vpn_session documentation

### DIFF
--- a/docs/resources/policy_ipsec_vpn_session.md
+++ b/docs/resources/policy_ipsec_vpn_session.md
@@ -74,15 +74,16 @@ The following arguments are supported:
   A Route Based VPN is more flexible, more powerful and recommended over policy based VPN. IP Tunnel port is created and all traffic routed via tunnel port is protected.
   Routes can be configured statically or can be learned through BGP. A route based VPN is a must for establishing redundant VPN session to remote site. For RouteBased VPN session, `ip_addresses` and `prefix_length` must be specified to create the tunnel interface and its subnet.
 * `compliance_suite` -  (Optional) Compliance suite. Value is one of `CNSA`, `SUITE_B_GCM_128`, `SUITE_B_GCM_256`, `PRIME`, `FOUNDATION`, `FIPS`, `None`.
-* `compliance_initiation_mode` - (Optional) Connection initiation mode used by local endpoint to establish ike connection with peer site.
+* `connection_initiation_mode` - (Optional) Connection initiation mode used by local endpoint to establish ike connection with peer site.
   `INITIATOR` - In this mode local endpoint initiates tunnel setup and will also respond to incoming tunnel setup requests from peer gateway.
   `RESPOND_ONLY` - In this mode, local endpoint shall only respond to incoming tunnel setup requests. It shall not initiate the tunnel setup.
   `ON_DEMAND` - In this mode local endpoint will initiate tunnel creation once first packet matching the policy rule is received and will also respond to incoming initiation request.
 * `authentication_mode` - (Optional) Peer authentication mode. `PSK` - In this mode a secret key shared between local and peer sites is to be used for authentication. The secret key can be a string with a maximum length of 128 characters. `CERTIFICATE` - In this mode a certificate defined at the global level is to be used for authentication. If user wants to configure compliance_suite, then the authentication_mode can only be `CERTIFICATE`.
+* `psk` - (Optional) IPSec Pre-shared key. Maximum length of this field is 128 characters.
 * `ip_addresses` - (Optional) IP Tunnel interface (commonly referred as VTI) ip_addresses. Only applied for Route Based VPN Session.
 * `prefix_length` - (Optional) Subnet Prefix Length. Only applied for Route Based VPN Session.
-* `peer_address` - (Optional) Public IPV4/V6 address of the remote device terminating the VPN connection.
-* `peer_id` - (Optional) Peer ID to uniquely identify the peer site. The peer ID is the public IP address of the remote device terminating the VPN tunnel. When NAT is configured for the peer, enter the private IP address of the peer.
+* `peer_address` - (Required) Public IPV4/V6 address of the remote device terminating the VPN connection.
+* `peer_id` - (Required) Peer ID to uniquely identify the peer site. The peer ID is the public IP address of the remote device terminating the VPN tunnel. When NAT is configured for the peer, enter the private IP address of the peer.
 * `local_endpoint_path` - (Required) Policy path referencing Local endpoint. In VMC, Local Endpoints are pre-configured the user can refer to their path using `data nsxt_policy_ipsec_vpn_local_endpoint` and using the "Private IP1" or "Public IP1" values to refer to the private and public endpoints respectively. Note that if `authentication_mode` is `CERTIFICATE`, then the local_endpoint must be configured with `certificate_path` and `trust_ca_paths`.
 * `rule` - (Optional) Protect policy rules defined for this IPSec VPN session. Only applicable to `PolicyBased` VPN Session.
     * `sources` - (Optional) List of source subnets. Subnet format is ipv4 or IPv6 CIDR.


### PR DESCRIPTION
Update argument requirements and parameter names in the nsxt_policy_ipsec_vpn_session documentation to match the Go implementation schema:

- Mark peer_id and peer_address as Required instead of Optional.
- Fix typo in connection_initiation_mode parameter name (was compliance_initiation_mode).
- Add missing psk optional argument documentation.