### PR TITLE
Support IPv6 for project IP address allocation

### DIFF
--- a/docs/resources/project_ip_address_allocation.md
+++ b/docs/resources/project_ip_address_allocation.md
@@ -8,7 +8,7 @@ description: A resource to configure IP Address Allocation under Project.
 
 This resource provides a method for allocating IP Address from IP block associated with VPC.
 
-This resource is applicable to NSX Policy Manager.
+This resource is applicable to NSX Policy Manager. IPv6-related arguments (`ip_address_type`, `ipv6_allocation_prefix_length`) are only available in v9.2.0 and above.
 
 ## Example Usage
 
@@ -22,6 +22,20 @@ resource "nsxt_policy_project_ip_address_allocation" "nat" {
 }
 ```
 
+## Example Usage - IPv6 Allocation (NSX 9.2.0+)
+
+```hcl
+resource "nsxt_policy_project_ip_address_allocation" "ipv6" {
+  context {
+    project_id = data.nsxt_policy_project.dev.id
+  }
+  display_name                  = "ipv6-alloc"
+  ip_address_type               = "IPV6"
+  ipv6_allocation_prefix_length = 64
+  ip_block                      = data.nsxt_policy_project.dev.ipv6_blocks[0]
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -30,8 +44,10 @@ The following arguments are supported:
 * `description` - (Optional) Description of the resource.
 * `tag` - (Optional) A list of scope + tag pairs to associate with this resource.
 * `nsx_id` - (Optional) The NSX ID of this resource. If set, this ID will be used to create the resource.
-* `allocation_size` - (Optional) The system will allocate IP addresses from unused IP addresses based on allocation size. Currently only size `1` is supported.
+* `allocation_size` - (Optional) The system will allocate IP addresses from unused IP addresses based on allocation size. Currently only size `1` is supported. Conflicts with `ipv6_allocation_prefix_length`.
 * `allocation_ips` - (Optional) If specified, IPs have to be within range of respective IP blocks.
+* `ip_address_type` - (Optional) Type of IP address to allocate. Allowed values are `IPV4` and `IPV6`. Defaults to `IPV4`. Immutable after creation (forces new resource). This attribute is only available in v9.2.0 and above.
+* `ipv6_allocation_prefix_length` - (Optional) Prefix length of the allocated IPv6 subnet. Allowed values are between `64` and `128`. Defaults to `64`. Conflicts with `allocation_size`. Immutable after creation (forces new resource). This attribute is only available in v9.2.0 and above.
 * `ip_block` - (Optional) Policy path for IP Block for the allocation.
 
 ## Attributes Reference

--- a/nsxt/resource_nsxt_policy_project_ip_address_allocation.go
+++ b/nsxt/resource_nsxt_policy_project_ip_address_allocation.go
@@ -10,6 +10,7 @@ import (
 	"reflect"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/vmware/terraform-provider-nsxt/api/orgs/projects"
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
@@ -19,6 +20,11 @@ import (
 )
 
 var cliProjectIpAddressAllocationsClient = projects.NewIpAddressAllocationsClient
+
+var projectIpAddressAllocationIpAddressTypeValues = []string{
+	model.ProjectIpAddressAllocation_IP_ADDRESS_TYPE_IPV4,
+	model.ProjectIpAddressAllocation_IP_ADDRESS_TYPE_IPV6,
+}
 
 var projectIpAddressAllocationSchema = map[string]*metadata.ExtendedSchema{
 	"nsx_id":       metadata.GetExtendedSchema(getNsxIDSchema()),
@@ -44,15 +50,49 @@ var projectIpAddressAllocationSchema = map[string]*metadata.ExtendedSchema{
 	},
 	"allocation_size": {
 		Schema: schema.Schema{
-			Type:     schema.TypeInt,
-			Optional: true,
-			Computed: true,
-			ForceNew: true,
+			Type:          schema.TypeInt,
+			Optional:      true,
+			Computed:      true,
+			ForceNew:      true,
+			ConflictsWith: []string{"ipv6_allocation_prefix_length"},
 		},
 		Metadata: metadata.Metadata{
 			SchemaType:   "int",
 			SdkFieldName: "AllocationSize",
 			OmitIfEmpty:  true,
+		},
+	},
+	"ip_address_type": {
+		Schema: schema.Schema{
+			Type:         schema.TypeString,
+			ValidateFunc: validation.StringInSlice(projectIpAddressAllocationIpAddressTypeValues, false),
+			Optional:     true,
+			Computed:     true,
+			// NSX API does not allow modifying IP address type on an existing allocation
+			ForceNew: true,
+		},
+		Metadata: metadata.Metadata{
+			IntroducedInVersion: "9.2.0",
+			SchemaType:          "string",
+			SdkFieldName:        "IpAddressType",
+			OmitIfEmpty:         true,
+		},
+	},
+	"ipv6_allocation_prefix_length": {
+		Schema: schema.Schema{
+			Type:          schema.TypeInt,
+			Optional:      true,
+			Computed:      true,
+			ValidateFunc:  validation.IntBetween(64, 128),
+			ConflictsWith: []string{"allocation_size"},
+			// NSX API does not allow modifying IPv6 prefix length on an existing allocation
+			ForceNew: true,
+		},
+		Metadata: metadata.Metadata{
+			IntroducedInVersion: "9.2.0",
+			SchemaType:          "int",
+			SdkFieldName:        "Ipv6AllocationPrefixLength",
+			OmitIfEmpty:         true,
 		},
 	},
 	"ip_block": {

--- a/nsxt/resource_nsxt_policy_project_ip_address_allocation_test.go
+++ b/nsxt/resource_nsxt_policy_project_ip_address_allocation_test.go
@@ -104,6 +104,65 @@ func TestAccResourceNsxtPolicyProjectIpAddressAllocation_importBasic(t *testing.
 	})
 }
 
+func TestAccResourceNsxtPolicyProjectIpAddressAllocation_ipv6(t *testing.T) {
+	testResourceName := "nsxt_policy_project_ip_address_allocation.test_ipv6"
+	createName := getAccTestResourceName()
+	updateName := getAccTestResourceName()
+	fixtureBase := getAccTestResourceName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccOnlyVPC(t)
+			testAccNSXVersion(t, "9.2.0")
+		},
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyProjectIpAddressAllocationCheckDestroy(state, updateName)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyProjectIpAddressAllocationIpv6Template(true, fixtureBase, createName, updateName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicyProjectIpAddressAllocationExists(createName, testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", createName),
+					resource.TestCheckResourceAttr(testResourceName, "description", accTestProjectIpAddressAllocationCreateAttributes["description"]),
+					resource.TestCheckResourceAttr(testResourceName, "ip_address_type", "IPV6"),
+					resource.TestCheckResourceAttr(testResourceName, "ipv6_allocation_prefix_length", "64"),
+					resource.TestCheckResourceAttrSet(testResourceName, "allocation_ips"),
+					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
+					resource.TestCheckResourceAttrPair("data.nsxt_policy_project_ip_address_allocation.test_ipv6", "path", testResourceName, "path"),
+				),
+			},
+			{
+				Config: testAccNsxtPolicyProjectIpAddressAllocationIpv6Template(false, fixtureBase, createName, updateName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicyProjectIpAddressAllocationExists(updateName, testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", updateName),
+					resource.TestCheckResourceAttr(testResourceName, "description", accTestProjectIpAddressAllocationUpdateAttributes["description"]),
+					resource.TestCheckResourceAttr(testResourceName, "ip_address_type", "IPV6"),
+					resource.TestCheckResourceAttr(testResourceName, "ipv6_allocation_prefix_length", "64"),
+					resource.TestCheckResourceAttrSet(testResourceName, "allocation_ips"),
+					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
+					resource.TestCheckResourceAttrPair("data.nsxt_policy_project_ip_address_allocation.test_ipv6", "path", testResourceName, "path"),
+				),
+			},
+			{
+				ResourceName:      testResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccResourceNsxtPolicyImportIDRetriever(testResourceName),
+			},
+		},
+	})
+}
+
 func testAccNsxtPolicyProjectIpAddressAllocationExists(displayName string, resourceName string) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
 
