### PR TITLE
Fix panic on invalid custom attribute ID import

### DIFF
--- a/nsxt/resource_nsxt_policy_context_profile_custom_attribute.go
+++ b/nsxt/resource_nsxt_policy_context_profile_custom_attribute.go
@@ -26,9 +26,12 @@ var customAttributeKeys = []string{
 	model.PolicyCustomAttributes_KEY_CUSTOM_URL,
 }
 
-func splitCustomAttributeID(id string) (string, string) {
-	s := strings.Split(id, "~")
-	return s[0], s[1]
+func splitCustomAttributeID(id string) (string, string, error) {
+	s := strings.SplitN(id, "~", 2)
+	if len(s) != 2 || s[0] == "" || s[1] == "" {
+		return "", "", fmt.Errorf("invalid Context Profile Custom Attribute ID %q: expected format <key>~<attribute>", id)
+	}
+	return s[0], s[1], nil
 }
 
 func makeCustomAttributeID(key string, attribute string) string {
@@ -67,7 +70,10 @@ func resourceNsxtPolicyContextProfileCustomAttributeExists(sessionContext utl.Se
 	var err error
 	var attrList model.PolicyContextProfileListResult
 
-	key, attribute := splitCustomAttributeID(id)
+	key, attribute, err := splitCustomAttributeID(id)
+	if err != nil {
+		return false, err
+	}
 	source := model.PolicyCustomAttributes_ATTRIBUTE_SOURCE_CUSTOM
 	client := cliDefaultClient(sessionContext, connector)
 	if client == nil {
@@ -104,7 +110,10 @@ func resourceNsxtPolicyContextProfileCustomAttributeExists(sessionContext utl.Se
 
 func resourceNsxtPolicyContextProfileCustomAttributeRead(d *schema.ResourceData, m interface{}) error {
 	id := d.Id()
-	key, attribute := splitCustomAttributeID(id)
+	key, attribute, err := splitCustomAttributeID(id)
+	if err != nil {
+		return err
+	}
 
 	log.Printf("[INFO] Reading ContextProfileCustomAttribute with ID %s", d.Id())
 
@@ -155,10 +164,13 @@ func resourceNsxtPolicyContextProfileCustomAttributeCreate(d *schema.ResourceDat
 }
 
 func resourceNsxtPolicyContextProfileCustomAttributeDelete(d *schema.ResourceData, m interface{}) error {
-	key, attribute := splitCustomAttributeID(d.Id())
+	key, attribute, err := splitCustomAttributeID(d.Id())
+	if err != nil {
+		return err
+	}
 	log.Printf("[INFO] Deleting ContextProfileCustomAttribute with ID %s", attribute)
 	attributes := []string{attribute}
-	err := resourceNsxtPolicyContextProfileCustomAttributeRead(d, m)
+	err = resourceNsxtPolicyContextProfileCustomAttributeRead(d, m)
 
 	if err != nil {
 		return err

--- a/nsxt/utgomock_resource_nsxt_policy_context_profile_custom_attribute_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_context_profile_custom_attribute_test.go
@@ -148,6 +148,23 @@ func TestMockResourceNsxtPolicyContextProfileCustomAttributeRead(t *testing.T) {
 		err := resourceNsxtPolicyContextProfileCustomAttributeRead(d, m)
 		require.Error(t, err)
 	})
+
+	t.Run("Read_fails_when_invalid_id", func(t *testing.T) {
+		invalidIDs := []string{
+			"invalid_id_no_tilde",
+			"",
+			"~example.com",
+			"DOMAIN_NAME~",
+		}
+		for _, id := range invalidIDs {
+			d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+			d.SetId(id)
+			m := newGoMockProviderClient()
+			err := resourceNsxtPolicyContextProfileCustomAttributeRead(d, m)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "invalid Context Profile Custom Attribute ID")
+		}
+	})
 }
 
 func TestMockResourceNsxtPolicyContextProfileCustomAttributeDelete(t *testing.T) {
@@ -213,5 +230,53 @@ func TestMockResourceNsxtPolicyContextProfileCustomAttributeDelete(t *testing.T)
 		m := newGoMockProviderClient()
 		err := resourceNsxtPolicyContextProfileCustomAttributeDelete(d, m)
 		require.Error(t, err)
+	})
+
+	t.Run("Delete_fails_when_invalid_id", func(t *testing.T) {
+		invalidIDs := []string{
+			"invalid_id_no_tilde",
+			"",
+			"~example.com",
+			"DOMAIN_NAME~",
+		}
+		for _, id := range invalidIDs {
+			d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+			d.SetId(id)
+			m := newGoMockProviderClient()
+			err := resourceNsxtPolicyContextProfileCustomAttributeDelete(d, m)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "invalid Context Profile Custom Attribute ID")
+		}
+	})
+}
+
+func TestUnitNsxt_splitCustomAttributeID(t *testing.T) {
+	t.Run("valid_id", func(t *testing.T) {
+		key, attr, err := splitCustomAttributeID("DOMAIN_NAME~example.com")
+		require.NoError(t, err)
+		assert.Equal(t, "DOMAIN_NAME", key)
+		assert.Equal(t, "example.com", attr)
+	})
+
+	t.Run("valid_id_with_nested_tilde", func(t *testing.T) {
+		key, attr, err := splitCustomAttributeID("CUSTOM_URL~https://example.com/~path")
+		require.NoError(t, err)
+		assert.Equal(t, "CUSTOM_URL", key)
+		assert.Equal(t, "https://example.com/~path", attr)
+	})
+
+	t.Run("invalid_ids", func(t *testing.T) {
+		testCases := []string{
+			"",
+			"invalid_id_no_tilde",
+			"plain_attribute_id",
+			"~example.com",
+			"DOMAIN_NAME~",
+		}
+		for _, tc := range testCases {
+			_, _, err := splitCustomAttributeID(tc)
+			require.Error(t, err, "expected error for input %q", tc)
+			assert.Contains(t, err.Error(), "invalid Context Profile Custom Attribute ID")
+		}
 	})
 }


### PR DESCRIPTION
Importing or reading nsxt_policy_context_profile_custom_attribute with an ID lacking the expected '~' separator causes splitCustomAttributeID to access index 1 of a single-element slice, triggering a runtime panic and crashing the provider plugin.

Validate the ID structure in splitCustomAttributeID and return an explicit error when the delimiter is missing, or when key/attribute parts are empty. Update callers to propagate the error cleanly.