### PR TITLE
Remove redundant sequence_number

### DIFF
--- a/docs/resources/policy_gateway_policy.md
+++ b/docs/resources/policy_gateway_policy.md
@@ -192,7 +192,6 @@ In addition to arguments listed above, the following attributes are exported:
 * `rule`:
     * `revision` - Indicates current revision number of the object as seen by NSX-T API server. This attribute can be useful for debugging.
     * `path` - The NSX path of the policy resource.
-    * `sequence_number` - Sequence number for the rule.
     * `rule_id` - Unique positive number that is assigned by the system and is useful for debugging.
 
 ~> **NOTE:** `display_name` argument for service entries is not supported for NSX 3.2.x and below.

--- a/docs/resources/policy_security_policy.md
+++ b/docs/resources/policy_security_policy.md
@@ -354,7 +354,6 @@ In addition to arguments listed above, the following attributes are exported:
 * `rule`:
     * `revision` - Indicates current revision number of the object as seen by NSX-T API server. This attribute can be useful for debugging.
     * `path` - The NSX path of the policy resource.
-    * `sequence_number` - Sequence number for the rule.
     * `rule_id` - Unique positive number that is assigned by the system and is useful for debugging.
 
 ~> **NOTE:** `display_name` argument for rule service entries is not supported for NSX 3.2.x and below.


### PR DESCRIPTION
The `sequence_number` attribute is redundant under the `rule` block for `nsxt_policy_gateway_policy` and `nsxt_policy_security_policy` resources.