@@ -119,7 +178,11 @@ func testAccNsxtPolicyProjectIpAddressAllocationExists(displayName string, resou
 			return fmt.Errorf("Policy ProjectIpAddressAllocation resource ID not set in resources")
 		}
 
-		exists, err := resourceNsxtPolicyProjectIpAddressAllocationExists(testAccGetSessionContext(), resourceID, connector)
+		sessionContext := testAccGetSessionContextFromParentPath(testAccProvider.Meta(), rs.Primary.Attributes["path"])
+		if sessionContext.ProjectID == "" {
+			sessionContext = testAccGetSessionContext()
+		}
+		exists, err := resourceNsxtPolicyProjectIpAddressAllocationExists(sessionContext, resourceID, connector)
 		if err != nil {
 			return err
 		}
@@ -140,7 +203,11 @@ func testAccNsxtPolicyProjectIpAddressAllocationCheckDestroy(state *terraform.St
 		}
 
 		resourceID := rs.Primary.Attributes["id"]
-		exists, err := resourceNsxtPolicyProjectIpAddressAllocationExists(testAccGetSessionContext(), resourceID, connector)
+		sessionContext := testAccGetSessionContextFromParentPath(testAccProvider.Meta(), rs.Primary.Attributes["path"])
+		if sessionContext.ProjectID == "" {
+			sessionContext = testAccGetSessionContext()
+		}
+		exists, err := resourceNsxtPolicyProjectIpAddressAllocationExists(sessionContext, resourceID, connector)
 		if err != nil {
 			return err
 		}
