### PR TITLE
policy_lb_service datasource not usable on GM

### DIFF
--- a/docs/data-sources/policy_lb_service.md
+++ b/docs/data-sources/policy_lb_service.md
@@ -8,7 +8,7 @@ description: Policy Load Balancer Service data source.
 
 This data source provides information about Policy Service for Load Balancer configured on NSX.
 
-This data source is applicable to NSX Global Manager, NSX Policy Manager and VMC (NSX version 3.0.0 onwards).
+This data source is applicable to NSX Policy Manager (NSX version 3.0.0 onwards).
 
 ## Example Usage
 


### PR DESCRIPTION
The doc wrongfully stated that this datasource is usable in GM and VMC. In fact LB services cannot be created in GM (no API is available) nor read even if created on LM.

As we can't validate this on VMC, removed this from the doc as well.