### PR TITLE
Filter provider managed tags during state read

### DIFF
--- a/nsxt/policy_utils.go
+++ b/nsxt/policy_utils.go
@@ -132,6 +132,9 @@ func getPolicyTagsFromSet(tagSet *schema.Set) []model.Tag {
 func initPolicyTagsSet(tags []model.Tag) []map[string]interface{} {
 	var tagList []map[string]interface{}
 	for _, tag := range tags {
+		if isManagedDefaultTag(tag) {
+			continue
+		}
 		elem := make(map[string]interface{})
 		elem["scope"] = tag.Scope
 		elem["tag"] = tag.Tag
@@ -305,6 +308,9 @@ func setCustomizedPolicyTagsInSchema(d *schema.ResourceData, tags []model.Tag, s
 	var ignoredTagList []map[string]interface{}
 	scopesToIgnore := getTagScopesToIgnore(d)
 	for _, tag := range tags {
+		if isManagedDefaultTag(tag) {
+			continue
+		}
 		elem := make(map[string]interface{})
 		elem["scope"] = tag.Scope
 		elem["tag"] = tag.Tag

--- a/nsxt/policy_utils_and_utils_unit_test.go
+++ b/nsxt/policy_utils_and_utils_unit_test.go
@@ -101,6 +101,32 @@ func TestUnitNsxt_setCustomizedPolicyTagsInSchema(t *testing.T) {
 	require.Equal(t, 1, st.Len())
 }
 
+func TestUnitNsxt_setCustomizedPolicyTagsInSchema_skipsManagedTags(t *testing.T) {
+	sch := map[string]*schema.Schema{"tag": getTagsSchema()}
+	d := schema.TestResourceDataRaw(t, sch, map[string]interface{}{})
+	s1, t1 := "scope1", "tag1"
+	sManaged, tManaged := managedDefaultTagScope, "some-run-id"
+	setCustomizedPolicyTagsInSchema(d, []model.Tag{
+		{Scope: &s1, Tag: &t1},
+		{Scope: &sManaged, Tag: &tManaged},
+	}, "tag")
+	st := d.Get("tag").(*schema.Set)
+	require.Equal(t, 1, st.Len())
+	elem := st.List()[0].(map[string]interface{})
+	assert.Equal(t, "scope1", elem["scope"])
+}
+
+func TestUnitNsxt_initPolicyTagsSet_skipsManagedTags(t *testing.T) {
+	s1, t1 := "scope1", "tag1"
+	sManaged, tManaged := managedDefaultTagScope, "some-run-id"
+	out := initPolicyTagsSet([]model.Tag{
+		{Scope: &s1, Tag: &t1},
+		{Scope: &sManaged, Tag: &tManaged},
+	})
+	require.Len(t, out, 1)
+	assert.Equal(t, "scope1", *out[0]["scope"].(*string))
+}
+
 func TestUnitNsxt_setPathListInSchema(t *testing.T) {
 	sch := map[string]*schema.Schema{
 		"paths": {


### PR DESCRIPTION
When NSXT_CACHE_MODE is set to config_scope, the provider automatically stamps provider-managed tracking tags (scope="nsx-tf/tf-run-id") onto NSX objects. When switching the cache mode back to disabled, reading resource state populates these nsx-tf/tf-run-id tags into Terraform state. Because isConfigScopedCacheMode evaluates to false in disabled mode, Terraform compares the refreshed state containing the managed tag against the HCL configuration and plans an in-place update to remove the tag.

Filter out isManagedDefaultTag in setCustomizedPolicyTagsInSchema and initPolicyTagsSet so provider-managed tracking tags are never stored in state schema during read operations regardless of active cache mode. Add unit tests to cover this behavior.