### PR TITLE
Fix plan drift on DHCPv6 preferred_time when left unset in config

### DIFF
--- a/nsxt/segment_common.go
+++ b/nsxt/segment_common.go
@@ -433,6 +433,7 @@ func getDhcpPreferredTimeSchema() *schema.Schema {
 		Type:         schema.TypeInt,
 		Description:  "The time interval in seconds, in which the prefix is advertised as preferred",
 		Optional:     true,
+		Computed:     true,
 		ValidateFunc: validation.IntAtLeast(48),
 	}
 }


### PR DESCRIPTION
NSX computes a server-side default for preferred_time (derived from lease_time) when it's omitted from the config. Since the schema was only Optional (no Computed, no Default), Terraform expected the attribute to plan back to null/zero on refresh, producing a spurious non-empty plan against the server-assigned value. Mark it Optional+ Computed so an omitted config value keeps whatever NSX/state already has, matching the pattern used for other server-defaulted attributes.

Fixes TestAccResourceNsxtVpcSubnetDhcpV6StaticBindingConfig920_basic and TestAccResourceNsxtVpcSubnetDhcpV6StaticBindingConfig920_importBasic failing on terraform-testacc-lm-92-latest #270.