### PR TITLE
Upgrade dependencies and migrate to stdlib packages (#2059)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/vmware/vsphere-automation-sdk-go/services/nsxt v0.12.1-0.20260614145640-9b3a306dd40d
 	github.com/vmware/vsphere-automation-sdk-go/services/nsxt-gm v0.9.1-0.20241118070726-666c7cd6e466
 	github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp v0.6.1-0.20241118070726-666c7cd6e466
-	golang.org/x/exp v0.0.0-20260813180055-c1d0aacb2297
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -202,8 +202,6 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.55.0 h1:+KWHjbgOaAQ66dh/YlkZKHlz9ZUlq61AFirAR9ntP8M=
 golang.org/x/crypto v0.55.0/go.mod h1:uq0V9dE/fzQuJtbnL+2EhWOE63vo164FY8xqEnV9xis=
-golang.org/x/exp v0.0.0-20260813180055-c1d0aacb2297 h1:YXnL44eJ77R+ji4/ooy8UsXIhz+lbi2Qgdlc8iRN0gY=
-golang.org/x/exp v0.0.0-20260813180055-c1d0aacb2297/go.mod h1:Mkmymgv+uMpSQ/XxJ/7GpdrdYoqm3u72jEbpCLiJmNk=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/mod v0.39.0 h1:UF5zwQdCRRUpHfyPwr7d4UrGiVeldIsogtzWVnczL74=
 golang.org/x/mod v0.39.0/go.mod h1:bvIbwjQ0HUFFf5AKukeeYQG4ZBUG9yxQbR9aEweIwYY=

--- a/nsxt/data_source_nsxt_upgrade_prepare_ready.go
+++ b/nsxt/data_source_nsxt_upgrade_prepare_ready.go
@@ -7,13 +7,13 @@ package nsxt
 import (
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/vmware/terraform-provider-nsxt/nsxt/util"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	nsxModel "github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp/nsx/model"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp/nsx/upgrade"
-	"golang.org/x/exp/slices"
 )
 
 func dataSourceNsxtUpgradePrepareReady() *schema.Resource {

--- a/nsxt/provider.go
+++ b/nsxt/provider.go
@@ -17,6 +17,7 @@ import (
 	"net/url"
 	"os"
 	"regexp"
+	"slices"
 	"strings"
 	"time"
 
@@ -32,7 +33,6 @@ import (
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/security"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp/nsx"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp/nsx/model"
-	"golang.org/x/exp/slices"
 )
 
 var defaultRetryOnStatusCodes = []int{400, 409, 429, 500, 503, 504}

--- a/nsxt/resource_nsxt_edge_transport_node.go
+++ b/nsxt/resource_nsxt_edge_transport_node.go
@@ -7,6 +7,7 @@ package nsxt
 import (
 	"fmt"
 	"log"
+	"maps"
 	"reflect"
 	"strings"
 	"time"
@@ -22,7 +23,6 @@ import (
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp/nsx/transport_nodes"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
-	"golang.org/x/exp/maps"
 
 	"github.com/vmware/terraform-provider-nsxt/nsxt/util"
 )

--- a/nsxt/resource_nsxt_manager_cluster.go
+++ b/nsxt/resource_nsxt_manager_cluster.go
@@ -9,10 +9,9 @@ import (
 	"log"
 	"math/rand"
 	"net"
+	"slices"
 	"strings"
 	"time"
-
-	"golang.org/x/exp/slices"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"


### PR DESCRIPTION
Replace golang.org/x/exp/slices and golang.org/x/exp/maps with the standard library equivalents.
   
(cherry picked from commit 246fab2d27fd0940f960fa43030eb3f67fb6cbab)