@@ -203,4 +270,51 @@ data "nsxt_policy_project_ip_address_allocation" "test" {
   %s
   allocation_ips = nsxt_policy_project_ip_address_allocation.test.allocation_ips
 }`, os.Getenv("NSXT_VPC_PROJECT_ID"), testAccNsxtProjectContext(), updateName, accTestProjectIpAddressAllocationUpdateAttributes["allocation_size"], testAccNsxtProjectContext())
+}
+
+func testAccNsxtPolicyProjectIpAddressAllocationIpv6Template(createFlow bool, fixtureBase, createName, updateName string) string {
+	var attrMap map[string]string
+	if createFlow {
+		attrMap = accTestProjectIpAddressAllocationCreateAttributes
+	} else {
+		attrMap = accTestProjectIpAddressAllocationUpdateAttributes
+	}
+	displayName := updateName
+	if createFlow {
+		displayName = createName
+	}
+	return fmt.Sprintf(`
+resource "nsxt_policy_ip_block" "ipv6_block" {
+  display_name = "%s-v6-block"
+  cidr         = "2001:db8:beef::/48"
+  visibility   = "EXTERNAL"
+}
+
+resource "nsxt_policy_project" "ipv6_proj" {
+  display_name = "%s-v6-proj"
+  ipv6_blocks  = [nsxt_policy_ip_block.ipv6_block.path]
+}
+
+resource "nsxt_policy_project_ip_address_allocation" "test_ipv6" {
+  context {
+    project_id = nsxt_policy_project.ipv6_proj.id
+  }
+  display_name                  = "%s"
+  description                   = "%s"
+  ip_address_type               = "IPV6"
+  ipv6_allocation_prefix_length = 64
+  ip_block                      = nsxt_policy_ip_block.ipv6_block.path
+  tag {
+    scope = "scope1"
+    tag   = "tag1"
+  }
+}
+
+data "nsxt_policy_project_ip_address_allocation" "test_ipv6" {
+  context {
+    project_id = nsxt_policy_project.ipv6_proj.id
+  }
+  allocation_ips = nsxt_policy_project_ip_address_allocation.test_ipv6.allocation_ips
+}
+`, fixtureBase, fixtureBase, displayName, attrMap["description"])
 }

--- a/nsxt/utgomock_resource_nsxt_policy_project_ip_address_allocation_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_project_ip_address_allocation_test.go
@@ -20,6 +20,7 @@ import (
 	projectsapi "github.com/vmware/terraform-provider-nsxt/api/orgs/projects"
 	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
 	projectsmocks "github.com/vmware/terraform-provider-nsxt/mocks/orgs/projects"
+	"github.com/vmware/terraform-provider-nsxt/nsxt/util"
 )
 
 var (
@@ -77,11 +78,18 @@ func TestMockResourceNsxtPolicyProjectIpAddressAllocationCreate(t *testing.T) {
 	mockSDK, restore := setupIpAllocMock(t, ctrl)
 	defer restore()
 
-	t.Run("Create success", func(t *testing.T) {
+	t.Run("Create success (defaults omitted on NSX 9.1)", func(t *testing.T) {
+		util.NsxVersion = "9.1.0"
+		defer func() { util.NsxVersion = "" }()
 		notFoundErr := vapiErrors.NotFound{}
 		gomock.InOrder(
 			mockSDK.EXPECT().Get(ipAllocOrgID, ipAllocProjectID, ipAllocID).Return(nsxModel.ProjectIpAddressAllocation{}, notFoundErr),
-			mockSDK.EXPECT().Patch(ipAllocOrgID, ipAllocProjectID, ipAllocID, gomock.Any()).Return(nil),
+			mockSDK.EXPECT().Patch(ipAllocOrgID, ipAllocProjectID, ipAllocID, gomock.Any()).DoAndReturn(
+				func(_ string, _ string, _ string, req nsxModel.ProjectIpAddressAllocation) error {
+					assert.Nil(t, req.IpAddressType)
+					assert.Nil(t, req.Ipv6AllocationPrefixLength)
+					return nil
+				}),
 			mockSDK.EXPECT().Get(ipAllocOrgID, ipAllocProjectID, ipAllocID).Return(ipAllocAPIResponse(), nil),
 		)
 
@@ -92,6 +100,50 @@ func TestMockResourceNsxtPolicyProjectIpAddressAllocationCreate(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, ipAllocID, d.Id())
 		assert.Equal(t, ipAllocDisplayName, d.Get("display_name"))
+	})
+
+	t.Run("Create success IPv6 on NSX 9.2", func(t *testing.T) {
+		util.NsxVersion = "9.2.0"
+		defer func() { util.NsxVersion = "" }()
+		notFoundErr := vapiErrors.NotFound{}
+		ipType := nsxModel.ProjectIpAddressAllocation_IP_ADDRESS_TYPE_IPV6
+		prefixLen := int64(64)
+		ipBlock := "/infra/ip-blocks/block-v6"
+		v6Response := nsxModel.ProjectIpAddressAllocation{
+			Id:                         &ipAllocID,
+			DisplayName:                &ipAllocDisplayName,
+			Description:                &ipAllocDescription,
+			Revision:                   &ipAllocRevision,
+			IpAddressType:              &ipType,
+			Ipv6AllocationPrefixLength: &prefixLen,
+			IpBlock:                    &ipBlock,
+		}
+		gomock.InOrder(
+			mockSDK.EXPECT().Get(ipAllocOrgID, ipAllocProjectID, ipAllocID).Return(nsxModel.ProjectIpAddressAllocation{}, notFoundErr),
+			mockSDK.EXPECT().Patch(ipAllocOrgID, ipAllocProjectID, ipAllocID, gomock.Any()).DoAndReturn(
+				func(_ string, _ string, _ string, req nsxModel.ProjectIpAddressAllocation) error {
+					assert.Equal(t, &ipType, req.IpAddressType)
+					assert.Equal(t, &prefixLen, req.Ipv6AllocationPrefixLength)
+					assert.Nil(t, req.AllocationSize)
+					assert.Equal(t, &ipBlock, req.IpBlock)
+					return nil
+				}),
+			mockSDK.EXPECT().Get(ipAllocOrgID, ipAllocProjectID, ipAllocID).Return(v6Response, nil),
+		)
+
+		res := resourceNsxtPolicyProjectIpAddressAllocation()
+		data := minimalIpAllocData()
+		data["ip_address_type"] = "IPV6"
+		data["ipv6_allocation_prefix_length"] = 64
+		data["ip_block"] = "/infra/ip-blocks/block-v6"
+		d := schema.TestResourceDataRaw(t, res.Schema, data)
+
+		err := resourceNsxtPolicyProjectIpAddressAllocationCreate(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, ipAllocID, d.Id())
+		assert.Equal(t, "IPV6", d.Get("ip_address_type"))
+		assert.Equal(t, 64, d.Get("ipv6_allocation_prefix_length"))
+		assert.Equal(t, 0, d.Get("allocation_size"))
 	})
 
 	t.Run("Create fails when already exists", func(t *testing.T) {
@@ -159,6 +211,40 @@ func TestMockResourceNsxtPolicyProjectIpAddressAllocationUpdate(t *testing.T) {
 
 		res := resourceNsxtPolicyProjectIpAddressAllocation()
 		d := schema.TestResourceDataRaw(t, res.Schema, minimalIpAllocData())
+		d.SetId(ipAllocID)
+
+		err := resourceNsxtPolicyProjectIpAddressAllocationUpdate(d, newGoMockProviderClient())
+		require.NoError(t, err)
+	})
+
+	t.Run("Update success IPv6 on NSX 9.2", func(t *testing.T) {
+		util.NsxVersion = "9.2.0"
+		defer func() { util.NsxVersion = "" }()
+		ipType := nsxModel.ProjectIpAddressAllocation_IP_ADDRESS_TYPE_IPV6
+		prefixLen := int64(64)
+		v6Response := nsxModel.ProjectIpAddressAllocation{
+			Id:                         &ipAllocID,
+			DisplayName:                &ipAllocDisplayName,
+			Description:                &ipAllocDescription,
+			Revision:                   &ipAllocRevision,
+			IpAddressType:              &ipType,
+			Ipv6AllocationPrefixLength: &prefixLen,
+		}
+		gomock.InOrder(
+			mockSDK.EXPECT().Update(ipAllocOrgID, ipAllocProjectID, ipAllocID, gomock.Any()).DoAndReturn(
+				func(_ string, _ string, _ string, req nsxModel.ProjectIpAddressAllocation) (nsxModel.ProjectIpAddressAllocation, error) {
+					assert.Equal(t, &ipType, req.IpAddressType)
+					assert.Equal(t, &prefixLen, req.Ipv6AllocationPrefixLength)
+					return v6Response, nil
+				}),
+			mockSDK.EXPECT().Get(ipAllocOrgID, ipAllocProjectID, ipAllocID).Return(v6Response, nil),
+		)
+
+		res := resourceNsxtPolicyProjectIpAddressAllocation()
+		data := minimalIpAllocData()
+		data["ip_address_type"] = "IPV6"
+		data["ipv6_allocation_prefix_length"] = 64
+		d := schema.TestResourceDataRaw(t, res.Schema, data)
 		d.SetId(ipAllocID)
 
 		err := resourceNsxtPolicyProjectIpAddressAllocationUpdate(d, newGoMockProviderClient())


### PR DESCRIPTION
Add `ip_address_type` and `ipv6_allocation_prefix_length` attributes to `nsxt_policy_project_ip_address_allocation` to support allocating IPv6 address blocks for project workloads.

Update resource documentation and add unit test coverage for IPv6 project IP address allocation creation.