### PR TITLE
Scope policy ID searches by resource type

### DIFF
--- a/nsxt/policy_search.go
+++ b/nsxt/policy_search.go
@@ -120,9 +120,9 @@ func policyDataSourceResourceReadWithValidation(d *schema.ResourceData, connecto
 		if resourceType == "PolicyEdgeNode" {
 			// Edge Node is a special case where id != nsx_id
 			// TODO: consider switching all searches to nsx id
-			resultValues, err = listPolicyResourcesByNsxID(connector, context, &objID, &additionalQueryString)
+			resultValues, err = listPolicyResourcesByNsxID(connector, context, &objID, resourceType, &additionalQueryString)
 		} else {
-			resultValues, err = listPolicyResourcesByID(connector, context, &objID, &additionalQueryString, isGlobal)
+			resultValues, err = listPolicyResourcesByID(connector, context, &objID, resourceType, &additionalQueryString, isGlobal)
 		}
 	} else {
 		resultValues, err = listPolicyResourcesByNameAndType(connector, context, objName, resourceType, &additionalQueryString, isGlobal)
@@ -218,13 +218,23 @@ func escapeSpecialCharacters(str string) string {
 	return str
 }
 
-func listPolicyResourcesByID(connector client.Connector, context utl.SessionContext, resourceID *string, additionalQuery *string, isGlobal bool) ([]*data.StructValue, error) {
-	query := fmt.Sprintf("id:%s AND marked_for_delete:false", escapeSpecialCharacters(*resourceID))
+func listPolicyResourcesByID(connector client.Connector, context utl.SessionContext, resourceID *string, resourceType string, additionalQuery *string, isGlobal bool) ([]*data.StructValue, error) {
+	var query string
+	if resourceType != "" {
+		query = fmt.Sprintf("resource_type:%s AND id:%s AND marked_for_delete:false", resourceType, escapeSpecialCharacters(*resourceID))
+	} else {
+		query = fmt.Sprintf("id:%s AND marked_for_delete:false", escapeSpecialCharacters(*resourceID))
+	}
 	return searchByContext(connector, context, query, additionalQuery)
 }
 
-func listPolicyResourcesByNsxID(connector client.Connector, context utl.SessionContext, resourceID *string, additionalQuery *string) ([]*data.StructValue, error) {
-	query := fmt.Sprintf("nsx_id:%s AND marked_for_delete:false", escapeSpecialCharacters(*resourceID))
+func listPolicyResourcesByNsxID(connector client.Connector, context utl.SessionContext, resourceID *string, resourceType string, additionalQuery *string) ([]*data.StructValue, error) {
+	var query string
+	if resourceType != "" {
+		query = fmt.Sprintf("resource_type:%s AND nsx_id:%s AND marked_for_delete:false", resourceType, escapeSpecialCharacters(*resourceID))
+	} else {
+		query = fmt.Sprintf("nsx_id:%s AND marked_for_delete:false", escapeSpecialCharacters(*resourceID))
+	}
 	return searchByContext(connector, context, query, additionalQuery)
 }
 

--- a/nsxt/policy_search_unit_test.go
+++ b/nsxt/policy_search_unit_test.go
@@ -132,9 +132,34 @@ func TestUnitNsxt_listPolicyResourcesByNsxID(t *testing.T) {
 	nsxID := "nsx-uuid-1"
 	add := ""
 	ctx := utl.SessionContext{ClientType: utl.Local}
-	out, err := listPolicyResourcesByNsxID(nil, ctx, &nsxID, &add)
+	out, err := listPolicyResourcesByNsxID(nil, ctx, &nsxID, "PolicyEdgeNode", &add)
 	require.NoError(t, err)
 	assert.Len(t, out, 1)
+}
+
+func TestUnitNsxt_listPolicyResourcesByID(t *testing.T) {
+	rt := "PolicyTransportZone"
+	sv := policyResourceToStructValue(t, gmModel.PolicyResource{
+		Id: str("tz-id"), DisplayName: str("tz-name"), Path: str("/infra/tz"), ResourceType: &rt,
+	})
+	stub := &seqQueryListClient{responses: []nsxModel.SearchResponse{
+		{Results: []*data.StructValue{sv}, ResultCount: i64(1)},
+		{Results: []*data.StructValue{sv}, ResultCount: i64(1)},
+	}}
+	defer setupCliQueryClientStub(t, stub)()
+	resID := "tz-id"
+	add := ""
+	ctx := utl.SessionContext{ClientType: utl.Local}
+
+	// with resourceType
+	out, err := listPolicyResourcesByID(nil, ctx, &resID, rt, &add, false)
+	require.NoError(t, err)
+	assert.Len(t, out, 1)
+
+	// without resourceType
+	out2, err2 := listPolicyResourcesByID(nil, ctx, &resID, "", &add, false)
+	require.NoError(t, err2)
+	assert.Len(t, out2, 1)
 }
 
 func TestUnitNsxt_listInventoryResourcesByAnyFieldAndType(t *testing.T) {


### PR DESCRIPTION
When querying policy data sources by ID,
policyDataSourceResourceReadWithValidation previously invoked listPolicyResourcesByID and listPolicyResourcesByNsxID without specifying resource_type in the search query.

If the NSX search index for an unrelated resource type becomes unsynced or degraded, an unscoped search query by ID triggers a global multi-type search and fails on the NSX Manager.

Pass resource_type into listPolicyResourcesByID and listPolicyResourcesByNsxID to scope queries to the target resource type, making ID-based data source lookups resilient to unrelated indexing failures.