### PR TITLE
Return node version when product version is unavailable

### DIFF
--- a/nsxt/utils.go
+++ b/nsxt/utils.go
@@ -580,7 +580,12 @@ func getNSXVersion(connector client.Connector) (string, error) {
 
 	}
 	log.Printf("[DEBUG] NSX version is %s", *version.NodeVersion)
-	return *version.ProductVersion, nil
+	if version.ProductVersion != nil {
+		return *version.ProductVersion, nil
+	} else if version.NodeVersion != nil {
+		return *version.NodeVersion, nil
+	}
+	return "", logAPIError("Failed to retrieve NSX version, but no error reported by NSX", err)
 }
 
 func initNSXVersion(connector client.Connector) error {


### PR DESCRIPTION
## Summary
- `getNSXVersion` unconditionally dereferenced `version.ProductVersion`, which can be nil, causing a panic. Fall back to `NodeVersion` when `ProductVersion` is unavailable, and return an error only if neither is set.
- This addresses an issue with FNS.

Note: master's #1948 ("Use product version instead of node version to determine manager version") is already satisfied on this branch — `getNSXVersion` already returns `ProductVersion` unconditionally, which is exactly the unguarded-nil-dereference bug this PR (#1993) fixes. Only #1993's fix is needed here.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `golangci-lint run ./nsxt/` — 0 new issues (3 pre-existing, unrelated `govet inline` findings will be resolved by #2300)

Direct, unmodified port — no test files touched in the source PR.