### PR TITLE
chore: add `main` branch to workflows

### DIFF
--- a/.github/workflows/fmt-check.yml
+++ b/.github/workflows/fmt-check.yml
@@ -8,6 +8,7 @@ on:
       - '.github/workflows/fmt-check.yml'
   push:
     branches:
+      - main
       - master
       - 'branch_*'
       - 'release-*'

--- a/.github/workflows/go-security.yml
+++ b/.github/workflows/go-security.yml
@@ -7,6 +7,7 @@ on:
       - README.md
   push:
     branches:
+      - main
       - master
       - 'branch_*'
       - 'release-*'

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -7,6 +7,7 @@ on:
       - README.md
   push:
     branches:
+      - main
       - master
       - 'branch_*'
       - 'release-*'

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -7,6 +7,7 @@ on:
       - README.md
   push:
     branches:
+      - main
       - master
       - 'branch_*'
       - 'release-*'

--- a/.github/workflows/unit-tests-nsxt.yml
+++ b/.github/workflows/unit-tests-nsxt.yml
@@ -9,6 +9,7 @@ on:
       - '.github/workflows/unit-tests-nsxt.yml'
   push:
     branches:
+      - main
       - master
       - 'branch_*'
       - 'release-*'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,19 +22,19 @@ Example:
 
 ``` shell
 git remote add upstream https://github.com/vmware/terraform-provider-nsxt.git
-git checkout -b my-new-feature master
+git checkout -b my-new-feature main
 git commit -a
 git push origin my-new-feature
 ```
 
 ### Staying In Sync With Upstream
 
-When your branch gets out of sync with the vmware/master branch, use the following to update:
+When your branch gets out of sync with the vmware/main branch, use the following to update:
 
 ``` shell
 git checkout my-new-feature
 git fetch -a
-git pull --rebase upstream master
+git pull --rebase upstream main
 git push --force-with-lease origin my-new-feature
 ```
 
@@ -57,7 +57,7 @@ If you need to squash changes into an earlier commit, you can use:
 ``` shell
 git add .
 git commit --fixup <commit>
-git rebase -i --autosquash master
+git rebase -i --autosquash main
 git push --force-with-lease origin my-new-feature
 ```
 


### PR DESCRIPTION
Adds `main` to the existing workflows alongside `master` for the first phase.

Post-merge `master` can be renamed to `main` and these same workflows can be updated to remove `master` and complete the transition of the default branch name.