### PR TITLE
Fix orphaned NSX allocation on IP realization failure

### DIFF
--- a/nsxt/resource_nsxt_policy_ip_address_allocation.go
+++ b/nsxt/resource_nsxt_policy_ip_address_allocation.go
@@ -144,9 +144,7 @@ func resourceNsxtPolicyIPAddressAllocationCreate(d *schema.ResourceData, m inter
 		stateConf := nsxtPolicyWaitForRealizationStateConf(connector, d, m, *obj.Path, timeout)
 		entity, err := stateConf.WaitForState()
 		if err != nil {
-			// Clean up NSX allocation
-			resourceNsxtPolicyIPAddressAllocationDelete(d, m)
-			return err
+			return cleanupFailedIPAddressAllocation(d, m, id, err)
 		}
 		realizedResource := entity.(model.GenericPolicyRealizedResource)
 		for _, attr := range realizedResource.ExtendedAttributes {
@@ -158,15 +156,27 @@ func resourceNsxtPolicyIPAddressAllocationCreate(d *schema.ResourceData, m inter
 				return resourceNsxtPolicyIPAddressAllocationRead(d, m)
 			}
 		}
-		// Clean up NSX allocation
-		resourceNsxtPolicyIPAddressAllocationDelete(d, m)
-		return fmt.Errorf("Failed to get realized IP for path %s", d.Get("path"))
+		return cleanupFailedIPAddressAllocation(d, m, id, fmt.Errorf("Failed to get realized IP for path %s", d.Get("path")))
 	}
 
 	d.SetId(id)
 	d.Set("nsx_id", id)
 	MarkPostWriteAndInvalidateCacheForResourceType(resourceTypeIpAddressAllocation, d.Id(), m)
 	return resourceNsxtPolicyIPAddressAllocationRead(d, m)
