### PR TITLE
Fix two terraform-cache-brownfield regressions in the resource cache

### DIFF
--- a/nsxt/policy_utils.go
+++ b/nsxt/policy_utils.go
@@ -143,6 +143,28 @@ func initPolicyTagsSet(tags []model.Tag) []map[string]interface{} {
 	return tagList
 }
 
+// initPolicyTagsSetForOutgoingPatch is initPolicyTagsSet without the provider-managed-tag
+// filter. GatewayPolicy/SecurityPolicy/VpcGroup's Create and Update seed d's "tag" attribute
+// with getPolicyTagsWithProviderManagedDefaults(d, m) immediately before building the NSX
+// PATCH payload from schema (via getValidatedTagsFromSchema, which just reads d.Get("tag")) —
+// the only way those resources' shared build-and-patch helpers pick up the provider-managed
+// tag for the outgoing payload. Using the filtered initPolicyTagsSet here silently strips the
+// tag right back out before that read ever happens, so every Update (e.g. a plain description
+// change) wipes the tag from the object, only for the next Read's cache-aware tag-check to
+// detect it missing and immediately re-patch it. The state actually persisted after Create/
+// Update is still correctly filtered regardless, since the CRUD function's own trailing Read
+// overwrites "tag" again via setPolicyTagsInSchema (which does filter).
+func initPolicyTagsSetForOutgoingPatch(tags []model.Tag) []map[string]interface{} {
+	var tagList []map[string]interface{}
+	for _, tag := range tags {
+		elem := make(map[string]interface{})
+		elem["scope"] = tag.Scope
+		elem["tag"] = tag.Tag
+		tagList = append(tagList, elem)
+	}
+	return tagList
+}
+
 func getIgnoredTagsFromSchema(d *schema.ResourceData) []model.Tag {
 	tags, defined := d.GetOk("ignore_tags")
 	if !defined {

--- a/nsxt/resource_nsxt_policy_gateway_policy.go
+++ b/nsxt/resource_nsxt_policy_gateway_policy.go
@@ -198,7 +198,7 @@ func policyGatewayPolicyBuildAndPatch(d *schema.ResourceData, m interface{}, con
 func resourceNsxtPolicyGatewayPolicyGeneralCreate(d *schema.ResourceData, m interface{}, withRule bool) error {
 	connector := getPolicyConnector(m)
 	if isConfigScopedCacheMode(m) {
-		_ = d.Set("tag", initPolicyTagsSet(getPolicyTagsWithProviderManagedDefaults(d, m)))
+		_ = d.Set("tag", initPolicyTagsSetForOutgoingPatch(getPolicyTagsWithProviderManagedDefaults(d, m)))
 	}
 
 	// Initialize resource Id and verify this ID is not yet used
@@ -291,7 +291,7 @@ func resourceNsxtPolicyGatewayPolicyGeneralUpdate(d *schema.ResourceData, m inte
 		return fmt.Errorf("Error obtaining Gateway Policy ID")
 	}
 	if isConfigScopedCacheMode(m) {
-		_ = d.Set("tag", initPolicyTagsSet(getPolicyTagsWithProviderManagedDefaults(d, m)))
+		_ = d.Set("tag", initPolicyTagsSetForOutgoingPatch(getPolicyTagsWithProviderManagedDefaults(d, m)))
 	}
 
 	err := policyGatewayPolicyBuildAndPatch(d, m, connector, isPolicyGlobalManager(m), id, false, withRule)

--- a/nsxt/resource_nsxt_policy_ip_pool_block_subnet.go
+++ b/nsxt/resource_nsxt_policy_ip_pool_block_subnet.go
@@ -134,7 +134,10 @@ func resourceNsxtPolicyIPPoolBlockSubnetRead(d *schema.ResourceData, m interface
 	var blockSubnet *model.IpAddressPoolBlockSubnet
 	var err error
 	if isCacheEnabledForRead(d, m) {
-		key := id
+		key := d.Get("path").(string)
+		if key == "" {
+			key = id
+		}
 		blockSubnet, _, _, err = CacheAwareResourceRead[model.IpAddressPoolBlockSubnet](
 			d,
 			m,

--- a/nsxt/resource_nsxt_policy_ip_pool_static_subnet.go
+++ b/nsxt/resource_nsxt_policy_ip_pool_static_subnet.go
@@ -169,7 +169,10 @@ func resourceNsxtPolicyIPPoolStaticSubnetRead(d *schema.ResourceData, m interfac
 	var staticSubnet *model.IpAddressPoolStaticSubnet
 	var err error
 	if isCacheEnabledForRead(d, m) {
-		key := id
+		key := d.Get("path").(string)
+		if key == "" {
+			key = id
+		}
 		staticSubnet, _, _, err = CacheAwareResourceRead[model.IpAddressPoolStaticSubnet](
 			d,
 			m,

--- a/nsxt/resource_nsxt_policy_security_policy.go
+++ b/nsxt/resource_nsxt_policy_security_policy.go
@@ -138,7 +138,7 @@ func resourceNsxtPolicySecurityPolicyGeneralCreate(d *schema.ResourceData, m int
 		domain = d.Get("domain").(string)
 	}
 	if isConfigScopedCacheMode(m) {
-		_ = d.Set("tag", initPolicyTagsSet(getPolicyTagsWithProviderManagedDefaults(d, m)))
+		_ = d.Set("tag", initPolicyTagsSetForOutgoingPatch(getPolicyTagsWithProviderManagedDefaults(d, m)))
 	}
 	id, err := getOrGenerateID2(d, m, resourceNsxtPolicySecurityPolicyExistsPartial(domain))
 	if err != nil {
@@ -175,7 +175,7 @@ func resourceNsxtPolicySecurityPolicyGeneralUpdate(d *schema.ResourceData, m int
 		return fmt.Errorf("Error obtaining Security Policy id")
 	}
 	if isConfigScopedCacheMode(m) {
-		_ = d.Set("tag", initPolicyTagsSet(getPolicyTagsWithProviderManagedDefaults(d, m)))
+		_ = d.Set("tag", initPolicyTagsSetForOutgoingPatch(getPolicyTagsWithProviderManagedDefaults(d, m)))
 	}
 	err := policySecurityPolicyBuildAndPatch(d, m, id, false, withRule, isVPC)
 	if err != nil {

--- a/nsxt/resource_nsxt_vpc_gateway_policy.go
+++ b/nsxt/resource_nsxt_vpc_gateway_policy.go
@@ -33,7 +33,7 @@ func resourceNsxtVPCGatewayPolicy() *schema.Resource {
 
 func resourceNsxtVPCGatewayPolicyCreate(d *schema.ResourceData, m interface{}) error {
 	if isConfigScopedCacheMode(m) {
-		_ = d.Set("tag", initPolicyTagsSet(getPolicyTagsWithProviderManagedDefaults(d, m)))
+		_ = d.Set("tag", initPolicyTagsSetForOutgoingPatch(getPolicyTagsWithProviderManagedDefaults(d, m)))
 	}
 	connector := getPolicyConnector(m)
 
@@ -121,7 +121,7 @@ func resourceNsxtVPCGatewayPolicyUpdate(d *schema.ResourceData, m interface{}) e
 		return fmt.Errorf("error obtaining VPC Gateway Policy ID")
 	}
 	if isConfigScopedCacheMode(m) {
-		_ = d.Set("tag", initPolicyTagsSet(getPolicyTagsWithProviderManagedDefaults(d, m)))
+		_ = d.Set("tag", initPolicyTagsSetForOutgoingPatch(getPolicyTagsWithProviderManagedDefaults(d, m)))
 	}
 
 	err := policyGatewayPolicyBuildAndPatch(d, m, connector, isPolicyGlobalManager(m), id, true, true)

--- a/nsxt/resource_nsxt_vpc_group.go
+++ b/nsxt/resource_nsxt_vpc_group.go
@@ -29,7 +29,7 @@ func resourceNsxtVPCGroup() *schema.Resource {
 
 func resourceNsxtVPCGroupCreate(d *schema.ResourceData, m interface{}) error {
 	if isConfigScopedCacheMode(m) {
-		_ = d.Set("tag", initPolicyTagsSet(getPolicyTagsWithProviderManagedDefaults(d, m)))
+		_ = d.Set("tag", initPolicyTagsSetForOutgoingPatch(getPolicyTagsWithProviderManagedDefaults(d, m)))
 	}
 	// resourceNsxtPolicyGroupGeneralCreate already marks/invalidates resourceTypeVPCGroup
 	// internally via groupCacheResourceType(false) — no separate call needed here.
@@ -114,7 +114,7 @@ func resourceNsxtVPCGroupRead(d *schema.ResourceData, m interface{}) error {
 
 func resourceNsxtVPCGroupUpdate(d *schema.ResourceData, m interface{}) error {
 	if isConfigScopedCacheMode(m) {
-		_ = d.Set("tag", initPolicyTagsSet(getPolicyTagsWithProviderManagedDefaults(d, m)))
+		_ = d.Set("tag", initPolicyTagsSetForOutgoingPatch(getPolicyTagsWithProviderManagedDefaults(d, m)))
 	}
 	// resourceNsxtPolicyGroupGeneralUpdate already marks/invalidates resourceTypeVPCGroup
 	// internally via groupCacheResourceType(false) — no separate call needed here.

--- a/nsxt/utgomock_resource_nsxt_policy_gateway_policy_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_gateway_policy_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	vapiErrors "github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/bindings"
 	vapiProtocolClient "github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
 	nsxModel "github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 	"go.uber.org/mock/gomock"
@@ -182,6 +183,50 @@ func TestMockResourceNsxtPolicyGatewayPolicyUpdate(t *testing.T) {
 
 		err := resourceNsxtPolicyGatewayPolicyUpdate(d, newGoMockProviderClient())
 		require.Error(t, err)
+	})
+
+	// TestMockResourceNsxtPolicyGatewayPolicyUpdatePreservesProviderTag is a regression test
+	// for the terraform-cache-brownfield STEP4 investigation: Update seeds d's "tag" attribute
+	// with getPolicyTagsWithProviderManagedDefaults(d, m) so policyGatewayPolicyBuildAndPatch's
+	// getValidatedTagsFromSchema(d) call picks up the provider-managed tag for the outgoing
+	// PATCH payload — but it used to do so via initPolicyTagsSet, which filters the
+	// provider-managed tag straight back out (it exists precisely to keep that tag out of
+	// Terraform state during Read), silently defeating the seed. Every Update — even a plain
+	// description change with no config drift on "tag" — wiped the object's tag, and the
+	// Read that immediately follows detected it missing and re-patched it: exactly the
+	// "Patched provider-managed tags successfully" appearing where STEP4 asserts none should.
+	// Captures both Patch calls Update triggers (its own, then the trailing Read's tag-check
+	// repatch) and asserts the FIRST one already carries the tag, so the second never needs
+	// to fire in a real run.
+	t.Run("Update in config_scope mode must not wipe the provider tag", func(t *testing.T) {
+		var captures []nsxModel.Infra
+		mockInfra.EXPECT().Patch(gomock.Any(), gomock.Any()).DoAndReturn(
+			func(infra nsxModel.Infra, _ *bool) error {
+				captures = append(captures, infra)
+				return nil
+			}).AnyTimes()
+		mockSDK.EXPECT().Get(gwPolicyDomain, gwPolicyID).Return(gwPolicyAPIResponse(), nil).AnyTimes()
+
+		res := resourceNsxtPolicyGatewayPolicy()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalGwPolicyData())
+		d.SetId(gwPolicyID)
+
+		m := newGoMockProviderClient()
+		m.CommonConfig.CacheMode = "config_scope"
+		m.CommonConfig.contextID = "localCacheTest"
+
+		err := resourceNsxtPolicyGatewayPolicyUpdate(d, m)
+		require.NoError(t, err)
+		require.NotEmpty(t, captures, "expected at least one Patch call")
+
+		converter := bindings.NewTypeConverter()
+		domainRefVal, errs := converter.ConvertToGolang(captures[0].Children[0], nsxModel.ChildResourceReferenceBindingType())
+		require.Empty(t, errs)
+		domainRef := domainRefVal.(nsxModel.ChildResourceReference)
+		childPolicyVal, errs := converter.ConvertToGolang(domainRef.Children[0], nsxModel.ChildGatewayPolicyBindingType())
+		require.Empty(t, errs)
+		childPolicy := childPolicyVal.(nsxModel.ChildGatewayPolicy)
+		assert.NotEmpty(t, childPolicy.GatewayPolicy.Tags, "the Update's OWN patch call (not any follow-up read-triggered patch) must not wipe the provider-managed tag")
 	})
 }
 

--- a/nsxt/utgomock_resource_nsxt_policy_ip_pool_static_subnet_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_ip_pool_static_subnet_test.go
@@ -13,7 +13,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	vapiErrors "github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/bindings"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/data"
 	vapiProtocolClient "github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 	"go.uber.org/mock/gomock"
 
 	ippoolsapi "github.com/vmware/terraform-provider-nsxt/api/infra/ip_pools"
@@ -111,6 +114,48 @@ func TestMockResourceNsxtPolicyIPPoolStaticSubnetRead(t *testing.T) {
 		err := resourceNsxtPolicyIPPoolStaticSubnetRead(d, newGoMockProviderClient())
 		require.Error(t, err)
 	})
+}
+
+// TestMockResourceNsxtPolicyIPPoolStaticSubnetReadUsesPathAsCacheKeyWhenAvailable is a
+// regression test for the terraform-cache-brownfield build #6/#7 failure: Read used to key
+// the cache lookup on d.Id() (the short subnet id) even once d.Get("path") was already
+// populated from a prior Create. For a path-indexed resource type (shouldIndexByPath),
+// that makes CacheAwareResourceRead's shortIDBypass fire on every single read and
+// permanently skip the cache in favor of a direct GET — see resource_nsxt_policy_service.go
+// / resource_nsxt_policy_segment_port.go / resource_nsxt_policy_nat_rule.go for the
+// "prefer d.Get(\"path\"), fall back to id" pattern this now matches. mockSDK.Get is
+// deliberately left unstubbed: if the cache key regresses to the short id, the resulting
+// fallback direct GET is an unexpected mock call and fails the test.
+func TestMockResourceNsxtPolicyIPPoolStaticSubnetReadUsesPathAsCacheKeyWhenAvailable(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	_, restore := setupStaticSubnetMock(t, ctrl)
+	defer restore()
+
+	staticSubnetPath := staticSubnetPoolPath + "/ip-subnets/" + staticSubnetID
+	converter := bindings.NewTypeConverter()
+	sv, errs := converter.ConvertToVapi(model.IpAddressPoolStaticSubnet{
+		Id:   strPtr(staticSubnetID),
+		Path: strPtr(staticSubnetPath),
+	}, model.IpAddressPoolStaticSubnetBindingType())
+	require.Empty(t, errs)
+
+	stub := &seqQueryListClient{responses: []model.SearchResponse{
+		{Results: []*data.StructValue{sv.(*data.StructValue)}, ResultCount: i64(1)},
+	}}
+	defer setupCliQueryClientStub(t, stub)()
+
+	res := resourceNsxtPolicyIPPoolStaticSubnet()
+	d := schema.TestResourceDataRaw(t, res.Schema, minimalStaticSubnetData())
+	d.SetId(staticSubnetID)
+	require.NoError(t, d.Set("path", staticSubnetPath))
+
+	m := newGoMockProviderClient()
+	m.CommonConfig.CacheMode = "global"
+
+	err := resourceNsxtPolicyIPPoolStaticSubnetRead(d, m)
+	require.NoError(t, err)
+	assert.Equal(t, staticSubnetPath, d.Get("path"))
 }
 
 func TestMockResourceNsxtPolicyIPPoolStaticSubnetUpdate(t *testing.T) {


### PR DESCRIPTION
terraform-cache-brownfield started failing after passing consistently,
across two unrelated bugs surfaced by config_scope cache mode:

1. IpAddressPoolStaticSubnet/IpAddressPoolBlockSubnet permanently
   bypassed the cache on every read. CacheAwareResourceRead has a
   shortIDBypass safety net: for path-indexed resource types, if the
   resourceID passed in doesn't contain "/", the cache is skipped
   entirely in favor of a direct GET, since a short id may not be
   unique across the project-wide search scope these types share.
   Both resources' Read functions unconditionally used the short
   d.Id() as that key instead of preferring d.Get("path") (populated
   since the prior Create) the way every other path-indexed resource
   does, so shortIDBypass fired on every single read, permanently.

   Fix: prefer d.Get("path"), falling back to d.Id() only when path
   isn't set yet (Create-then-Read within the same apply, or import) —
   matching the existing pattern already used by e.g. Service,
   SegmentPort, and PolicyNatRule.

2. GatewayPolicy, SecurityPolicy, and VpcGroup silently wiped their
   provider-managed cache tracking tag (scope="nsx-tf/tf-run-id") on
   every Update, including a bare description change with no config
   drift on tags. Their Create/Update seeds Terraform state's "tag"
   attribute with the merged (user + provider-managed) tag list
   immediately before building the outgoing NSX PATCH payload from
   that same state — the only way the shared build-and-patch helpers
   pick up the provider-managed tag for the payload. That seed used
   initPolicyTagsSet, which filters the provider-managed tag out — a
   filter added so Read never leaks the tag into state — silently
   defeating the seed before the payload was ever built. Every Update
   sent an empty tag list, and the Read that immediately follows
   caught the tag missing and re-patched it — a spurious extra write
   on every steady-state apply.

   Fix: add initPolicyTagsSetForOutgoingPatch, the same conversion
   without the filter, for this one seed-before-build-and-patch use
   across all 8 call sites (gateway policy, security policy, VPC
   gateway policy, VPC group; Create and Update). The tag actually
   persisted to Terraform state is unaffected — each CRUD function's
   own trailing Read still overwrites "tag" via setPolicyTagsInSchema,
   which filters correctly for that purpose.

Both fixes include a mock-based regression test that fails against
the pre-fix code and passes with the fix.
