### PR TITLE
Fix nsxt_transport_node data source get-by-id EdgeNode check

### DIFF
--- a/nsxt/data_source_nsxt_transport_node.go
+++ b/nsxt/data_source_nsxt_transport_node.go
@@ -43,7 +43,7 @@ func dataSourceNsxtTransportNodeRead(d *schema.ResourceData, m interface{}) erro
 
 		// Make sure that found obj is an EdgeNode
 		converter := bindings.NewTypeConverter()
-		base, errs := converter.ConvertToGolang(obj.NodeDeploymentInfo, model.NodeBindingType())
+		base, errs := converter.ConvertToGolang(objGet.NodeDeploymentInfo, model.NodeBindingType())
 		if errs != nil {
 			return fmt.Errorf("failed to convert NodeDeploymentInfo for node %s %v", objID, errs[0])
 		}


### PR DESCRIPTION
dataSourceNsxtTransportNodeRead converted obj.NodeDeploymentInfo before obj was ever assigned from the freshly-fetched objGet, so the EdgeNode type check always operated on a zero-value node and the "get by id" path could never succeed.