+}
+
+// cleanupFailedIPAddressAllocation deletes an IPAddressAllocation that was already
+// created on NSX (via Patch) but whose realization failed, so it isn't leaked.
+// The ID is set temporarily so resourceNsxtPolicyIPAddressAllocationDelete can be
+// reused (including its cache invalidation), then cleared again since Create is
+// failing and no resource should end up in Terraform state.
+func cleanupFailedIPAddressAllocation(d *schema.ResourceData, m interface{}, id string, originalErr error) error {
+	d.SetId(id)
+	if deleteErr := resourceNsxtPolicyIPAddressAllocationDelete(d, m); deleteErr != nil {
+		log.Printf("[WARNING] Failed to clean up IPAddressAllocation with ID %s after create failure: %v", id, deleteErr)
+	}
+	d.SetId("")
+	return originalErr
 }
 
 func resourceNsxtPolicyIPAddressAllocationRead(d *schema.ResourceData, m interface{}) error {

--- a/nsxt/resource_nsxt_policy_ip_address_allocation_test.go
+++ b/nsxt/resource_nsxt_policy_ip_address_allocation_test.go
@@ -6,6 +6,7 @@ package nsxt
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -28,6 +29,18 @@ var accTestPolicyIPAddressAllocationUpdateAttributes = map[string]string{
 
 var accTestPolicyIPAddressAllocationPoolName = getAccTestResourceName()
 var accTestPolicyIPAddressAllocationSubnetName = getAccTestResourceName()
+
+var accTestPolicyIPAddressAllocationExhaustedPoolName = getAccTestResourceName()
+var accTestPolicyIPAddressAllocationExhaustedSubnetName = getAccTestResourceName()
+var accTestPolicyIPAddressAllocationExhaustedConsumerName = getAccTestResourceName()
+var accTestPolicyIPAddressAllocationExhaustedName = getAccTestResourceName()
+var accTestPolicyIPAddressAllocationExhaustedID = getAccTestResourceName()
+
+var accTestPolicyIPAddressAllocationExhausted92PoolName = getAccTestResourceName()
+var accTestPolicyIPAddressAllocationExhausted92SubnetName = getAccTestResourceName()
+var accTestPolicyIPAddressAllocationExhausted92ConsumerName = getAccTestResourceName()
+var accTestPolicyIPAddressAllocationExhausted92Name = getAccTestResourceName()
+var accTestPolicyIPAddressAllocationExhausted92ID = getAccTestResourceName()
 
 func TestAccResourceNsxtPolicyIPAddressAllocation_basic(t *testing.T) {
 	testAccResourceNsxtPolicyIPAddressAllocationBasic(t, false, func() {
@@ -192,6 +205,125 @@ func TestAccResourceNsxtPolicyIPAddressAllocation_importBasic_multitenancy(t *te
 		},
 	})
 }
+
+// TestAccResourceNsxtPolicyIPAddressAllocation_poolExhausted verifies that, on NSX
+// versions below 9.2.0, when an IP pool has no free addresses left, a create with
+// allocation_ip unset passes the initial PATCH but then fails once NSX can't
+// asynchronously realize an actual IP, and that the failed allocation is not left
+// behind as an orphaned object on NSX Manager. This exercises the cleanup path fixed
+// in resourceNsxtPolicyIPAddressAllocationCreate for realization failures.
+//
+// On NSX 9.2.0+ pool exhaustion is instead rejected synchronously by the PATCH call
+// itself, so the create never reaches that cleanup path; see the _poolExhausted92
+// sibling test below for that behavior.
+func TestAccResourceNsxtPolicyIPAddressAllocation_poolExhausted(t *testing.T) {
+	testResourceName := "nsxt_policy_ip_address_allocation.consumer"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccOnlyLocalManager(t)
+			testAccPreCheck(t)
+			testAccNSXVersionLessThan(t, "9.2.0")
+		},
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			if err := testAccNsxtPolicyIPAddressAllocationCheckDestroy(state, accTestPolicyIPAddressAllocationExhaustedConsumerName); err != nil {
+				return err
+			}
+			return testAccNsxtPolicyIPAddressAllocationCheckNotLeaked(state, accTestPolicyIPAddressAllocationExhaustedID)
+		},
+		Steps: []resource.TestStep{
+			{
+				// Consume the single IP available in the pool.
+				Config: testAccNsxtPolicyIPAddressAllocationExhaustedTemplate(false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicyIPAddressAllocationExists(testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "allocation_ip", "13.13.13.10"),
+				),
+			},
+			{
+				// The pool now has no free IPs left; this allocation must fail, and
+				// must not leave an orphaned allocation behind on NSX Manager.
+				Config:      testAccNsxtPolicyIPAddressAllocationExhaustedTemplate(true),
+				ExpectError: regexp.MustCompile("Failed to get realized IP for path"),
+			},
+		},
+	})
+}
+
+// TestAccResourceNsxtPolicyIPAddressAllocation_poolExhausted92 covers the same pool
+// exhaustion scenario as TestAccResourceNsxtPolicyIPAddressAllocation_poolExhausted,
+// but for NSX 9.2.0+, where the backend validates IP availability synchronously
+// inside the initial PATCH call and rejects it outright (error code 520054) rather
+// than deferring the failure to async realization. Nothing is created on NSX in this
+// case, so this does not exercise the realization-failure cleanup path (covered by
+// the pre-9.2 sibling test above); it exists so pool exhaustion still has acceptance
+// coverage on 9.2+.
+func TestAccResourceNsxtPolicyIPAddressAllocation_poolExhausted92(t *testing.T) {
+	testResourceName := "nsxt_policy_ip_address_allocation.consumer"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccOnlyLocalManager(t)
+			testAccPreCheck(t)
+			testAccNSXVersion(t, "9.2.0")
+		},
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			if err := testAccNsxtPolicyIPAddressAllocationCheckDestroy(state, accTestPolicyIPAddressAllocationExhausted92ConsumerName); err != nil {
+				return err
+			}
+			return testAccNsxtPolicyIPAddressAllocationCheckNotLeaked(state, accTestPolicyIPAddressAllocationExhausted92ID)
+		},
+		Steps: []resource.TestStep{
+			{
+				// Consume the single IP available in the pool.
+				Config: testAccNsxtPolicyIPAddressAllocationExhausted92Template(false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicyIPAddressAllocationExists(testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "allocation_ip", "13.13.13.10"),
+				),
+			},
+			{
+				// The pool now has no free IPs left; NSX rejects the PATCH outright.
+				Config:      testAccNsxtPolicyIPAddressAllocationExhausted92Template(true),
+				ExpectError: regexp.MustCompile("is exhausted, no free IPs available for allocation"),
+			},
+		},
+	})
+}
+
+// testAccNsxtPolicyIPAddressAllocationCheckNotLeaked verifies that the IP address
+// allocation identified by exhaustedID does not exist on NSX Manager. It is used to
+// confirm that an allocation whose create failed (e.g. due to pool exhaustion) was
+// properly cleaned up rather than orphaned.
+func testAccNsxtPolicyIPAddressAllocationCheckNotLeaked(state *terraform.State, exhaustedID string) error {
+	rs, ok := state.RootModule().Resources["nsxt_policy_ip_address_allocation.consumer"]
+	if !ok {
+		return fmt.Errorf("Policy IPAddressAllocation resource %s not found in resources", "nsxt_policy_ip_address_allocation.consumer")
+	}
+	poolPath := rs.Primary.Attributes["pool_path"]
+	if poolPath == "" {
+		return fmt.Errorf("No pool_path found for IP Address Allocation with ID %s", rs.Primary.ID)
+	}
+	poolID := getPolicyIDFromPath(poolPath)
+
+	connector := getPolicyConnector(testAccProvider.Meta().(nsxtClients))
+	nsxClient := ippools.NewIpAllocationsClient(testAccGetSessionContext(), connector)
+	if nsxClient == nil {
+		return policyResourceNotSupportedError()
+	}
+
+	_, err := nsxClient.Get(poolID, exhaustedID)
+	if err == nil {
+		return fmt.Errorf("Policy IPAddressAllocation with ID %s was left behind on NSX Manager after a failed create caused by pool exhaustion", exhaustedID)
+	}
+	if !isNotFoundError(err) {
+		return err
+	}
+	return nil
+}
+
 func testAccNSXPolicyIPAddressAllocationImporterGetID(s *terraform.State) (string, error) {
 	rs, ok := s.RootModule().Resources["nsxt_policy_ip_address_allocation.test"]
 	if !ok {
@@ -346,4 +478,70 @@ resource "nsxt_policy_ip_pool_static_subnet" "test" {
 data "nsxt_policy_realization_info" "subnet_realization" {
   path = nsxt_policy_ip_pool_static_subnet.test.path
 }`, context, accTestPolicyIPAddressAllocationPoolName, context, accTestPolicyIPAddressAllocationSubnetName)
+}
+
+// testAccNsxtPolicyIPAddressAllocationExhaustedTemplateNames builds a pool with a
+// single available IP. The "consumer" resource always consumes that IP. When
+// includeExhausting is true, a second allocation with a known, fixed nsx_id is added;
+// since the pool is already exhausted at that point, its create is expected to fail.
+func testAccNsxtPolicyIPAddressAllocationExhaustedTemplateNames(poolName, subnetName, consumerName, exhaustedID, exhaustedName string, includeExhausting bool) string {
+	config := fmt.Sprintf(`
+resource "nsxt_policy_ip_pool" "exhausted" {
+  display_name = "%s"
+}
+
+resource "nsxt_policy_ip_pool_static_subnet" "exhausted" {
+  display_name = "%s"
+  pool_path    = nsxt_policy_ip_pool.exhausted.path
+  cidr         = "13.13.13.0/24"
+  allocation_range {
+    start = "13.13.13.10"
+    end   = "13.13.13.10"
+  }
+}
+
+data "nsxt_policy_realization_info" "exhausted_subnet_realization" {
+  path = nsxt_policy_ip_pool_static_subnet.exhausted.path
+}
+
+resource "nsxt_policy_ip_address_allocation" "consumer" {
+  display_name = "%s"
+  pool_path    = nsxt_policy_ip_pool.exhausted.path
+  depends_on   = [data.nsxt_policy_realization_info.exhausted_subnet_realization]
+}`, poolName, subnetName, consumerName)
+
+	if !includeExhausting {
+		return config
+	}
+
+	return config + fmt.Sprintf(`
+
+resource "nsxt_policy_ip_address_allocation" "exhausted" {
+  nsx_id       = "%s"
+  display_name = "%s"
+  pool_path    = nsxt_policy_ip_pool.exhausted.path
+  depends_on   = [nsxt_policy_ip_address_allocation.consumer]
+}`, exhaustedID, exhaustedName)
+}
+
+func testAccNsxtPolicyIPAddressAllocationExhaustedTemplate(includeExhausting bool) string {
+	return testAccNsxtPolicyIPAddressAllocationExhaustedTemplateNames(
+		accTestPolicyIPAddressAllocationExhaustedPoolName,
+		accTestPolicyIPAddressAllocationExhaustedSubnetName,
+		accTestPolicyIPAddressAllocationExhaustedConsumerName,
+		accTestPolicyIPAddressAllocationExhaustedID,
+		accTestPolicyIPAddressAllocationExhaustedName,
+		includeExhausting,
+	)
+}
+
+func testAccNsxtPolicyIPAddressAllocationExhausted92Template(includeExhausting bool) string {
+	return testAccNsxtPolicyIPAddressAllocationExhaustedTemplateNames(
+		accTestPolicyIPAddressAllocationExhausted92PoolName,
+		accTestPolicyIPAddressAllocationExhausted92SubnetName,
+		accTestPolicyIPAddressAllocationExhausted92ConsumerName,
+		accTestPolicyIPAddressAllocationExhausted92ID,
+		accTestPolicyIPAddressAllocationExhausted92Name,
+		includeExhausting,
+	)
 }

--- a/nsxt/resource_nsxt_policy_ip_address_allocation_test.go
+++ b/nsxt/resource_nsxt_policy_ip_address_allocation_test.go
@@ -34,13 +34,11 @@ var accTestPolicyIPAddressAllocationExhaustedPoolName = getAccTestResourceName()
 var accTestPolicyIPAddressAllocationExhaustedSubnetName = getAccTestResourceName()
 var accTestPolicyIPAddressAllocationExhaustedConsumerName = getAccTestResourceName()
 var accTestPolicyIPAddressAllocationExhaustedName = getAccTestResourceName()
-var accTestPolicyIPAddressAllocationExhaustedID = getAccTestResourceName()
 
 var accTestPolicyIPAddressAllocationExhausted92PoolName = getAccTestResourceName()
 var accTestPolicyIPAddressAllocationExhausted92SubnetName = getAccTestResourceName()
 var accTestPolicyIPAddressAllocationExhausted92ConsumerName = getAccTestResourceName()
 var accTestPolicyIPAddressAllocationExhausted92Name = getAccTestResourceName()
-var accTestPolicyIPAddressAllocationExhausted92ID = getAccTestResourceName()
 
 func TestAccResourceNsxtPolicyIPAddressAllocation_basic(t *testing.T) {
 	testAccResourceNsxtPolicyIPAddressAllocationBasic(t, false, func() {
@@ -230,7 +228,7 @@ func TestAccResourceNsxtPolicyIPAddressAllocation_poolExhausted(t *testing.T) {
 			if err := testAccNsxtPolicyIPAddressAllocationCheckDestroy(state, accTestPolicyIPAddressAllocationExhaustedConsumerName); err != nil {
 				return err
 			}
-			return testAccNsxtPolicyIPAddressAllocationCheckNotLeaked(state, accTestPolicyIPAddressAllocationExhaustedID)
+			return testAccNsxtPolicyIPAddressAllocationCheckNotLeaked(state)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -273,7 +271,7 @@ func TestAccResourceNsxtPolicyIPAddressAllocation_poolExhausted92(t *testing.T) 
 			if err := testAccNsxtPolicyIPAddressAllocationCheckDestroy(state, accTestPolicyIPAddressAllocationExhausted92ConsumerName); err != nil {
 				return err
 			}
-			return testAccNsxtPolicyIPAddressAllocationCheckNotLeaked(state, accTestPolicyIPAddressAllocationExhausted92ID)
+			return testAccNsxtPolicyIPAddressAllocationCheckNotLeaked(state)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -293,11 +291,14 @@ func TestAccResourceNsxtPolicyIPAddressAllocation_poolExhausted92(t *testing.T) 
 	})
 }
 
-// testAccNsxtPolicyIPAddressAllocationCheckNotLeaked verifies that the IP address
-// allocation identified by exhaustedID does not exist on NSX Manager. It is used to
-// confirm that an allocation whose create failed (e.g. due to pool exhaustion) was
-// properly cleaned up rather than orphaned.
-func testAccNsxtPolicyIPAddressAllocationCheckNotLeaked(state *terraform.State, exhaustedID string) error {
+// testAccNsxtPolicyIPAddressAllocationCheckNotLeaked verifies that the only
+// IPAddressAllocation left on NSX Manager under the pool is the "consumer" one. Since
+// the failed "exhausted" allocation gets an auto-generated nsx_id (unknown to the
+// test), it can't be looked up directly; instead this lists everything under the
+// pool and confirms nothing besides the consumer's ID is present, to confirm that an
+// allocation whose create failed (e.g. due to pool exhaustion) was properly cleaned
+// up rather than orphaned.
+func testAccNsxtPolicyIPAddressAllocationCheckNotLeaked(state *terraform.State) error {
 	rs, ok := state.RootModule().Resources["nsxt_policy_ip_address_allocation.consumer"]
 	if !ok {
 		return fmt.Errorf("Policy IPAddressAllocation resource %s not found in resources", "nsxt_policy_ip_address_allocation.consumer")
@@ -314,12 +315,14 @@ func testAccNsxtPolicyIPAddressAllocationCheckNotLeaked(state *terraform.State, 
 		return policyResourceNotSupportedError()
 	}
 
-	_, err := nsxClient.Get(poolID, exhaustedID)
-	if err == nil {
-		return fmt.Errorf("Policy IPAddressAllocation with ID %s was left behind on NSX Manager after a failed create caused by pool exhaustion", exhaustedID)
-	}
-	if !isNotFoundError(err) {
+	result, err := nsxClient.List(poolID, nil, nil, nil, nil, nil, nil)
+	if err != nil {
 		return err
+	}
+	for _, alloc := range result.Results {
+		if alloc.Id != nil && *alloc.Id != rs.Primary.ID {
+			return fmt.Errorf("Policy IPAddressAllocation %s was left behind on NSX Manager after a failed create caused by pool exhaustion", *alloc.Id)
+		}
 	}
 	return nil
 }
@@ -482,9 +485,11 @@ data "nsxt_policy_realization_info" "subnet_realization" {
 
 // testAccNsxtPolicyIPAddressAllocationExhaustedTemplateNames builds a pool with a
 // single available IP. The "consumer" resource always consumes that IP. When
-// includeExhausting is true, a second allocation with a known, fixed nsx_id is added;
-// since the pool is already exhausted at that point, its create is expected to fail.
-func testAccNsxtPolicyIPAddressAllocationExhaustedTemplateNames(poolName, subnetName, consumerName, exhaustedID, exhaustedName string, includeExhausting bool) string {
+// includeExhausting is true, a second allocation with an auto-generated nsx_id is
+// added; since the pool is already exhausted at that point, its create is expected
+// to fail. Leaving nsx_id auto-generated (rather than fixed) matches the common case
+// and is an exact repro of the reported customer issue.
+func testAccNsxtPolicyIPAddressAllocationExhaustedTemplateNames(poolName, subnetName, consumerName, exhaustedName string, includeExhausting bool) string {
 	config := fmt.Sprintf(`
 resource "nsxt_policy_ip_pool" "exhausted" {
   display_name = "%s"
@@ -517,11 +522,10 @@ resource "nsxt_policy_ip_address_allocation" "consumer" {
 	return config + fmt.Sprintf(`
 
 resource "nsxt_policy_ip_address_allocation" "exhausted" {
-  nsx_id       = "%s"
   display_name = "%s"
   pool_path    = nsxt_policy_ip_pool.exhausted.path
   depends_on   = [nsxt_policy_ip_address_allocation.consumer]
-}`, exhaustedID, exhaustedName)
+}`, exhaustedName)
 }
 
 func testAccNsxtPolicyIPAddressAllocationExhaustedTemplate(includeExhausting bool) string {
@@ -529,7 +533,6 @@ func testAccNsxtPolicyIPAddressAllocationExhaustedTemplate(includeExhausting boo
 		accTestPolicyIPAddressAllocationExhaustedPoolName,
 		accTestPolicyIPAddressAllocationExhaustedSubnetName,
 		accTestPolicyIPAddressAllocationExhaustedConsumerName,
-		accTestPolicyIPAddressAllocationExhaustedID,
 		accTestPolicyIPAddressAllocationExhaustedName,
 		includeExhausting,
 	)
@@ -540,7 +543,6 @@ func testAccNsxtPolicyIPAddressAllocationExhausted92Template(includeExhausting b
 		accTestPolicyIPAddressAllocationExhausted92PoolName,
 		accTestPolicyIPAddressAllocationExhausted92SubnetName,
 		accTestPolicyIPAddressAllocationExhausted92ConsumerName,
-		accTestPolicyIPAddressAllocationExhausted92ID,
 		accTestPolicyIPAddressAllocationExhausted92Name,
 		includeExhausting,
 	)

--- a/nsxt/utgomock_resource_nsxt_policy_ip_address_allocation_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_ip_address_allocation_test.go
@@ -7,6 +7,7 @@
 package nsxt
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -18,8 +19,10 @@ import (
 	"go.uber.org/mock/gomock"
 
 	ippoolsapi "github.com/vmware/terraform-provider-nsxt/api/infra/ip_pools"
+	realizedstateapi "github.com/vmware/terraform-provider-nsxt/api/infra/realized_state"
 	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
 	ippoolmocks "github.com/vmware/terraform-provider-nsxt/mocks/infra/ip_pools"
+	realizedstatemocks "github.com/vmware/terraform-provider-nsxt/mocks/infra/realized_state"
 )
 
 var (
@@ -55,6 +58,13 @@ func minimalNsxtIpAllocData() map[string]interface{} {
 	}
 }
 
+func minimalNsxtIpAllocDataNoIP() map[string]interface{} {
+	data := minimalNsxtIpAllocData()
+	delete(data, "allocation_ip")
+	data["timeout"] = 5
+	return data
+}
+
 func setupNsxtIpAllocMock(t *testing.T, ctrl *gomock.Controller) (*ippoolmocks.MockIpAllocationsClient, func()) {
 	mockSDK := ippoolmocks.NewMockIpAllocationsClient(ctrl)
 	mockWrapper := &ippoolsapi.IpAddressAllocationClientContext{
@@ -67,6 +77,20 @@ func setupNsxtIpAllocMock(t *testing.T, ctrl *gomock.Controller) (*ippoolmocks.M
 		return mockWrapper
 	}
 	return mockSDK, func() { cliIpAllocationsClient = original }
+}
+
+func setupNsxtIpAllocRealizedMock(t *testing.T, ctrl *gomock.Controller) (*realizedstatemocks.MockRealizedEntitiesClient, func()) {
+	mockSDK := realizedstatemocks.NewMockRealizedEntitiesClient(ctrl)
+	mockWrapper := &realizedstateapi.RealizedEntityClientContext{
+		Client:     mockSDK,
+		ClientType: utl.Local,
+	}
+
+	original := cliRealizedEntitiesClient
+	cliRealizedEntitiesClient = func(_ utl.SessionContext, _ vapiProtocolClient.Connector) *realizedstateapi.RealizedEntityClientContext {
+		return mockWrapper
+	}
+	return mockSDK, func() { cliRealizedEntitiesClient = original }
 }
 
 func TestMockResourceNsxtPolicyIPAddressAllocationCreate(t *testing.T) {
@@ -100,6 +124,64 @@ func TestMockResourceNsxtPolicyIPAddressAllocationCreate(t *testing.T) {
 
 		err := resourceNsxtPolicyIPAddressAllocationCreate(d, newGoMockProviderClient())
 		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyIPAddressAllocationCreateRealizationCleanup(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restoreAlloc := setupNsxtIpAllocMock(t, ctrl)
+	defer restoreAlloc()
+	mockRealizedSDK, restoreRealized := setupNsxtIpAllocRealizedMock(t, ctrl)
+	defer restoreRealized()
+
+	t.Run("Create cleans up and clears ID when realization fails", func(t *testing.T) {
+		notFoundErr := vapiErrors.NotFound{}
+		gomock.InOrder(
+			mockSDK.EXPECT().Get(nsxtIpAllocPoolID, nsxtIpAllocID).Return(nsxModel.IpAddressAllocation{}, notFoundErr),
+			mockSDK.EXPECT().Patch(nsxtIpAllocPoolID, nsxtIpAllocID, gomock.Any()).Return(nil),
+			mockSDK.EXPECT().Get(nsxtIpAllocPoolID, nsxtIpAllocID).Return(nsxtIpAllocAPIResponse(), nil),
+		)
+		mockRealizedSDK.EXPECT().List(nsxtIpAllocPath, nil).Return(nsxModel.GenericPolicyRealizedResourceListResult{}, errors.New("realization query failed"))
+		// Cleanup must delete the already-created NSX object, keyed by the
+		// resource ID directly (not read back from d.Id(), which isn't set yet).
+		mockSDK.EXPECT().Delete(nsxtIpAllocPoolID, nsxtIpAllocID).Return(nil)
+
+		res := resourceNsxtPolicyIPAddressAllocation()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalNsxtIpAllocDataNoIP())
+
+		err := resourceNsxtPolicyIPAddressAllocationCreate(d, newGoMockProviderClient())
+		require.Error(t, err)
+		assert.Equal(t, "", d.Id())
+	})
+
+	t.Run("Create cleans up and clears ID when realized IP attribute is missing", func(t *testing.T) {
+		notFoundErr := vapiErrors.NotFound{}
+		realizedState := "REALIZED"
+		otherAttrKey := "other_attr"
+		gomock.InOrder(
+			mockSDK.EXPECT().Get(nsxtIpAllocPoolID, nsxtIpAllocID).Return(nsxModel.IpAddressAllocation{}, notFoundErr),
+			mockSDK.EXPECT().Patch(nsxtIpAllocPoolID, nsxtIpAllocID, gomock.Any()).Return(nil),
+			mockSDK.EXPECT().Get(nsxtIpAllocPoolID, nsxtIpAllocID).Return(nsxtIpAllocAPIResponse(), nil),
+		)
+		mockRealizedSDK.EXPECT().List(nsxtIpAllocPath, nil).Return(nsxModel.GenericPolicyRealizedResourceListResult{
+			Results: []nsxModel.GenericPolicyRealizedResource{
+				{
+					State: &realizedState,
+					ExtendedAttributes: []nsxModel.AttributeVal{
+						{Key: &otherAttrKey, Values: []string{"x"}},
+					},
+				},
+			},
+		}, nil)
+		mockSDK.EXPECT().Delete(nsxtIpAllocPoolID, nsxtIpAllocID).Return(nil)
+
+		res := resourceNsxtPolicyIPAddressAllocation()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalNsxtIpAllocDataNoIP())
+
+		err := resourceNsxtPolicyIPAddressAllocationCreate(d, newGoMockProviderClient())
+		require.Error(t, err)
+		assert.Equal(t, "", d.Id())
 	})
 }
 


### PR DESCRIPTION
## Summary
- `resourceNsxtPolicyIPAddressAllocationCreate` waits for realization when `allocation_ip` is unset, and on failure tried to clean up the already-created NSX object via `resourceNsxtPolicyIPAddressAllocationDelete(d, m)`. That function reads `d.Id()`, but the ID is only set on success — so on failure the cleanup silently no-op'd on an empty ID, leaking the IP allocation on NSX Manager with no corresponding Terraform state.
- Fix: temporarily set `d.SetId(id)` so the real delete path (including its cache invalidation) can be reused for cleanup, then clear the ID again before returning the original error so `Create` still correctly reports nothing was created.

## Test plan
- [x] `go build ./...` and `go vet ./...`
- [x] New unit tests in `utgomock_resource_nsxt_policy_ip_address_allocation_test.go` cover both failure paths (realization query error, and realized response missing the `allocation_ip` attribute), asserting cleanup actually deletes the NSX object and `d.Id()` ends up empty
- [x] `go test -tags unittest ./nsxt/...` passes for this resource

🤖 Generated with [Claude Code](https://claude.com/claude-code)