### PR TITLE
Mark identity_source_id as Computed on policy role binding

### DIFF
--- a/nsxt/resource_nsxt_policy_role_binding.go
+++ b/nsxt/resource_nsxt_policy_role_binding.go
@@ -66,6 +66,7 @@ func resourceNsxtPolicyUserManagementRoleBinding() *schema.Resource {
 				Type:        schema.TypeString,
 				Description: "ID of the external identity source",
 				Optional:    true,
+				Computed:    true,
 			},
 			"identity_source_type": {
 				Type:         schema.TypeString,


### PR DESCRIPTION
## Summary
- NSX can populate this field even when it's left unset in config, causing spurious drift. Mark it `Computed` so Terraform accepts the server-assigned value.

Partial port of master's #1959 ("Revise LDAP tests to pass with OpenLDAP server"): only this production schema fix is applicable here — the rest of that PR revises LDAP acceptance tests to target OpenLDAP infrastructure specifics unrelated to this branch.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `golangci-lint run ./nsxt/` — 0 new issues