### PR TITLE
Network span is not usable in Global Manager

### DIFF
--- a/docs/resources/policy_network_span.md
+++ b/docs/resources/policy_network_span.md
@@ -8,7 +8,7 @@ description: A resource to configure a NetworkSpan.
 
 This resource provides a method for the management of a NetworkSpan.
 
-This resource is applicable to NSX Global Manager, NSX Policy Manager with version 9.1.0 onwards.
+This resource is applicable to NSX Policy Manager with version 9.1.0 onwards.
 
 ## Example Usage
 


### PR DESCRIPTION
This resource is wrongfully marked as supported by GM. Correct documentation.