### PR TITLE
Expand unit test coverage to 81% across idps, gateway, and LB resources

### DIFF
--- a/nsxt/data_source_nsxt_policy_idps_cluster_config.go
+++ b/nsxt/data_source_nsxt_policy_idps_cluster_config.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/settings/firewall/security/intrusion_services"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 )
 
@@ -62,7 +61,7 @@ func dataSourceNsxtPolicyIdpsClusterConfigRead(d *schema.ResourceData, m interfa
 
 	var obj model.IdsClusterConfig
 
-	client := intrusion_services.NewClusterConfigsClient(connector)
+	client := cliIdsClusterConfigsClient(connector)
 	if client == nil {
 		return policyResourceNotSupportedError()
 	}

--- a/nsxt/data_source_nsxt_policy_idps_custom_signature.go
+++ b/nsxt/data_source_nsxt_policy_idps_custom_signature.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
-	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/settings/firewall/security/intrusion_services/custom_signature_versions"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 )
 
@@ -123,7 +122,7 @@ func dataSourceNsxtPolicyIdpsCustomSignatureRead(d *schema.ResourceData, m inter
 		sigID = id
 	}
 
-	client := custom_signature_versions.NewCustomSignaturesClient(connector)
+	client := cliIdsCustomSignaturesClient(connector)
 	obj, err := client.Get(versionID, sigID)
 	if err != nil {
 		if isNotFoundError(err) {

--- a/nsxt/data_source_nsxt_policy_idps_settings.go
+++ b/nsxt/data_source_nsxt_policy_idps_settings.go
@@ -9,8 +9,6 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/settings/firewall/security"
-	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/settings/firewall/security/intrusion_services/custom_signature_versions"
 )
 
 func dataSourceNsxtPolicyIdpsSettings() *schema.Resource {
@@ -60,7 +58,7 @@ func dataSourceNsxtPolicyIdpsSettingsRead(d *schema.ResourceData, m interface{})
 	}
 
 	// Read IdsSettings
-	client := security.NewIntrusionServicesClient(connector)
+	client := cliIdsSettingsClient(connector)
 
 	obj, err := client.Get()
 	if err != nil {
@@ -80,7 +78,7 @@ func dataSourceNsxtPolicyIdpsSettingsRead(d *schema.ResourceData, m interface{})
 	// Read IdsCustomSignatureSettings if custom_signature_version_id is provided
 	customSigVersionID := d.Get("custom_signature_version_id").(string)
 	if customSigVersionID != "" {
-		customSigSettingsClient := custom_signature_versions.NewSettingsClient(connector)
+		customSigSettingsClient := cliIdsCustomSigSettingsClient(connector)
 		customSigSettings, err := customSigSettingsClient.Get(customSigVersionID)
 		if err != nil {
 			log.Printf("[WARN] Failed to read custom signature settings for version %s: %v", customSigVersionID, err)

--- a/nsxt/data_source_nsxt_policy_idps_signature_diff.go
+++ b/nsxt/data_source_nsxt_policy_idps_signature_diff.go
@@ -6,8 +6,14 @@ package nsxt
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/settings/firewall/security/intrusion_services/custom_signature_versions"
 )
+
+// cliIdsCustomSignaturesDiffClient is swapped out in unit tests to inject a mock client.
+var cliIdsCustomSignaturesDiffClient = func(connector client.Connector) custom_signature_versions.CustomSignaturesDiffClient {
+	return custom_signature_versions.NewCustomSignaturesDiffClient(connector)
+}
 
 func dataSourceNsxtPolicyIdpsSignatureDiff() *schema.Resource {
 	return &schema.Resource{
@@ -55,7 +61,7 @@ func dataSourceNsxtPolicyIdpsSignatureDiffRead(d *schema.ResourceData, m interfa
 	}
 
 	versionID := d.Get("signature_version_id").(string)
-	client := custom_signature_versions.NewCustomSignaturesDiffClient(connector)
+	client := cliIdsCustomSignaturesDiffClient(connector)
 	diff, err := client.Get(versionID)
 	if err != nil {
 		return handleDataSourceReadError(d, "IdsCustomSignaturesDiff", versionID, err)

--- a/nsxt/data_source_nsxt_policy_idps_signature_version.go
+++ b/nsxt/data_source_nsxt_policy_idps_signature_version.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/settings/firewall/security/intrusion_services"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 )
 
@@ -85,7 +84,7 @@ func dataSourceNsxtPolicyIdpsSignatureVersionRead(d *schema.ResourceData, m inte
 	objID := d.Get("id").(string)
 	objName := d.Get("display_name").(string)
 
-	client := intrusion_services.NewSignatureVersionsClient(connector)
+	client := cliIdsSignatureVersionsClient(connector)
 	if client == nil {
 		return policyResourceNotSupportedError()
 	}

--- a/nsxt/data_source_nsxt_policy_idps_system_signatures.go
+++ b/nsxt/data_source_nsxt_policy_idps_system_signatures.go
@@ -10,10 +10,15 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/settings/firewall/security/intrusion_services"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/settings/firewall/security/intrusion_services/signature_versions"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 )
+
+// cliIdsSignaturesClient is swapped out in unit tests to inject a mock client.
+var cliIdsSignaturesClient = func(connector client.Connector) signature_versions.SignaturesClient {
+	return signature_versions.NewSignaturesClient(connector)
+}
 
 func dataSourceNsxtPolicyIdpsSystemSignatures() *schema.Resource {
 	return &schema.Resource{
@@ -168,7 +173,7 @@ func dataSourceNsxtPolicyIdpsSystemSignaturesRead(d *schema.ResourceData, m inte
 
 	// If version_id not specified, get the active version
 	if versionID == "" {
-		versionsClient := intrusion_services.NewSignatureVersionsClient(connector)
+		versionsClient := cliIdsSignatureVersionsClient(connector)
 		if versionsClient == nil {
 			return policyResourceNotSupportedError()
 		}
@@ -210,7 +215,7 @@ func dataSourceNsxtPolicyIdpsSystemSignaturesRead(d *schema.ResourceData, m inte
 	d.Set("version_id", versionID)
 
 	// Get signatures client for the specific version
-	signaturesClient := signature_versions.NewSignaturesClient(connector)
+	signaturesClient := cliIdsSignaturesClient(connector)
 	if signaturesClient == nil {
 		return policyResourceNotSupportedError()
 	}

--- a/nsxt/lb_virtual_server_conversion_unit_test.go
+++ b/nsxt/lb_virtual_server_conversion_unit_test.go
@@ -1,0 +1,353 @@
+//go:build unittest
+
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package nsxt
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/bindings"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/data"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+)
+
+// These tests exercise the schema<->struct conversion helpers in
+// resource_nsxt_policy_lb_virtual_server.go directly. They are pure logic (no SDK client
+// calls), so no mocking is needed - only a *schema.ResourceData built from the resource's own
+// schema via schema.TestResourceDataRaw.
+
+func lbVsConverterStructValue(t *testing.T, obj interface{}, bt bindings.BindingType) *data.StructValue {
+	t.Helper()
+	converter := bindings.NewTypeConverter()
+	sv, errs := converter.ConvertToVapi(obj, bt)
+	require.Empty(t, errs)
+	return sv.(*data.StructValue)
+}
+
+func TestUnitNsxt_getPolicyClientSSLBindingFromSchema(t *testing.T) {
+	res := resourceNsxtPolicyLBVirtualServer()
+
+	t.Run("empty when no client_ssl block is set", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		assert.Nil(t, getPolicyClientSSLBindingFromSchema(d))
+	})
+
+	t.Run("parses a client_ssl block", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+			"client_ssl": []interface{}{
+				map[string]interface{}{
+					"certificate_chain_depth":  3,
+					"client_auth":              model.LBClientSslProfileBinding_CLIENT_AUTH_REQUIRED,
+					"ca_paths":                 []interface{}{"/infra/certs/ca1"},
+					"crl_paths":                []interface{}{"/infra/crls/crl1"},
+					"default_certificate_path": "/infra/certs/default",
+					"ssl_profile_path":         "/infra/ssl-profiles/p1",
+					"sni_paths":                []interface{}{"/infra/certs/sni1"},
+				},
+			},
+		})
+
+		binding := getPolicyClientSSLBindingFromSchema(d)
+		require.NotNil(t, binding)
+		assert.Equal(t, int64(3), *binding.CertificateChainDepth)
+		assert.Equal(t, model.LBClientSslProfileBinding_CLIENT_AUTH_REQUIRED, *binding.ClientAuth)
+		assert.Equal(t, []string{"/infra/certs/ca1"}, binding.ClientAuthCaPaths)
+		assert.Equal(t, "/infra/certs/default", *binding.DefaultCertificatePath)
+		assert.Equal(t, "/infra/ssl-profiles/p1", *binding.SslProfilePath)
+	})
+}
+
+func TestUnitNsxt_setPolicyClientSSLBindingInSchema(t *testing.T) {
+	res := resourceNsxtPolicyLBVirtualServer()
+
+	t.Run("clears the block when binding is nil", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		setPolicyClientSSLBindingInSchema(d, nil)
+		assert.Empty(t, d.Get("client_ssl").([]interface{}))
+	})
+
+	t.Run("sets the block from a binding", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		depth := int64(2)
+		auth := model.LBClientSslProfileBinding_CLIENT_AUTH_IGNORE
+		cert := "/infra/certs/default"
+		profile := "/infra/ssl-profiles/p1"
+		setPolicyClientSSLBindingInSchema(d, &model.LBClientSslProfileBinding{
+			CertificateChainDepth:  &depth,
+			ClientAuth:             &auth,
+			DefaultCertificatePath: &cert,
+			SslProfilePath:         &profile,
+		})
+
+		list := d.Get("client_ssl").([]interface{})
+		require.Len(t, list, 1)
+		elem := list[0].(map[string]interface{})
+		assert.Equal(t, 2, elem["certificate_chain_depth"])
+		assert.Equal(t, auth, elem["client_auth"])
+	})
+}
+
+func TestUnitNsxt_getPolicyServerSSLBindingFromSchema(t *testing.T) {
+	res := resourceNsxtPolicyLBVirtualServer()
+
+	t.Run("empty when no server_ssl block is set", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		assert.Nil(t, getPolicyServerSSLBindingFromSchema(d))
+	})
+
+	t.Run("parses a server_ssl block", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+			"server_ssl": []interface{}{
+				map[string]interface{}{
+					"certificate_chain_depth": 4,
+					"server_auth":             model.LBServerSslProfileBinding_SERVER_AUTH_REQUIRED,
+					"ca_paths":                []interface{}{"/infra/certs/ca2"},
+					"crl_paths":               []interface{}{"/infra/crls/crl2"},
+					"client_certificate_path": "/infra/certs/client",
+					"ssl_profile_path":        "/infra/ssl-profiles/p2",
+				},
+			},
+		})
+
+		binding := getPolicyServerSSLBindingFromSchema(d)
+		require.NotNil(t, binding)
+		assert.Equal(t, int64(4), *binding.CertificateChainDepth)
+		assert.Equal(t, model.LBServerSslProfileBinding_SERVER_AUTH_REQUIRED, *binding.ServerAuth)
+		assert.Equal(t, "/infra/certs/client", *binding.ClientCertificatePath)
+		assert.Equal(t, "/infra/ssl-profiles/p2", *binding.SslProfilePath)
+	})
+}
+
+func TestUnitNsxt_setPolicyServerSSLBindingInSchema(t *testing.T) {
+	res := resourceNsxtPolicyLBVirtualServer()
+
+	t.Run("clears the block when binding is nil", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		setPolicyServerSSLBindingInSchema(d, nil)
+		assert.Empty(t, d.Get("server_ssl").([]interface{}))
+	})
+
+	t.Run("sets the block from a binding", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		depth := int64(1)
+		auth := model.LBServerSslProfileBinding_SERVER_AUTH_AUTO_APPLY
+		profile := "/infra/ssl-profiles/p2"
+		setPolicyServerSSLBindingInSchema(d, &model.LBServerSslProfileBinding{
+			CertificateChainDepth: &depth,
+			ServerAuth:            &auth,
+			SslProfilePath:        &profile,
+		})
+
+		list := d.Get("server_ssl").([]interface{})
+		require.Len(t, list, 1)
+		elem := list[0].(map[string]interface{})
+		assert.Equal(t, 1, elem["certificate_chain_depth"])
+		assert.Equal(t, auth, elem["server_auth"])
+	})
+}
+
+func TestUnitNsxt_getPolicyAccessListControlFromSchema(t *testing.T) {
+	res := resourceNsxtPolicyLBVirtualServer()
+
+	t.Run("empty when no access_list_control block is set", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		assert.Nil(t, getPolicyAccessListControlFromSchema(d))
+	})
+
+	t.Run("parses an access_list_control block", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+			"access_list_control": []interface{}{
+				map[string]interface{}{
+					"action":     model.LBAccessListControl_ACTION_DROP,
+					"enabled":    true,
+					"group_path": "/infra/domains/default/groups/g1",
+				},
+			},
+		})
+
+		control := getPolicyAccessListControlFromSchema(d)
+		require.NotNil(t, control)
+		assert.Equal(t, model.LBAccessListControl_ACTION_DROP, *control.Action)
+		assert.True(t, *control.Enabled)
+		assert.Equal(t, "/infra/domains/default/groups/g1", *control.GroupPath)
+	})
+}
+
+func TestUnitNsxt_setPolicyAccessListControlInSchema(t *testing.T) {
+	res := resourceNsxtPolicyLBVirtualServer()
+
+	t.Run("clears the block when control is nil", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		setPolicyAccessListControlInSchema(d, nil)
+		assert.Empty(t, d.Get("access_list_control").([]interface{}))
+	})
+
+	t.Run("sets the block from a control", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		action := model.LBAccessListControl_ACTION_ALLOW
+		enabled := true
+		groupPath := "/infra/domains/default/groups/g1"
+		setPolicyAccessListControlInSchema(d, &model.LBAccessListControl{
+			Action:    &action,
+			Enabled:   &enabled,
+			GroupPath: &groupPath,
+		})
+
+		list := d.Get("access_list_control").([]interface{})
+		require.Len(t, list, 1)
+		elem := list[0].(map[string]interface{})
+		assert.Equal(t, action, elem["action"])
+		assert.Equal(t, groupPath, elem["group_path"])
+	})
+}
+
+func TestUnitNsxt_getRuleActionOrMethod(t *testing.T) {
+	t.Run("empty list yields no results", func(t *testing.T) {
+		ruleData := map[string]interface{}{"connection_drop": []interface{}{}}
+		result := getRuleActionOrMethod(ruleData, "connection_drop", nil, nil, model.LBRuleAction_TYPE_LBCONNECTIONDROPACTION)
+		assert.Empty(t, result)
+	})
+
+	t.Run("builds a StructValue with string and bool fields set", func(t *testing.T) {
+		ruleData := map[string]interface{}{
+			"http_request_method": []interface{}{
+				map[string]interface{}{"method": "GET", "inverse": true},
+			},
+		}
+		result := getRuleActionOrMethod(ruleData, "http_request_method", []string{"method"}, []string{"inverse"}, model.LBRuleCondition_TYPE_LBHTTPREQUESTMETHODCONDITION)
+		require.Len(t, result, 1)
+
+		converter := bindings.NewTypeConverter()
+		golang, errs := converter.ConvertToGolang(result[0], model.LBHttpRequestMethodConditionBindingType())
+		require.Empty(t, errs)
+		cond := golang.(model.LBHttpRequestMethodCondition)
+		assert.Equal(t, "GET", *cond.Method)
+		assert.True(t, *cond.Inverse)
+	})
+
+	t.Run("skips empty string fields", func(t *testing.T) {
+		ruleData := map[string]interface{}{
+			"select_pool": []interface{}{
+				map[string]interface{}{"pool_id": ""},
+			},
+		}
+		result := getRuleActionOrMethod(ruleData, "select_pool", []string{"pool_id"}, nil, model.LBRuleAction_TYPE_LBSELECTPOOLACTION)
+		require.Len(t, result, 1)
+
+		converter := bindings.NewTypeConverter()
+		golang, errs := converter.ConvertToGolang(result[0], model.LBSelectPoolActionBindingType())
+		require.Empty(t, errs)
+		action := golang.(model.LBSelectPoolAction)
+		assert.Nil(t, action.PoolId)
+	})
+}
+
+func TestUnitNsxt_setPolicyLbRulesInSchema(t *testing.T) {
+	res := resourceNsxtPolicyLBVirtualServer()
+
+	t.Run("empty rule list clears the block", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		setPolicyLbRulesInSchema(d, nil)
+		assert.Empty(t, d.Get("rule").([]interface{}))
+	})
+
+	t.Run("converts a rule with simple actions and conditions", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+
+		poolID := "/infra/lb-pools/pool-1"
+		selectPoolSV := lbVsConverterStructValue(t, model.LBSelectPoolAction{
+			Type_:  model.LBRuleAction_TYPE_LBSELECTPOOLACTION,
+			PoolId: &poolID,
+		}, model.LBSelectPoolActionBindingType())
+
+		method := "GET"
+		methodSV := lbVsConverterStructValue(t, model.LBHttpRequestMethodCondition{
+			Type_:  model.LBRuleCondition_TYPE_LBHTTPREQUESTMETHODCONDITION,
+			Method: &method,
+		}, model.LBHttpRequestMethodConditionBindingType())
+
+		name := "rule-1"
+		strategy := model.LBRule_MATCH_STRATEGY_ALL
+		phase := model.LBRule_PHASE_HTTP_ACCESS
+		rules := []model.LBRule{
+			{
+				DisplayName:     &name,
+				MatchStrategy:   &strategy,
+				Phase:           &phase,
+				Actions:         []*data.StructValue{selectPoolSV},
+				MatchConditions: []*data.StructValue{methodSV},
+			},
+		}
+
+		setPolicyLbRulesInSchema(d, rules)
+
+		list := d.Get("rule").([]interface{})
+		require.Len(t, list, 1)
+		ruleElem := list[0].(map[string]interface{})
+		assert.Equal(t, name, ruleElem["display_name"])
+
+		actionList := ruleElem["action"].([]interface{})
+		require.Len(t, actionList, 1)
+		actionElem := actionList[0].(map[string]interface{})
+		selectPoolList := actionElem["select_pool"].([]interface{})
+		require.Len(t, selectPoolList, 1)
+		assert.Equal(t, poolID, selectPoolList[0].(map[string]interface{})["pool_id"])
+
+		conditionList := ruleElem["condition"].([]interface{})
+		require.Len(t, conditionList, 1)
+		conditionElem := conditionList[0].(map[string]interface{})
+		methodList := conditionElem["http_request_method"].([]interface{})
+		require.Len(t, methodList, 1)
+		assert.Equal(t, method, methodList[0].(map[string]interface{})["method"])
+	})
+
+	t.Run("converts a jwt_auth action with a certificate key", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+
+		realm := "myrealm"
+		passToPool := true
+		certPath := "/infra/certs/jwt"
+		keySV := lbVsConverterStructValue(t, model.LBJwtCertificateKey{
+			Type_:           model.LBJwtKey_TYPE_LBJWTCERTIFICATEKEY,
+			CertificatePath: &certPath,
+		}, model.LBJwtCertificateKeyBindingType())
+		jwtAction := model.LBJwtAuthAction{
+			Type_:         model.LBRuleAction_TYPE_LBJWTAUTHACTION,
+			Realm:         &realm,
+			PassJwtToPool: &passToPool,
+			Key:           keySV,
+			Tokens:        []string{"Authorization"},
+		}
+		jwtSV := lbVsConverterStructValue(t, jwtAction, model.LBJwtAuthActionBindingType())
+
+		name := "rule-jwt"
+		strategy := model.LBRule_MATCH_STRATEGY_ANY
+		phase := model.LBRule_PHASE_HTTP_ACCESS
+		rules := []model.LBRule{
+			{
+				DisplayName:   &name,
+				MatchStrategy: &strategy,
+				Phase:         &phase,
+				Actions:       []*data.StructValue{jwtSV},
+			},
+		}
+
+		setPolicyLbRulesInSchema(d, rules)
+
+		list := d.Get("rule").([]interface{})
+		require.Len(t, list, 1)
+		actionElem := list[0].(map[string]interface{})["action"].([]interface{})[0].(map[string]interface{})
+		jwtList := actionElem["jwt_auth"].([]interface{})
+		require.Len(t, jwtList, 1)
+		jwtElem := jwtList[0].(map[string]interface{})
+		assert.Equal(t, realm, jwtElem["realm"])
+		keySet := jwtElem["key"].(*schema.Set)
+		require.Equal(t, 1, keySet.Len())
+	})
+}

--- a/nsxt/lb_virtual_server_conversion_unit_test.go
+++ b/nsxt/lb_virtual_server_conversion_unit_test.go
@@ -350,4 +350,348 @@ func TestUnitNsxt_setPolicyLbRulesInSchema(t *testing.T) {
 		keySet := jwtElem["key"].(*schema.Set)
 		require.Equal(t, 1, keySet.Len())
 	})
+
+	t.Run("converts a rule with every action and condition type populated", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+
+		name := "rule-full"
+		strategy := model.LBRule_MATCH_STRATEGY_ALL
+		phase := model.LBRule_PHASE_HTTP_ACCESS
+		rules := []model.LBRule{
+			{
+				DisplayName:     &name,
+				MatchStrategy:   &strategy,
+				Phase:           &phase,
+				Actions:         fullLbRuleActionStructValues(t),
+				MatchConditions: fullLbRuleConditionStructValues(t),
+			},
+		}
+
+		setPolicyLbRulesInSchema(d, rules)
+
+		list := d.Get("rule").([]interface{})
+		require.Len(t, list, 1)
+		ruleElem := list[0].(map[string]interface{})
+		actionElem := ruleElem["action"].([]interface{})[0].(map[string]interface{})
+		conditionElem := ruleElem["condition"].([]interface{})[0].(map[string]interface{})
+
+		for _, key := range []string{
+			"connection_drop", "select_pool", "http_redirect", "http_request_uri_rewrite",
+			"http_request_header_rewrite", "http_reject", "http_response_header_rewrite",
+			"http_request_header_delete", "http_response_header_delete", "variable_assignment",
+			"variable_persistence_on", "variable_persistence_learn", "jwt_auth", "ssl_mode_selection",
+		} {
+			assert.Lenf(t, actionElem[key], 1, "action block %q", key)
+		}
+		for _, key := range []string{
+			"http_request_body", "http_request_uri", "http_request_header", "http_request_method",
+			"http_request_uri_arguments", "http_request_version", "http_request_cookie",
+			"http_response_header", "tcp_header", "ip_header", "variable", "ssl_sni", "http_ssl",
+		} {
+			assert.Lenf(t, conditionElem[key], 1, "condition block %q", key)
+		}
+
+		httpSslElem := conditionElem["http_ssl"].([]interface{})[0].(map[string]interface{})
+		assert.Equal(t, 1, httpSslElem["client_certificate_issuer_dn"].(*schema.Set).Len())
+		assert.Equal(t, 1, httpSslElem["client_certificate_subject_dn"].(*schema.Set).Len())
+	})
+}
+
+// fullLbRuleActionStructValues returns one *data.StructValue per action type (mirroring
+// fullLbRuleActionData's schema-side fixture), so a single setPolicyLbRulesInSchema call
+// exercises every action-type case in its switch statement.
+func fullLbRuleActionStructValues(t *testing.T) []*data.StructValue {
+	t.Helper()
+	poolID := "/infra/lb-pools/pool-1"
+	redirectStatus, redirectURL := "301", "http://example.com"
+	uri, uriArgs := "/new", "a=b"
+	headerName, headerValue := "X-Foo", "bar"
+	replyMsg, replyStatus := "denied", "403"
+	respHeaderName, respHeaderValue := "X-Bar", "baz"
+	respDeleteHeaderName := "X-Bar"
+	varName, varValue := "v1", "val1"
+	persistPath, persistVar := "/infra/lb-persistence-profiles/p1", "v2"
+	persistHash := true
+	sslMode := model.LBSslModeSelectionAction_SSL_MODE_OFFLOAD
+	realm := "myrealm"
+	passToPool := true
+	certPath := "/infra/certs/jwt"
+	keySV := lbVsConverterStructValue(t, model.LBJwtCertificateKey{
+		Type_:           model.LBJwtKey_TYPE_LBJWTCERTIFICATEKEY,
+		CertificatePath: &certPath,
+	}, model.LBJwtCertificateKeyBindingType())
+
+	return []*data.StructValue{
+		lbVsConverterStructValue(t, model.LBConnectionDropAction{Type_: model.LBRuleAction_TYPE_LBCONNECTIONDROPACTION}, model.LBConnectionDropActionBindingType()),
+		lbVsConverterStructValue(t, model.LBSelectPoolAction{Type_: model.LBRuleAction_TYPE_LBSELECTPOOLACTION, PoolId: &poolID}, model.LBSelectPoolActionBindingType()),
+		lbVsConverterStructValue(t, model.LBHttpRedirectAction{Type_: model.LBRuleAction_TYPE_LBHTTPREDIRECTACTION, RedirectStatus: &redirectStatus, RedirectUrl: &redirectURL}, model.LBHttpRedirectActionBindingType()),
+		lbVsConverterStructValue(t, model.LBHttpRequestUriRewriteAction{Type_: model.LBRuleAction_TYPE_LBHTTPREQUESTURIREWRITEACTION, Uri: &uri, UriArguments: &uriArgs}, model.LBHttpRequestUriRewriteActionBindingType()),
+		lbVsConverterStructValue(t, model.LBHttpRequestHeaderRewriteAction{Type_: model.LBRuleAction_TYPE_LBHTTPREQUESTHEADERREWRITEACTION, HeaderName: &headerName, HeaderValue: &headerValue}, model.LBHttpRequestHeaderRewriteActionBindingType()),
+		lbVsConverterStructValue(t, model.LBHttpRejectAction{Type_: model.LBRuleAction_TYPE_LBHTTPREJECTACTION, ReplyMessage: &replyMsg, ReplyStatus: &replyStatus}, model.LBHttpRejectActionBindingType()),
+		lbVsConverterStructValue(t, model.LBHttpResponseHeaderRewriteAction{Type_: model.LBRuleAction_TYPE_LBHTTPRESPONSEHEADERREWRITEACTION, HeaderName: &respHeaderName, HeaderValue: &respHeaderValue}, model.LBHttpResponseHeaderRewriteActionBindingType()),
+		lbVsConverterStructValue(t, model.LBHttpRequestHeaderDeleteAction{Type_: model.LBRuleAction_TYPE_LBHTTPREQUESTHEADERDELETEACTION, HeaderName: &headerName}, model.LBHttpRequestHeaderDeleteActionBindingType()),
+		lbVsConverterStructValue(t, model.LBHttpResponseHeaderDeleteAction{Type_: model.LBRuleAction_TYPE_LBHTTPRESPONSEHEADERDELETEACTION, HeaderName: &respDeleteHeaderName}, model.LBHttpResponseHeaderDeleteActionBindingType()),
+		lbVsConverterStructValue(t, model.LBVariableAssignmentAction{Type_: model.LBRuleAction_TYPE_LBVARIABLEASSIGNMENTACTION, VariableName: &varName, VariableValue: &varValue}, model.LBVariableAssignmentActionBindingType()),
+		lbVsConverterStructValue(t, model.LBVariablePersistenceOnAction{Type_: model.LBRuleAction_TYPE_LBVARIABLEPERSISTENCEONACTION, PersistenceProfilePath: &persistPath, VariableName: &persistVar, VariableHashEnabled: &persistHash}, model.LBVariablePersistenceOnActionBindingType()),
+		lbVsConverterStructValue(t, model.LBVariablePersistenceLearnAction{Type_: model.LBRuleAction_TYPE_LBVARIABLEPERSISTENCELEARNACTION, PersistenceProfilePath: &persistPath, VariableName: &persistVar, VariableHashEnabled: &persistHash}, model.LBVariablePersistenceLearnActionBindingType()),
+		lbVsConverterStructValue(t, model.LBSslModeSelectionAction{Type_: model.LBRuleAction_TYPE_LBSSLMODESELECTIONACTION, SslMode: &sslMode}, model.LBSslModeSelectionActionBindingType()),
+		lbVsConverterStructValue(t, model.LBJwtAuthAction{
+			Type_:         model.LBRuleAction_TYPE_LBJWTAUTHACTION,
+			Realm:         &realm,
+			PassJwtToPool: &passToPool,
+			Key:           keySV,
+			Tokens:        []string{"Authorization"},
+		}, model.LBJwtAuthActionBindingType()),
+	}
+}
+
+// fullLbRuleConditionStructValues returns one *data.StructValue per condition type (mirroring
+// fullLbRuleConditionData's schema-side fixture), so a single setPolicyLbRulesInSchema call
+// exercises every condition-type case in its switch statement.
+func fullLbRuleConditionStructValues(t *testing.T) []*data.StructValue {
+	t.Helper()
+	trueVal, falseVal := true, false
+	matchEquals := model.LBHttpRequestBodyCondition_MATCH_TYPE_EQUALS
+	bodyValue := "v"
+	cookieName, cookieValue := "c1", "v1"
+	headerName, headerValue := "X-Foo", "bar"
+	method := "GET"
+	uriArgs := "a=b"
+	uri := "/foo"
+	version := "HTTP_VERSION_1_1"
+	respHeaderName, respHeaderValue := "X-Bar", "baz"
+	groupPath, sourceAddr := "/infra/domains/default/groups/g1", "1.2.3.4"
+	sni := "example.com"
+	sourcePort := "8080"
+	varName, varValue := "v1", "val1"
+	issuerDn := "CN=issuer"
+	subjectDn := "CN=subject"
+	sessionReused, usedProtocol, usedCipher := "IGNORE", "TLS_V1_2", "TLS_RSA_WITH_AES_128_CBC_SHA"
+
+	return []*data.StructValue{
+		lbVsConverterStructValue(t, model.LBHttpRequestBodyCondition{Type_: model.LBRuleCondition_TYPE_LBHTTPREQUESTBODYCONDITION, BodyValue: &bodyValue, MatchType: &matchEquals, CaseSensitive: &trueVal, Inverse: &falseVal}, model.LBHttpRequestBodyConditionBindingType()),
+		lbVsConverterStructValue(t, model.LBHttpRequestUriCondition{Type_: model.LBRuleCondition_TYPE_LBHTTPREQUESTURICONDITION, Uri: &uri, MatchType: &matchEquals, CaseSensitive: &trueVal, Inverse: &falseVal}, model.LBHttpRequestUriConditionBindingType()),
+		lbVsConverterStructValue(t, model.LBHttpRequestHeaderCondition{Type_: model.LBRuleCondition_TYPE_LBHTTPREQUESTHEADERCONDITION, HeaderName: &headerName, HeaderValue: &headerValue, MatchType: &matchEquals, CaseSensitive: &trueVal, Inverse: &falseVal}, model.LBHttpRequestHeaderConditionBindingType()),
+		lbVsConverterStructValue(t, model.LBHttpRequestMethodCondition{Type_: model.LBRuleCondition_TYPE_LBHTTPREQUESTMETHODCONDITION, Method: &method, Inverse: &falseVal}, model.LBHttpRequestMethodConditionBindingType()),
+		lbVsConverterStructValue(t, model.LBHttpRequestUriArgumentsCondition{Type_: model.LBRuleCondition_TYPE_LBHTTPREQUESTURIARGUMENTSCONDITION, UriArguments: &uriArgs, MatchType: &matchEquals, CaseSensitive: &trueVal, Inverse: &falseVal}, model.LBHttpRequestUriArgumentsConditionBindingType()),
+		lbVsConverterStructValue(t, model.LBHttpRequestVersionCondition{Type_: model.LBRuleCondition_TYPE_LBHTTPREQUESTVERSIONCONDITION, Version: &version, Inverse: &falseVal}, model.LBHttpRequestVersionConditionBindingType()),
+		lbVsConverterStructValue(t, model.LBHttpRequestCookieCondition{Type_: model.LBRuleCondition_TYPE_LBHTTPREQUESTCOOKIECONDITION, CookieName: &cookieName, CookieValue: &cookieValue, MatchType: &matchEquals, CaseSensitive: &trueVal, Inverse: &falseVal}, model.LBHttpRequestCookieConditionBindingType()),
+		lbVsConverterStructValue(t, model.LBHttpResponseHeaderCondition{Type_: model.LBRuleCondition_TYPE_LBHTTPRESPONSEHEADERCONDITION, HeaderName: &respHeaderName, HeaderValue: &respHeaderValue, MatchType: &matchEquals, CaseSensitive: &trueVal, Inverse: &falseVal}, model.LBHttpResponseHeaderConditionBindingType()),
+		lbVsConverterStructValue(t, model.LBTcpHeaderCondition{Type_: model.LBRuleCondition_TYPE_LBTCPHEADERCONDITION, SourcePort: &sourcePort, Inverse: &falseVal}, model.LBTcpHeaderConditionBindingType()),
+		lbVsConverterStructValue(t, model.LBIpHeaderCondition{Type_: model.LBRuleCondition_TYPE_LBIPHEADERCONDITION, GroupPath: &groupPath, SourceAddress: &sourceAddr, Inverse: &falseVal}, model.LBIpHeaderConditionBindingType()),
+		lbVsConverterStructValue(t, model.LBVariableCondition{Type_: model.LBRuleCondition_TYPE_LBVARIABLECONDITION, VariableName: &varName, VariableValue: &varValue, MatchType: &matchEquals, CaseSensitive: &trueVal, Inverse: &falseVal}, model.LBVariableConditionBindingType()),
+		lbVsConverterStructValue(t, model.LBSslSniCondition{Type_: model.LBRuleCondition_TYPE_LBSSLSNICONDITION, Sni: &sni, MatchType: &matchEquals, CaseSensitive: &trueVal, Inverse: &falseVal}, model.LBSslSniConditionBindingType()),
+		lbVsConverterStructValue(t, model.LBHttpSslCondition{
+			Type_:   model.LBRuleCondition_TYPE_LBHTTPSSLCONDITION,
+			Inverse: &falseVal,
+			ClientCertificateIssuerDn: &model.LBClientCertificateIssuerDnCondition{
+				CaseSensitive: &trueVal, IssuerDn: &issuerDn, MatchType: &matchEquals,
+			},
+			ClientCertificateSubjectDn: &model.LBClientCertificateSubjectDnCondition{
+				CaseSensitive: &trueVal, SubjectDn: &subjectDn, MatchType: &matchEquals,
+			},
+			ClientSupportedSslCiphers: []string{"TLS_RSA_WITH_AES_128_CBC_SHA"},
+			SessionReused:             &sessionReused,
+			UsedProtocol:              &usedProtocol,
+			UsedSslCipher:             &usedCipher,
+		}, model.LBHttpSslConditionBindingType()),
+	}
+}
+
+// fullLbRuleActionData returns an "action" block populated with every simple
+// (string/bool-field) action type plus a jwt_auth action using a certificate key, so a single
+// getPolicyLbRulesFromSchema call exercises every action-type append call site.
+func fullLbRuleActionData() map[string]interface{} {
+	return map[string]interface{}{
+		"connection_drop": []interface{}{map[string]interface{}{}},
+		"http_redirect": []interface{}{map[string]interface{}{
+			"redirect_status": "301",
+			"redirect_url":    "http://example.com",
+		}},
+		"http_reject": []interface{}{map[string]interface{}{
+			"reply_message": "denied",
+			"reply_status":  "403",
+		}},
+		"http_request_header_delete": []interface{}{map[string]interface{}{
+			"header_name": "X-Foo",
+		}},
+		"http_request_header_rewrite": []interface{}{map[string]interface{}{
+			"header_name":  "X-Foo",
+			"header_value": "bar",
+		}},
+		"http_request_uri_rewrite": []interface{}{map[string]interface{}{
+			"uri":           "/new",
+			"uri_arguments": "a=b",
+		}},
+		"http_response_header_delete": []interface{}{map[string]interface{}{
+			"header_name": "X-Bar",
+		}},
+		"http_response_header_rewrite": []interface{}{map[string]interface{}{
+			"header_name":  "X-Bar",
+			"header_value": "baz",
+		}},
+		"select_pool": []interface{}{map[string]interface{}{
+			"pool_id": "/infra/lb-pools/pool-1",
+		}},
+		"ssl_mode_selection": []interface{}{map[string]interface{}{
+			"ssl_mode": "SSL",
+		}},
+		"variable_assignment": []interface{}{map[string]interface{}{
+			"variable_name":  "v1",
+			"variable_value": "val1",
+		}},
+		"variable_persistence_learn": []interface{}{map[string]interface{}{
+			"persistence_profile_path": "/infra/lb-persistence-profiles/p1",
+			"variable_name":            "v2",
+			"variable_hash_enabled":    true,
+		}},
+		"variable_persistence_on": []interface{}{map[string]interface{}{
+			"persistence_profile_path": "/infra/lb-persistence-profiles/p2",
+			"variable_name":            "v3",
+			"variable_hash_enabled":    false,
+		}},
+		"jwt_auth": []interface{}{map[string]interface{}{
+			"realm":            "myrealm",
+			"pass_jwt_to_pool": true,
+			"key": []interface{}{map[string]interface{}{
+				"certificate_path": "/infra/certs/jwt",
+			}},
+			"tokens": []interface{}{"Authorization"},
+		}},
+	}
+}
+
+// fullLbRuleConditionData returns a "condition" block populated with every simple
+// (string/bool-field) condition type plus an http_ssl condition using both DN sets, so a
+// single getPolicyLbRulesFromSchema call exercises every condition-type append call site.
+func fullLbRuleConditionData() map[string]interface{} {
+	return map[string]interface{}{
+		"http_request_body": []interface{}{map[string]interface{}{
+			"body_value": "v", "match_type": "EQUALS", "case_sensitive": true, "inverse": false,
+		}},
+		"http_request_cookie": []interface{}{map[string]interface{}{
+			"cookie_name": "c1", "cookie_value": "v1", "match_type": "EQUALS", "case_sensitive": true, "inverse": false,
+		}},
+		"http_request_header": []interface{}{map[string]interface{}{
+			"header_name": "X-Foo", "header_value": "bar", "match_type": "EQUALS", "case_sensitive": true, "inverse": false,
+		}},
+		"http_request_method": []interface{}{map[string]interface{}{
+			"method": "GET", "inverse": false,
+		}},
+		"http_request_uri_arguments": []interface{}{map[string]interface{}{
+			"uri_arguments": "a=b", "match_type": "EQUALS", "case_sensitive": true, "inverse": false,
+		}},
+		"http_request_uri": []interface{}{map[string]interface{}{
+			"uri": "/foo", "match_type": "EQUALS", "case_sensitive": true, "inverse": false,
+		}},
+		"http_request_version": []interface{}{map[string]interface{}{
+			"version": "HTTP_VERSION_1_1", "inverse": false,
+		}},
+		"http_response_header": []interface{}{map[string]interface{}{
+			"header_name": "X-Bar", "header_value": "baz", "match_type": "EQUALS", "case_sensitive": true, "inverse": false,
+		}},
+		"ip_header": []interface{}{map[string]interface{}{
+			"group_path": "/infra/domains/default/groups/g1", "source_address": "1.2.3.4", "inverse": false,
+		}},
+		"ssl_sni": []interface{}{map[string]interface{}{
+			"sni": "example.com", "match_type": "EQUALS", "case_sensitive": true, "inverse": false,
+		}},
+		"tcp_header": []interface{}{map[string]interface{}{
+			"source_port": "8080", "inverse": false,
+		}},
+		"variable": []interface{}{map[string]interface{}{
+			"match_type": "EQUALS", "variable_name": "v1", "variable_value": "val1", "case_sensitive": true, "inverse": false,
+		}},
+		"http_ssl": []interface{}{map[string]interface{}{
+			"inverse": false,
+			"client_certificate_issuer_dn": []interface{}{map[string]interface{}{
+				"issuer_dn": "CN=issuer", "case_sensitive": true, "match_type": "EQUALS",
+			}},
+			"client_certificate_subject_dn": []interface{}{map[string]interface{}{
+				"subject_dn": "CN=subject", "case_sensitive": true, "match_type": "EQUALS",
+			}},
+			"client_supported_ssl_ciphers": []interface{}{"TLS_RSA_WITH_AES_128_CBC_SHA"},
+			"session_reused":               "IGNORE",
+			"used_protocol":                "TLS_V1_2",
+			"used_ssl_cipher":              "TLS_RSA_WITH_AES_128_CBC_SHA",
+		}},
+	}
+}
+
+func TestUnitNsxt_getPolicyLbRulesFromSchema(t *testing.T) {
+	res := resourceNsxtPolicyLBVirtualServer()
+
+	t.Run("converts a rule with every action and condition type populated", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+			"rule": []interface{}{
+				map[string]interface{}{
+					"display_name":   "rule-1",
+					"match_strategy": "ALL",
+					"phase":          "HTTP_ACCESS",
+					"action":         []interface{}{fullLbRuleActionData()},
+					"condition":      []interface{}{fullLbRuleConditionData()},
+				},
+			},
+		})
+
+		rules := getPolicyLbRulesFromSchema(d)
+		require.Len(t, rules, 1)
+		rule := rules[0]
+		assert.Equal(t, "rule-1", *rule.DisplayName)
+		assert.Equal(t, "ALL", *rule.MatchStrategy)
+		assert.Equal(t, "HTTP_ACCESS", *rule.Phase)
+		// 13 simple actions + 1 jwt_auth = 14
+		assert.Len(t, rule.Actions, 14)
+		// 12 simple conditions + 1 http_ssl = 13
+		assert.Len(t, rule.MatchConditions, 13)
+	})
+
+	t.Run("jwt_auth with a public key", func(t *testing.T) {
+		action := fullLbRuleActionData()
+		action["jwt_auth"] = []interface{}{map[string]interface{}{
+			"realm": "myrealm",
+			"key": []interface{}{map[string]interface{}{
+				"public_key_content": "-----BEGIN PUBLIC KEY-----",
+			}},
+		}}
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+			"rule": []interface{}{
+				map[string]interface{}{
+					"display_name": "rule-2",
+					"action":       []interface{}{action},
+				},
+			},
+		})
+
+		rules := getPolicyLbRulesFromSchema(d)
+		require.Len(t, rules, 1)
+		assert.Len(t, rules[0].Actions, 14)
+	})
+
+	t.Run("jwt_auth with a symmetric key", func(t *testing.T) {
+		action := fullLbRuleActionData()
+		action["jwt_auth"] = []interface{}{map[string]interface{}{
+			"realm": "myrealm",
+			"key": []interface{}{map[string]interface{}{
+				"symmetric_key": "shared-secret",
+			}},
+		}}
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+			"rule": []interface{}{
+				map[string]interface{}{
+					"display_name": "rule-3",
+					"action":       []interface{}{action},
+				},
+			},
+		})
+
+		rules := getPolicyLbRulesFromSchema(d)
+		require.Len(t, rules, 1)
+		assert.Len(t, rules[0].Actions, 14)
+	})
+
+	t.Run("no rules returns nil", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		assert.Nil(t, getPolicyLbRulesFromSchema(d))
+	})
 }

--- a/nsxt/resource_nsxt_edge_transport_node_deployment_ipv4_unit_test.go
+++ b/nsxt/resource_nsxt_edge_transport_node_deployment_ipv4_unit_test.go
@@ -1,0 +1,381 @@
+//go:build unittest
+
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package nsxt
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	vapiErrors "github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+	"go.uber.org/mock/gomock"
+
+	cliinfra "github.com/vmware/terraform-provider-nsxt/api/infra"
+	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
+	inframocks "github.com/vmware/terraform-provider-nsxt/mocks/infra"
+)
+
+// getEdgeNodeDeploymentConfigFromSchema, setEdgeDeploymentConfigInSchema, and
+// setVMDeploymentConfigInSchema are pure schema<->struct conversion helpers (no SDK calls), so
+// they're covered directly. getIPAssignmentFromSchema/setIPAssignmentInSchema mirror the IPv6
+// round-trip pattern already used in resource_nsxt_edge_transport_node_schema_unit_test.go.
+
+func minimalDeploymentConfigSchemaData() map[string]interface{} {
+	return map[string]interface{}{
+		"form_factor": "SMALL",
+		"node_user_settings": []interface{}{
+			map[string]interface{}{
+				"audit_username": "auditor",
+				"audit_password": "auditpw",
+				"cli_password":   "clipw",
+				"cli_username":   "admin",
+				"root_password":  "rootpw",
+			},
+		},
+		"vm_deployment_config": []interface{}{
+			map[string]interface{}{
+				"compute_folder_id":       "folder-1",
+				"compute_id":              "compute-1",
+				"data_network_ids":        []interface{}{"net-1", "net-2"},
+				"default_gateway_address": []interface{}{"10.0.0.1"},
+				"host_id":                 "host-1",
+				"management_network_id":   "mgmt-net-1",
+				"storage_id":              "storage-1",
+				"vc_id":                   "vc-1",
+				"management_port_subnet": []interface{}{
+					map[string]interface{}{
+						"ip_addresses":  []interface{}{"10.0.0.5"},
+						"prefix_length": 24,
+					},
+				},
+				"reservation_info": []interface{}{
+					map[string]interface{}{
+						"cpu_reservation_in_mhz":        1000,
+						"cpu_reservation_in_shares":     "NORMAL",
+						"memory_reservation_percentage": 50,
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestUnitNsxt_getEdgeNodeDeploymentConfigFromSchema(t *testing.T) {
+	t.Run("nil input returns nil", func(t *testing.T) {
+		cfg, err := getEdgeNodeDeploymentConfigFromSchema(nil)
+		require.NoError(t, err)
+		assert.Nil(t, cfg)
+	})
+
+	t.Run("empty list returns nil", func(t *testing.T) {
+		cfg, err := getEdgeNodeDeploymentConfigFromSchema([]interface{}{})
+		require.NoError(t, err)
+		assert.Nil(t, cfg)
+	})
+
+	t.Run("builds full deployment config", func(t *testing.T) {
+		cfg, err := getEdgeNodeDeploymentConfigFromSchema([]interface{}{minimalDeploymentConfigSchemaData()})
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+		assert.Equal(t, "SMALL", *cfg.FormFactor)
+		require.NotNil(t, cfg.NodeUserSettings)
+		assert.Equal(t, "admin", *cfg.NodeUserSettings.CliUsername)
+		assert.Equal(t, "auditor", *cfg.NodeUserSettings.AuditUsername)
+		require.NotNil(t, cfg.VmDeploymentConfig)
+	})
+
+	t.Run("ipv6 management address sets the IPv6 assignment type", func(t *testing.T) {
+		data := minimalDeploymentConfigSchemaData()
+		vdc := data["vm_deployment_config"].([]interface{})[0].(map[string]interface{})
+		vdc["management_port_subnet"] = []interface{}{
+			map[string]interface{}{
+				"ip_addresses":  []interface{}{"fe80::5"},
+				"prefix_length": 64,
+			},
+		}
+		cfg, err := getEdgeNodeDeploymentConfigFromSchema([]interface{}{data})
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+	})
+
+	t.Run("minimal config without optional fields", func(t *testing.T) {
+		data := map[string]interface{}{
+			"form_factor":        "SMALL",
+			"node_user_settings": []interface{}{},
+			"vm_deployment_config": []interface{}{
+				map[string]interface{}{
+					"compute_folder_id":       "",
+					"compute_id":              "compute-1",
+					"data_network_ids":        []interface{}{},
+					"default_gateway_address": []interface{}{},
+					"host_id":                 "",
+					"management_network_id":   "mgmt-net-1",
+					"storage_id":              "storage-1",
+					"vc_id":                   "vc-1",
+					"management_port_subnet":  []interface{}{},
+					"reservation_info":        []interface{}{},
+				},
+			},
+		}
+		cfg, err := getEdgeNodeDeploymentConfigFromSchema([]interface{}{data})
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+		assert.Nil(t, cfg.NodeUserSettings)
+	})
+}
+
+func TestUnitNsxt_setEdgeDeploymentConfigInSchema(t *testing.T) {
+	res := resourceNsxtEdgeTransportNode()
+
+	t.Run("round trips a full deployment config into schema", func(t *testing.T) {
+		cfg, err := getEdgeNodeDeploymentConfigFromSchema([]interface{}{minimalDeploymentConfigSchemaData()})
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		err = setEdgeDeploymentConfigInSchema(d, cfg)
+		require.NoError(t, err)
+
+		dc := d.Get("deployment_config").([]interface{})
+		require.Len(t, dc, 1)
+		elem := dc[0].(map[string]interface{})
+		assert.Equal(t, "SMALL", elem["form_factor"])
+
+		vdc := elem["vm_deployment_config"].([]interface{})
+		require.Len(t, vdc, 1)
+		vdcElem := vdc[0].(map[string]interface{})
+		assert.Equal(t, "compute-1", vdcElem["compute_id"])
+	})
+}
+
+func TestUnitNsxt_setVMDeploymentConfigInSchema(t *testing.T) {
+	t.Run("converts a vsphere deployment config", func(t *testing.T) {
+		cfg, err := getEdgeNodeDeploymentConfigFromSchema([]interface{}{minimalDeploymentConfigSchemaData()})
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+
+		result, err := setVMDeploymentConfigInSchema(cfg.VmDeploymentConfig)
+		require.NoError(t, err)
+		list := result.([]interface{})
+		require.Len(t, list, 1)
+		elem := list[0].(map[string]interface{})
+		assert.Equal(t, "compute-1", *elem["compute_id"].(*string))
+		assert.Equal(t, "storage-1", *elem["storage_id"].(*string))
+		assert.Equal(t, "vc-1", *elem["vc_id"].(*string))
+	})
+}
+
+func TestUnitNsxt_getIPAssignmentFromSchema(t *testing.T) {
+	t.Run("nil input returns nil", func(t *testing.T) {
+		sv, err := getIPAssignmentFromSchema(nil)
+		require.NoError(t, err)
+		assert.Nil(t, sv)
+	})
+
+	t.Run("empty list returns nil", func(t *testing.T) {
+		sv, err := getIPAssignmentFromSchema([]interface{}{})
+		require.NoError(t, err)
+		assert.Nil(t, sv)
+	})
+
+	t.Run("assigned_by_dhcp", func(t *testing.T) {
+		sv, err := getIPAssignmentFromSchema([]interface{}{
+			map[string]interface{}{"assigned_by_dhcp": true},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, sv)
+	})
+
+	t.Run("no_ipv4", func(t *testing.T) {
+		sv, err := getIPAssignmentFromSchema([]interface{}{
+			map[string]interface{}{"no_ipv4": true},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, sv)
+	})
+
+	t.Run("static_ip", func(t *testing.T) {
+		sv, err := getIPAssignmentFromSchema([]interface{}{
+			map[string]interface{}{
+				"static_ip": []interface{}{
+					map[string]interface{}{
+						"default_gateway": "192.168.1.1",
+						"ip_addresses":    []interface{}{"192.168.1.2"},
+						"subnet_mask":     "255.255.255.0",
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, sv)
+	})
+
+	t.Run("static_ip_mac", func(t *testing.T) {
+		sv, err := getIPAssignmentFromSchema([]interface{}{
+			map[string]interface{}{
+				"static_ip_mac": []interface{}{
+					map[string]interface{}{
+						"default_gateway": "192.168.1.1",
+						"ip_mac_pair": []interface{}{
+							map[string]interface{}{"ip_address": "192.168.1.2", "mac_address": "aa:bb:cc:dd:ee:ff"},
+						},
+						"subnet_mask": "255.255.255.0",
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, sv)
+	})
+
+	t.Run("static_ip_pool", func(t *testing.T) {
+		sv, err := getIPAssignmentFromSchema([]interface{}{
+			map[string]interface{}{"static_ip_pool": "pool-1"},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, sv)
+	})
+
+	t.Run("no assignment set errors", func(t *testing.T) {
+		_, err := getIPAssignmentFromSchema([]interface{}{
+			map[string]interface{}{},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no valid IP assignment found")
+	})
+
+	t.Run("multiple assignments set errors", func(t *testing.T) {
+		_, err := getIPAssignmentFromSchema([]interface{}{
+			map[string]interface{}{"assigned_by_dhcp": true, "no_ipv4": true},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "exactly one IP assignment")
+	})
+}
+
+func TestUnitNsxt_setIPAssignmentInSchema_roundTrip(t *testing.T) {
+	cases := []struct {
+		name string
+		in   map[string]interface{}
+		key  string
+	}{
+		{"assigned_by_dhcp", map[string]interface{}{"assigned_by_dhcp": true}, "assigned_by_dhcp"},
+		{"no_ipv4", map[string]interface{}{"no_ipv4": true}, "no_ipv4"},
+		{"static_ip_pool", map[string]interface{}{"static_ip_pool": "pool-1"}, "static_ip_pool"},
+		{"static_ip", map[string]interface{}{
+			"static_ip": []interface{}{
+				map[string]interface{}{"default_gateway": "192.168.1.1", "ip_addresses": []interface{}{"192.168.1.2"}, "subnet_mask": "255.255.255.0"},
+			},
+		}, "static_ip"},
+		{"static_ip_mac", map[string]interface{}{
+			"static_ip_mac": []interface{}{
+				map[string]interface{}{
+					"default_gateway": "192.168.1.1",
+					"ip_mac_pair":     []interface{}{map[string]interface{}{"ip_address": "192.168.1.2", "mac_address": "aa:bb:cc:dd:ee:ff"}},
+					"subnet_mask":     "255.255.255.0",
+				},
+			},
+		}, "static_ip_mac"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sv, err := getIPAssignmentFromSchema([]interface{}{tc.in})
+			require.NoError(t, err)
+			require.NotNil(t, sv)
+
+			result, err := setIPAssignmentInSchema(sv)
+			require.NoError(t, err)
+			list := result.([]interface{})
+			require.Len(t, list, 1)
+			elem := list[0].(map[string]interface{})
+			assert.Contains(t, elem, tc.key)
+		})
+	}
+}
+
+func TestUnitNsxt_setIPv6AssignmentInSchema_roundTripAllBranches(t *testing.T) {
+	cases := []struct {
+		name string
+		in   map[string]interface{}
+		key  string
+	}{
+		{"assigned_by_autoconf", map[string]interface{}{"assigned_by_autoconf": true}, "assigned_by_autoconf"},
+		{"no_ipv6", map[string]interface{}{"no_ipv6": true}, "no_ipv6"},
+		{"static_ip_pool", map[string]interface{}{"static_ip_pool": "pool-1"}, "static_ip_pool"},
+		{"static_ip", map[string]interface{}{
+			"static_ip": []interface{}{
+				map[string]interface{}{"default_gateway": "fe80::1", "ip_addresses": []interface{}{"fe80::2"}, "prefix_length": "64"},
+			},
+		}, "static_ip"},
+		{"static_ip_mac", map[string]interface{}{
+			"static_ip_mac": []interface{}{
+				map[string]interface{}{
+					"default_gateway": "fe80::1",
+					"ip_mac_pair":     []interface{}{map[string]interface{}{"ip_address": "fe80::2", "mac_address": "aa:bb:cc:dd:ee:ff"}},
+					"prefix_length":   "64",
+				},
+			},
+		}, "static_ip_mac"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sv, err := getIPv6AssignmentFromSchema([]interface{}{tc.in})
+			require.NoError(t, err)
+			require.NotNil(t, sv)
+
+			result, err := setIPv6AssignmentInSchema(sv)
+			require.NoError(t, err)
+			list := result.([]interface{})
+			require.Len(t, list, 1)
+			elem := list[0].(map[string]interface{})
+			assert.Contains(t, elem, tc.key)
+		})
+	}
+}
+
+func setupHostSwitchProfilesMock(t *testing.T) *inframocks.MockHostSwitchProfilesClient {
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	mockSDK := inframocks.NewMockHostSwitchProfilesClient(ctrl)
+	mockWrapper := &cliinfra.HostSwitchProfilesClientContext{
+		Client:     mockSDK,
+		ClientType: utl.Local,
+	}
+	originalCli := cliHostSwitchProfilesClient
+	t.Cleanup(func() { cliHostSwitchProfilesClient = originalCli })
+	cliHostSwitchProfilesClient = func(sessionContext utl.SessionContext, connector client.Connector) *cliinfra.HostSwitchProfilesClientContext {
+		return mockWrapper
+	}
+	return mockSDK
+}
+
+func TestMockNsxt_getHostSwitchProfileResourceType(t *testing.T) {
+	t.Run("List error propagates", func(t *testing.T) {
+		mockSDK := setupHostSwitchProfilesMock(t)
+		mockSDK.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(model.PolicyHostSwitchProfilesListResult{}, vapiErrors.InternalServerError{})
+
+		_, err := getHostSwitchProfileResourceType(newGoMockProviderClient(), "profile-1")
+		require.Error(t, err)
+	})
+
+	t.Run("not found errors", func(t *testing.T) {
+		mockSDK := setupHostSwitchProfilesMock(t)
+		mockSDK.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(model.PolicyHostSwitchProfilesListResult{}, nil)
+
+		_, err := getHostSwitchProfileResourceType(newGoMockProviderClient(), "profile-1")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}

--- a/nsxt/resource_nsxt_edge_transport_node_schema_unit_test.go
+++ b/nsxt/resource_nsxt_edge_transport_node_schema_unit_test.go
@@ -9,8 +9,11 @@ package nsxt
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/bindings"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/data"
 	mpmodel "github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp/nsx/model"
 )
 
@@ -278,4 +281,97 @@ func TestUnitNsxt_setHostSwitchProfileIDsInSchema(t *testing.T) {
 	assert.Equal(t, &uplinkVal, parentMap["uplink_profile"])
 	assert.Equal(t, &haVal, parentMap["vtep_ha_profile"])
 	assert.Equal(t, []interface{}{&uplinkVal, &haVal}, parentMap["host_switch_profile"])
+}
+
+func hostSwitchSpecStructValue(t *testing.T, nodeType string) *data.StructValue {
+	t.Helper()
+	hostSwitchID, hostSwitchName := "hs-1", "hs-name"
+	hostSwitchMode := mpmodel.StandardHostSwitch_HOST_SWITCH_MODE_STANDARD
+	isMigrate := true
+	deviceName, uplinkName := "vmnic0", "uplink-1"
+	numLcores, numaIdx := int64(4), int64(0)
+	vdsUplinkName, vdsLagName := "uplink-1", "lag-1"
+	tzID := "tz-1"
+	tzpID := "tzp-1"
+	subConfigName := "sub-1"
+	destNetwork, vmkDevice := "dvpg-1", "vmk0"
+
+	ipSV, err := getIPAssignmentFromSchema([]interface{}{map[string]interface{}{"assigned_by_dhcp": true}})
+	require.NoError(t, err)
+	ip6SV, err := getIPv6AssignmentFromSchema([]interface{}{map[string]interface{}{"assigned_by_autoconf": true}})
+	require.NoError(t, err)
+
+	sw := mpmodel.StandardHostSwitch{
+		HostSwitchId:       &hostSwitchID,
+		HostSwitchName:     &hostSwitchName,
+		Pnics:              []mpmodel.Pnic{{DeviceName: &deviceName, UplinkName: &uplinkName}},
+		IpAssignmentSpec:   ipSV,
+		Ipv6AssignmentSpec: ip6SV,
+		TransportZoneEndpoints: []mpmodel.TransportZoneEndPoint{
+			{TransportZoneId: &tzID, TransportZoneProfileIds: []mpmodel.TransportZoneProfileTypeIdEntry{{ProfileId: &tzpID}}},
+		},
+	}
+	if nodeType == nodeTypeHost {
+		sw.CpuConfig = []mpmodel.CpuCoreConfigForEnhancedNetworkingStackSwitch{{NumLcores: &numLcores, NumaNodeIndex: &numaIdx}}
+		sw.IsMigratePnics = &isMigrate
+		sw.HostSwitchMode = &hostSwitchMode
+		sw.Uplinks = []mpmodel.VdsUplink{{UplinkName: &uplinkName, VdsLagName: &vdsLagName, VdsUplinkName: &vdsUplinkName}}
+		sw.TransportNodeProfileSubConfigs = []mpmodel.TransportNodeProfileSubConfig{
+			{
+				Name: &subConfigName,
+				HostSwitchConfigOption: &mpmodel.HostSwitchConfigOption{
+					HostSwitchId:       &hostSwitchID,
+					IpAssignmentSpec:   ipSV,
+					Ipv6AssignmentSpec: ip6SV,
+					Uplinks:            []mpmodel.VdsUplink{{UplinkName: &uplinkName}},
+				},
+			},
+		}
+		sw.VmkInstallMigration = []mpmodel.VmknicNetwork{{DestinationNetwork: &destNetwork, DeviceName: &vmkDevice}}
+	}
+
+	spec := mpmodel.StandardHostSwitchSpec{
+		HostSwitches: []mpmodel.StandardHostSwitch{sw},
+		ResourceType: mpmodel.HostSwitchSpec_RESOURCE_TYPE_STANDARDHOSTSWITCHSPEC,
+	}
+	converter := bindings.NewTypeConverter()
+	sv, errs := converter.ConvertToVapi(spec, mpmodel.StandardHostSwitchSpecBindingType())
+	require.Empty(t, errs)
+	return sv.(*data.StructValue)
+}
+
+func TestUnitNsxt_setHostSwitchSpecInSchema(t *testing.T) {
+	t.Run("edge node type populates the standard fields only", func(t *testing.T) {
+		res := resourceNsxtEdgeTransportNode()
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+
+		err := setHostSwitchSpecInSchema(d, hostSwitchSpecStructValue(t, nodeTypeEdge), nodeTypeEdge)
+		require.NoError(t, err)
+
+		list := d.Get("standard_host_switch").([]interface{})
+		require.Len(t, list, 1)
+		elem := list[0].(map[string]interface{})
+		assert.Equal(t, "hs-1", elem["host_switch_id"])
+		require.Len(t, elem["pnic"].([]interface{}), 1)
+		require.NotNil(t, elem["ip_assignment"])
+		require.NotNil(t, elem["ipv6_assignment"])
+	})
+
+	t.Run("host node type also populates host-only fields", func(t *testing.T) {
+		// getStandardHostSwitchSchema(nodeTypeHost) is only wired into the policy host
+		// transport node resource's schema, not the (edge-only) manager resource's.
+		res := resourceNsxtPolicyHostTransportNode()
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+
+		err := setHostSwitchSpecInSchema(d, hostSwitchSpecStructValue(t, nodeTypeHost), nodeTypeHost)
+		require.NoError(t, err)
+
+		list := d.Get("standard_host_switch").([]interface{})
+		require.Len(t, list, 1)
+		elem := list[0].(map[string]interface{})
+		require.Len(t, elem["cpu_config"].([]interface{}), 1)
+		assert.Equal(t, true, elem["is_migrate_pnics"])
+		require.Len(t, elem["transport_node_profile_sub_config"].([]interface{}), 1)
+		require.Len(t, elem["vmk_install_migration"].([]interface{}), 1)
+	})
 }

--- a/nsxt/resource_nsxt_policy_idps_settings.go
+++ b/nsxt/resource_nsxt_policy_idps_settings.go
@@ -10,10 +10,21 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/settings/firewall/security"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/settings/firewall/security/intrusion_services/custom_signature_versions"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 )
+
+// cliIdsSettingsClient and cliIdsCustomSigSettingsClient are swapped out in unit tests to
+// inject mock clients.
+var cliIdsSettingsClient = func(connector client.Connector) security.IntrusionServicesClient {
+	return security.NewIntrusionServicesClient(connector)
+}
+
+var cliIdsCustomSigSettingsClient = func(connector client.Connector) custom_signature_versions.SettingsClient {
+	return custom_signature_versions.NewSettingsClient(connector)
+}
 
 var idpsOversubscriptionValues = []string{"BYPASSED", "DROPPED"}
 
@@ -101,7 +112,7 @@ func resourceNsxtPolicyIdpsSettingsRead(d *schema.ResourceData, m interface{}) e
 	}
 
 	// Read IdsSettings
-	client := security.NewIntrusionServicesClient(connector)
+	client := cliIdsSettingsClient(connector)
 
 	obj, err := client.Get()
 	if err != nil {
@@ -123,7 +134,7 @@ func resourceNsxtPolicyIdpsSettingsRead(d *schema.ResourceData, m interface{}) e
 	// Read IdsCustomSignatureSettings if custom_signature_version_id is set
 	customSigVersionID := d.Get("custom_signature_version_id").(string)
 	if customSigVersionID != "" {
-		customSigSettingsClient := custom_signature_versions.NewSettingsClient(connector)
+		customSigSettingsClient := cliIdsCustomSigSettingsClient(connector)
 		customSigSettings, err := customSigSettingsClient.Get(customSigVersionID)
 		if err != nil {
 			log.Printf("[WARN] Failed to read custom signature settings for version %s: %v", customSigVersionID, err)
@@ -167,7 +178,7 @@ func resourceNsxtPolicyIdpsSettingsUpdate(d *schema.ResourceData, m interface{})
 	}
 
 	// Get current revision
-	client := security.NewIntrusionServicesClient(connector)
+	client := cliIdsSettingsClient(connector)
 
 	existingObj, err := client.Get()
 	if err == nil && existingObj.Revision != nil {
@@ -195,7 +206,7 @@ func resourceNsxtPolicyIdpsSettingsUpdate(d *schema.ResourceData, m interface{})
 			EnableCustomSignatures: &enableCustomSig,
 		}
 
-		customSigSettingsClient := custom_signature_versions.NewSettingsClient(connector)
+		customSigSettingsClient := cliIdsCustomSigSettingsClient(connector)
 
 		// Get current revision
 		existingCustomSigSettings, err := customSigSettingsClient.Get(customSigVersionID)
@@ -232,7 +243,7 @@ func resourceNsxtPolicyIdpsSettingsDelete(d *schema.ResourceData, m interface{})
 	// Reset to default values
 	log.Printf("[INFO] Resetting IDPS Settings to defaults with ID %s (DELETE operation)", id)
 
-	client := security.NewIntrusionServicesClient(connector)
+	client := cliIdsSettingsClient(connector)
 
 	// Get current object to preserve revision
 	existingObj, err := client.Get()
@@ -271,7 +282,7 @@ func resourceNsxtPolicyIdpsSettingsDelete(d *schema.ResourceData, m interface{})
 			EnableCustomSignatures: &defaultEnableCustomSig,
 		}
 
-		customSigSettingsClient := custom_signature_versions.NewSettingsClient(connector)
+		customSigSettingsClient := cliIdsCustomSigSettingsClient(connector)
 
 		existingCustomSigSettings, err := customSigSettingsClient.Get(customSigVersionID)
 		if err == nil && existingCustomSigSettings.Revision != nil {

--- a/nsxt/resource_nsxt_policy_idps_signature_version.go
+++ b/nsxt/resource_nsxt_policy_idps_signature_version.go
@@ -9,8 +9,14 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/settings/firewall/security/intrusion_services"
 )
+
+// cliIdsSignatureVersionsClient is swapped out in unit tests to inject a mock client.
+var cliIdsSignatureVersionsClient = func(connector client.Connector) intrusion_services.SignatureVersionsClient {
+	return intrusion_services.NewSignatureVersionsClient(connector)
+}
 
 // NOTE: IDS Signature Versions are system-managed resources in NSX.
 // They are created automatically by NSX when signature updates are downloaded.
@@ -108,7 +114,7 @@ func resourceNsxtPolicyIdpsSignatureVersionCreate(d *schema.ResourceData, m inte
 	}
 
 	// Verify the version exists
-	client := intrusion_services.NewSignatureVersionsClient(connector)
+	client := cliIdsSignatureVersionsClient(connector)
 	_, err := client.Get(id)
 	if err != nil {
 		return handleCreateError("IdsSignatureVersion", id, err)
@@ -132,7 +138,7 @@ func resourceNsxtPolicyIdpsSignatureVersionRead(d *schema.ResourceData, m interf
 		return fmt.Errorf("Error obtaining IDS Signature Version ID")
 	}
 
-	client := intrusion_services.NewSignatureVersionsClient(connector)
+	client := cliIdsSignatureVersionsClient(connector)
 	obj, err := client.Get(id)
 	if err != nil {
 		return handleReadError(d, "IdsSignatureVersion", id, err)
@@ -179,7 +185,7 @@ func resourceNsxtPolicyIdpsSignatureVersionUpdate(d *schema.ResourceData, m inte
 		case "ACTIVE":
 			log.Printf("[INFO] Making IDS Signature Version %s ACTIVE", id)
 
-			client := intrusion_services.NewSignatureVersionsClient(connector)
+			client := cliIdsSignatureVersionsClient(connector)
 
 			// Get current version object
 			obj, err := client.Get(id)

--- a/nsxt/segment_common_unit_test.go
+++ b/nsxt/segment_common_unit_test.go
@@ -1,0 +1,213 @@
+//go:build unittest
+
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package nsxt
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+)
+
+func TestUnitNsxt_parseSegmentPolicyPath(t *testing.T) {
+	tests := []struct {
+		name      string
+		path      string
+		wantIsT0  bool
+		wantGwID  string
+		wantSegID string
+	}{
+		{"infra segment", "/infra/segments/seg-1", false, "", "seg-1"},
+		{"project segment", "/orgs/o1/projects/p1/infra/segments/seg-1", false, "", "seg-1"},
+		{"fixed tier-1 segment", "/infra/tier-1s/gw-1/segments/seg-1", false, "gw-1", "seg-1"},
+		{"fixed tier-0 segment", "/infra/tier-0s/gw-1/segments/seg-1", true, "gw-1", "seg-1"},
+		{"not a segment path", "/infra/tier-1s/gw-1", false, "", ""},
+		{"too short", "seg-1", false, "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isT0, gwID, segID := parseSegmentPolicyPath(tt.path)
+			assert.Equal(t, tt.wantIsT0, isT0)
+			assert.Equal(t, tt.wantGwID, gwID)
+			assert.Equal(t, tt.wantSegID, segID)
+		})
+	}
+}
+
+func TestUnitNsxt_setBridgeConfigInStructAndSchema(t *testing.T) {
+	segSchema := getPolicyCommonSegmentSchema(false, false)
+
+	t.Run("no bridge config is a no-op", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, segSchema, map[string]interface{}{})
+		obj := model.Segment{}
+		setBridgeConfigInStruct(d, &obj)
+		assert.Empty(t, obj.BridgeProfiles)
+	})
+
+	t.Run("bridge config round-trips through struct and back to schema", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, segSchema, map[string]interface{}{
+			"bridge_config": []interface{}{
+				map[string]interface{}{
+					"profile_path":          "/infra/bridge-profiles/bp-1",
+					"uplink_teaming_policy": "policy-1",
+					"vlan_ids":              []interface{}{"100"},
+					"transport_zone_path":   "/infra/transport-zones/tz-1",
+				},
+			},
+		})
+		obj := model.Segment{}
+		setBridgeConfigInStruct(d, &obj)
+		require.Len(t, obj.BridgeProfiles, 1)
+		assert.Equal(t, "/infra/bridge-profiles/bp-1", *obj.BridgeProfiles[0].BridgeProfilePath)
+
+		d2 := schema.TestResourceDataRaw(t, segSchema, map[string]interface{}{})
+		setSegmentBridgeConfigInSchema(d2, &obj)
+		got := d2.Get("bridge_config").([]interface{})
+		require.Len(t, got, 1)
+		assert.Equal(t, "/infra/bridge-profiles/bp-1", got[0].(map[string]interface{})["profile_path"])
+	})
+}
+
+func TestUnitNsxt_nsxtPolicySegmentAddGatewayToInfraStruct(t *testing.T) {
+	segSchema := getPolicyCommonSegmentSchema(true, true)
+	dummySegID := "dummy-seg"
+	dummyTargetType := "Segment"
+	dummyChild, err := vAPIConversion(model.ChildResourceReference{
+		Id:           &dummySegID,
+		ResourceType: "ChildResourceReference",
+		TargetType:   &dummyTargetType,
+	}, model.ChildResourceReferenceBindingType())
+	require.NoError(t, err)
+
+	t.Run("valid tier-1 connectivity_path succeeds", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, segSchema, map[string]interface{}{
+			"connectivity_path": "/infra/tier-1s/gw-1",
+		})
+		val, err := nsxtPolicySegmentAddGatewayToInfraStruct(d, dummyChild)
+		require.NoError(t, err)
+		assert.NotNil(t, val)
+	})
+
+	t.Run("tier-0 connectivity_path is rejected", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, segSchema, map[string]interface{}{
+			"connectivity_path": "/infra/tier-0s/gw-1",
+		})
+		_, err := nsxtPolicySegmentAddGatewayToInfraStruct(d, dummyChild)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Tier0")
+	})
+
+	t.Run("empty connectivity_path is rejected", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, segSchema, map[string]interface{}{})
+		_, err := nsxtPolicySegmentAddGatewayToInfraStruct(d, dummyChild)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not a valid gateway path")
+	})
+}
+
+func TestUnitNsxt_nsxtPolicySegmentProfileSetInStruct(t *testing.T) {
+	segSchema := getPolicyCommonSegmentSchema(false, false)
+
+	t.Run("discovery profile: no old, no new is a no-op", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, segSchema, map[string]interface{}{})
+		val, err := nsxtPolicySegmentDiscoveryProfileSetInStruct(d)
+		require.NoError(t, err)
+		assert.Nil(t, val)
+	})
+
+	t.Run("discovery profile: new profile configured", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, segSchema, map[string]interface{}{
+			"discovery_profile": []interface{}{
+				map[string]interface{}{
+					"ip_discovery_profile_path":  "/infra/ip-discovery-profiles/p1",
+					"mac_discovery_profile_path": "",
+					"binding_map_path":           "",
+					"revision":                   0,
+				},
+			},
+		})
+		val, err := nsxtPolicySegmentDiscoveryProfileSetInStruct(d)
+		require.NoError(t, err)
+		assert.NotNil(t, val)
+	})
+
+	t.Run("qos profile: new profile configured", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, segSchema, map[string]interface{}{
+			"qos_profile": []interface{}{
+				map[string]interface{}{
+					"qos_profile_path": "/infra/qos-profiles/p1",
+					"binding_map_path": "",
+					"revision":         0,
+				},
+			},
+		})
+		val, err := nsxtPolicySegmentQosProfileSetInStruct(d)
+		require.NoError(t, err)
+		assert.NotNil(t, val)
+	})
+
+	t.Run("qos profile: no old, no new is a no-op", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, segSchema, map[string]interface{}{})
+		val, err := nsxtPolicySegmentQosProfileSetInStruct(d)
+		require.NoError(t, err)
+		assert.Nil(t, val)
+	})
+
+	t.Run("security profile: new profile configured", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, segSchema, map[string]interface{}{
+			"security_profile": []interface{}{
+				map[string]interface{}{
+					"spoofguard_profile_path": "/infra/spoofguard-profiles/p1",
+					"security_profile_path":   "/infra/segment-security-profiles/p1",
+					"binding_map_path":        "",
+					"revision":                0,
+				},
+			},
+		})
+		val, err := nsxtPolicySegmentSecurityProfileSetInStruct(d)
+		require.NoError(t, err)
+		assert.NotNil(t, val)
+	})
+
+	t.Run("security profile: no old, no new is a no-op", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, segSchema, map[string]interface{}{})
+		val, err := nsxtPolicySegmentSecurityProfileSetInStruct(d)
+		require.NoError(t, err)
+		assert.Nil(t, val)
+	})
+}
+
+func TestUnitNsxt_policySegmentResourceToInfraStruct(t *testing.T) {
+	m := newGoMockProviderClient()
+
+	t.Run("vlan segment builds an Infra struct", func(t *testing.T) {
+		segSchema := getPolicyCommonSegmentSchema(true, false)
+		d := schema.TestResourceDataRaw(t, segSchema, map[string]interface{}{
+			"display_name":        "seg-1",
+			"transport_zone_path": "/infra/transport-zones/tz-1",
+			"vlan_ids":            []interface{}{"100"},
+			"replication_mode":    model.Segment_REPLICATION_MODE_MTEP,
+		})
+		obj, err := policySegmentResourceToInfraStruct(getSessionContext(d, m), "seg-1", d, m, true, false)
+		require.NoError(t, err)
+		assert.NotNil(t, obj.Children)
+	})
+
+	t.Run("missing transport_zone_path on local manager overlay segment is an error", func(t *testing.T) {
+		segSchema := getPolicyCommonSegmentSchema(false, false)
+		d := schema.TestResourceDataRaw(t, segSchema, map[string]interface{}{
+			"display_name":      "seg-1",
+			"connectivity_path": "/infra/tier-1s/gw-1",
+			"replication_mode":  model.Segment_REPLICATION_MODE_MTEP,
+		})
+		_, err := policySegmentResourceToInfraStruct(getSessionContext(d, m), "seg-1", d, m, false, false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "transport_zone_path")
+	})
+}

--- a/nsxt/segment_common_unit_test.go
+++ b/nsxt/segment_common_unit_test.go
@@ -12,8 +12,70 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	vapiErrors "github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+	"go.uber.org/mock/gomock"
+
+	segmentsapi "github.com/vmware/terraform-provider-nsxt/api/infra"
+	segmentsprofilesapi "github.com/vmware/terraform-provider-nsxt/api/infra/segments"
+	tier1sapi "github.com/vmware/terraform-provider-nsxt/api/infra/tier_1s"
+	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
+	segmentmocks "github.com/vmware/terraform-provider-nsxt/mocks/infra"
+	segmentprofilemocks "github.com/vmware/terraform-provider-nsxt/mocks/infra/segments"
+	tier1segmentmocks "github.com/vmware/terraform-provider-nsxt/mocks/infra/tier_1s"
 )
+
+func setupSegmentExistsMocks(t *testing.T) (*segmentmocks.MockSegmentsClient, *tier1segmentmocks.MockSegmentsClient) {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	mockSegSDK := segmentmocks.NewMockSegmentsClient(ctrl)
+	origSeg := cliSegmentsClient
+	t.Cleanup(func() { cliSegmentsClient = origSeg })
+	cliSegmentsClient = func(_ utl.SessionContext, _ client.Connector) *segmentsapi.SegmentClientContext {
+		return &segmentsapi.SegmentClientContext{Client: mockSegSDK, ClientType: utl.Local}
+	}
+
+	mockT1SegSDK := tier1segmentmocks.NewMockSegmentsClient(ctrl)
+	origT1Seg := cliTier1SegmentsClient
+	t.Cleanup(func() { cliTier1SegmentsClient = origT1Seg })
+	cliTier1SegmentsClient = func(_ utl.SessionContext, _ client.Connector) *tier1sapi.SegmentClientContext {
+		return &tier1sapi.SegmentClientContext{Client: mockT1SegSDK, ClientType: utl.Local}
+	}
+
+	return mockSegSDK, mockT1SegSDK
+}
+
+func setupSegmentProfileReadMocks(t *testing.T) (*segmentprofilemocks.MockSegmentDiscoveryProfileBindingMapsClient, *segmentprofilemocks.MockSegmentQosProfileBindingMapsClient, *segmentprofilemocks.MockSegmentSecurityProfileBindingMapsClient) {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	mockDiscoverySDK := segmentprofilemocks.NewMockSegmentDiscoveryProfileBindingMapsClient(ctrl)
+	origDiscovery := cliSegmentDiscoveryProfileBindingMapsClient
+	t.Cleanup(func() { cliSegmentDiscoveryProfileBindingMapsClient = origDiscovery })
+	cliSegmentDiscoveryProfileBindingMapsClient = func(_ utl.SessionContext, _ client.Connector) *segmentsprofilesapi.SegmentDiscoveryProfileBindingMapClientContext {
+		return &segmentsprofilesapi.SegmentDiscoveryProfileBindingMapClientContext{Client: mockDiscoverySDK, ClientType: utl.Local}
+	}
+
+	mockQosSDK := segmentprofilemocks.NewMockSegmentQosProfileBindingMapsClient(ctrl)
+	origQos := cliSegmentQosProfileBindingMapsClient
+	t.Cleanup(func() { cliSegmentQosProfileBindingMapsClient = origQos })
+	cliSegmentQosProfileBindingMapsClient = func(_ utl.SessionContext, _ client.Connector) *segmentsprofilesapi.SegmentQosProfileBindingMapClientContext {
+		return &segmentsprofilesapi.SegmentQosProfileBindingMapClientContext{Client: mockQosSDK, ClientType: utl.Local}
+	}
+
+	mockSecuritySDK := segmentprofilemocks.NewMockSegmentSecurityProfileBindingMapsClient(ctrl)
+	origSecurity := cliSegmentSecurityProfileBindingMapsClient
+	t.Cleanup(func() { cliSegmentSecurityProfileBindingMapsClient = origSecurity })
+	cliSegmentSecurityProfileBindingMapsClient = func(_ utl.SessionContext, _ client.Connector) *segmentsprofilesapi.SegmentSecurityProfileBindingMapClientContext {
+		return &segmentsprofilesapi.SegmentSecurityProfileBindingMapClientContext{Client: mockSecuritySDK, ClientType: utl.Local}
+	}
+
+	return mockDiscoverySDK, mockQosSDK, mockSecuritySDK
+}
 
 func TestUnitNsxt_parseSegmentPolicyPath(t *testing.T) {
 	tests := []struct {
@@ -209,5 +271,298 @@ func TestUnitNsxt_policySegmentResourceToInfraStruct(t *testing.T) {
 		_, err := policySegmentResourceToInfraStruct(getSessionContext(d, m), "seg-1", d, m, false, false)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "transport_zone_path")
+	})
+
+	t.Run("overlay segment with subnets, advanced_config, l2_extension and profiles builds an Infra struct", func(t *testing.T) {
+		segSchema := getPolicyCommonSegmentSchema(false, false)
+		d := schema.TestResourceDataRaw(t, segSchema, map[string]interface{}{
+			"display_name":        "seg-1",
+			"description":         "a segment",
+			"domain_name":         "example.com",
+			"transport_zone_path": "/infra/transport-zones/tz-1",
+			"connectivity_path":   "/infra/tier-1s/gw-1",
+			"overlay_id":          100,
+			"replication_mode":    model.Segment_REPLICATION_MODE_MTEP,
+			"subnet": []interface{}{
+				map[string]interface{}{
+					"cidr":        "10.0.0.1/24",
+					"network":     "10.0.0.0/24",
+					"dhcp_ranges": []interface{}{"10.0.0.100-10.0.0.200"},
+					"dhcp_v4_config": []interface{}{
+						map[string]interface{}{
+							"server_address": "10.0.0.2/24",
+							"lease_time":     3600,
+						},
+					},
+				},
+			},
+			"advanced_config": []interface{}{
+				map[string]interface{}{
+					"connectivity":          "ON",
+					"hybrid":                true,
+					"local_egress":          false,
+					"multicast":             true,
+					"address_pool_path":     "/infra/ip-pools/p1",
+					"uplink_teaming_policy": "policy-1",
+					"urpf_mode":             "STRICT",
+				},
+			},
+			"l2_extension": []interface{}{
+				map[string]interface{}{
+					"l2vpn_paths": []interface{}{"/infra/tier-0s/gw-1/l2vpn-services/svc-1"},
+					"tunnel_id":   5,
+				},
+			},
+			"discovery_profile": []interface{}{
+				map[string]interface{}{
+					"ip_discovery_profile_path": "/infra/ip-discovery-profiles/p1",
+				},
+			},
+			"bridge_config": []interface{}{
+				map[string]interface{}{
+					"profile_path": "/infra/bridge-profiles/bp-1",
+				},
+			},
+		})
+		obj, err := policySegmentResourceToInfraStruct(getSessionContext(d, m), "seg-1", d, m, false, false)
+		require.NoError(t, err)
+		require.NotNil(t, obj.Children)
+		require.Len(t, obj.Children, 1)
+	})
+
+	t.Run("fixed segment builds an Infra struct via the gateway child path", func(t *testing.T) {
+		segSchema := getPolicyCommonSegmentSchema(false, true)
+		d := schema.TestResourceDataRaw(t, segSchema, map[string]interface{}{
+			"display_name":      "seg-1",
+			"connectivity_path": "/infra/tier-1s/gw-1",
+			"replication_mode":  model.Segment_REPLICATION_MODE_MTEP,
+		})
+		obj, err := policySegmentResourceToInfraStruct(getSessionContext(d, m), "seg-1", d, m, false, true)
+		require.NoError(t, err)
+		require.Len(t, obj.Children, 1)
+	})
+
+	t.Run("multitenancy segment cannot change transport_zone_path", func(t *testing.T) {
+		segSchema := getPolicyCommonSegmentSchema(false, false)
+		d := schema.TestResourceDataRaw(t, segSchema, map[string]interface{}{
+			"display_name":        "seg-1",
+			"connectivity_path":   "/infra/tier-1s/gw-1",
+			"transport_zone_path": "/infra/transport-zones/tz-1",
+			"replication_mode":    model.Segment_REPLICATION_MODE_MTEP,
+		})
+		d.Set("transport_zone_path", "/infra/transport-zones/tz-2")
+		mtM := newGoMockProviderClient()
+		ctx := utl.SessionContext{ClientType: utl.Multitenancy, ProjectID: "proj-1"}
+		_, err := policySegmentResourceToInfraStruct(ctx, "seg-1", d, mtM, false, false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot be specified for project based segments")
+	})
+}
+
+func TestMockNsxt_nsxtPolicySegmentProfileReads(t *testing.T) {
+	segSchema := getPolicyCommonSegmentSchema(false, false)
+
+	t.Run("discovery profile read populates schema when a result is found", func(t *testing.T) {
+		mockDiscoverySDK, _, _ := setupSegmentProfileReadMocks(t)
+		path := "/infra/ip-discovery-profiles/p1"
+		mockDiscoverySDK.EXPECT().List("seg-1", nil, nil, nil, nil, nil, nil, nil).Return(
+			model.SegmentDiscoveryProfileBindingMapListResult{Results: []model.SegmentDiscoveryProfileBindingMap{{IpDiscoveryProfilePath: &path}}}, nil,
+		)
+
+		d := schema.TestResourceDataRaw(t, segSchema, map[string]interface{}{})
+		d.SetId("seg-1")
+		err := nsxtPolicySegmentDiscoveryProfileRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		list := d.Get("discovery_profile").([]interface{})
+		require.Len(t, list, 1)
+	})
+
+	t.Run("discovery profile read propagates List error", func(t *testing.T) {
+		mockDiscoverySDK, _, _ := setupSegmentProfileReadMocks(t)
+		mockDiscoverySDK.EXPECT().List("seg-1", nil, nil, nil, nil, nil, nil, nil).Return(
+			model.SegmentDiscoveryProfileBindingMapListResult{}, vapiErrors.InternalServerError{},
+		)
+
+		d := schema.TestResourceDataRaw(t, segSchema, map[string]interface{}{})
+		d.SetId("seg-1")
+		err := nsxtPolicySegmentDiscoveryProfileRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+
+	t.Run("qos profile read populates schema only when path is non-empty", func(t *testing.T) {
+		mockDiscoverySDK, mockQosSDK, mockSecuritySDK := setupSegmentProfileReadMocks(t)
+		mockDiscoverySDK.EXPECT().List("seg-1", nil, nil, nil, nil, nil, nil, nil).Return(
+			model.SegmentDiscoveryProfileBindingMapListResult{}, nil,
+		)
+		empty := ""
+		path := "/infra/qos-profiles/p1"
+		mockQosSDK.EXPECT().List("seg-1", nil, nil, nil, nil, nil).Return(
+			model.SegmentQosProfileBindingMapListResult{Results: []model.SegmentQosProfileBindingMap{{QosProfilePath: &empty}, {QosProfilePath: &path}}}, nil,
+		)
+		mockSecuritySDK.EXPECT().List("seg-1", nil, nil, nil, nil, nil).Return(
+			model.SegmentSecurityProfileBindingMapListResult{}, nil,
+		)
+
+		d := schema.TestResourceDataRaw(t, segSchema, map[string]interface{}{})
+		d.SetId("seg-1")
+		err := nsxtPolicySegmentProfilesRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		list := d.Get("qos_profile").([]interface{})
+		require.Len(t, list, 1)
+	})
+
+	t.Run("security profile read populates schema when a result is found", func(t *testing.T) {
+		mockDiscoverySDK, mockQosSDK, mockSecuritySDK := setupSegmentProfileReadMocks(t)
+		mockDiscoverySDK.EXPECT().List("seg-1", nil, nil, nil, nil, nil, nil, nil).Return(
+			model.SegmentDiscoveryProfileBindingMapListResult{}, nil,
+		)
+		mockQosSDK.EXPECT().List("seg-1", nil, nil, nil, nil, nil).Return(
+			model.SegmentQosProfileBindingMapListResult{}, nil,
+		)
+		secPath := "/infra/segment-security-profiles/p1"
+		mockSecuritySDK.EXPECT().List("seg-1", nil, nil, nil, nil, nil).Return(
+			model.SegmentSecurityProfileBindingMapListResult{Results: []model.SegmentSecurityProfileBindingMap{{SegmentSecurityProfilePath: &secPath}}}, nil,
+		)
+
+		d := schema.TestResourceDataRaw(t, segSchema, map[string]interface{}{})
+		d.SetId("seg-1")
+		err := nsxtPolicySegmentProfilesRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		list := d.Get("security_profile").([]interface{})
+		require.Len(t, list, 1)
+	})
+
+	t.Run("security profile read propagates List error", func(t *testing.T) {
+		mockDiscoverySDK, mockQosSDK, mockSecuritySDK := setupSegmentProfileReadMocks(t)
+		mockDiscoverySDK.EXPECT().List("seg-1", nil, nil, nil, nil, nil, nil, nil).Return(
+			model.SegmentDiscoveryProfileBindingMapListResult{}, nil,
+		)
+		mockQosSDK.EXPECT().List("seg-1", nil, nil, nil, nil, nil).Return(
+			model.SegmentQosProfileBindingMapListResult{}, nil,
+		)
+		mockSecuritySDK.EXPECT().List("seg-1", nil, nil, nil, nil, nil).Return(
+			model.SegmentSecurityProfileBindingMapListResult{}, vapiErrors.InternalServerError{},
+		)
+
+		d := schema.TestResourceDataRaw(t, segSchema, map[string]interface{}{})
+		d.SetId("seg-1")
+		err := nsxtPolicySegmentProfilesRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockNsxt_nsxtPolicySegmentRead(t *testing.T) {
+	segSchema := getPolicyCommonSegmentSchema(false, false)
+
+	t.Run("populates advanced_config, l2_extension, subnet and profile blocks", func(t *testing.T) {
+		mockSegSDK, _ := setupSegmentExistsMocks(t)
+		mockDiscoverySDK, mockQosSDK, mockSecuritySDK := setupSegmentProfileReadMocks(t)
+
+		connPath := "/infra/tier-1s/gw-1"
+		revision := int64(1)
+		urpf := "STRICT"
+		egress := false
+		hybrid := true
+		multicast := true
+		gwAddr := "10.0.0.1/24"
+		network := "10.0.0.0/24"
+		mockSegSDK.EXPECT().Get("seg-1").Return(model.Segment{
+			ConnectivityPath: &connPath,
+			Revision:         &revision,
+			AdvancedConfig: &model.SegmentAdvancedConfig{
+				UrpfMode:    &urpf,
+				LocalEgress: &egress,
+				Hybrid:      &hybrid,
+				Multicast:   &multicast,
+			},
+			L2Extension: &model.L2Extension{TunnelId: &revision},
+			Subnets: []model.SegmentSubnet{
+				{GatewayAddress: &gwAddr, Network: &network},
+			},
+		}, nil)
+		mockDiscoverySDK.EXPECT().List("seg-1", nil, nil, nil, nil, nil, nil, nil).Return(model.SegmentDiscoveryProfileBindingMapListResult{}, nil)
+		mockQosSDK.EXPECT().List("seg-1", nil, nil, nil, nil, nil).Return(model.SegmentQosProfileBindingMapListResult{}, nil)
+		mockSecuritySDK.EXPECT().List("seg-1", nil, nil, nil, nil, nil).Return(model.SegmentSecurityProfileBindingMapListResult{}, nil)
+
+		d := schema.TestResourceDataRaw(t, segSchema, map[string]interface{}{})
+		d.SetId("seg-1")
+		err := nsxtPolicySegmentRead(d, newGoMockProviderClient(), false, false)
+		require.NoError(t, err)
+		assert.Equal(t, connPath, d.Get("connectivity_path"))
+		advList := d.Get("advanced_config").([]interface{})
+		require.Len(t, advList, 1)
+		l2List := d.Get("l2_extension").([]interface{})
+		require.Len(t, l2List, 1)
+		subnetList := d.Get("subnet").([]interface{})
+		require.Len(t, subnetList, 1)
+	})
+
+	t.Run("empty ID is an error", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, segSchema, map[string]interface{}{})
+		err := nsxtPolicySegmentRead(d, newGoMockProviderClient(), false, false)
+		require.Error(t, err)
+	})
+
+	t.Run("Get error propagates", func(t *testing.T) {
+		mockSegSDK, _ := setupSegmentExistsMocks(t)
+		mockSegSDK.EXPECT().Get("seg-1").Return(model.Segment{}, vapiErrors.InternalServerError{})
+
+		d := schema.TestResourceDataRaw(t, segSchema, map[string]interface{}{})
+		d.SetId("seg-1")
+		err := nsxtPolicySegmentRead(d, newGoMockProviderClient(), false, false)
+		require.Error(t, err)
+	})
+}
+
+func TestMockNsxt_resourceNsxtPolicySegmentExists(t *testing.T) {
+	ctx := utl.SessionContext{ClientType: utl.Local}
+
+	t.Run("non-fixed segment: Get succeeds means it exists", func(t *testing.T) {
+		mockSegSDK, _ := setupSegmentExistsMocks(t)
+		mockSegSDK.EXPECT().Get("seg-1").Return(model.Segment{}, nil)
+
+		exists, err := resourceNsxtPolicySegmentExists(ctx, "", false)(ctx, "seg-1", nil)
+		require.NoError(t, err)
+		assert.True(t, exists)
+	})
+
+	t.Run("non-fixed segment: NotFound means it does not exist", func(t *testing.T) {
+		mockSegSDK, _ := setupSegmentExistsMocks(t)
+		mockSegSDK.EXPECT().Get("seg-1").Return(model.Segment{}, vapiErrors.NotFound{})
+
+		exists, err := resourceNsxtPolicySegmentExists(ctx, "", false)(ctx, "seg-1", nil)
+		require.NoError(t, err)
+		assert.False(t, exists)
+	})
+
+	t.Run("non-fixed segment: other errors propagate", func(t *testing.T) {
+		mockSegSDK, _ := setupSegmentExistsMocks(t)
+		mockSegSDK.EXPECT().Get("seg-1").Return(model.Segment{}, vapiErrors.InternalServerError{})
+
+		_, err := resourceNsxtPolicySegmentExists(ctx, "", false)(ctx, "seg-1", nil)
+		require.Error(t, err)
+	})
+
+	t.Run("fixed tier-1 segment: Get succeeds means it exists", func(t *testing.T) {
+		_, mockT1SegSDK := setupSegmentExistsMocks(t)
+		mockT1SegSDK.EXPECT().Get("gw-1", "seg-1").Return(model.Segment{}, nil)
+
+		exists, err := resourceNsxtPolicySegmentExists(ctx, "/infra/tier-1s/gw-1", true)(ctx, "seg-1", nil)
+		require.NoError(t, err)
+		assert.True(t, exists)
+	})
+
+	t.Run("fixed tier-0 segment path is rejected", func(t *testing.T) {
+		setupSegmentExistsMocks(t)
+		_, err := resourceNsxtPolicySegmentExists(ctx, "/infra/tier-0s/gw-1", true)(ctx, "seg-1", nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Tier-0")
+	})
+
+	t.Run("fixed segment with invalid gwPath is rejected", func(t *testing.T) {
+		setupSegmentExistsMocks(t)
+		_, err := resourceNsxtPolicySegmentExists(ctx, "", true)(ctx, "seg-1", nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not a valid gateway path")
 	})
 }

--- a/nsxt/segment_port_common_unit_test.go
+++ b/nsxt/segment_port_common_unit_test.go
@@ -12,8 +12,70 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	vapiErrors "github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+	"go.uber.org/mock/gomock"
+
+	portsapi "github.com/vmware/terraform-provider-nsxt/api/infra/segments"
+	t1portsapi "github.com/vmware/terraform-provider-nsxt/api/infra/tier_1s/segments"
+	t1profilesapi "github.com/vmware/terraform-provider-nsxt/api/infra/tier_1s/segments/ports"
+	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
+	portmocks "github.com/vmware/terraform-provider-nsxt/mocks/infra/segments"
+	t1portmocks "github.com/vmware/terraform-provider-nsxt/mocks/infra/tier_1s/segments"
+	t1profilemocks "github.com/vmware/terraform-provider-nsxt/mocks/infra/tier_1s/segments/ports"
 )
+
+func setupSegmentPortExistsMocks(t *testing.T) (*portmocks.MockPortsClient, *t1portmocks.MockPortsClient) {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	mockPortSDK := portmocks.NewMockPortsClient(ctrl)
+	origPorts := cliPortsClient
+	t.Cleanup(func() { cliPortsClient = origPorts })
+	cliPortsClient = func(_ utl.SessionContext, _ client.Connector) *portsapi.SegmentPortClientContext {
+		return &portsapi.SegmentPortClientContext{Client: mockPortSDK, ClientType: utl.Local}
+	}
+
+	mockT1PortSDK := t1portmocks.NewMockPortsClient(ctrl)
+	origT1Ports := cliT1SegmentPortsClient
+	t.Cleanup(func() { cliT1SegmentPortsClient = origT1Ports })
+	cliT1SegmentPortsClient = func(_ utl.SessionContext, _ client.Connector) *t1portsapi.SegmentPortClientContext {
+		return &t1portsapi.SegmentPortClientContext{Client: mockT1PortSDK, ClientType: utl.Local}
+	}
+
+	return mockPortSDK, mockT1PortSDK
+}
+
+func setupT1PortProfileMocks(t *testing.T) (*t1profilemocks.MockPortDiscoveryProfileBindingMapsClient, *t1profilemocks.MockPortQosProfileBindingMapsClient, *t1profilemocks.MockPortSecurityProfileBindingMapsClient) {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	mockDiscovery := t1profilemocks.NewMockPortDiscoveryProfileBindingMapsClient(ctrl)
+	origDiscovery := cliT1PortDiscoveryProfileBindingMapsClient
+	t.Cleanup(func() { cliT1PortDiscoveryProfileBindingMapsClient = origDiscovery })
+	cliT1PortDiscoveryProfileBindingMapsClient = func(_ utl.SessionContext, _ client.Connector) *t1profilesapi.PortDiscoveryProfileBindingMapClientContext {
+		return &t1profilesapi.PortDiscoveryProfileBindingMapClientContext{Client: mockDiscovery, ClientType: utl.Local}
+	}
+
+	mockQos := t1profilemocks.NewMockPortQosProfileBindingMapsClient(ctrl)
+	origQos := cliT1PortQosProfileBindingMapsClient
+	t.Cleanup(func() { cliT1PortQosProfileBindingMapsClient = origQos })
+	cliT1PortQosProfileBindingMapsClient = func(_ utl.SessionContext, _ client.Connector) *t1profilesapi.PortQosProfileBindingMapClientContext {
+		return &t1profilesapi.PortQosProfileBindingMapClientContext{Client: mockQos, ClientType: utl.Local}
+	}
+
+	mockSecurity := t1profilemocks.NewMockPortSecurityProfileBindingMapsClient(ctrl)
+	origSecurity := cliT1PortSecurityProfileBindingMapsClient
+	t.Cleanup(func() { cliT1PortSecurityProfileBindingMapsClient = origSecurity })
+	cliT1PortSecurityProfileBindingMapsClient = func(_ utl.SessionContext, _ client.Connector) *t1profilesapi.PortSecurityProfileBindingMapClientContext {
+		return &t1profilesapi.PortSecurityProfileBindingMapClientContext{Client: mockSecurity, ClientType: utl.Local}
+	}
+
+	return mockDiscovery, mockQos, mockSecurity
+}
 
 func TestUnitNsxt_isT1Segment(t *testing.T) {
 	tests := []struct {
@@ -198,5 +260,137 @@ func TestUnitNsxt_policySegmentPortResourceToInfraStruct(t *testing.T) {
 		obj, err := policySegmentPortResourceToInfraStructWithTags("port-1", d, true, nil)
 		require.NoError(t, err)
 		assert.NotNil(t, obj.Children)
+	})
+}
+
+func TestMockNsxt_resourceNsxtPolicySegmentPortExists(t *testing.T) {
+	portSchema := segmentPortTestSchema()
+	ctx := utl.SessionContext{ClientType: utl.Local}
+
+	t.Run("non-tier1 segment: Get succeeds means it exists", func(t *testing.T) {
+		mockPortSDK, _ := setupSegmentPortExistsMocks(t)
+		mockPortSDK.EXPECT().Get("seg-1", "port-1").Return(model.SegmentPort{}, nil)
+
+		d := schema.TestResourceDataRaw(t, portSchema, map[string]interface{}{"segment_path": "/infra/segments/seg-1"})
+		exists, err := resourceNsxtPolicySegmentPortExists(d)(ctx, "port-1", nil)
+		require.NoError(t, err)
+		assert.True(t, exists)
+	})
+
+	t.Run("non-tier1 segment: NotFound means it does not exist", func(t *testing.T) {
+		mockPortSDK, _ := setupSegmentPortExistsMocks(t)
+		mockPortSDK.EXPECT().Get("seg-1", "port-1").Return(model.SegmentPort{}, vapiErrors.NotFound{})
+
+		d := schema.TestResourceDataRaw(t, portSchema, map[string]interface{}{"segment_path": "/infra/segments/seg-1"})
+		exists, err := resourceNsxtPolicySegmentPortExists(d)(ctx, "port-1", nil)
+		require.NoError(t, err)
+		assert.False(t, exists)
+	})
+
+	t.Run("non-tier1 segment: other errors propagate", func(t *testing.T) {
+		mockPortSDK, _ := setupSegmentPortExistsMocks(t)
+		mockPortSDK.EXPECT().Get("seg-1", "port-1").Return(model.SegmentPort{}, vapiErrors.InternalServerError{})
+
+		d := schema.TestResourceDataRaw(t, portSchema, map[string]interface{}{"segment_path": "/infra/segments/seg-1"})
+		_, err := resourceNsxtPolicySegmentPortExists(d)(ctx, "port-1", nil)
+		require.Error(t, err)
+	})
+
+	t.Run("tier-1 segment: Get succeeds means it exists", func(t *testing.T) {
+		_, mockT1PortSDK := setupSegmentPortExistsMocks(t)
+		mockT1PortSDK.EXPECT().Get("gw-1", "seg-1", "port-1").Return(model.SegmentPort{}, nil)
+
+		d := schema.TestResourceDataRaw(t, portSchema, map[string]interface{}{"segment_path": "/infra/tier-1s/gw-1/segments/seg-1"})
+		exists, err := resourceNsxtPolicySegmentPortExists(d)(ctx, "port-1", nil)
+		require.NoError(t, err)
+		assert.True(t, exists)
+	})
+}
+
+func TestMockNsxt_tier1SegmentPortProfileReads(t *testing.T) {
+	c := tier1SegmentPort{
+		tier1GatewayId: "gw-1",
+		ids:            &segmentPort{segmentId: "seg-1", portId: "port-1"},
+	}
+	portSchema := segmentPortTestSchema()
+
+	t.Run("discovery profile read populates schema", func(t *testing.T) {
+		mockDiscovery, _, _ := setupT1PortProfileMocks(t)
+		ipPath := "/infra/ip-discovery-profiles/p1"
+		mockDiscovery.EXPECT().List("gw-1", "seg-1", "port-1", nil, nil, nil, nil, nil, nil, nil).Return(
+			model.PortDiscoveryProfileBindingMapListResult{Results: []model.PortDiscoveryProfileBindingMap{{IpDiscoveryProfilePath: &ipPath}}}, nil,
+		)
+
+		d := schema.TestResourceDataRaw(t, portSchema, map[string]interface{}{})
+		err := c.nsxtPolicySegmentPortDiscoveryProfileRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		got := d.Get("discovery_profile").([]interface{})
+		require.Len(t, got, 1)
+		assert.Equal(t, ipPath, got[0].(map[string]interface{})["ip_discovery_profile_path"])
+	})
+
+	t.Run("discovery profile read propagates API error", func(t *testing.T) {
+		mockDiscovery, _, _ := setupT1PortProfileMocks(t)
+		mockDiscovery.EXPECT().List("gw-1", "seg-1", "port-1", nil, nil, nil, nil, nil, nil, nil).Return(
+			model.PortDiscoveryProfileBindingMapListResult{}, vapiErrors.InternalServerError{},
+		)
+
+		d := schema.TestResourceDataRaw(t, portSchema, map[string]interface{}{})
+		err := c.nsxtPolicySegmentPortDiscoveryProfileRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+
+	t.Run("qos profile read populates schema", func(t *testing.T) {
+		_, mockQos, _ := setupT1PortProfileMocks(t)
+		qosPath := "/infra/qos-profiles/p1"
+		mockQos.EXPECT().List("gw-1", "seg-1", "port-1", nil, nil, nil, nil, nil).Return(
+			model.PortQosProfileBindingMapListResult{Results: []model.PortQosProfileBindingMap{{QosProfilePath: &qosPath}}}, nil,
+		)
+
+		d := schema.TestResourceDataRaw(t, portSchema, map[string]interface{}{})
+		err := c.nsxtPolicySegmentPortQosProfileRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		got := d.Get("qos_profile").([]interface{})
+		require.Len(t, got, 1)
+		assert.Equal(t, qosPath, got[0].(map[string]interface{})["qos_profile_path"])
+	})
+
+	t.Run("qos profile read skips entries with no qos_profile_path", func(t *testing.T) {
+		_, mockQos, _ := setupT1PortProfileMocks(t)
+		empty := ""
+		mockQos.EXPECT().List("gw-1", "seg-1", "port-1", nil, nil, nil, nil, nil).Return(
+			model.PortQosProfileBindingMapListResult{Results: []model.PortQosProfileBindingMap{{QosProfilePath: &empty}}}, nil,
+		)
+
+		d := schema.TestResourceDataRaw(t, portSchema, map[string]interface{}{})
+		err := c.nsxtPolicySegmentPortQosProfileRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Empty(t, d.Get("qos_profile").([]interface{}))
+	})
+
+	t.Run("security profile read populates schema", func(t *testing.T) {
+		_, _, mockSecurity := setupT1PortProfileMocks(t)
+		secPath := "/infra/segment-security-profiles/p1"
+		mockSecurity.EXPECT().List("gw-1", "seg-1", "port-1", nil, nil, nil, nil, nil).Return(
+			model.PortSecurityProfileBindingMapListResult{Results: []model.PortSecurityProfileBindingMap{{SegmentSecurityProfilePath: &secPath}}}, nil,
+		)
+
+		d := schema.TestResourceDataRaw(t, portSchema, map[string]interface{}{})
+		err := c.nsxtPolicyPortSegmentSecurityProfileRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		got := d.Get("security_profile").([]interface{})
+		require.Len(t, got, 1)
+		assert.Equal(t, secPath, got[0].(map[string]interface{})["security_profile_path"])
+	})
+
+	t.Run("security profile read propagates API error", func(t *testing.T) {
+		_, _, mockSecurity := setupT1PortProfileMocks(t)
+		mockSecurity.EXPECT().List("gw-1", "seg-1", "port-1", nil, nil, nil, nil, nil).Return(
+			model.PortSecurityProfileBindingMapListResult{}, vapiErrors.InternalServerError{},
+		)
+
+		d := schema.TestResourceDataRaw(t, portSchema, map[string]interface{}{})
+		err := c.nsxtPolicyPortSegmentSecurityProfileRead(d, newGoMockProviderClient())
+		require.Error(t, err)
 	})
 }

--- a/nsxt/segment_port_common_unit_test.go
+++ b/nsxt/segment_port_common_unit_test.go
@@ -1,0 +1,202 @@
+//go:build unittest
+
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package nsxt
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+)
+
+func TestUnitNsxt_isT1Segment(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{"tier-1 segment port path", "/infra/tier-1s/gw-1/segments/seg-1", true},
+		{"infra segment path", "/infra/segments/seg-1", false},
+		{"too short", "seg-1", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isT1Segment(tt.path))
+		})
+	}
+}
+
+func TestUnitNsxt_getSegmentIdFromSegPath(t *testing.T) {
+	assert.Equal(t, "seg-1", getSegmentIdFromSegPath("/infra/segments/seg-1"))
+	assert.Equal(t, "seg-1", getSegmentIdFromSegPath("/infra/tier-1s/gw-1/segments/seg-1"))
+}
+
+func TestUnitNsxt_getT1IdFromSegPath(t *testing.T) {
+	assert.Equal(t, "gw-1", getT1IdFromSegPath("/infra/tier-1s/gw-1/segments/seg-1"))
+	assert.Equal(t, "", getT1IdFromSegPath("/infra/segments/seg-1"))
+}
+
+func TestUnitNsxt_getPolicySegmentPathFromPortPath(t *testing.T) {
+	t.Run("valid port path", func(t *testing.T) {
+		got, err := getPolicySegmentPathFromPortPath("/infra/segments/seg-1/ports/port-1")
+		require.NoError(t, err)
+		assert.Equal(t, "/infra/segments/seg-1", got)
+	})
+
+	t.Run("path without /ports/ errors", func(t *testing.T) {
+		_, err := getPolicySegmentPathFromPortPath("/infra/segments/seg-1")
+		require.Error(t, err)
+	})
+}
+
+func segmentPortTestSchema() map[string]*schema.Schema {
+	return resourceNsxtPolicySegmentPort().Schema
+}
+
+func TestUnitNsxt_nsxtPolicySegmentPortAttachmentConfigSetInStruct(t *testing.T) {
+	portSchema := segmentPortTestSchema()
+
+	t.Run("no attachment is a no-op", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, portSchema, map[string]interface{}{})
+		obj := model.SegmentPort{}
+		nsxtPolicySegmentPortAttachmentConfigSetInStruct(d, &obj)
+		assert.Nil(t, obj.Attachment)
+	})
+
+	t.Run("attachment fields are set from schema", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, portSchema, map[string]interface{}{
+			"attachment": []interface{}{
+				map[string]interface{}{
+					"id":                 "att-1",
+					"allocate_addresses": "BOTH",
+					"app_id":             "app-1",
+					"context_id":         "ctx-1",
+					"context_type":       "VIF",
+					"evpn_vlans":         []interface{}{"100", "200"},
+					"hyperbus_mode":      "NONE",
+					"type":               "STATIC",
+					"traffic_tag":        5,
+				},
+			},
+		})
+		obj := model.SegmentPort{}
+		nsxtPolicySegmentPortAttachmentConfigSetInStruct(d, &obj)
+		require.NotNil(t, obj.Attachment)
+		assert.Equal(t, "att-1", *obj.Attachment.Id)
+		assert.Equal(t, "app-1", *obj.Attachment.AppId)
+		assert.Equal(t, []string{"100", "200"}, obj.Attachment.EvpnVlans)
+		assert.EqualValues(t, 5, *obj.Attachment.TrafficTag)
+	})
+}
+
+func TestUnitNsxt_nsxtPolicyPortProfileSetInStruct(t *testing.T) {
+	portSchema := segmentPortTestSchema()
+
+	t.Run("discovery profile: no old, no new is a no-op", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, portSchema, map[string]interface{}{})
+		val, err := nsxtPolicyPortDiscoveryProfileSetInStruct(d)
+		require.NoError(t, err)
+		assert.Nil(t, val)
+	})
+
+	t.Run("discovery profile: new profile configured", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, portSchema, map[string]interface{}{
+			"discovery_profile": []interface{}{
+				map[string]interface{}{
+					"ip_discovery_profile_path":  "/infra/ip-discovery-profiles/p1",
+					"mac_discovery_profile_path": "",
+					"binding_map_path":           "",
+					"revision":                   0,
+				},
+			},
+		})
+		val, err := nsxtPolicyPortDiscoveryProfileSetInStruct(d)
+		require.NoError(t, err)
+		assert.NotNil(t, val)
+	})
+
+	t.Run("qos profile: new profile configured", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, portSchema, map[string]interface{}{
+			"qos_profile": []interface{}{
+				map[string]interface{}{
+					"qos_profile_path": "/infra/qos-profiles/p1",
+					"binding_map_path": "",
+					"revision":         0,
+				},
+			},
+		})
+		val, err := nsxtPolicyPortQosProfileSetInStruct(d)
+		require.NoError(t, err)
+		assert.NotNil(t, val)
+	})
+
+	t.Run("qos profile: no old, no new is a no-op", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, portSchema, map[string]interface{}{})
+		val, err := nsxtPolicyPortQosProfileSetInStruct(d)
+		require.NoError(t, err)
+		assert.Nil(t, val)
+	})
+
+	t.Run("security profile: new profile configured", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, portSchema, map[string]interface{}{
+			"security_profile": []interface{}{
+				map[string]interface{}{
+					"spoofguard_profile_path": "/infra/spoofguard-profiles/p1",
+					"security_profile_path":   "/infra/segment-security-profiles/p1",
+					"binding_map_path":        "",
+					"revision":                0,
+				},
+			},
+		})
+		val, err := nsxtPolicyPortSecurityProfileSetInStruct(d)
+		require.NoError(t, err)
+		assert.NotNil(t, val)
+	})
+
+	t.Run("security profile: no old, no new is a no-op", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, portSchema, map[string]interface{}{})
+		val, err := nsxtPolicyPortSecurityProfileSetInStruct(d)
+		require.NoError(t, err)
+		assert.Nil(t, val)
+	})
+}
+
+func TestUnitNsxt_policySegmentPortResourceToInfraStruct(t *testing.T) {
+	portSchema := segmentPortTestSchema()
+
+	t.Run("infra segment port builds an Infra struct", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, portSchema, map[string]interface{}{
+			"display_name": "port-1",
+			"segment_path": "/infra/segments/seg-1",
+		})
+		obj, err := policySegmentPortResourceToInfraStruct("port-1", d, false)
+		require.NoError(t, err)
+		assert.NotNil(t, obj.Children)
+	})
+
+	t.Run("tier-1 segment port builds a nested Infra struct", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, portSchema, map[string]interface{}{
+			"display_name": "port-1",
+			"segment_path": "/infra/tier-1s/gw-1/segments/seg-1",
+		})
+		obj, err := policySegmentPortResourceToInfraStruct("port-1", d, false)
+		require.NoError(t, err)
+		assert.NotNil(t, obj.Children)
+	})
+
+	t.Run("isDestroy marks the child for delete", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, portSchema, map[string]interface{}{
+			"display_name": "port-1",
+			"segment_path": "/infra/segments/seg-1",
+		})
+		obj, err := policySegmentPortResourceToInfraStructWithTags("port-1", d, true, nil)
+		require.NoError(t, err)
+		assert.NotNil(t, obj.Children)
+	})
+}

--- a/nsxt/utgomock_data_source_nsxt_policy_baremetal_server_interface_test.go
+++ b/nsxt/utgomock_data_source_nsxt_policy_baremetal_server_interface_test.go
@@ -55,7 +55,7 @@ func TestMockDataSourceNsxtPolicyBareMetalServerInterfaceValidation(t *testing.T
 	assert.Contains(t, dataSource.Schema, "display_name")
 }
 
-func TestMockBareMetalServerInterfaceConversion(t *testing.T) {
+func TestMockNsxtBareMetalServerInterfaceConversion(t *testing.T) {
 	// Test the conversion function for bare metal server interfaces
 	externalId := "test-interface-id"
 	displayName := "test-interface"

--- a/nsxt/utgomock_data_source_nsxt_policy_baremetal_server_test.go
+++ b/nsxt/utgomock_data_source_nsxt_policy_baremetal_server_test.go
@@ -55,7 +55,7 @@ func TestMockDataSourceNsxtPolicyBareMetalServerValidation(t *testing.T) {
 	assert.Contains(t, dataSource.Schema, "display_name")
 }
 
-func TestMockBareMetalServerConversion(t *testing.T) {
+func TestMockNsxtBareMetalServerConversion(t *testing.T) {
 	// Test the conversion function for bare metal servers
 	externalId := "test-server-id"
 	displayName := "test-server"

--- a/nsxt/utgomock_data_source_nsxt_policy_idps_cluster_config_test.go
+++ b/nsxt/utgomock_data_source_nsxt_policy_idps_cluster_config_test.go
@@ -4,11 +4,10 @@
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0
 
-// dataSourceNsxtPolicyIdpsClusterConfigRead uses
-// intrusion_services.NewClusterConfigsClient(connector) directly rather than
-// an injectable wrapper variable, so full mock-based Read tests are not
-// possible. These tests cover the guard conditions that run before any
-// client call.
+// dataSourceNsxtPolicyIdpsClusterConfigRead reads through the cliIdsClusterConfigsClient
+// package-level var (declared in resource_nsxt_policy_idps_cluster_config.go, see
+// utgomock_resource_nsxt_policy_idps_cluster_config_test.go for the mock setup helper), so
+// both the guard conditions and the mocked lookups are covered here.
 
 package nsxt
 
@@ -18,6 +17,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	vapiErrors "github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 )
 
 func TestMockDataSourceNsxtPolicyIdpsClusterConfigRead(t *testing.T) {
@@ -40,5 +41,91 @@ func TestMockDataSourceNsxtPolicyIdpsClusterConfigRead(t *testing.T) {
 		err := dataSourceNsxtPolicyIdpsClusterConfigRead(d, newGoMockProviderClient())
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "obtaining IdsClusterConfig")
+	})
+}
+
+func TestMockDataSourceNsxtPolicyIdpsClusterConfigReadMocked(t *testing.T) {
+	ds := dataSourceNsxtPolicyIdpsClusterConfig()
+
+	t.Run("Read by id succeeds", func(t *testing.T) {
+		mockClient := setupIdpsClusterConfigMock(t)
+		id := "cfg-1"
+		targetID, targetType := "domain-c1", "VC_Cluster"
+		mockClient.EXPECT().Get("cfg-1", nil).Return(model.IdsClusterConfig{
+			Id:      &id,
+			Cluster: &model.PolicyResourceReference{TargetId: &targetID, TargetType: &targetType},
+		}, nil)
+
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{"id": "cfg-1"})
+
+		err := dataSourceNsxtPolicyIdpsClusterConfigRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, "cfg-1", d.Id())
+	})
+
+	t.Run("Read by id propagates API error", func(t *testing.T) {
+		mockClient := setupIdpsClusterConfigMock(t)
+		mockClient.EXPECT().Get("cfg-1", nil).Return(model.IdsClusterConfig{}, vapiErrors.InternalServerError{})
+
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{"id": "cfg-1"})
+
+		err := dataSourceNsxtPolicyIdpsClusterConfigRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+
+	t.Run("Read by display_name matches a perfect match over a prefix match", func(t *testing.T) {
+		mockClient := setupIdpsClusterConfigMock(t)
+		perfectID, prefixID := "cfg-1", "cfg-2"
+		perfectName, prefixName := "myconfig", "myconfig-extra"
+		mockClient.EXPECT().List(nil, nil, nil, nil, nil, nil, nil, nil).Return(
+			model.IdsClusterConfigListResult{Results: []model.IdsClusterConfig{
+				{Id: &prefixID, DisplayName: &prefixName},
+				{Id: &perfectID, DisplayName: &perfectName},
+			}}, nil,
+		)
+
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{"display_name": "myconfig"})
+
+		err := dataSourceNsxtPolicyIdpsClusterConfigRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, "cfg-1", d.Id())
+	})
+
+	t.Run("Read by display_name with only a prefix match succeeds", func(t *testing.T) {
+		mockClient := setupIdpsClusterConfigMock(t)
+		prefixID := "cfg-2"
+		prefixName := "myconfig-extra"
+		mockClient.EXPECT().List(nil, nil, nil, nil, nil, nil, nil, nil).Return(
+			model.IdsClusterConfigListResult{Results: []model.IdsClusterConfig{{Id: &prefixID, DisplayName: &prefixName}}}, nil,
+		)
+
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{"display_name": "myconfig"})
+
+		err := dataSourceNsxtPolicyIdpsClusterConfigRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, "cfg-2", d.Id())
+	})
+
+	t.Run("Read by display_name with no match fails", func(t *testing.T) {
+		mockClient := setupIdpsClusterConfigMock(t)
+		mockClient.EXPECT().List(nil, nil, nil, nil, nil, nil, nil, nil).Return(model.IdsClusterConfigListResult{}, nil)
+
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{"display_name": "myconfig"})
+
+		err := dataSourceNsxtPolicyIdpsClusterConfigRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("List error propagates", func(t *testing.T) {
+		mockClient := setupIdpsClusterConfigMock(t)
+		mockClient.EXPECT().List(nil, nil, nil, nil, nil, nil, nil, nil).Return(
+			model.IdsClusterConfigListResult{}, vapiErrors.InternalServerError{},
+		)
+
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{"display_name": "myconfig"})
+
+		err := dataSourceNsxtPolicyIdpsClusterConfigRead(d, newGoMockProviderClient())
+		require.Error(t, err)
 	})
 }

--- a/nsxt/utgomock_data_source_nsxt_policy_idps_custom_signature_test.go
+++ b/nsxt/utgomock_data_source_nsxt_policy_idps_custom_signature_test.go
@@ -4,11 +4,9 @@
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MPL-2.0
 
-// dataSourceNsxtPolicyIdpsCustomSignatureRead uses
-// custom_signature_versions.NewCustomSignaturesClient(connector) directly
-// rather than an injectable wrapper variable, so full mock-based Read tests
-// are not possible. These tests cover the guard/parsing conditions that run
-// before any client call.
+// dataSourceNsxtPolicyIdpsCustomSignatureRead reads through the cliIdsCustomSignaturesClient
+// package-level var (see utgomock_resource_nsxt_policy_idps_custom_signature_test.go for the
+// mock setup helper), so both the guard/parsing conditions and mocked lookups are covered here.
 
 package nsxt
 
@@ -18,6 +16,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	vapiErrors "github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+	"go.uber.org/mock/gomock"
 )
 
 func TestMockDataSourceNsxtPolicyIdpsCustomSignatureRead(t *testing.T) {
@@ -42,5 +43,89 @@ func TestMockDataSourceNsxtPolicyIdpsCustomSignatureRead(t *testing.T) {
 		err := dataSourceNsxtPolicyIdpsCustomSignatureRead(d, newGoMockProviderClient())
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "signature_version_id must be set")
+	})
+}
+
+func TestMockDataSourceNsxtPolicyIdpsCustomSignatureReadMocked(t *testing.T) {
+	ds := dataSourceNsxtPolicyIdpsCustomSignature()
+
+	t.Run("Read succeeds via composite ID", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSigs, _, restore := setupIdpsCustomSignatureMocks(ctrl)
+		defer restore()
+		name := "sig-name"
+		mockSigs.EXPECT().Get("default", "5000001").Return(model.IdsCustomSignature{DisplayName: &name}, nil)
+
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{"id": "default/5000001"})
+
+		err := dataSourceNsxtPolicyIdpsCustomSignatureRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, "default/5000001", d.Id())
+		assert.Equal(t, "sig-name", d.Get("display_name"))
+	})
+
+	t.Run("Read succeeds via signature_version_id plus bare signature_id", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSigs, _, restore := setupIdpsCustomSignatureMocks(ctrl)
+		defer restore()
+		mockSigs.EXPECT().Get("default", "5000001").Return(model.IdsCustomSignature{}, nil)
+
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{
+			"id":                   "5000001",
+			"signature_version_id": "default",
+		})
+
+		err := dataSourceNsxtPolicyIdpsCustomSignatureRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, "default/5000001", d.Id())
+	})
+
+	t.Run("Read falls back to list search when not found by Get", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSigs, _, restore := setupIdpsCustomSignatureMocks(ctrl)
+		defer restore()
+		sigID := "5000001"
+		mockSigs.EXPECT().Get("default", "5000001").Return(model.IdsCustomSignature{}, vapiErrors.NotFound{})
+		mockSigs.EXPECT().List("default", gomock.Any(), gomock.Any(), nil, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(
+			model.IdsCustomSignatureListResult{Results: []model.IdsCustomSignature{{Id: &sigID}}}, nil,
+		).AnyTimes()
+
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{"id": "default/5000001"})
+
+		err := dataSourceNsxtPolicyIdpsCustomSignatureRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, "default/5000001", d.Id())
+	})
+
+	t.Run("Read fails when neither Get nor list search find the signature", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSigs, _, restore := setupIdpsCustomSignatureMocks(ctrl)
+		defer restore()
+		mockSigs.EXPECT().Get("default", "5000001").Return(model.IdsCustomSignature{}, vapiErrors.NotFound{})
+		mockSigs.EXPECT().List("default", gomock.Any(), gomock.Any(), nil, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(
+			model.IdsCustomSignatureListResult{}, nil,
+		).AnyTimes()
+
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{"id": "default/5000001"})
+
+		err := dataSourceNsxtPolicyIdpsCustomSignatureRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+
+	t.Run("Read propagates non-NotFound API errors", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSigs, _, restore := setupIdpsCustomSignatureMocks(ctrl)
+		defer restore()
+		mockSigs.EXPECT().Get("default", "5000001").Return(model.IdsCustomSignature{}, vapiErrors.InternalServerError{})
+
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{"id": "default/5000001"})
+
+		err := dataSourceNsxtPolicyIdpsCustomSignatureRead(d, newGoMockProviderClient())
+		require.Error(t, err)
 	})
 }

--- a/nsxt/utgomock_data_source_nsxt_policy_idps_settings_test.go
+++ b/nsxt/utgomock_data_source_nsxt_policy_idps_settings_test.go
@@ -12,12 +12,15 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	vapiErrors "github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+	"go.uber.org/mock/gomock"
 )
 
-// dataSourceNsxtPolicyIdpsSettingsRead calls security.NewIntrusionServicesClient(connector)
-// directly rather than through an injectable wrapper variable (same as
-// resourceNsxtPolicyIdpsSettings, see utgomock_resource_nsxt_policy_idps_settings_test.go),
-// so only the guard condition that doesn't require an API call can be exercised here.
+// dataSourceNsxtPolicyIdpsSettingsRead reads through the cliIdsSettingsClient and
+// cliIdsCustomSigSettingsClient package-level vars (see
+// utgomock_resource_nsxt_policy_idps_settings_test.go for the mock setup helper), so both the
+// guard condition and the mocked lookups are covered here.
 
 func TestMockDataSourceNsxtPolicyIdpsSettingsReadGuard(t *testing.T) {
 	t.Run("Read fails for global manager", func(t *testing.T) {
@@ -27,5 +30,71 @@ func TestMockDataSourceNsxtPolicyIdpsSettingsReadGuard(t *testing.T) {
 		err := dataSourceNsxtPolicyIdpsSettingsRead(d, newGoMockGlobalProviderClient())
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "Global Manager")
+	})
+}
+
+func TestMockDataSourceNsxtPolicyIdpsSettingsReadMocked(t *testing.T) {
+	t.Run("Read succeeds without a custom signature version set", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSettings, _, restore := setupIdpsSettingsMocks(ctrl)
+		defer restore()
+		oversub := "DROPPED"
+		mockSettings.EXPECT().Get().Return(model.IdsSettings{Oversubscription: &oversub}, nil)
+
+		ds := dataSourceNsxtPolicyIdpsSettings()
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{})
+
+		err := dataSourceNsxtPolicyIdpsSettingsRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, "DROPPED", d.Get("oversubscription"))
+		assert.Equal(t, false, d.Get("enable_custom_signatures"))
+	})
+
+	t.Run("Read also fetches custom signature settings when a version id is set", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSettings, mockCustomSig, restore := setupIdpsSettingsMocks(ctrl)
+		defer restore()
+		mockSettings.EXPECT().Get().Return(model.IdsSettings{}, nil)
+		enabled := true
+		mockCustomSig.EXPECT().Get("default").Return(model.IdsCustomSignatureSettings{EnableCustomSignatures: &enabled}, nil)
+
+		ds := dataSourceNsxtPolicyIdpsSettings()
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{"custom_signature_version_id": "default"})
+
+		err := dataSourceNsxtPolicyIdpsSettingsRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, true, d.Get("enable_custom_signatures"))
+	})
+
+	t.Run("Read falls back to false when custom signature settings lookup errors", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSettings, mockCustomSig, restore := setupIdpsSettingsMocks(ctrl)
+		defer restore()
+		mockSettings.EXPECT().Get().Return(model.IdsSettings{}, nil)
+		mockCustomSig.EXPECT().Get("default").Return(model.IdsCustomSignatureSettings{}, vapiErrors.InternalServerError{})
+
+		ds := dataSourceNsxtPolicyIdpsSettings()
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{"custom_signature_version_id": "default"})
+
+		err := dataSourceNsxtPolicyIdpsSettingsRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, false, d.Get("enable_custom_signatures"))
+	})
+
+	t.Run("Read propagates the main settings API error", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSettings, _, restore := setupIdpsSettingsMocks(ctrl)
+		defer restore()
+		mockSettings.EXPECT().Get().Return(model.IdsSettings{}, vapiErrors.InternalServerError{})
+
+		ds := dataSourceNsxtPolicyIdpsSettings()
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{})
+
+		err := dataSourceNsxtPolicyIdpsSettingsRead(d, newGoMockProviderClient())
+		require.Error(t, err)
 	})
 }

--- a/nsxt/utgomock_data_source_nsxt_policy_idps_signature_diff_test.go
+++ b/nsxt/utgomock_data_source_nsxt_policy_idps_signature_diff_test.go
@@ -12,12 +12,26 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	vapiErrors "github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/settings/firewall/security/intrusion_services/custom_signature_versions"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+	"go.uber.org/mock/gomock"
+
+	sigdiffmocks "github.com/vmware/terraform-provider-nsxt/mocks/infra/settings/firewall/security/intrusion_services/custom_signature_versions"
 )
 
-// dataSourceNsxtPolicyIdpsSignatureDiffRead calls
-// custom_signature_versions.NewCustomSignaturesDiffClient(connector) directly rather than
-// through an injectable wrapper variable, so only the guard condition that doesn't require
-// an API call can be exercised here (same limitation as the sibling idps data sources).
+// dataSourceNsxtPolicyIdpsSignatureDiffRead reads through the cliIdsCustomSignaturesDiffClient
+// package-level var, so it's mockable via setupIdpsSignatureDiffMock.
+
+func setupIdpsSignatureDiffMock(ctrl *gomock.Controller) (*sigdiffmocks.MockCustomSignaturesDiffClient, func()) {
+	mockClient := sigdiffmocks.NewMockCustomSignaturesDiffClient(ctrl)
+	orig := cliIdsCustomSignaturesDiffClient
+	cliIdsCustomSignaturesDiffClient = func(_ client.Connector) custom_signature_versions.CustomSignaturesDiffClient {
+		return mockClient
+	}
+	return mockClient, func() { cliIdsCustomSignaturesDiffClient = orig }
+}
 
 func TestMockDataSourceNsxtPolicyIdpsSignatureDiffReadGuard(t *testing.T) {
 	t.Run("Read fails for global manager", func(t *testing.T) {
@@ -29,5 +43,41 @@ func TestMockDataSourceNsxtPolicyIdpsSignatureDiffReadGuard(t *testing.T) {
 		err := dataSourceNsxtPolicyIdpsSignatureDiffRead(d, newGoMockGlobalProviderClient())
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "Global Manager")
+	})
+}
+
+func TestMockDataSourceNsxtPolicyIdpsSignatureDiffReadMocked(t *testing.T) {
+	t.Run("Read succeeds", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockClient, restore := setupIdpsSignatureDiffMock(ctrl)
+		defer restore()
+		mockClient.EXPECT().Get("default").Return(model.IdsCustomSignaturesDiff{
+			NewlyAddedSignatures: []string{"sig-1"},
+			DeletedSignatures:    []string{"sig-2"},
+			ExistingSignatures:   []string{"sig-3"},
+		}, nil)
+
+		ds := dataSourceNsxtPolicyIdpsSignatureDiff()
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{"signature_version_id": "default"})
+
+		err := dataSourceNsxtPolicyIdpsSignatureDiffRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, "default", d.Id())
+		assert.Equal(t, []interface{}{"sig-1"}, d.Get("newly_added_signatures"))
+	})
+
+	t.Run("Read propagates API error", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockClient, restore := setupIdpsSignatureDiffMock(ctrl)
+		defer restore()
+		mockClient.EXPECT().Get("default").Return(model.IdsCustomSignaturesDiff{}, vapiErrors.InternalServerError{})
+
+		ds := dataSourceNsxtPolicyIdpsSignatureDiff()
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{"signature_version_id": "default"})
+
+		err := dataSourceNsxtPolicyIdpsSignatureDiffRead(d, newGoMockProviderClient())
+		require.Error(t, err)
 	})
 }

--- a/nsxt/utgomock_data_source_nsxt_policy_idps_signature_version_test.go
+++ b/nsxt/utgomock_data_source_nsxt_policy_idps_signature_version_test.go
@@ -12,12 +12,14 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	vapiErrors "github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+	"go.uber.org/mock/gomock"
 )
 
-// dataSourceNsxtPolicyIdpsSignatureVersionRead calls
-// intrusion_services.NewSignatureVersionsClient(connector) directly rather than through an
-// injectable wrapper variable, so only guard/validation branches that don't require an API
-// call can be exercised here (same limitation as the sibling idps data sources).
+// dataSourceNsxtPolicyIdpsSignatureVersionRead reads through the cliIdsSignatureVersionsClient
+// package-level var (see utgomock_resource_nsxt_policy_idps_signature_version_test.go for the
+// mock setup helper), so both the guard/validation branches and the mocked lookups are covered.
 
 func TestMockDataSourceNsxtPolicyIdpsSignatureVersionReadGuard(t *testing.T) {
 	t.Run("Read fails for global manager", func(t *testing.T) {
@@ -38,5 +40,111 @@ func TestMockDataSourceNsxtPolicyIdpsSignatureVersionReadMissingSelector(t *test
 		err := dataSourceNsxtPolicyIdpsSignatureVersionRead(d, newGoMockProviderClient())
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "'id' or 'display_name'")
+	})
+}
+
+func TestMockDataSourceNsxtPolicyIdpsSignatureVersionReadByID(t *testing.T) {
+	t.Run("Read by id succeeds", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockClient, restore := setupIdpsSignatureVersionMock(ctrl)
+		defer restore()
+		id := "sig-ver-1"
+		mockClient.EXPECT().Get("sig-ver-1").Return(model.IdsSignatureVersion{Id: &id}, nil)
+
+		ds := dataSourceNsxtPolicyIdpsSignatureVersion()
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{"id": "sig-ver-1"})
+
+		err := dataSourceNsxtPolicyIdpsSignatureVersionRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, "sig-ver-1", d.Id())
+	})
+
+	t.Run("Read by id propagates API error", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockClient, restore := setupIdpsSignatureVersionMock(ctrl)
+		defer restore()
+		mockClient.EXPECT().Get("sig-ver-1").Return(model.IdsSignatureVersion{}, vapiErrors.InternalServerError{})
+
+		ds := dataSourceNsxtPolicyIdpsSignatureVersion()
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{"id": "sig-ver-1"})
+
+		err := dataSourceNsxtPolicyIdpsSignatureVersionRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockDataSourceNsxtPolicyIdpsSignatureVersionReadByName(t *testing.T) {
+	t.Run("Read by display_name matches a single result", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockClient, restore := setupIdpsSignatureVersionMock(ctrl)
+		defer restore()
+		id, name := "sig-ver-1", "myversion"
+		mockClient.EXPECT().List(nil, nil, nil, nil, nil, nil, nil).Return(
+			model.IdsSignatureVersionListResult{Results: []model.IdsSignatureVersion{{Id: &id, DisplayName: &name}}}, nil,
+		)
+
+		ds := dataSourceNsxtPolicyIdpsSignatureVersion()
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{"display_name": "myversion"})
+
+		err := dataSourceNsxtPolicyIdpsSignatureVersionRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, "sig-ver-1", d.Id())
+	})
+
+	t.Run("Read by display_name with no match fails", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockClient, restore := setupIdpsSignatureVersionMock(ctrl)
+		defer restore()
+		mockClient.EXPECT().List(nil, nil, nil, nil, nil, nil, nil).Return(
+			model.IdsSignatureVersionListResult{}, nil,
+		)
+
+		ds := dataSourceNsxtPolicyIdpsSignatureVersion()
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{"display_name": "myversion"})
+
+		err := dataSourceNsxtPolicyIdpsSignatureVersionRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("Read by display_name with multiple matches fails", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockClient, restore := setupIdpsSignatureVersionMock(ctrl)
+		defer restore()
+		id1, id2, name := "sig-ver-1", "sig-ver-2", "myversion"
+		mockClient.EXPECT().List(nil, nil, nil, nil, nil, nil, nil).Return(
+			model.IdsSignatureVersionListResult{Results: []model.IdsSignatureVersion{
+				{Id: &id1, DisplayName: &name},
+				{Id: &id2, DisplayName: &name},
+			}}, nil,
+		)
+
+		ds := dataSourceNsxtPolicyIdpsSignatureVersion()
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{"display_name": "myversion"})
+
+		err := dataSourceNsxtPolicyIdpsSignatureVersionRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "multiple")
+	})
+
+	t.Run("List error propagates", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockClient, restore := setupIdpsSignatureVersionMock(ctrl)
+		defer restore()
+		mockClient.EXPECT().List(nil, nil, nil, nil, nil, nil, nil).Return(
+			model.IdsSignatureVersionListResult{}, vapiErrors.InternalServerError{},
+		)
+
+		ds := dataSourceNsxtPolicyIdpsSignatureVersion()
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{"display_name": "myversion"})
+
+		err := dataSourceNsxtPolicyIdpsSignatureVersionRead(d, newGoMockProviderClient())
+		require.Error(t, err)
 	})
 }

--- a/nsxt/utgomock_data_source_nsxt_policy_idps_system_signatures_test.go
+++ b/nsxt/utgomock_data_source_nsxt_policy_idps_system_signatures_test.go
@@ -12,13 +12,28 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	vapiErrors "github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/settings/firewall/security/intrusion_services/signature_versions"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+	"go.uber.org/mock/gomock"
+
+	signaturesmocks "github.com/vmware/terraform-provider-nsxt/mocks/infra/settings/firewall/security/intrusion_services/signature_versions"
 )
 
-// dataSourceNsxtPolicyIdpsSystemSignaturesRead calls
-// intrusion_services.NewSignatureVersionsClient(connector) and
-// signature_versions.NewSignaturesClient(connector) directly rather than through injectable
-// wrapper variables, so only the guard condition that doesn't require an API call can be
-// exercised here (same limitation as the sibling idps data sources).
+// dataSourceNsxtPolicyIdpsSystemSignaturesRead reads through the cliIdsSignatureVersionsClient
+// and cliIdsSignaturesClient package-level vars (see
+// utgomock_resource_nsxt_policy_idps_signature_version_test.go for the version-client mock
+// helper), so both the guard condition and the mocked lookups are covered here.
+
+func setupIdpsSignaturesMock(ctrl *gomock.Controller) (*signaturesmocks.MockSignaturesClient, func()) {
+	mockClient := signaturesmocks.NewMockSignaturesClient(ctrl)
+	orig := cliIdsSignaturesClient
+	cliIdsSignaturesClient = func(_ client.Connector) signature_versions.SignaturesClient {
+		return mockClient
+	}
+	return mockClient, func() { cliIdsSignaturesClient = orig }
+}
 
 func TestMockDataSourceNsxtPolicyIdpsSystemSignaturesReadGuard(t *testing.T) {
 	t.Run("Read fails for global manager", func(t *testing.T) {
@@ -28,5 +43,177 @@ func TestMockDataSourceNsxtPolicyIdpsSystemSignaturesReadGuard(t *testing.T) {
 		err := dataSourceNsxtPolicyIdpsSystemSignaturesRead(d, newGoMockGlobalProviderClient())
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "Global Manager")
+	})
+}
+
+func TestMockDataSourceNsxtPolicyIdpsSystemSignaturesReadExplicitVersion(t *testing.T) {
+	t.Run("skips the version lookup when version_id is set and applies filters", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSigs, restoreSigs := setupIdpsSignaturesMock(ctrl)
+		defer restoreSigs()
+
+		matchID, otherID := "sig-1", "sig-2"
+		matchName, otherName := "Match Name", "Other Name"
+		high, low := "HIGH", "LOW"
+		count := int64(2)
+		mockSigs.EXPECT().List("v1", (*string)(nil), nil, nil, nil, nil, nil, nil).Return(
+			model.IdsSignatureListResult{
+				Results: []model.IdsSignature{
+					{Id: &matchID, DisplayName: &matchName, Severity: &high},
+					{Id: &otherID, DisplayName: &otherName, Severity: &low},
+				},
+				ResultCount: &count,
+			}, nil,
+		)
+
+		ds := dataSourceNsxtPolicyIdpsSystemSignatures()
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{
+			"version_id":   "v1",
+			"severity":     "HIGH",
+			"display_name": "match",
+		})
+
+		err := dataSourceNsxtPolicyIdpsSystemSignaturesRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		sigs := d.Get("signatures").([]interface{})
+		require.Len(t, sigs, 1)
+		assert.Equal(t, "sig-1", sigs[0].(map[string]interface{})["id"])
+	})
+
+	t.Run("signatures List error propagates", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSigs, restoreSigs := setupIdpsSignaturesMock(ctrl)
+		defer restoreSigs()
+		mockSigs.EXPECT().List("v1", (*string)(nil), nil, nil, nil, nil, nil, nil).Return(
+			model.IdsSignatureListResult{}, vapiErrors.InternalServerError{},
+		)
+
+		ds := dataSourceNsxtPolicyIdpsSystemSignatures()
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{"version_id": "v1"})
+
+		err := dataSourceNsxtPolicyIdpsSystemSignaturesRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+
+	t.Run("paginates across cursors", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSigs, restoreSigs := setupIdpsSignaturesMock(ctrl)
+		defer restoreSigs()
+
+		id1, id2 := "sig-1", "sig-2"
+		count := int64(2)
+		cursor := "next-page"
+		mockSigs.EXPECT().List("v1", (*string)(nil), nil, nil, nil, nil, nil, nil).Return(
+			model.IdsSignatureListResult{Results: []model.IdsSignature{{Id: &id1}}, ResultCount: &count, Cursor: &cursor}, nil,
+		)
+		mockSigs.EXPECT().List("v1", &cursor, nil, nil, nil, nil, nil, nil).Return(
+			model.IdsSignatureListResult{Results: []model.IdsSignature{{Id: &id2}}, ResultCount: &count}, nil,
+		)
+
+		ds := dataSourceNsxtPolicyIdpsSystemSignatures()
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{"version_id": "v1"})
+
+		err := dataSourceNsxtPolicyIdpsSystemSignaturesRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Len(t, d.Get("signatures").([]interface{}), 2)
+	})
+}
+
+func TestMockDataSourceNsxtPolicyIdpsSystemSignaturesReadVersionLookup(t *testing.T) {
+	t.Run("uses the ACTIVE version when version_id is unset", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockVersions, restoreVersions := setupIdpsSignatureVersionMock(ctrl)
+		defer restoreVersions()
+		mockSigs, restoreSigs := setupIdpsSignaturesMock(ctrl)
+		defer restoreSigs()
+
+		activeID, notActiveID := "active-ver", "old-ver"
+		activeState, notActiveState := "ACTIVE", "NOTACTIVE"
+		mockVersions.EXPECT().List(nil, nil, nil, nil, nil, nil, nil).Return(
+			model.IdsSignatureVersionListResult{Results: []model.IdsSignatureVersion{
+				{Id: &notActiveID, State: &notActiveState},
+				{Id: &activeID, State: &activeState},
+			}}, nil,
+		)
+		count := int64(0)
+		mockSigs.EXPECT().List("active-ver", (*string)(nil), nil, nil, nil, nil, nil, nil).Return(
+			model.IdsSignatureListResult{ResultCount: &count}, nil,
+		)
+
+		ds := dataSourceNsxtPolicyIdpsSystemSignatures()
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{})
+
+		err := dataSourceNsxtPolicyIdpsSystemSignaturesRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, "active-ver", d.Get("version_id"))
+	})
+
+	t.Run("falls back to the first version when none is ACTIVE", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockVersions, restoreVersions := setupIdpsSignatureVersionMock(ctrl)
+		defer restoreVersions()
+		mockSigs, restoreSigs := setupIdpsSignaturesMock(ctrl)
+		defer restoreSigs()
+
+		firstID := "first-ver"
+		notActiveState := "NOTACTIVE"
+		mockVersions.EXPECT().List(nil, nil, nil, nil, nil, nil, nil).Return(
+			model.IdsSignatureVersionListResult{Results: []model.IdsSignatureVersion{{Id: &firstID, State: &notActiveState}}}, nil,
+		)
+		count := int64(0)
+		mockSigs.EXPECT().List("first-ver", (*string)(nil), nil, nil, nil, nil, nil, nil).Return(
+			model.IdsSignatureListResult{ResultCount: &count}, nil,
+		)
+
+		ds := dataSourceNsxtPolicyIdpsSystemSignatures()
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{})
+
+		err := dataSourceNsxtPolicyIdpsSystemSignaturesRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, "first-ver", d.Get("version_id"))
+	})
+
+	t.Run("falls back to DEFAULT when the version list is empty", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockVersions, restoreVersions := setupIdpsSignatureVersionMock(ctrl)
+		defer restoreVersions()
+		mockSigs, restoreSigs := setupIdpsSignaturesMock(ctrl)
+		defer restoreSigs()
+
+		mockVersions.EXPECT().List(nil, nil, nil, nil, nil, nil, nil).Return(model.IdsSignatureVersionListResult{}, nil)
+		count := int64(0)
+		mockSigs.EXPECT().List("DEFAULT", (*string)(nil), nil, nil, nil, nil, nil, nil).Return(
+			model.IdsSignatureListResult{ResultCount: &count}, nil,
+		)
+
+		ds := dataSourceNsxtPolicyIdpsSystemSignatures()
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{})
+
+		err := dataSourceNsxtPolicyIdpsSystemSignaturesRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, "DEFAULT", d.Get("version_id"))
+	})
+
+	t.Run("version list error propagates", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockVersions, restoreVersions := setupIdpsSignatureVersionMock(ctrl)
+		defer restoreVersions()
+
+		mockVersions.EXPECT().List(nil, nil, nil, nil, nil, nil, nil).Return(
+			model.IdsSignatureVersionListResult{}, vapiErrors.InternalServerError{},
+		)
+
+		ds := dataSourceNsxtPolicyIdpsSystemSignatures()
+		d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{})
+
+		err := dataSourceNsxtPolicyIdpsSystemSignaturesRead(d, newGoMockProviderClient())
+		require.Error(t, err)
 	})
 }

--- a/nsxt/utgomock_provider_test.go
+++ b/nsxt/utgomock_provider_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/security"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp/nsx"
 	nsxModel "github.com/vmware/vsphere-automation-sdk-go/services/nsxt-mp/nsx/model"
 	"go.uber.org/mock/gomock"
@@ -552,5 +553,116 @@ func TestUnitNsxt_configureNsxtClient(t *testing.T) {
 		require.NotNil(t, clients.NsxtClientConfig)
 		assert.Equal(t, "nsxmanager.example.com", clients.NsxtClientConfig.Host)
 		assert.NotNil(t, clients.NsxtClient)
+	})
+}
+
+func TestUnitNsxt_getConfiguredSecurityContext(t *testing.T) {
+	t.Run("username/password auth sets user-password scheme", func(t *testing.T) {
+		ctx, err := getConfiguredSecurityContext(&nsxtClients{}, nil, "admin", "password")
+		require.NoError(t, err)
+		assert.Equal(t, security.USER_PASSWORD_SCHEME_ID, ctx.Property(security.AUTHENTICATION_SCHEME_ID))
+		assert.Equal(t, "admin", ctx.Property(security.USER_KEY))
+		assert.Equal(t, "password", ctx.Property(security.PASSWORD_KEY))
+	})
+
+	t.Run("zero vmcAuthInfo falls back to username/password", func(t *testing.T) {
+		ctx, err := getConfiguredSecurityContext(&nsxtClients{}, &vmcAuthInfo{}, "admin", "password")
+		require.NoError(t, err)
+		assert.Equal(t, security.USER_PASSWORD_SCHEME_ID, ctx.Property(security.AUTHENTICATION_SCHEME_ID))
+	})
+
+	t.Run("missing username errors", func(t *testing.T) {
+		_, err := getConfiguredSecurityContext(&nsxtClients{}, nil, "", "password")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "username")
+	})
+
+	t.Run("missing password errors", func(t *testing.T) {
+		_, err := getConfiguredSecurityContext(&nsxtClients{}, nil, "admin", "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "password")
+	})
+
+	t.Run("vmc auth sets bearer token and oauth scheme", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"access_token":"abc123"}`))
+		}))
+		defer server.Close()
+		restore := redirectDefaultClientTo(server)
+		defer restore()
+
+		clients := &nsxtClients{}
+		vmc := &vmcAuthInfo{authHost: "vmc.example.com", accessToken: "refresh-token"}
+		ctx, err := getConfiguredSecurityContext(clients, vmc, "", "")
+		require.NoError(t, err)
+		assert.Equal(t, "abc123", clients.CommonConfig.BearerToken)
+		assert.Equal(t, security.OAUTH_SCHEME_ID, ctx.Property(security.AUTHENTICATION_SCHEME_ID))
+	})
+
+	t.Run("vmc auth with Bearer authMode skips oauth scheme property", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"access_token":"abc123"}`))
+		}))
+		defer server.Close()
+		restore := redirectDefaultClientTo(server)
+		defer restore()
+
+		clients := &nsxtClients{}
+		vmc := &vmcAuthInfo{authHost: "vmc.example.com", accessToken: "refresh-token", authMode: "Bearer"}
+		ctx, err := getConfiguredSecurityContext(clients, vmc, "", "")
+		require.NoError(t, err)
+		assert.Equal(t, "abc123", clients.CommonConfig.BearerToken)
+		assert.Nil(t, ctx.Property(security.AUTHENTICATION_SCHEME_ID))
+	})
+
+	t.Run("vmc token exchange error propagates", func(t *testing.T) {
+		clients := &nsxtClients{}
+		vmc := &vmcAuthInfo{authHost: "example.com"}
+		_, err := getConfiguredSecurityContext(clients, vmc, "", "")
+		require.Error(t, err)
+	})
+}
+
+func TestUnitNsxt_logRequestProcessorFilter(t *testing.T) {
+	p := newLogRequestProcessor()
+
+	t.Run("filter set and path does not match skips logging", func(t *testing.T) {
+		t.Setenv("TF_LOG_PROVIDER_NSX_HTTP_URI_FILTER", "/other")
+		req, _ := http.NewRequest("GET", "http://example.com/path", nil)
+		err := p.Process(req)
+		require.NoError(t, err)
+	})
+
+	t.Run("filter set and path matches logs the request", func(t *testing.T) {
+		t.Setenv("TF_LOG_PROVIDER_NSX_HTTP_URI_FILTER", "/path")
+		req, _ := http.NewRequest("GET", "http://example.com/path", nil)
+		err := p.Process(req)
+		require.NoError(t, err)
+	})
+}
+
+func TestUnitNsxt_logResponseAcceptorFilter(t *testing.T) {
+	a := newLogResponseAcceptor()
+
+	t.Run("filter set and path does not match skips logging", func(t *testing.T) {
+		t.Setenv("TF_LOG_PROVIDER_NSX_HTTP_URI_FILTER", "/other")
+		req, _ := http.NewRequest("GET", "http://example.com/path", nil)
+		resp := &http.Response{StatusCode: 200, Body: http.NoBody, Request: req}
+		a.Accept(resp)
+	})
+
+	t.Run("filter set and path matches logs the response", func(t *testing.T) {
+		t.Setenv("TF_LOG_PROVIDER_NSX_HTTP_URI_FILTER", "/path")
+		req, _ := http.NewRequest("GET", "http://example.com/path", nil)
+		resp := &http.Response{StatusCode: 200, Body: http.NoBody, Request: req}
+		a.Accept(resp)
+	})
+
+	t.Run("nil request with filter set is skipped safely", func(t *testing.T) {
+		t.Setenv("TF_LOG_PROVIDER_NSX_HTTP_URI_FILTER", "/path")
+		resp := &http.Response{StatusCode: 200, Body: http.NoBody, Request: nil}
+		a.Accept(resp)
 	})
 }

--- a/nsxt/utgomock_resource_nsxt_policy_bgp_neighbor_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_bgp_neighbor_test.go
@@ -456,3 +456,39 @@ func TestMockResourceNsxtPolicyBgpNeighborCreate_sourceAttachment920(t *testing.
 	err := resourceNsxtPolicyBgpNeighborCreate(d, m)
 	require.NoError(t, err)
 }
+
+func TestUnitNsxt_resourceNsxtPolicyBgpNeighborImport(t *testing.T) {
+	t.Run("wrong segment count is rejected", func(t *testing.T) {
+		res := resourceNsxtPolicyBgpNeighbor()
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		d.SetId("t0-1/default")
+
+		_, err := resourceNsxtPolicyBgpNeighborImport(d, newGoMockProviderClient())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "tier0-id")
+	})
+
+	t.Run("valid path succeeds and sets bgp_path", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockNeighborsSDK := bgpMocks.NewMockNeighborsClient(ctrl)
+		nbWrapper := &bgpapi.BgpNeighborConfigClientContext{Client: mockNeighborsSDK, ClientType: utl.Local}
+		originalCli := cliBgpNeighborsClient
+		defer func() { cliBgpNeighborsClient = originalCli }()
+		cliBgpNeighborsClient = func(sessionContext utl.SessionContext, connector client.Connector) *bgpapi.BgpNeighborConfigClientContext {
+			return nbWrapper
+		}
+		parentPath := bgpNbBgpPath
+		mockNeighborsSDK.EXPECT().Get(bgpNbT0ID, bgpNbServiceID, bgpNbID).Return(model.BgpNeighborConfig{ParentPath: &parentPath}, nil)
+
+		res := resourceNsxtPolicyBgpNeighbor()
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		d.SetId(bgpNbT0ID + "/" + bgpNbServiceID + "/" + bgpNbID)
+
+		out, err := resourceNsxtPolicyBgpNeighborImport(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		require.Len(t, out, 1)
+		assert.Equal(t, bgpNbID, d.Id())
+		assert.Equal(t, bgpNbBgpPath, d.Get("bgp_path"))
+	})
+}

--- a/nsxt/utgomock_resource_nsxt_policy_dhcp_v4_static_binding_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_dhcp_v4_static_binding_test.go
@@ -20,10 +20,32 @@ import (
 	"go.uber.org/mock/gomock"
 
 	infrasegsapi "github.com/vmware/terraform-provider-nsxt/api/infra/segments"
+	t1segsapi "github.com/vmware/terraform-provider-nsxt/api/infra/tier_1s/segments"
 	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
 	segsDhcpMocks "github.com/vmware/terraform-provider-nsxt/mocks/infra/segments"
+	t1segsDhcpMocks "github.com/vmware/terraform-provider-nsxt/mocks/infra/tier_1s/segments"
 	"github.com/vmware/terraform-provider-nsxt/nsxt/util"
 )
+
+func setupDhcpV4SegmentMock(ctrl *gomock.Controller) (*segsDhcpMocks.MockDhcpStaticBindingConfigsClient, func()) {
+	mockSDK := segsDhcpMocks.NewMockDhcpStaticBindingConfigsClient(ctrl)
+	wrapper := &infrasegsapi.StructValueClientContext{Client: mockSDK, ClientType: utl.Local}
+	orig := cliSegmentsDhcpStaticBindingConfigsClient
+	cliSegmentsDhcpStaticBindingConfigsClient = func(_ utl.SessionContext, _ client.Connector) *infrasegsapi.StructValueClientContext {
+		return wrapper
+	}
+	return mockSDK, func() { cliSegmentsDhcpStaticBindingConfigsClient = orig }
+}
+
+func setupDhcpV4T1SegmentMock(ctrl *gomock.Controller) (*t1segsDhcpMocks.MockDhcpStaticBindingConfigsClient, func()) {
+	mockSDK := t1segsDhcpMocks.NewMockDhcpStaticBindingConfigsClient(ctrl)
+	wrapper := &t1segsapi.StructValueClientContext{Client: mockSDK, ClientType: utl.Local}
+	orig := cliT1SegmentsDhcpStaticBindingConfigsClient
+	cliT1SegmentsDhcpStaticBindingConfigsClient = func(_ utl.SessionContext, _ client.Connector) *t1segsapi.StructValueClientContext {
+		return wrapper
+	}
+	return mockSDK, func() { cliT1SegmentsDhcpStaticBindingConfigsClient = orig }
+}
 
 var (
 	dhcpV4ID          = "dhcpv4-1"
@@ -53,6 +75,147 @@ func dhcpV4StructValue(t *testing.T) *data.StructValue {
 	val, errs := converter.ConvertToVapi(obj, model.DhcpV4StaticBindingConfigBindingType())
 	require.Empty(t, errs)
 	return val.(*data.StructValue)
+}
+
+func TestUnitNsxt_getDhcpOptsFromSchema(t *testing.T) {
+	res := resourceNsxtPolicyDhcpV4StaticBinding()
+
+	t.Run("nil when neither option block is set", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		assert.Nil(t, getDhcpOptsFromSchema(d))
+	})
+
+	t.Run("parses option_121 and generic options", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+			"dhcp_option_121": []interface{}{
+				map[string]interface{}{"network": "10.0.0.0/24", "next_hop": "10.0.0.1"},
+			},
+			"dhcp_generic_option": []interface{}{
+				map[string]interface{}{"code": 43, "values": []interface{}{"foo"}},
+			},
+		})
+		opts := getDhcpOptsFromSchema(d)
+		require.NotNil(t, opts)
+		require.NotNil(t, opts.Option121)
+		require.Len(t, opts.Others, 1)
+	})
+}
+
+func TestMockNsxt_getPolicyDchpStaticBindingOnSegment(t *testing.T) {
+	t.Run("infra segment success", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSDK, restore := setupDhcpV4SegmentMock(ctrl)
+		defer restore()
+		sv := dhcpV4StructValue(t)
+		mockSDK.EXPECT().Get(dhcpV4SegmentID, dhcpV4ID).Return(sv, nil)
+
+		obj, err := getPolicyDchpStaticBindingOnSegment(utl.SessionContext{ClientType: utl.Local}, dhcpV4ID, dhcpV4SegmentPath, nil)
+		require.NoError(t, err)
+		assert.NotNil(t, obj)
+	})
+
+	t.Run("fixed tier-1 segment success", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSDK, restore := setupDhcpV4T1SegmentMock(ctrl)
+		defer restore()
+		sv := dhcpV4StructValue(t)
+		mockSDK.EXPECT().Get("gw-1", dhcpV4SegmentID, dhcpV4ID).Return(sv, nil)
+
+		obj, err := getPolicyDchpStaticBindingOnSegment(utl.SessionContext{ClientType: utl.Local}, dhcpV4ID, "/infra/tier-1s/gw-1/segments/"+dhcpV4SegmentID, nil)
+		require.NoError(t, err)
+		assert.NotNil(t, obj)
+	})
+
+	t.Run("invalid segment path errors", func(t *testing.T) {
+		_, err := getPolicyDchpStaticBindingOnSegment(utl.SessionContext{ClientType: utl.Local}, dhcpV4ID, "/infra/tier-1s/gw-1", nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Invalid Segment Path")
+	})
+}
+
+func TestMockNsxt_resourceNsxtPolicyDhcpStaticBindingExistsOnSegment(t *testing.T) {
+	t.Run("Get succeeds means it exists", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSDK, restore := setupDhcpV4SegmentMock(ctrl)
+		defer restore()
+		sv := dhcpV4StructValue(t)
+		mockSDK.EXPECT().Get(dhcpV4SegmentID, dhcpV4ID).Return(sv, nil)
+
+		exists, err := resourceNsxtPolicyDhcpStaticBindingExistsOnSegment(utl.SessionContext{ClientType: utl.Local}, dhcpV4ID, dhcpV4SegmentPath, nil)
+		require.NoError(t, err)
+		assert.True(t, exists)
+	})
+
+	t.Run("NotFound means it does not exist", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSDK, restore := setupDhcpV4SegmentMock(ctrl)
+		defer restore()
+		mockSDK.EXPECT().Get(dhcpV4SegmentID, dhcpV4ID).Return(nil, vapiErrors.NotFound{})
+
+		exists, err := resourceNsxtPolicyDhcpStaticBindingExistsOnSegment(utl.SessionContext{ClientType: utl.Local}, dhcpV4ID, dhcpV4SegmentPath, nil)
+		require.NoError(t, err)
+		assert.False(t, exists)
+	})
+
+	t.Run("other errors propagate", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSDK, restore := setupDhcpV4SegmentMock(ctrl)
+		defer restore()
+		mockSDK.EXPECT().Get(dhcpV4SegmentID, dhcpV4ID).Return(nil, vapiErrors.InternalServerError{})
+
+		_, err := resourceNsxtPolicyDhcpStaticBindingExistsOnSegment(utl.SessionContext{ClientType: utl.Local}, dhcpV4ID, dhcpV4SegmentPath, nil)
+		require.Error(t, err)
+	})
+}
+
+func TestUnitNsxt_nsxtSegmentResourceImporter(t *testing.T) {
+	res := resourceNsxtPolicyDhcpV4StaticBinding()
+
+	t.Run("full policy path is parsed directly", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		d.SetId(dhcpV4SegmentPath + "/dhcp-static-binding-configs/" + dhcpV4ID)
+
+		out, err := nsxtSegmentResourceImporter(d, nil)
+		require.NoError(t, err)
+		require.Len(t, out, 1)
+		assert.Equal(t, dhcpV4SegmentPath, out[0].Get("segment_path"))
+	})
+
+	t.Run("legacy segmentID/bindingID format", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		d.SetId(dhcpV4SegmentID + "/" + dhcpV4ID)
+
+		out, err := nsxtSegmentResourceImporter(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		require.Len(t, out, 1)
+		assert.Equal(t, "/infra/segments/"+dhcpV4SegmentID, out[0].Get("segment_path"))
+		assert.Equal(t, dhcpV4ID, out[0].Id())
+	})
+
+	t.Run("legacy gatewayID/segmentID/bindingID format", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		d.SetId("gw-1/" + dhcpV4SegmentID + "/" + dhcpV4ID)
+
+		out, err := nsxtSegmentResourceImporter(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		require.Len(t, out, 1)
+		assert.Equal(t, "/infra/tier-1s/gw-1/segments/"+dhcpV4SegmentID, out[0].Get("segment_path"))
+		assert.Equal(t, dhcpV4ID, out[0].Id())
+	})
+
+	t.Run("too short legacy format errors", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		d.SetId("just-one-segment")
+
+		_, err := nsxtSegmentResourceImporter(d, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Import format")
+	})
 }
 
 func TestMockResourceNsxtPolicyDhcpV4StaticBindingCreate(t *testing.T) {

--- a/nsxt/utgomock_resource_nsxt_policy_domain_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_domain_test.go
@@ -232,6 +232,145 @@ func TestMockResourceNsxtPolicyDomainDelete(t *testing.T) {
 	})
 }
 
+func setupDomainMocks(ctrl *gomock.Controller) (*globalInfraMocks.MockDomainsClient, *globalInfraDomainsMocks.MockDomainDeploymentMapsClient, func()) {
+	mockDomainsSDK := globalInfraMocks.NewMockDomainsClient(ctrl)
+	mockDMSDK := globalInfraDomainsMocks.NewMockDomainDeploymentMapsClient(ctrl)
+
+	domainWrapper := &infraapi.DomainClientContext{Client: mockDomainsSDK, ClientType: utl.Global}
+	dmWrapper := &domainsapi.DomainDeploymentMapClientContext{Client: mockDMSDK, ClientType: utl.Global}
+
+	originalDomains := cliDomainsClient
+	originalDMs := cliDomainDeploymentMapsClient
+	cliDomainsClient = func(sessionContext utl.SessionContext, connector client.Connector) *infraapi.DomainClientContext {
+		return domainWrapper
+	}
+	cliDomainDeploymentMapsClient = func(sessionContext utl.SessionContext, connector client.Connector) *domainsapi.DomainDeploymentMapClientContext {
+		return dmWrapper
+	}
+	return mockDomainsSDK, mockDMSDK, func() {
+		cliDomainsClient = originalDomains
+		cliDomainDeploymentMapsClient = originalDMs
+	}
+}
+
+func TestUnitNsxt_createChildDomainDeploymentMap(t *testing.T) {
+	m := newGoMockProviderClient()
+
+	dataValue, err := createChildDomainDeploymentMap(m, "domain-1", "default")
+	require.NoError(t, err)
+	assert.NotNil(t, dataValue)
+}
+
+func TestUnitNsxt_setDomainStructWithChildrenCreate(t *testing.T) {
+	m := newGoMockProviderClient()
+	id := "domain-1"
+	domain := &model.Domain{Id: &id}
+
+	err := setDomainStructWithChildren(m, domain, []string{"default"}, false)
+	require.NoError(t, err)
+	assert.Len(t, domain.Children, 1)
+}
+
+func TestMockNsxtSetDomainStructWithChildrenUpdate(t *testing.T) {
+	t.Run("no stale locations to remove", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		_, mockDM, restore := setupDomainMocks(ctrl)
+		defer restore()
+		mockDM.EXPECT().List(domainID, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(
+			gm_model.DomainDeploymentMapListResult{Results: []gm_model.DomainDeploymentMap{{DisplayName: &domainSiteName}}}, nil,
+		)
+
+		m := newGoMockProviderClient()
+		id := domainID
+		domain := &model.Domain{Id: &id}
+		err := setDomainStructWithChildren(m, domain, []string{domainSiteName}, true)
+		require.NoError(t, err)
+		assert.Len(t, domain.Children, 1)
+	})
+
+	t.Run("removes stale locations", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		_, mockDM, restore := setupDomainMocks(ctrl)
+		defer restore()
+		staleName := "stale-site"
+		mockDM.EXPECT().List(domainID, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(
+			gm_model.DomainDeploymentMapListResult{Results: []gm_model.DomainDeploymentMap{
+				{DisplayName: &domainSiteName},
+				{DisplayName: &staleName},
+			}}, nil,
+		)
+
+		m := newGoMockProviderClient()
+		id := domainID
+		domain := &model.Domain{Id: &id}
+		err := setDomainStructWithChildren(m, domain, []string{domainSiteName}, true)
+		require.NoError(t, err)
+		// one child for the new location, one delete-child for the stale location
+		assert.Len(t, domain.Children, 2)
+	})
+
+	t.Run("List error propagates", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		_, mockDM, restore := setupDomainMocks(ctrl)
+		defer restore()
+		mockDM.EXPECT().List(domainID, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(
+			gm_model.DomainDeploymentMapListResult{}, vapiErrors.InternalServerError{},
+		)
+
+		m := newGoMockProviderClient()
+		id := domainID
+		domain := &model.Domain{Id: &id}
+		err := setDomainStructWithChildren(m, domain, []string{domainSiteName}, true)
+		require.Error(t, err)
+	})
+}
+
+func TestMockNsxtResourceNsxtPolicyDomainExists(t *testing.T) {
+	t.Run("fails when not global manager", func(t *testing.T) {
+		exists, err := resourceNsxtPolicyDomainExists(domainID, nil, false)
+		require.Error(t, err)
+		assert.False(t, exists)
+	})
+
+	t.Run("returns false on not found", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockDomainsSDK, _, restore := setupDomainMocks(ctrl)
+		defer restore()
+		mockDomainsSDK.EXPECT().Get(domainID).Return(gm_model.Domain{}, vapiErrors.NotFound{})
+
+		exists, err := resourceNsxtPolicyDomainExists(domainID, nil, true)
+		require.NoError(t, err)
+		assert.False(t, exists)
+	})
+
+	t.Run("propagates other errors", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockDomainsSDK, _, restore := setupDomainMocks(ctrl)
+		defer restore()
+		mockDomainsSDK.EXPECT().Get(domainID).Return(gm_model.Domain{}, vapiErrors.InternalServerError{})
+
+		exists, err := resourceNsxtPolicyDomainExists(domainID, nil, true)
+		require.Error(t, err)
+		assert.False(t, exists)
+	})
+}
+
+func TestMockResourceNsxtPolicyDomainUpdateEmptyID(t *testing.T) {
+	t.Run("Update fails when ID is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyDomain()
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+
+		err := resourceNsxtPolicyDomainUpdate(d, newGoMockGlobalProviderClient())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Domain ID")
+	})
+}
+
 // Verify that the model conversion from gm_model to local model works correctly.
 func TestDomainModelConversion(t *testing.T) {
 	displayName := "test-domain"

--- a/nsxt/utgomock_resource_nsxt_policy_edge_cluster_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_edge_cluster_test.go
@@ -298,3 +298,26 @@ func TestMockResourceNsxtPolicyEdgeClusterDelete(t *testing.T) {
 		require.Error(t, err)
 	})
 }
+
+func TestUnitNsxt_resourceNsxtPolicyEdgeClusterImporter(t *testing.T) {
+	res := resourceNsxtPolicyEdgeCluster()
+
+	t.Run("valid path succeeds and sets enforcement_point and site_path", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		d.SetId(edgeClusterSitePath + "/enforcement-points/" + edgeClusterEPID + "/edge-clusters/" + edgeClusterID)
+
+		out, err := resourceNsxtPolicyEdgeClusterImporter(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		require.Len(t, out, 1)
+		assert.Equal(t, edgeClusterEPID, d.Get("enforcement_point"))
+		assert.Equal(t, edgeClusterSitePath, d.Get("site_path"))
+	})
+
+	t.Run("invalid path is rejected", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		d.SetId("not-a-policy-path")
+
+		_, err := resourceNsxtPolicyEdgeClusterImporter(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}

--- a/nsxt/utgomock_resource_nsxt_policy_edge_transport_node_schema_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_edge_transport_node_schema_test.go
@@ -311,4 +311,142 @@ func TestUnitNsxt_setPolicyIPAssignmentsInSchema(t *testing.T) {
 		elem := out.([]interface{})[0].(map[string]interface{})
 		require.Contains(t, elem, "static_ipv6_list")
 	})
+
+	t.Run("dhcp_v4", func(t *testing.T) {
+		sv := toStructValue(t, model.Dhcpv4{IpAssignmentType: model.PolicyIpAssignmentSpec_IP_ASSIGNMENT_TYPE_DHCPV4}, model.Dhcpv4BindingType())
+		out, err := setPolicyIPAssignmentsInSchema([]*data.StructValue{sv})
+		require.NoError(t, err)
+		elem := out.([]interface{})[0].(map[string]interface{})
+		assert.Equal(t, true, elem["dhcp_v4"])
+	})
+
+	t.Run("dhcp_v6", func(t *testing.T) {
+		sv := toStructValue(t, model.Dhcpv6{IpAssignmentType: model.PolicyIpAssignmentSpec_IP_ASSIGNMENT_TYPE_DHCPV6}, model.Dhcpv6BindingType())
+		out, err := setPolicyIPAssignmentsInSchema([]*data.StructValue{sv})
+		require.NoError(t, err)
+		elem := out.([]interface{})[0].(map[string]interface{})
+		assert.Equal(t, true, elem["dhcp_v6"])
+	})
+
+	t.Run("no_assignment", func(t *testing.T) {
+		sv := toStructValue(t, model.NoAssignment{IpAssignmentType: model.PolicyIpAssignmentSpec_IP_ASSIGNMENT_TYPE_NOASSIGNMENT}, model.NoAssignmentBindingType())
+		out, err := setPolicyIPAssignmentsInSchema([]*data.StructValue{sv})
+		require.NoError(t, err)
+		elem := out.([]interface{})[0].(map[string]interface{})
+		assert.Equal(t, true, elem["no_assignment"])
+	})
+
+	t.Run("static_ipv4_list", func(t *testing.T) {
+		gw := "10.0.0.1"
+		mask := "255.255.255.0"
+		sv := toStructValue(t, model.StaticIpv4List{
+			DefaultGateway:   &gw,
+			IpList:           []string{"10.0.0.2"},
+			SubnetMask:       &mask,
+			IpAssignmentType: model.PolicyIpAssignmentSpec_IP_ASSIGNMENT_TYPE_STATICIPV4LIST,
+		}, model.StaticIpv4ListBindingType())
+		out, err := setPolicyIPAssignmentsInSchema([]*data.StructValue{sv})
+		require.NoError(t, err)
+		elem := out.([]interface{})[0].(map[string]interface{})
+		list := elem["static_ipv4_list"].([]interface{})[0].(map[string]interface{})
+		assert.Equal(t, []string{"10.0.0.2"}, list["ip_addresses"])
+		assert.Equal(t, &mask, list["subnet_mask"])
+	})
+
+	t.Run("static_ipv4_mac_list", func(t *testing.T) {
+		gw := "10.0.0.1"
+		ip := "10.0.0.2"
+		mac := "00:11:22:33:44:55"
+		mask := "255.255.255.0"
+		sv := toStructValue(t, model.StaticIpv4MacList{
+			DefaultGateway:   &gw,
+			IpMacList:        []model.IpMacPair{{Ip: &ip, Mac: &mac}},
+			SubnetMask:       &mask,
+			IpAssignmentType: model.PolicyIpAssignmentSpec_IP_ASSIGNMENT_TYPE_STATICIPV4MACLIST,
+		}, model.StaticIpv4MacListBindingType())
+		out, err := setPolicyIPAssignmentsInSchema([]*data.StructValue{sv})
+		require.NoError(t, err)
+		elem := out.([]interface{})[0].(map[string]interface{})
+		list := elem["static_ipv4_mac_list"].([]interface{})[0].(map[string]interface{})
+		pairs := list["ip_mac_pair"].([]interface{})
+		require.Len(t, pairs, 1)
+		assert.Equal(t, &ip, pairs[0].(map[string]interface{})["ip_address"])
+	})
+
+	t.Run("static_ipv6", func(t *testing.T) {
+		gw := "fe80::1"
+		sv := toStructValue(t, model.StaticIpv6{
+			DefaultGateway: []string{gw},
+			ManagementPortSubnets: []model.IPv6Subnet{
+				{IpAddresses: []string{"fe80::2"}, PrefixLength: int64Ptr(64)},
+			},
+			IpAssignmentType: model.PolicyIpAssignmentSpec_IP_ASSIGNMENT_TYPE_STATICIPV6,
+		}, model.StaticIpv6BindingType())
+		out, err := setPolicyIPAssignmentsInSchema([]*data.StructValue{sv})
+		require.NoError(t, err)
+		elem := out.([]interface{})[0].(map[string]interface{})
+		require.Contains(t, elem, "static_ipv6")
+	})
+
+	t.Run("static_ipv6_mac_list", func(t *testing.T) {
+		gw := "fe80::1"
+		ip := "fe80::2"
+		mac := "00:11:22:33:44:55"
+		prefixLength := "64"
+		sv := toStructValue(t, model.StaticIpv6MacList{
+			DefaultGateway:   &gw,
+			IpMacList:        []model.Ipv6MacPair{{Ipv6: &ip, Mac: &mac}},
+			PrefixLength:     &prefixLength,
+			IpAssignmentType: model.PolicyIpAssignmentSpec_IP_ASSIGNMENT_TYPE_STATICIPV6MACLIST,
+		}, model.StaticIpv6MacListBindingType())
+		out, err := setPolicyIPAssignmentsInSchema([]*data.StructValue{sv})
+		require.NoError(t, err)
+		elem := out.([]interface{})[0].(map[string]interface{})
+		list := elem["static_ipv6_mac_list"].([]interface{})[0].(map[string]interface{})
+		assert.Equal(t, 64, list["subnet_mask"])
+		pairs := list["ip_mac_pair"].([]interface{})
+		require.Len(t, pairs, 1)
+		assert.Equal(t, &ip, pairs[0].(map[string]interface{})["ip_address"])
+	})
+
+	t.Run("static_ipv6_pool", func(t *testing.T) {
+		pool := "/infra/ip-pools/pool-1"
+		sv := toStructValue(t, model.StaticIpv6Pool{IpPool: &pool, IpAssignmentType: model.PolicyIpAssignmentSpec_IP_ASSIGNMENT_TYPE_STATICIPV6POOL}, model.StaticIpv6PoolBindingType())
+		out, err := setPolicyIPAssignmentsInSchema([]*data.StructValue{sv})
+		require.NoError(t, err)
+		elem := out.([]interface{})[0].(map[string]interface{})
+		assert.Equal(t, &pool, elem["static_ipv6_pool"])
+	})
+}
+
+func TestUnitNsxt_resourceNsxtPolicyEdgeTransportNodeImporter(t *testing.T) {
+	res := resourceNsxtPolicyEdgeTransportNode()
+
+	t.Run("succeeds with a valid enforcement-point child path", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		d.SetId("/infra/sites/default/enforcement-points/default/edge-transport-nodes/etn-1")
+
+		out, err := resourceNsxtPolicyEdgeTransportNodeImporter(d, nil)
+		require.NoError(t, err)
+		require.Len(t, out, 1)
+		assert.Equal(t, "etn-1", out[0].Id())
+		assert.Equal(t, "default", out[0].Get("enforcement_point"))
+		assert.Equal(t, "/infra/sites/default", out[0].Get("site_path"))
+	})
+
+	t.Run("fails with an empty ID", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		d.SetId("")
+
+		_, err := resourceNsxtPolicyEdgeTransportNodeImporter(d, nil)
+		require.Error(t, err)
+	})
+
+	t.Run("fails when the path has no enforcement-points/edge-transport-nodes delimiters", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		d.SetId("/infra/sites/default/foo/etn-1")
+
+		_, err := resourceNsxtPolicyEdgeTransportNodeImporter(d, nil)
+		require.Error(t, err)
+	})
 }

--- a/nsxt/utgomock_resource_nsxt_policy_edge_transport_node_schema_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_edge_transport_node_schema_test.go
@@ -1,0 +1,314 @@
+//go:build unittest
+
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package nsxt
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/bindings"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/data"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+)
+
+// These cover the pure schema<->SDK-struct conversion helpers used by
+// resourceNsxtPolicyEdgeTransportNode. They take plain Go values (not a live
+// connector), so no mocking is required.
+
+func TestUnitNsxt_getCredentialsFromSchema(t *testing.T) {
+	t.Run("nil input returns nil", func(t *testing.T) {
+		assert.Nil(t, getCredentialsFromSchema(nil))
+	})
+
+	t.Run("required fields are always set, optional audit fields only when non-empty", func(t *testing.T) {
+		creds := []interface{}{
+			map[string]interface{}{
+				"cli_username":   "admin",
+				"cli_password":   "pw1",
+				"root_password":  "pw2",
+				"audit_username": "",
+				"audit_password": "",
+			},
+		}
+		obj := getCredentialsFromSchema(creds)
+		require.NotNil(t, obj)
+		assert.Equal(t, "admin", *obj.CliUsername)
+		assert.Equal(t, "pw1", *obj.CliPassword)
+		assert.Equal(t, "pw2", *obj.RootPassword)
+		assert.Nil(t, obj.AuditUsername)
+		assert.Nil(t, obj.AuditPassword)
+	})
+
+	t.Run("audit fields are set when non-empty", func(t *testing.T) {
+		creds := []interface{}{
+			map[string]interface{}{
+				"cli_username":   "admin",
+				"cli_password":   "pw1",
+				"root_password":  "pw2",
+				"audit_username": "auditor",
+				"audit_password": "pw3",
+			},
+		}
+		obj := getCredentialsFromSchema(creds)
+		require.NotNil(t, obj)
+		require.NotNil(t, obj.AuditUsername)
+		require.NotNil(t, obj.AuditPassword)
+		assert.Equal(t, "auditor", *obj.AuditUsername)
+		assert.Equal(t, "pw3", *obj.AuditPassword)
+	})
+}
+
+func TestUnitNsxt_getPolicyIPAssignmentsFromSchema(t *testing.T) {
+	t.Run("nil input returns nil, nil", func(t *testing.T) {
+		specs, err := getPolicyIPAssignmentsFromSchema(nil)
+		require.NoError(t, err)
+		assert.Nil(t, specs)
+	})
+
+	cases := []struct {
+		name string
+		elem map[string]interface{}
+	}{
+		{"auto_conf", map[string]interface{}{"auto_conf": true}},
+		{"dhcp_v4", map[string]interface{}{"dhcp_v4": true}},
+		{"dhcp_v6", map[string]interface{}{"dhcp_v6": true}},
+		{"no_assignment", map[string]interface{}{"no_assignment": true}},
+		{"static_ipv4", map[string]interface{}{
+			"static_ipv4": []interface{}{
+				map[string]interface{}{
+					"default_gateway": "10.0.0.1",
+					"management_port_subnet": []interface{}{
+						map[string]interface{}{
+							"ip_addresses":  []interface{}{"10.0.0.2"},
+							"prefix_length": 24,
+						},
+					},
+				},
+			},
+		}},
+		{"static_ipv4_list", map[string]interface{}{
+			"static_ipv4_list": []interface{}{
+				map[string]interface{}{
+					"default_gateway": "10.0.0.1",
+					"ip_addresses":    []interface{}{"10.0.0.2"},
+					"subnet_mask":     "255.255.255.0",
+				},
+			},
+		}},
+		{"static_ipv4_mac_list", map[string]interface{}{
+			"static_ipv4_mac_list": []interface{}{
+				map[string]interface{}{
+					"default_gateway": "10.0.0.1",
+					"ip_mac_pair": []interface{}{
+						map[string]interface{}{"ip_address": "10.0.0.2", "mac_address": "00:11:22:33:44:55"},
+					},
+					"subnet_mask": "255.255.255.0",
+				},
+			},
+		}},
+		{"static_ipv4_pool", map[string]interface{}{"static_ipv4_pool": "/infra/ip-pools/pool-1"}},
+		{"static_ipv6", map[string]interface{}{
+			"static_ipv6": []interface{}{
+				map[string]interface{}{
+					"default_gateway": "fe80::1",
+					"management_port_subnet": []interface{}{
+						map[string]interface{}{
+							"ip_addresses":  []interface{}{"fe80::2"},
+							"prefix_length": 64,
+						},
+					},
+				},
+			},
+		}},
+		{"static_ipv6_list", map[string]interface{}{
+			"static_ipv6_list": []interface{}{
+				map[string]interface{}{
+					"default_gateway": "fe80::1",
+					"ip_addresses":    []interface{}{"fe80::2"},
+					"prefix_length":   64,
+				},
+			},
+		}},
+		{"static_ipv6_mac_list", map[string]interface{}{
+			"static_ipv6_mac_list": []interface{}{
+				map[string]interface{}{
+					"default_gateway": "fe80::1",
+					"ip_mac_pair": []interface{}{
+						map[string]interface{}{"ip_address": "fe80::2", "mac_address": "00:11:22:33:44:55"},
+					},
+					"prefix_length": 64,
+				},
+			},
+		}},
+		{"static_ipv6_pool", map[string]interface{}{"static_ipv6_pool": "/infra/ip-pools/pool-2"}},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			specs, err := getPolicyIPAssignmentsFromSchema([]interface{}{c.elem})
+			require.NoError(t, err)
+			require.Len(t, specs, 1)
+		})
+	}
+}
+
+func TestUnitNsxt_getManagementInterfaceFromSchema(t *testing.T) {
+	t.Run("nil input returns nil, nil", func(t *testing.T) {
+		obj, err := getManagementInterfaceFromSchema(nil)
+		require.NoError(t, err)
+		assert.Nil(t, obj)
+	})
+
+	t.Run("valid input sets network id and ip assignment", func(t *testing.T) {
+		mgtIntf := []interface{}{
+			map[string]interface{}{
+				"network_id":    "network-1",
+				"ip_assignment": []interface{}{map[string]interface{}{"dhcp_v4": true}},
+			},
+		}
+		obj, err := getManagementInterfaceFromSchema(mgtIntf)
+		require.NoError(t, err)
+		require.NotNil(t, obj)
+		assert.Equal(t, "network-1", *obj.NetworkId)
+		assert.Len(t, obj.IpAssignmentSpecs, 1)
+	})
+}
+
+func TestUnitNsxt_setApplianceConfigInSchema(t *testing.T) {
+	res := resourceNsxtPolicyEdgeTransportNode()
+
+	t.Run("nil object is a no-op", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		err := setApplianceConfigInSchema(d, nil)
+		require.NoError(t, err)
+	})
+
+	t.Run("populates appliance_config including syslog servers", func(t *testing.T) {
+		allowSSHRoot, enableSSH, enableUpt := true, true, false
+		logLevel, port, protocol, server := "INFO", "514", "UDP", "syslog.example.com"
+		obj := &model.PolicyVmApplianceConfig{
+			AllowSshRootLogin: &allowSSHRoot,
+			DnsServers:        []string{"8.8.8.8"},
+			EnableSsh:         &enableSSH,
+			EnableUptMode:     &enableUpt,
+			SyslogServers: []model.SyslogConfiguration{
+				{LogLevel: &logLevel, Port: &port, Protocol: &protocol, Server: &server},
+			},
+		}
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		err := setApplianceConfigInSchema(d, obj)
+		require.NoError(t, err)
+		cfg := d.Get("appliance_config").([]interface{})
+		require.Len(t, cfg, 1)
+		cfgMap := cfg[0].(map[string]interface{})
+		assert.Equal(t, true, cfgMap["allow_ssh_root_login"])
+		servers := cfgMap["syslog_server"].([]interface{})
+		require.Len(t, servers, 1)
+		assert.Equal(t, "syslog.example.com", servers[0].(map[string]interface{})["server"])
+	})
+}
+
+func TestUnitNsxt_setCredentialsInSchema(t *testing.T) {
+	res := resourceNsxtPolicyEdgeTransportNode()
+
+	t.Run("nil object is a no-op", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		err := setCredentialsInSchema(d, nil)
+		require.NoError(t, err)
+	})
+
+	t.Run("merges usernames into existing credentials block", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+			"credentials": []interface{}{
+				map[string]interface{}{
+					"cli_username":  "admin",
+					"cli_password":  "pw1",
+					"root_password": "pw2",
+				},
+			},
+		})
+		auditUsername, cliUsername := "auditor", "admin2"
+		obj := &model.PolicyEdgeTransportNodeCredential{AuditUsername: &auditUsername, CliUsername: &cliUsername}
+		err := setCredentialsInSchema(d, obj)
+		require.NoError(t, err)
+		creds := d.Get("credentials").([]interface{})
+		require.Len(t, creds, 1)
+		credMap := creds[0].(map[string]interface{})
+		assert.Equal(t, "admin2", credMap["cli_username"])
+		assert.Equal(t, "auditor", credMap["audit_username"])
+	})
+
+	t.Run("creates credentials block when none set yet", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		cliUsername := "admin"
+		obj := &model.PolicyEdgeTransportNodeCredential{CliUsername: &cliUsername}
+		err := setCredentialsInSchema(d, obj)
+		require.NoError(t, err)
+		creds := d.Get("credentials").([]interface{})
+		require.Len(t, creds, 1)
+	})
+}
+
+func TestUnitNsxt_setPolicyIPAssignmentsInSchema(t *testing.T) {
+	converter := bindings.NewTypeConverter()
+
+	toStructValue := func(t *testing.T, obj interface{}, bindingType bindings.BindingType) *data.StructValue {
+		t.Helper()
+		dv, errs := converter.ConvertToVapi(obj, bindingType)
+		require.Empty(t, errs)
+		return dv.(*data.StructValue)
+	}
+
+	t.Run("auto_conf", func(t *testing.T) {
+		sv := toStructValue(t, model.AutoConf{IpAssignmentType: model.PolicyIpAssignmentSpec_IP_ASSIGNMENT_TYPE_AUTOCONF}, model.AutoConfBindingType())
+		out, err := setPolicyIPAssignmentsInSchema([]*data.StructValue{sv})
+		require.NoError(t, err)
+		elem := out.([]interface{})[0].(map[string]interface{})
+		assert.Equal(t, true, elem["auto_conf"])
+	})
+
+	t.Run("static_ipv4", func(t *testing.T) {
+		gw := "10.0.0.1"
+		sv := toStructValue(t, model.StaticIpv4{
+			DefaultGateway:   []string{gw},
+			IpAssignmentType: model.PolicyIpAssignmentSpec_IP_ASSIGNMENT_TYPE_STATICIPV4,
+			ManagementPortSubnets: []model.IPv4Subnet{
+				{IpAddresses: []string{"10.0.0.2"}, PrefixLength: int64Ptr(24)},
+			},
+		}, model.StaticIpv4BindingType())
+		out, err := setPolicyIPAssignmentsInSchema([]*data.StructValue{sv})
+		require.NoError(t, err)
+		elem := out.([]interface{})[0].(map[string]interface{})
+		require.Contains(t, elem, "static_ipv4")
+	})
+
+	t.Run("static_ipv4_pool", func(t *testing.T) {
+		pool := "/infra/ip-pools/pool-1"
+		sv := toStructValue(t, model.StaticIpv4Pool{IpPool: &pool, IpAssignmentType: model.PolicyIpAssignmentSpec_IP_ASSIGNMENT_TYPE_STATICIPV4POOL}, model.StaticIpv4PoolBindingType())
+		out, err := setPolicyIPAssignmentsInSchema([]*data.StructValue{sv})
+		require.NoError(t, err)
+		elem := out.([]interface{})[0].(map[string]interface{})
+		assert.Equal(t, &pool, elem["static_ipv4_pool"])
+	})
+
+	t.Run("static_ipv6_list", func(t *testing.T) {
+		gw := "fe80::1"
+		prefixLength := "64"
+		sv := toStructValue(t, model.StaticIpv6List{
+			DefaultGateway:   &gw,
+			IpList:           []string{"fe80::2"},
+			PrefixLength:     &prefixLength,
+			IpAssignmentType: model.PolicyIpAssignmentSpec_IP_ASSIGNMENT_TYPE_STATICIPV6LIST,
+		}, model.StaticIpv6ListBindingType())
+		out, err := setPolicyIPAssignmentsInSchema([]*data.StructValue{sv})
+		require.NoError(t, err)
+		elem := out.([]interface{})[0].(map[string]interface{})
+		require.Contains(t, elem, "static_ipv6_list")
+	})
+}

--- a/nsxt/utgomock_resource_nsxt_policy_edge_transport_node_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_edge_transport_node_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	vapiErrors "github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/bindings"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/data"
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 	"go.uber.org/mock/gomock"
@@ -267,6 +269,95 @@ func TestMockResourceNsxtPolicyEdgeTransportNodeRead(t *testing.T) {
 		err := resourceNsxtPolicyEdgeTransportNodeRead(d, m)
 		require.NoError(t, err)
 		assert.Empty(t, d.Id())
+	})
+
+	t.Run("Read_populates_switch_details_and_vm_deployment_config", func(t *testing.T) {
+		converter := bindings.NewTypeConverter()
+		// dhcp_v4 is the one assignment type allowed by both the management_interface and
+		// tunnel_endpoint ip_assignment schemas (managementAssignments / tepAssignments).
+		dhcpSV, errs := converter.ConvertToVapi(model.Dhcpv4{IpAssignmentType: model.PolicyIpAssignmentSpec_IP_ASSIGNMENT_TYPE_DHCPV4}, model.Dhcpv4BindingType())
+		require.Empty(t, errs)
+
+		hostGroup := "hg-1"
+		computeID := "compute-1"
+		cpuMhz := int64(2000)
+		memPct := int64(50)
+		vmDeployConfig := model.PolicyVsphereDeploymentConfig{
+			ComputeId:              &computeID,
+			EdgeHostAffinityConfig: &model.EdgeHostAffinityConfig{HostGroupName: &hostGroup},
+			ReservationInfo: &model.ReservationInfo{
+				CpuReservation:    &model.CPUReservation{ReservationInMhz: &cpuMhz},
+				MemoryReservation: &model.MemoryReservation{ReservationPercentage: &memPct},
+			},
+			PlacementType: model.PolicyVmDeploymentConfig_PLACEMENT_TYPE_POLICYVSPHEREDEPLOYMENTCONFIG,
+		}
+		vmDeployConfigSV, errs := converter.ConvertToVapi(vmDeployConfig, model.PolicyVsphereDeploymentConfigBindingType())
+		require.Empty(t, errs)
+
+		datapathID := "dp-1"
+		deviceName := "eth0"
+		uplinkName := "uplink-1"
+		uplinkKey := model.PolicyEdgeTransportNodeSwitchProfileTypePathEntry_KEY_UPLINKHOSTSWITCHPROFILE
+		uplinkVal := "/infra/host-switch-profiles/uplink-1"
+		lldpKey := model.PolicyEdgeTransportNodeSwitchProfileTypePathEntry_KEY_LLDPHOSTSWITCHPROFILE
+		lldpVal := "/infra/host-switch-profiles/lldp-1"
+		switchName := "nsxDefaultHostSwitch"
+		vlan := int64(100)
+
+		obj := policyETNAPIResponse()
+		obj.ManagementInterface = &model.PolicyEdgeTransportManagementInterface{
+			IpAssignmentSpecs: []*data.StructValue{dhcpSV.(*data.StructValue)},
+			NetworkId:         &policyETNID,
+		}
+		obj.VmDeploymentConfig = vmDeployConfigSV.(*data.StructValue)
+		obj.SwitchSpec = &model.PolicyEdgeTransportNodeSwitchSpec{
+			Switches: []model.PolicyEdgeTransportNodeSwitch{
+				{
+					SwitchName:                &switchName,
+					OverlayTransportZonePaths: []string{"/infra/sites/default/enforcement-points/default/transport-zones/tz-1"},
+					VlanTransportZonePaths:    []string{"/infra/sites/default/enforcement-points/default/transport-zones/tz-2"},
+					Pnics: []model.PolicyEdgeTransportNodePnic{
+						{DatapathNetworkId: &datapathID, DeviceName: &deviceName, UplinkName: &uplinkName},
+					},
+					ProfilePaths: []model.PolicyEdgeTransportNodeSwitchProfileTypePathEntry{
+						{Key: &uplinkKey, Value: &uplinkVal},
+						{Key: &lldpKey, Value: &lldpVal},
+					},
+					TunnelEndpoints: []model.PolicyEdgeTransportNodeSwitchTunnelEndPoint{
+						{IpAssignmentSpecs: []*data.StructValue{dhcpSV.(*data.StructValue)}, Vlan: &vlan},
+					},
+				},
+			},
+		}
+
+		mockETNSDK.EXPECT().Get(policyETNSiteID, policyETNEPID, policyETNID).Return(obj, nil)
+
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+			"site_path":         policyETNSitePath,
+			"enforcement_point": policyETNEPID,
+			"hostname":          policyETNHostname,
+			"switch":            minimalPolicyETNSwitchData(),
+		})
+		d.SetId(policyETNID)
+		m := newGoMockProviderClient()
+		err := resourceNsxtPolicyEdgeTransportNodeRead(d, m)
+		require.NoError(t, err)
+
+		switches := d.Get("switch").([]interface{})
+		require.Len(t, switches, 1)
+		sw := switches[0].(map[string]interface{})
+		assert.Equal(t, "/infra/sites/default/enforcement-points/default/transport-zones/tz-1", sw["overlay_transport_zone_path"])
+		assert.Equal(t, uplinkVal, sw["uplink_host_switch_profile_path"])
+		assert.Equal(t, lldpVal, sw["lldp_host_switch_profile_path"])
+		pnics := sw["pnic"].([]interface{})
+		require.Len(t, pnics, 1)
+		assert.Equal(t, deviceName, pnics[0].(map[string]interface{})["device_name"])
+		teps := sw["tunnel_endpoint"].([]interface{})
+		require.Len(t, teps, 1)
+
+		mgmt := d.Get("management_interface").([]interface{})
+		require.Len(t, mgmt, 1)
+		assert.Equal(t, policyETNID, mgmt[0].(map[string]interface{})["network_id"])
 	})
 }
 

--- a/nsxt/utgomock_resource_nsxt_policy_gateway_policy_rule_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_gateway_policy_rule_test.go
@@ -192,3 +192,62 @@ func TestMockResourceNsxtPolicyGatewayPolicyRuleDelete(t *testing.T) {
 		require.Error(t, err)
 	})
 }
+
+func TestMockNsxtGatewayPolicyRuleImporter(t *testing.T) {
+	res := resourceNsxtPolicyGatewayRulePolicy()
+
+	t.Run("valid path succeeds and sets policy_path", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		d.SetId(gwRulePolicyPath + "/rules/rule-1")
+
+		out, err := nsxtGatewayPolicyRuleImporter(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		require.Len(t, out, 1)
+		assert.Equal(t, gwRulePolicyPath, d.Get("policy_path"))
+	})
+
+	t.Run("path without a rule segment is rejected", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		d.SetId(gwRulePolicyPath + "/somethingelse/x")
+
+		_, err := nsxtGatewayPolicyRuleImporter(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockNsxtResourceNsxtPolicyGatewayPolicyRuleExists(t *testing.T) {
+	t.Run("Get succeeds means it exists", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSDK, restore := setupGwRuleMock(t, ctrl)
+		defer restore()
+		mockSDK.EXPECT().Get(gwRuleDomain, gwRulePolicyID, gwRuleID).Return(gwRuleAPIResponse(), nil)
+
+		exists, err := resourceNsxtPolicyGatewayPolicyRuleExists(utl.SessionContext{ClientType: utl.Local}, gwRuleID, gwRulePolicyPath, nil)
+		require.NoError(t, err)
+		assert.True(t, exists)
+	})
+
+	t.Run("NotFound means it does not exist", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSDK, restore := setupGwRuleMock(t, ctrl)
+		defer restore()
+		mockSDK.EXPECT().Get(gwRuleDomain, gwRulePolicyID, gwRuleID).Return(nsxModel.Rule{}, vapiErrors.NotFound{})
+
+		exists, err := resourceNsxtPolicyGatewayPolicyRuleExists(utl.SessionContext{ClientType: utl.Local}, gwRuleID, gwRulePolicyPath, nil)
+		require.NoError(t, err)
+		assert.False(t, exists)
+	})
+
+	t.Run("other errors propagate", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSDK, restore := setupGwRuleMock(t, ctrl)
+		defer restore()
+		mockSDK.EXPECT().Get(gwRuleDomain, gwRulePolicyID, gwRuleID).Return(nsxModel.Rule{}, vapiErrors.InternalServerError{})
+
+		_, err := resourceNsxtPolicyGatewayPolicyRuleExists(utl.SessionContext{ClientType: utl.Local}, gwRuleID, gwRulePolicyPath, nil)
+		require.Error(t, err)
+	})
+}

--- a/nsxt/utgomock_resource_nsxt_policy_idps_custom_signature_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_idps_custom_signature_test.go
@@ -355,6 +355,281 @@ func TestMockNsxtIdpsCustomSignatureCountPreview(t *testing.T) {
 	})
 }
 
+func TestMockResourceNsxtPolicyIdpsCustomSignatureCreateMocked(t *testing.T) {
+	t.Run("Create succeeds without publish (validate-only, warns on validate failure)", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSigs, mockVersions, restore := setupIdpsCustomSignatureMocks(ctrl)
+		defer restore()
+
+		mockVersions.EXPECT().Create("default", gomock.Any(), idpsCustomSignatureCreateActionAdd).Return(nil)
+		sigID := "sig-1"
+		origSig := `alert tcp any any -> any 80 (msg:"Test"; sid:9000001; rev:1;)`
+		mockSigs.EXPECT().List("default", nil, gomock.Any(), nil, nil, nil, gomock.Any(), nil, nil).Return(
+			model.IdsCustomSignatureListResult{Results: []model.IdsCustomSignature{{Id: &sigID, OriginalSignature: &origSig}}}, nil,
+		)
+		rev := int64(1)
+		mockVersions.EXPECT().Get("default").Return(model.IdsCustomSignatureVersion{Revision: &rev}, nil)
+		mockSigs.EXPECT().Create("default", gomock.Any(), idpsCustomSignatureActionValidate).Return(vapiErrors.InternalServerError{})
+
+		// Read after create
+		mockSigs.EXPECT().Get("default", "sig-1").Return(model.IdsCustomSignature{OriginalSignature: &origSig}, nil)
+
+		res := resourceNsxtPolicyIdpsCustomSignature()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalIdpsCustomSigData())
+
+		err := resourceNsxtPolicyIdpsCustomSignatureCreate(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, "default/sig-1", d.Id())
+	})
+
+	t.Run("Create with publish=true validates and publishes", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSigs, mockVersions, restore := setupIdpsCustomSignatureMocks(ctrl)
+		defer restore()
+
+		mockVersions.EXPECT().Create("default", gomock.Any(), idpsCustomSignatureCreateActionAdd).Return(nil)
+		sigID := "sig-1"
+		origSig := `alert tcp any any -> any 80 (msg:"Test"; sid:9000001; rev:1;)`
+		mockSigs.EXPECT().List("default", nil, gomock.Any(), nil, nil, nil, gomock.Any(), nil, nil).Return(
+			model.IdsCustomSignatureListResult{Results: []model.IdsCustomSignature{{Id: &sigID, OriginalSignature: &origSig}}}, nil,
+		)
+		rev := int64(1)
+		mockVersions.EXPECT().Get("default").Return(model.IdsCustomSignatureVersion{Revision: &rev}, nil).Times(2)
+		mockSigs.EXPECT().Create("default", gomock.Any(), idpsCustomSignatureActionValidate).Return(nil)
+		mockSigs.EXPECT().Create("default", gomock.Any(), idpsCustomSignatureActionPublish).Return(nil)
+		mockSigs.EXPECT().Get("default", "sig-1").Return(model.IdsCustomSignature{OriginalSignature: &origSig}, nil)
+
+		data := minimalIdpsCustomSigData()
+		data["publish"] = true
+		res := resourceNsxtPolicyIdpsCustomSignature()
+		d := schema.TestResourceDataRaw(t, res.Schema, data)
+
+		err := resourceNsxtPolicyIdpsCustomSignatureCreate(d, newGoMockProviderClient())
+		require.NoError(t, err)
+	})
+
+	t.Run("Create fails when signature is empty", func(t *testing.T) {
+		res := resourceNsxtPolicyIdpsCustomSignature()
+		data := minimalIdpsCustomSigData()
+		data["signature"] = ""
+		d := schema.TestResourceDataRaw(t, res.Schema, data)
+
+		err := resourceNsxtPolicyIdpsCustomSignatureCreate(d, newGoMockProviderClient())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "signature is required")
+	})
+
+	t.Run("Create fails when the ADD call errors", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSigs, mockVersions, restore := setupIdpsCustomSignatureMocks(ctrl)
+		defer restore()
+		mockVersions.EXPECT().Create("default", gomock.Any(), idpsCustomSignatureCreateActionAdd).Return(vapiErrors.InternalServerError{})
+		_ = mockSigs
+
+		res := resourceNsxtPolicyIdpsCustomSignature()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalIdpsCustomSigData())
+
+		err := resourceNsxtPolicyIdpsCustomSignatureCreate(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+
+	t.Run("Create fails when the newly added signature can't be found in the list", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSigs, mockVersions, restore := setupIdpsCustomSignatureMocks(ctrl)
+		defer restore()
+		mockVersions.EXPECT().Create("default", gomock.Any(), idpsCustomSignatureCreateActionAdd).Return(nil)
+		mockSigs.EXPECT().List("default", nil, gomock.Any(), nil, nil, nil, gomock.Any(), nil, nil).Return(
+			model.IdsCustomSignatureListResult{}, nil,
+		)
+
+		res := resourceNsxtPolicyIdpsCustomSignature()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalIdpsCustomSigData())
+
+		err := resourceNsxtPolicyIdpsCustomSignatureCreate(d, newGoMockProviderClient())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to find newly created")
+	})
+}
+
+func TestMockResourceNsxtPolicyIdpsCustomSignatureReadMocked(t *testing.T) {
+	t.Run("Read succeeds via direct Get", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSigs, _, restore := setupIdpsCustomSignatureMocks(ctrl)
+		defer restore()
+		name := "sig-name"
+		mockSigs.EXPECT().Get("default", "sig-1").Return(model.IdsCustomSignature{DisplayName: &name}, nil)
+
+		res := resourceNsxtPolicyIdpsCustomSignature()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalIdpsCustomSigData())
+		d.SetId("default/sig-1")
+
+		err := resourceNsxtPolicyIdpsCustomSignatureRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, "sig-name", d.Get("display_name"))
+	})
+
+	t.Run("Read falls back to list search on NotFound, clears state when absent", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSigs, _, restore := setupIdpsCustomSignatureMocks(ctrl)
+		defer restore()
+		mockSigs.EXPECT().Get("default", "sig-1").Return(model.IdsCustomSignature{}, vapiErrors.NotFound{})
+		mockSigs.EXPECT().List("default", gomock.Any(), gomock.Any(), nil, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(
+			model.IdsCustomSignatureListResult{}, nil,
+		).AnyTimes()
+
+		res := resourceNsxtPolicyIdpsCustomSignature()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalIdpsCustomSigData())
+		d.SetId("default/sig-1")
+
+		err := resourceNsxtPolicyIdpsCustomSignatureRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, "", d.Id())
+	})
+
+	t.Run("Read propagates non-NotFound errors", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSigs, _, restore := setupIdpsCustomSignatureMocks(ctrl)
+		defer restore()
+		mockSigs.EXPECT().Get("default", "sig-1").Return(model.IdsCustomSignature{}, vapiErrors.InternalServerError{})
+
+		res := resourceNsxtPolicyIdpsCustomSignature()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalIdpsCustomSigData())
+		d.SetId("default/sig-1")
+
+		err := resourceNsxtPolicyIdpsCustomSignatureRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyIdpsCustomSignatureUpdateMocked(t *testing.T) {
+	t.Run("Update with no signature change and no publish just re-reads", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSigs, mockVersions, restore := setupIdpsCustomSignatureMocks(ctrl)
+		defer restore()
+		rev := int64(2)
+		mockVersions.EXPECT().Get("default").Return(model.IdsCustomSignatureVersion{Revision: &rev}, nil)
+		origSig := `alert tcp any any -> any 80 (msg:"Test"; sid:9000001; rev:1;)`
+		mockSigs.EXPECT().Get("default", "sig-1").Return(model.IdsCustomSignature{OriginalSignature: &origSig}, nil)
+
+		res := resourceNsxtPolicyIdpsCustomSignature()
+		// Deliberately omit "signature" so HasChange("signature") is false: TestResourceDataRaw
+		// has no prior state to diff against, so any populated field would otherwise look changed.
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{"signature_version_id": "default"})
+		d.SetId("default/sig-1")
+
+		err := resourceNsxtPolicyIdpsCustomSignatureUpdate(d, newGoMockProviderClient())
+		require.NoError(t, err)
+	})
+
+	t.Run("Update propagates the version Get error", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		_, mockVersions, restore := setupIdpsCustomSignatureMocks(ctrl)
+		defer restore()
+		mockVersions.EXPECT().Get("default").Return(model.IdsCustomSignatureVersion{}, vapiErrors.InternalServerError{})
+
+		res := resourceNsxtPolicyIdpsCustomSignature()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalIdpsCustomSigData())
+		d.SetId("default/sig-1")
+
+		err := resourceNsxtPolicyIdpsCustomSignatureUpdate(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+
+	t.Run("Update with publish=true validates and publishes after re-read", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSigs, mockVersions, restore := setupIdpsCustomSignatureMocks(ctrl)
+		defer restore()
+		rev := int64(2)
+		mockVersions.EXPECT().Get("default").Return(model.IdsCustomSignatureVersion{Revision: &rev}, nil).Times(3)
+		mockSigs.EXPECT().Create("default", gomock.Any(), idpsCustomSignatureActionValidate).Return(nil)
+		mockSigs.EXPECT().Create("default", gomock.Any(), idpsCustomSignatureActionPublish).Return(nil)
+		origSig := `alert tcp any any -> any 80 (msg:"Test"; sid:9000001; rev:1;)`
+		mockSigs.EXPECT().Get("default", "sig-1").Return(model.IdsCustomSignature{OriginalSignature: &origSig}, nil)
+
+		// Omit "signature" so HasChange("signature") is false and only the publish branch fires.
+		data := map[string]interface{}{"signature_version_id": "default", "publish": true}
+		res := resourceNsxtPolicyIdpsCustomSignature()
+		d := schema.TestResourceDataRaw(t, res.Schema, data)
+		d.SetId("default/sig-1")
+
+		err := resourceNsxtPolicyIdpsCustomSignatureUpdate(d, newGoMockProviderClient())
+		require.NoError(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyIdpsCustomSignatureDeleteMocked(t *testing.T) {
+	t.Run("Delete succeeds: validate accepts first path, publish succeeds, signature gone", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSigs, mockVersions, restore := setupIdpsCustomSignatureMocks(ctrl)
+		defer restore()
+		rev := int64(1)
+		mockVersions.EXPECT().Get("default").Return(model.IdsCustomSignatureVersion{Revision: &rev}, nil).Times(2)
+		mockSigs.EXPECT().Get("default", "sig-1").Return(model.IdsCustomSignature{}, vapiErrors.NotFound{})
+		mockSigs.EXPECT().Create("default", gomock.Any(), idpsCustomSignatureActionValidate).Return(nil)
+		mockSigs.EXPECT().Create("default", gomock.Any(), idpsCustomSignatureActionPublish).Return(nil)
+		mockSigs.EXPECT().List("default", gomock.Any(), gomock.Any(), nil, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(
+			model.IdsCustomSignatureListResult{}, nil,
+		).AnyTimes()
+
+		res := resourceNsxtPolicyIdpsCustomSignature()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalIdpsCustomSigData())
+		d.SetId("default/sig-1")
+
+		err := resourceNsxtPolicyIdpsCustomSignatureDelete(d, newGoMockProviderClient())
+		require.NoError(t, err)
+	})
+
+	t.Run("Delete propagates the initial version Get error", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		_, mockVersions, restore := setupIdpsCustomSignatureMocks(ctrl)
+		defer restore()
+		mockVersions.EXPECT().Get("default").Return(model.IdsCustomSignatureVersion{}, vapiErrors.InternalServerError{})
+
+		res := resourceNsxtPolicyIdpsCustomSignature()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalIdpsCustomSigData())
+		d.SetId("default/sig-1")
+
+		err := resourceNsxtPolicyIdpsCustomSignatureDelete(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+
+	t.Run("Delete falls back to CANCEL when all VALIDATE paths fail and preview signatures exist", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSigs, mockVersions, restore := setupIdpsCustomSignatureMocks(ctrl)
+		defer restore()
+		rev := int64(1)
+		mockVersions.EXPECT().Get("default").Return(model.IdsCustomSignatureVersion{Revision: &rev}, nil)
+		mockSigs.EXPECT().Get("default", "sig-1").Return(model.IdsCustomSignature{}, vapiErrors.NotFound{})
+		mockSigs.EXPECT().Create("default", gomock.Any(), idpsCustomSignatureActionValidate).Return(vapiErrors.InvalidRequest{}).AnyTimes()
+		previewID := "sig-1"
+		mockSigs.EXPECT().List("default", gomock.Any(), gomock.Any(), nil, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(
+			model.IdsCustomSignatureListResult{Results: []model.IdsCustomSignature{{Id: &previewID}}}, nil,
+		).AnyTimes()
+		mockSigs.EXPECT().Create("default", gomock.Any(), idpsCustomSignatureActionCancel).Return(nil)
+
+		res := resourceNsxtPolicyIdpsCustomSignature()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalIdpsCustomSigData())
+		d.SetId("default/sig-1")
+
+		err := resourceNsxtPolicyIdpsCustomSignatureDelete(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, "", d.Id())
+	})
+}
+
 func TestMockNsxtResourceNsxtPolicyIdpsCustomSignatureExistsByContent(t *testing.T) {
 	t.Run("finds matching content", func(t *testing.T) {
 		ctrl := gomock.NewController(t)

--- a/nsxt/utgomock_resource_nsxt_policy_idps_settings_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_idps_settings_test.go
@@ -12,10 +12,37 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	vapiErrors "github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/settings/firewall/security"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/settings/firewall/security/intrusion_services/custom_signature_versions"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+	"go.uber.org/mock/gomock"
+
+	idssettingsmocks "github.com/vmware/terraform-provider-nsxt/mocks/infra/settings/firewall/security"
+	customsigsettingsmocks "github.com/vmware/terraform-provider-nsxt/mocks/infra/settings/firewall/security/intrusion_services/custom_signature_versions"
 )
 
-// resourceNsxtPolicyIdpsSettings uses security.NewIntrusionServicesClient(connector) directly
-// rather than an injectable wrapper variable. These tests cover guard conditions and validation.
+// resourceNsxtPolicyIdpsSettings talks to the SDK-generated clients via the cliIdsSettingsClient
+// and cliIdsCustomSigSettingsClient package-level vars, so it's mockable via
+// setupIdpsSettingsMocks. These tests cover guard conditions, validation, and mocked CRUD paths.
+
+func setupIdpsSettingsMocks(ctrl *gomock.Controller) (*idssettingsmocks.MockIntrusionServicesClient, *customsigsettingsmocks.MockSettingsClient, func()) {
+	mockSettings := idssettingsmocks.NewMockIntrusionServicesClient(ctrl)
+	mockCustomSig := customsigsettingsmocks.NewMockSettingsClient(ctrl)
+	origSettings := cliIdsSettingsClient
+	cliIdsSettingsClient = func(_ client.Connector) security.IntrusionServicesClient {
+		return mockSettings
+	}
+	origCustomSig := cliIdsCustomSigSettingsClient
+	cliIdsCustomSigSettingsClient = func(_ client.Connector) custom_signature_versions.SettingsClient {
+		return mockCustomSig
+	}
+	return mockSettings, mockCustomSig, func() {
+		cliIdsSettingsClient = origSettings
+		cliIdsCustomSigSettingsClient = origCustomSig
+	}
+}
 
 func minimalIdpsSettingsData() map[string]interface{} {
 	return map[string]interface{}{
@@ -80,6 +107,209 @@ func TestMockResourceNsxtPolicyIdpsSettingsReadEmptyID(t *testing.T) {
 		d := schema.TestResourceDataRaw(t, res.Schema, minimalIdpsSettingsData())
 
 		err := resourceNsxtPolicyIdpsSettingsRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyIdpsSettingsReadMocked(t *testing.T) {
+	t.Run("Read populates fields without a custom signature version set", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSettings, _, restore := setupIdpsSettingsMocks(ctrl)
+		defer restore()
+		oversub := "DROPPED"
+		mockSettings.EXPECT().Get().Return(model.IdsSettings{Oversubscription: &oversub}, nil)
+
+		res := resourceNsxtPolicyIdpsSettings()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalIdpsSettingsData())
+		d.SetId(idpsSettingsID)
+
+		err := resourceNsxtPolicyIdpsSettingsRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, "DROPPED", d.Get("oversubscription"))
+	})
+
+	t.Run("Read also fetches custom signature settings when a version id is set", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSettings, mockCustomSig, restore := setupIdpsSettingsMocks(ctrl)
+		defer restore()
+		mockSettings.EXPECT().Get().Return(model.IdsSettings{}, nil)
+		enabled := true
+		mockCustomSig.EXPECT().Get("default").Return(model.IdsCustomSignatureSettings{EnableCustomSignatures: &enabled}, nil)
+
+		data := minimalIdpsSettingsData()
+		data["custom_signature_version_id"] = "default"
+		res := resourceNsxtPolicyIdpsSettings()
+		d := schema.TestResourceDataRaw(t, res.Schema, data)
+		d.SetId(idpsSettingsID)
+
+		err := resourceNsxtPolicyIdpsSettingsRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, true, d.Get("enable_custom_signatures"))
+	})
+
+	t.Run("Read propagates the main settings API error", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSettings, _, restore := setupIdpsSettingsMocks(ctrl)
+		defer restore()
+		mockSettings.EXPECT().Get().Return(model.IdsSettings{}, vapiErrors.InternalServerError{})
+
+		res := resourceNsxtPolicyIdpsSettings()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalIdpsSettingsData())
+		d.SetId(idpsSettingsID)
+
+		err := resourceNsxtPolicyIdpsSettingsRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+
+	t.Run("Read tolerates a custom signature settings API error", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSettings, mockCustomSig, restore := setupIdpsSettingsMocks(ctrl)
+		defer restore()
+		mockSettings.EXPECT().Get().Return(model.IdsSettings{}, nil)
+		mockCustomSig.EXPECT().Get("default").Return(model.IdsCustomSignatureSettings{}, vapiErrors.InternalServerError{})
+
+		data := minimalIdpsSettingsData()
+		data["custom_signature_version_id"] = "default"
+		res := resourceNsxtPolicyIdpsSettings()
+		d := schema.TestResourceDataRaw(t, res.Schema, data)
+		d.SetId(idpsSettingsID)
+
+		err := resourceNsxtPolicyIdpsSettingsRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyIdpsSettingsUpdateMocked(t *testing.T) {
+	t.Run("Update succeeds without a custom signature version set", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSettings, _, restore := setupIdpsSettingsMocks(ctrl)
+		defer restore()
+		rev := int64(2)
+		mockSettings.EXPECT().Get().Return(model.IdsSettings{Revision: &rev}, nil).Times(2)
+		mockSettings.EXPECT().Update(gomock.Any()).Return(model.IdsSettings{}, nil)
+
+		res := resourceNsxtPolicyIdpsSettings()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalIdpsSettingsData())
+		d.SetId(idpsSettingsID)
+
+		err := resourceNsxtPolicyIdpsSettingsUpdate(d, newGoMockProviderClient())
+		require.NoError(t, err)
+	})
+
+	t.Run("Update also patches custom signature settings when a version id is set", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSettings, mockCustomSig, restore := setupIdpsSettingsMocks(ctrl)
+		defer restore()
+		mockSettings.EXPECT().Get().Return(model.IdsSettings{}, nil).Times(2)
+		mockSettings.EXPECT().Update(gomock.Any()).Return(model.IdsSettings{}, nil)
+		rev := int64(1)
+		mockCustomSig.EXPECT().Get("default").Return(model.IdsCustomSignatureSettings{Revision: &rev}, nil).Times(2)
+		mockCustomSig.EXPECT().Patch("default", gomock.Any()).Return(nil)
+
+		data := minimalIdpsSettingsData()
+		data["custom_signature_version_id"] = "default"
+		data["enable_custom_signatures"] = true
+		res := resourceNsxtPolicyIdpsSettings()
+		d := schema.TestResourceDataRaw(t, res.Schema, data)
+		d.SetId(idpsSettingsID)
+
+		err := resourceNsxtPolicyIdpsSettingsUpdate(d, newGoMockProviderClient())
+		require.NoError(t, err)
+	})
+
+	t.Run("Update propagates the main settings Update error", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSettings, _, restore := setupIdpsSettingsMocks(ctrl)
+		defer restore()
+		mockSettings.EXPECT().Get().Return(model.IdsSettings{}, nil)
+		mockSettings.EXPECT().Update(gomock.Any()).Return(model.IdsSettings{}, vapiErrors.InternalServerError{})
+
+		res := resourceNsxtPolicyIdpsSettings()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalIdpsSettingsData())
+		d.SetId(idpsSettingsID)
+
+		err := resourceNsxtPolicyIdpsSettingsUpdate(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+
+	t.Run("Update propagates the custom signature settings Patch error", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSettings, mockCustomSig, restore := setupIdpsSettingsMocks(ctrl)
+		defer restore()
+		mockSettings.EXPECT().Get().Return(model.IdsSettings{}, nil)
+		mockSettings.EXPECT().Update(gomock.Any()).Return(model.IdsSettings{}, nil)
+		mockCustomSig.EXPECT().Get("default").Return(model.IdsCustomSignatureSettings{}, vapiErrors.InternalServerError{})
+		mockCustomSig.EXPECT().Patch("default", gomock.Any()).Return(vapiErrors.InternalServerError{})
+
+		data := minimalIdpsSettingsData()
+		data["custom_signature_version_id"] = "default"
+		res := resourceNsxtPolicyIdpsSettings()
+		d := schema.TestResourceDataRaw(t, res.Schema, data)
+		d.SetId(idpsSettingsID)
+
+		err := resourceNsxtPolicyIdpsSettingsUpdate(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyIdpsSettingsDeleteMocked(t *testing.T) {
+	t.Run("Delete resets settings to defaults", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSettings, _, restore := setupIdpsSettingsMocks(ctrl)
+		defer restore()
+		rev := int64(3)
+		mockSettings.EXPECT().Get().Return(model.IdsSettings{Revision: &rev}, nil)
+		mockSettings.EXPECT().Update(gomock.Any()).Return(model.IdsSettings{}, nil)
+
+		res := resourceNsxtPolicyIdpsSettings()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalIdpsSettingsData())
+		d.SetId(idpsSettingsID)
+
+		err := resourceNsxtPolicyIdpsSettingsDelete(d, newGoMockProviderClient())
+		require.NoError(t, err)
+	})
+
+	t.Run("Delete resets custom signature settings when a version id was set", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSettings, mockCustomSig, restore := setupIdpsSettingsMocks(ctrl)
+		defer restore()
+		mockSettings.EXPECT().Get().Return(model.IdsSettings{}, nil)
+		mockSettings.EXPECT().Update(gomock.Any()).Return(model.IdsSettings{}, nil)
+		mockCustomSig.EXPECT().Get("default").Return(model.IdsCustomSignatureSettings{}, nil)
+		mockCustomSig.EXPECT().Patch("default", gomock.Any()).Return(nil)
+
+		data := minimalIdpsSettingsData()
+		data["custom_signature_version_id"] = "default"
+		res := resourceNsxtPolicyIdpsSettings()
+		d := schema.TestResourceDataRaw(t, res.Schema, data)
+		d.SetId(idpsSettingsID)
+
+		err := resourceNsxtPolicyIdpsSettingsDelete(d, newGoMockProviderClient())
+		require.NoError(t, err)
+	})
+
+	t.Run("Delete fails when reading current settings errors", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSettings, _, restore := setupIdpsSettingsMocks(ctrl)
+		defer restore()
+		mockSettings.EXPECT().Get().Return(model.IdsSettings{}, vapiErrors.InternalServerError{})
+
+		res := resourceNsxtPolicyIdpsSettings()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalIdpsSettingsData())
+		d.SetId(idpsSettingsID)
+
+		err := resourceNsxtPolicyIdpsSettingsDelete(d, newGoMockProviderClient())
 		require.Error(t, err)
 	})
 }

--- a/nsxt/utgomock_resource_nsxt_policy_idps_signature_version_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_idps_signature_version_test.go
@@ -12,11 +12,27 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	vapiErrors "github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/settings/firewall/security/intrusion_services"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+	"go.uber.org/mock/gomock"
+
+	versionmocks "github.com/vmware/terraform-provider-nsxt/mocks/infra/settings/firewall/security/intrusion_services"
 )
 
-// resourceNsxtPolicyIdpsSignatureVersion uses intrusion_services.NewSignatureVersionsClient(connector)
-// directly rather than an injectable wrapper variable. These tests cover guard conditions and
-// validation logic that doesn't require API calls.
+// resourceNsxtPolicyIdpsSignatureVersion talks to the SDK-generated client via the
+// cliIdsSignatureVersionsClient package-level var, so it's mockable via setupIdpsSignatureVersionMock.
+// These tests cover guard conditions, validation logic, and mocked CRUD paths.
+
+func setupIdpsSignatureVersionMock(ctrl *gomock.Controller) (*versionmocks.MockSignatureVersionsClient, func()) {
+	mockClient := versionmocks.NewMockSignatureVersionsClient(ctrl)
+	orig := cliIdsSignatureVersionsClient
+	cliIdsSignatureVersionsClient = func(_ client.Connector) intrusion_services.SignatureVersionsClient {
+		return mockClient
+	}
+	return mockClient, func() { cliIdsSignatureVersionsClient = orig }
+}
 
 func minimalIdpsSigVersionData() map[string]interface{} {
 	return map[string]interface{}{
@@ -99,5 +115,110 @@ func TestMockResourceNsxtPolicyIdpsSignatureVersionUpdateInvalidState(t *testing
 		// Verify schema definition is correct.
 		assert.NotNil(t, res.Schema["state"])
 		assert.NotNil(t, res.Schema["version_id"])
+	})
+}
+
+func TestMockResourceNsxtPolicyIdpsSignatureVersionCreateMocked(t *testing.T) {
+	t.Run("Create succeeds when version exists", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockClient, restore := setupIdpsSignatureVersionMock(ctrl)
+		defer restore()
+		mockClient.EXPECT().Get("sig-ver-1").Return(model.IdsSignatureVersion{}, nil).Times(2)
+
+		res := resourceNsxtPolicyIdpsSignatureVersion()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalIdpsSigVersionData())
+
+		err := resourceNsxtPolicyIdpsSignatureVersionCreate(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, "sig-ver-1", d.Id())
+	})
+
+	t.Run("Create fails when version does not exist", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockClient, restore := setupIdpsSignatureVersionMock(ctrl)
+		defer restore()
+		mockClient.EXPECT().Get("sig-ver-1").Return(model.IdsSignatureVersion{}, vapiErrors.NotFound{})
+
+		res := resourceNsxtPolicyIdpsSignatureVersion()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalIdpsSigVersionData())
+
+		err := resourceNsxtPolicyIdpsSignatureVersionCreate(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyIdpsSignatureVersionReadMocked(t *testing.T) {
+	t.Run("Read populates fields from the API object", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockClient, restore := setupIdpsSignatureVersionMock(ctrl)
+		defer restore()
+		state := "ACTIVE"
+		mockClient.EXPECT().Get("sig-ver-1").Return(model.IdsSignatureVersion{State: &state}, nil)
+
+		res := resourceNsxtPolicyIdpsSignatureVersion()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalIdpsSigVersionData())
+		d.SetId("sig-ver-1")
+
+		err := resourceNsxtPolicyIdpsSignatureVersionRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, "ACTIVE", d.Get("state"))
+	})
+
+	t.Run("Read propagates API error", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockClient, restore := setupIdpsSignatureVersionMock(ctrl)
+		defer restore()
+		mockClient.EXPECT().Get("sig-ver-1").Return(model.IdsSignatureVersion{}, vapiErrors.InternalServerError{})
+
+		res := resourceNsxtPolicyIdpsSignatureVersion()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalIdpsSigVersionData())
+		d.SetId("sig-ver-1")
+
+		err := resourceNsxtPolicyIdpsSignatureVersionRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyIdpsSignatureVersionUpdateMocked(t *testing.T) {
+	t.Run("Update to ACTIVE calls Makeactiveversion", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockClient, restore := setupIdpsSignatureVersionMock(ctrl)
+		defer restore()
+		obj := model.IdsSignatureVersion{}
+		mockClient.EXPECT().Get("sig-ver-1").Return(obj, nil).Times(2)
+		mockClient.EXPECT().Makeactiveversion(obj).Return(nil)
+
+		res := resourceNsxtPolicyIdpsSignatureVersion()
+		data := minimalIdpsSigVersionData()
+		data["state"] = "ACTIVE"
+		d := schema.TestResourceDataRaw(t, res.Schema, data)
+		d.SetId("sig-ver-1")
+
+		err := resourceNsxtPolicyIdpsSignatureVersionUpdate(d, newGoMockProviderClient())
+		require.NoError(t, err)
+	})
+
+	t.Run("Update to ACTIVE propagates Makeactiveversion error", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockClient, restore := setupIdpsSignatureVersionMock(ctrl)
+		defer restore()
+		obj := model.IdsSignatureVersion{}
+		mockClient.EXPECT().Get("sig-ver-1").Return(obj, nil)
+		mockClient.EXPECT().Makeactiveversion(obj).Return(vapiErrors.InternalServerError{})
+
+		res := resourceNsxtPolicyIdpsSignatureVersion()
+		data := minimalIdpsSigVersionData()
+		data["state"] = "ACTIVE"
+		d := schema.TestResourceDataRaw(t, res.Schema, data)
+		d.SetId("sig-ver-1")
+
+		err := resourceNsxtPolicyIdpsSignatureVersionUpdate(d, newGoMockProviderClient())
+		require.Error(t, err)
 	})
 }

--- a/nsxt/utgomock_resource_nsxt_policy_ip_pool_static_subnet_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_ip_pool_static_subnet_test.go
@@ -13,7 +13,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	vapiErrors "github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/bindings"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/data"
 	vapiProtocolClient "github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 	"go.uber.org/mock/gomock"
 
 	ippoolsapi "github.com/vmware/terraform-provider-nsxt/api/infra/ip_pools"
@@ -44,6 +47,24 @@ func minimalStaticSubnetData() map[string]interface{} {
 	}
 }
 
+func staticSubnetAPIStructValue(t *testing.T) *data.StructValue {
+	displayName := "Test Static Subnet"
+	description := "Test static subnet"
+	gateway := "10.0.0.1"
+	obj := model.IpAddressPoolStaticSubnet{
+		Id:           &staticSubnetID,
+		DisplayName:  &displayName,
+		Description:  &description,
+		ResourceType: "IpAddressPoolStaticSubnet",
+		Cidr:         &staticSubnetCIDR,
+		GatewayIp:    &gateway,
+	}
+	converter := bindings.NewTypeConverter()
+	dataValue, errs := converter.ConvertToVapi(obj, model.IpAddressPoolStaticSubnetBindingType())
+	require.Empty(t, errs)
+	return dataValue.(*data.StructValue)
+}
+
 func setupStaticSubnetMock(t *testing.T, ctrl *gomock.Controller) (*ipSubnetMocks.MockIpSubnetsClient, func()) {
 	mockSDK := ipSubnetMocks.NewMockIpSubnetsClient(ctrl)
 	mockWrapper := &ippoolsapi.StructValueClientContext{
@@ -72,6 +93,34 @@ func TestMockResourceNsxtPolicyIPPoolStaticSubnetCreate(t *testing.T) {
 		err := resourceNsxtPolicyIPPoolStaticSubnetCreate(d, newGoMockProviderClient())
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "already exists")
+	})
+
+	t.Run("Create success", func(t *testing.T) {
+		gomock.InOrder(
+			mockSDK.EXPECT().Get(staticSubnetPoolID, staticSubnetID).Return(nil, vapiErrors.NotFound{}),
+			mockSDK.EXPECT().Patch(staticSubnetPoolID, staticSubnetID, gomock.Any()).Return(nil),
+			mockSDK.EXPECT().Get(staticSubnetPoolID, staticSubnetID).Return(staticSubnetAPIStructValue(t), nil),
+		)
+
+		res := resourceNsxtPolicyIPPoolStaticSubnet()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalStaticSubnetData())
+
+		err := resourceNsxtPolicyIPPoolStaticSubnetCreate(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, staticSubnetID, d.Id())
+	})
+
+	t.Run("Create propagates a Patch error", func(t *testing.T) {
+		gomock.InOrder(
+			mockSDK.EXPECT().Get(staticSubnetPoolID, staticSubnetID).Return(nil, vapiErrors.NotFound{}),
+			mockSDK.EXPECT().Patch(staticSubnetPoolID, staticSubnetID, gomock.Any()).Return(vapiErrors.InternalServerError{}),
+		)
+
+		res := resourceNsxtPolicyIPPoolStaticSubnet()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalStaticSubnetData())
+
+		err := resourceNsxtPolicyIPPoolStaticSubnetCreate(d, newGoMockProviderClient())
+		require.Error(t, err)
 	})
 }
 
@@ -111,12 +160,36 @@ func TestMockResourceNsxtPolicyIPPoolStaticSubnetRead(t *testing.T) {
 		err := resourceNsxtPolicyIPPoolStaticSubnetRead(d, newGoMockProviderClient())
 		require.Error(t, err)
 	})
+
+	t.Run("Read success populates fields from the API object", func(t *testing.T) {
+		mockSDK.EXPECT().Get(staticSubnetPoolID, staticSubnetID).Return(staticSubnetAPIStructValue(t), nil)
+
+		res := resourceNsxtPolicyIPPoolStaticSubnet()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalStaticSubnetData())
+		d.SetId(staticSubnetID)
+
+		err := resourceNsxtPolicyIPPoolStaticSubnetRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, staticSubnetCIDR, d.Get("cidr"))
+		assert.Equal(t, "10.0.0.1", d.Get("gateway"))
+	})
+
+	t.Run("Read succeeds when the ID is a path and gets normalized", func(t *testing.T) {
+		mockSDK.EXPECT().Get(staticSubnetPoolID, staticSubnetID).Return(staticSubnetAPIStructValue(t), nil)
+
+		res := resourceNsxtPolicyIPPoolStaticSubnet()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalStaticSubnetData())
+		d.SetId("/infra/ip-pools/pool-2/ip-subnets/" + staticSubnetID)
+
+		err := resourceNsxtPolicyIPPoolStaticSubnetRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+	})
 }
 
 func TestMockResourceNsxtPolicyIPPoolStaticSubnetUpdate(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
-	_, restore := setupStaticSubnetMock(t, ctrl)
+	mockSDK, restore := setupStaticSubnetMock(t, ctrl)
 	defer restore()
 
 	t.Run("Update fails when ID is empty", func(t *testing.T) {
@@ -126,12 +199,37 @@ func TestMockResourceNsxtPolicyIPPoolStaticSubnetUpdate(t *testing.T) {
 		err := resourceNsxtPolicyIPPoolStaticSubnetUpdate(d, newGoMockProviderClient())
 		require.Error(t, err)
 	})
+
+	t.Run("Update success", func(t *testing.T) {
+		gomock.InOrder(
+			mockSDK.EXPECT().Patch(staticSubnetPoolID, staticSubnetID, gomock.Any()).Return(nil),
+			mockSDK.EXPECT().Get(staticSubnetPoolID, staticSubnetID).Return(staticSubnetAPIStructValue(t), nil),
+		)
+
+		res := resourceNsxtPolicyIPPoolStaticSubnet()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalStaticSubnetData())
+		d.SetId(staticSubnetID)
+
+		err := resourceNsxtPolicyIPPoolStaticSubnetUpdate(d, newGoMockProviderClient())
+		require.NoError(t, err)
+	})
+
+	t.Run("Update propagates a Patch error", func(t *testing.T) {
+		mockSDK.EXPECT().Patch(staticSubnetPoolID, staticSubnetID, gomock.Any()).Return(vapiErrors.InternalServerError{})
+
+		res := resourceNsxtPolicyIPPoolStaticSubnet()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalStaticSubnetData())
+		d.SetId(staticSubnetID)
+
+		err := resourceNsxtPolicyIPPoolStaticSubnetUpdate(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
 }
 
 func TestMockResourceNsxtPolicyIPPoolStaticSubnetDelete(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
-	_, restore := setupStaticSubnetMock(t, ctrl)
+	mockSDK, restore := setupStaticSubnetMock(t, ctrl)
 	defer restore()
 
 	t.Run("Delete fails when ID is empty", func(t *testing.T) {
@@ -140,5 +238,45 @@ func TestMockResourceNsxtPolicyIPPoolStaticSubnetDelete(t *testing.T) {
 
 		err := resourceNsxtPolicyIPPoolStaticSubnetDelete(d, newGoMockProviderClient())
 		require.Error(t, err)
+	})
+
+	t.Run("Delete success", func(t *testing.T) {
+		mockSDK.EXPECT().Delete(staticSubnetPoolID, staticSubnetID, nil).Return(nil)
+
+		res := resourceNsxtPolicyIPPoolStaticSubnet()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalStaticSubnetData())
+		d.SetId(staticSubnetID)
+
+		err := resourceNsxtPolicyIPPoolStaticSubnetDelete(d, newGoMockProviderClient())
+		require.NoError(t, err)
+	})
+
+	t.Run("Delete propagates an API error", func(t *testing.T) {
+		mockSDK.EXPECT().Delete(staticSubnetPoolID, staticSubnetID, nil).Return(vapiErrors.InternalServerError{})
+
+		res := resourceNsxtPolicyIPPoolStaticSubnet()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalStaticSubnetData())
+		d.SetId(staticSubnetID)
+
+		err := resourceNsxtPolicyIPPoolStaticSubnetDelete(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestUnitNsxt_resourceNsxtPolicyIPPoolStaticSubnetSchemaToStructValue(t *testing.T) {
+	t.Run("converts schema data to a StructValue round-trippable back to the model", func(t *testing.T) {
+		res := resourceNsxtPolicyIPPoolStaticSubnet()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalStaticSubnetData())
+
+		sv, err := resourceNsxtPolicyIPPoolStaticSubnetSchemaToStructValue(d, staticSubnetID)
+		require.NoError(t, err)
+		require.NotNil(t, sv)
+
+		converter := bindings.NewTypeConverter()
+		golangValue, errs := converter.ConvertToGolang(sv, model.IpAddressPoolStaticSubnetBindingType())
+		require.Empty(t, errs)
+		obj := golangValue.(model.IpAddressPoolStaticSubnet)
+		assert.Equal(t, staticSubnetCIDR, *obj.Cidr)
+		assert.Equal(t, staticSubnetID, *obj.Id)
 	})
 }

--- a/nsxt/utgomock_resource_nsxt_policy_ipsec_vpn_service_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_ipsec_vpn_service_test.go
@@ -17,9 +17,13 @@ import (
 	nsxModel "github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 	"go.uber.org/mock/gomock"
 
+	tier0ipsecvpnsvcapi "github.com/vmware/terraform-provider-nsxt/api/infra/tier_0s/ipsec_vpn_services"
 	ipsecvpnapi "github.com/vmware/terraform-provider-nsxt/api/infra/tier_1s/ipsec_vpn_services"
+	t1localeservicesapi "github.com/vmware/terraform-provider-nsxt/api/infra/tier_1s/locale_services"
 	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
+	t0Mocks "github.com/vmware/terraform-provider-nsxt/mocks/infra/tier_0s"
 	t1Mocks "github.com/vmware/terraform-provider-nsxt/mocks/infra/tier_1s"
+	t1LocaleServiceMocks "github.com/vmware/terraform-provider-nsxt/mocks/infra/tier_1s/locale_services"
 )
 
 var (
@@ -71,6 +75,32 @@ func setupIPSecSvcMock(t *testing.T, ctrl *gomock.Controller) (*t1Mocks.MockIpse
 		return mockWrapper
 	}
 	return mockSDK, func() { cliTier1IpsecVpnServicesClient = original }
+}
+
+func setupIPSecSvcT0Mock(t *testing.T, ctrl *gomock.Controller) (*t0Mocks.MockIpsecVpnServicesClient, func()) {
+	mockSDK := t0Mocks.NewMockIpsecVpnServicesClient(ctrl)
+	mockWrapper := &tier0ipsecvpnsvcapi.IPSecVpnServiceClientContext{
+		Client:     mockSDK,
+		ClientType: utl.Local,
+	}
+	original := cliTier0IpsecVpnServicesClient
+	cliTier0IpsecVpnServicesClient = func(_ utl.SessionContext, _ vapiProtocolClient.Connector) *tier0ipsecvpnsvcapi.IPSecVpnServiceClientContext {
+		return mockWrapper
+	}
+	return mockSDK, func() { cliTier0IpsecVpnServicesClient = original }
+}
+
+func setupIPSecSvcLocaleServiceMock(t *testing.T, ctrl *gomock.Controller) (*t1LocaleServiceMocks.MockIpsecVpnServicesClient, func()) {
+	mockSDK := t1LocaleServiceMocks.NewMockIpsecVpnServicesClient(ctrl)
+	mockWrapper := &t1localeservicesapi.IPSecVpnServiceClientContext{
+		Client:     mockSDK,
+		ClientType: utl.Local,
+	}
+	original := cliTier1IpsecVpnLocaleServicesClient
+	cliTier1IpsecVpnLocaleServicesClient = func(_ utl.SessionContext, _ vapiProtocolClient.Connector) *t1localeservicesapi.IPSecVpnServiceClientContext {
+		return mockWrapper
+	}
+	return mockSDK, func() { cliTier1IpsecVpnLocaleServicesClient = original }
 }
 
 func TestMockResourceNsxtPolicyIPSecVpnServiceCreate(t *testing.T) {
@@ -195,6 +225,180 @@ func TestMockResourceNsxtPolicyIPSecVpnServiceDelete(t *testing.T) {
 		d := schema.TestResourceDataRaw(t, res.Schema, minimalIPSecSvcData())
 
 		err := resourceNsxtPolicyIPSecVpnServiceDelete(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyIPSecVpnServiceT0GatewayPath(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupIPSecSvcT0Mock(t, ctrl)
+	defer restore()
+
+	data := minimalIPSecSvcData()
+	data["gateway_path"] = "/infra/tier-0s/t0-gw-1"
+
+	t.Run("Read success against a T0 gateway", func(t *testing.T) {
+		mockSDK.EXPECT().Get("t0-gw-1", ipsecSvcID).Return(ipsecSvcAPIResponse(), nil)
+
+		res := resourceNsxtPolicyIPSecVpnService()
+		d := schema.TestResourceDataRaw(t, res.Schema, data)
+		d.SetId(ipsecSvcID)
+
+		err := resourceNsxtPolicyIPSecVpnServiceRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, ipsecSvcDisplayName, d.Get("display_name"))
+	})
+
+	t.Run("Delete success against a T0 gateway", func(t *testing.T) {
+		mockSDK.EXPECT().Delete("t0-gw-1", ipsecSvcID).Return(nil)
+
+		res := resourceNsxtPolicyIPSecVpnService()
+		d := schema.TestResourceDataRaw(t, res.Schema, data)
+		d.SetId(ipsecSvcID)
+
+		err := resourceNsxtPolicyIPSecVpnServiceDelete(d, newGoMockProviderClient())
+		require.NoError(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyIPSecVpnServiceLocaleServicePath(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupIPSecSvcLocaleServiceMock(t, ctrl)
+	defer restore()
+
+	data := minimalIPSecSvcData()
+	delete(data, "gateway_path")
+	data["locale_service_path"] = "/infra/tier-1s/t1-gw-1/locale-services/default"
+
+	t.Run("Read success against a locale-service-scoped T1 gateway", func(t *testing.T) {
+		mockSDK.EXPECT().Get("t1-gw-1", "default", ipsecSvcID).Return(ipsecSvcAPIResponse(), nil)
+
+		res := resourceNsxtPolicyIPSecVpnService()
+		d := schema.TestResourceDataRaw(t, res.Schema, data)
+		d.SetId(ipsecSvcID)
+
+		err := resourceNsxtPolicyIPSecVpnServiceRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, ipsecSvcDisplayName, d.Get("display_name"))
+	})
+
+	t.Run("Delete success against a locale-service-scoped T1 gateway", func(t *testing.T) {
+		mockSDK.EXPECT().Delete("t1-gw-1", "default", ipsecSvcID).Return(nil)
+
+		res := resourceNsxtPolicyIPSecVpnService()
+		d := schema.TestResourceDataRaw(t, res.Schema, data)
+		d.SetId(ipsecSvcID)
+
+		err := resourceNsxtPolicyIPSecVpnServiceDelete(d, newGoMockProviderClient())
+		require.NoError(t, err)
+	})
+}
+
+func TestUnitNsxt_ipsecVpnServiceMultitenancyLocaleServiceError(t *testing.T) {
+	t.Run("locale-service-scoped VPN under a project path is rejected", func(t *testing.T) {
+		data := minimalIPSecSvcData()
+		delete(data, "gateway_path")
+		data["locale_service_path"] = "/orgs/default/projects/proj-1/infra/tier-1s/t1-gw-1/locale-services/default"
+
+		res := resourceNsxtPolicyIPSecVpnService()
+		d := schema.TestResourceDataRaw(t, res.Schema, data)
+		d.SetId(ipsecSvcID)
+
+		err := resourceNsxtPolicyIPSecVpnServiceRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "project context is not supported")
+	})
+}
+
+func TestUnitNsxt_getLocaleServiceAndGatewayPath(t *testing.T) {
+	t.Run("fails when neither path is set", func(t *testing.T) {
+		res := resourceNsxtPolicyIPSecVpnService()
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+
+		_, _, err := getLocaleServiceAndGatewayPath(d)
+		require.Error(t, err)
+	})
+
+	t.Run("succeeds when gateway_path is set", func(t *testing.T) {
+		res := resourceNsxtPolicyIPSecVpnService()
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{"gateway_path": ipsecSvcGwPath})
+
+		gw, ls, err := getLocaleServiceAndGatewayPath(d)
+		require.NoError(t, err)
+		assert.Equal(t, ipsecSvcGwPath, gw)
+		assert.Equal(t, "", ls)
+	})
+}
+
+func TestUnitNsxt_extractProjectIDFromPolicyPath(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{"project path", "/orgs/default/projects/proj-1/infra/tier-1s/t1-gw-1", "proj-1"},
+		{"non-project path", "/infra/tier-1s/t1-gw-1", ""},
+		{"projects at end with no id", "/orgs/default/projects", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, extractProjectIDFromPolicyPath(tt.path))
+		})
+	}
+}
+
+func TestUnitNsxt_resourceNsxtPolicyIPSecVpnServiceImport(t *testing.T) {
+	res := resourceNsxtPolicyIPSecVpnService()
+
+	t.Run("gateway-scoped path sets gateway_path", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		d.SetId("/infra/tier-0s/t0-gw-1/ipsec-vpn-services/svc-1")
+
+		out, err := resourceNsxtPolicyIPSecVpnServiceImport(d, nil)
+		require.NoError(t, err)
+		require.Len(t, out, 1)
+		assert.Equal(t, "svc-1", d.Id())
+		assert.Equal(t, "/infra/tier-0s/t0-gw-1", d.Get("gateway_path"))
+	})
+
+	t.Run("locale-service-scoped path sets locale_service_path", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		d.SetId("/infra/tier-0s/t0-gw-1/locale-services/default/ipsec-vpn-services/svc-1")
+
+		out, err := resourceNsxtPolicyIPSecVpnServiceImport(d, nil)
+		require.NoError(t, err)
+		require.Len(t, out, 1)
+		assert.Equal(t, "svc-1", d.Id())
+		assert.Equal(t, "/infra/tier-0s/t0-gw-1/locale-services/default", d.Get("locale_service_path"))
+	})
+
+	t.Run("project-scoped path sets context", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		d.SetId("/orgs/default/projects/proj-1/infra/tier-1s/t1-gw-1/ipsec-vpn-services/svc-1")
+
+		out, err := resourceNsxtPolicyIPSecVpnServiceImport(d, nil)
+		require.NoError(t, err)
+		require.Len(t, out, 1)
+		ctxList := d.Get("context").([]interface{})
+		require.Len(t, ctxList, 1)
+		assert.Equal(t, "proj-1", ctxList[0].(map[string]interface{})["project_id"])
+	})
+
+	t.Run("path without ipsec-vpn-services segment fails", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		d.SetId("/infra/tier-0s/t0-gw-1")
+
+		_, err := resourceNsxtPolicyIPSecVpnServiceImport(d, nil)
+		require.Error(t, err)
+	})
+
+	t.Run("empty trailing segment fails", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		d.SetId("/infra/tier-0s/t0-gw-1/ipsec-vpn-services/")
+
+		_, err := resourceNsxtPolicyIPSecVpnServiceImport(d, nil)
 		require.Error(t, err)
 	})
 }

--- a/nsxt/utgomock_resource_nsxt_policy_ipsec_vpn_session_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_ipsec_vpn_session_test.go
@@ -489,3 +489,146 @@ func TestMockResourceNsxtPolicyIPSecVpnSessionTier1Locale(t *testing.T) {
 		assert.Contains(t, err.Error(), "project context is not supported")
 	})
 }
+
+func TestUnitNsxt_nsxtVpnSessionImporter(t *testing.T) {
+	res := resourceNsxtPolicyIPSecVpnSession()
+
+	t.Run("valid path sets id, service_path", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		d.SetId("/infra/tier-1s/t1-gw-1/locale-services/default/ipsec-vpn-services/svc-1/sessions/sess-1")
+
+		out, err := nsxtVpnSessionImporter(d, nil)
+		require.NoError(t, err)
+		require.Len(t, out, 1)
+		assert.Equal(t, "sess-1", d.Id())
+		assert.Equal(t, "/infra/tier-1s/t1-gw-1/locale-services/default/ipsec-vpn-services/svc-1", d.Get("service_path"))
+	})
+
+	t.Run("project-scoped path sets context", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		d.SetId("/orgs/default/projects/proj-1/infra/tier-1s/t1-gw-1/ipsec-vpn-services/svc-1/sessions/sess-1")
+
+		out, err := nsxtVpnSessionImporter(d, nil)
+		require.NoError(t, err)
+		require.Len(t, out, 1)
+		ctxList := d.Get("context").([]interface{})
+		require.Len(t, ctxList, 1)
+		assert.Equal(t, "proj-1", ctxList[0].(map[string]interface{})["project_id"])
+	})
+
+	t.Run("too-short path fails", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		d.SetId("/infra/tier-1s/t1-gw-1")
+
+		_, err := nsxtVpnSessionImporter(d, nil)
+		require.Error(t, err)
+	})
+
+	t.Run("path without /sessions/ segment fails", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		d.SetId("/infra/tier-1s/t1-gw-1/ipsec-vpn-services/svc-1/foo/bar/baz")
+
+		_, err := nsxtVpnSessionImporter(d, nil)
+		require.Error(t, err)
+	})
+}
+
+func TestUnitNsxt_parseIPSecVPNServicePolicyPath(t *testing.T) {
+	t.Run("T0 non-locale path", func(t *testing.T) {
+		isT0, gwID, localeServiceID, serviceID, err := parseIPSecVPNServicePolicyPath("/infra/tier-0s/t0-gw-1/ipsec-vpn-services/svc-1")
+		require.NoError(t, err)
+		assert.True(t, isT0)
+		assert.Equal(t, "t0-gw-1", gwID)
+		assert.Equal(t, "", localeServiceID)
+		assert.Equal(t, "svc-1", serviceID)
+	})
+
+	t.Run("T1 locale-service path", func(t *testing.T) {
+		isT0, gwID, localeServiceID, serviceID, err := parseIPSecVPNServicePolicyPath("/infra/tier-1s/t1-gw-1/locale-services/default/ipsec-vpn-services/svc-1")
+		require.NoError(t, err)
+		assert.False(t, isT0)
+		assert.Equal(t, "t1-gw-1", gwID)
+		assert.Equal(t, "default", localeServiceID)
+		assert.Equal(t, "svc-1", serviceID)
+	})
+
+	t.Run("missing tier segment fails", func(t *testing.T) {
+		_, _, _, _, err := parseIPSecVPNServicePolicyPath("/infra/foo/bar/ipsec-vpn-services/svc-1")
+		require.Error(t, err)
+	})
+
+	t.Run("missing ipsec-vpn-services segment fails", func(t *testing.T) {
+		_, _, _, _, err := parseIPSecVPNServicePolicyPath("/infra/tier-1s/t1-gw-1")
+		require.Error(t, err)
+	})
+
+	t.Run("too-short path fails", func(t *testing.T) {
+		_, _, _, _, err := parseIPSecVPNServicePolicyPath("x")
+		require.Error(t, err)
+	})
+}
+
+func TestUnitNsxt_getIPSecVPNSessionFromSchemaValidation(t *testing.T) {
+	res := resourceNsxtPolicyIPSecVpnSession()
+
+	t.Run("route-based session requires ip_addresses and prefix_length", func(t *testing.T) {
+		data := minimalIPSecSessionData()
+		delete(data, "ip_addresses")
+		delete(data, "prefix_length")
+		d := schema.TestResourceDataRaw(t, res.Schema, data)
+
+		_, err := getIPSecVPNSessionFromSchema(d)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Route Based VPN")
+	})
+
+	t.Run("unknown vpn_type fails", func(t *testing.T) {
+		data := minimalIPSecSessionData()
+		data["vpn_type"] = "BogusType"
+		d := schema.TestResourceDataRaw(t, res.Schema, data)
+
+		_, err := getIPSecVPNSessionFromSchema(d)
+		require.Error(t, err)
+	})
+
+	t.Run("policy-based session converts successfully", func(t *testing.T) {
+		data := minimalIPSecSessionData()
+		data["vpn_type"] = policyBasedIPSecVpnSession
+		delete(data, "ip_addresses")
+		delete(data, "prefix_length")
+		d := schema.TestResourceDataRaw(t, res.Schema, data)
+
+		sv, err := getIPSecVPNSessionFromSchema(d)
+		require.NoError(t, err)
+		assert.NotNil(t, sv)
+	})
+}
+
+func TestMockResourceNsxtPolicyIPSecVpnSessionExists(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupIPSecSessionMock(t, ctrl)
+	defer restore()
+
+	t.Run("Get succeeds means it exists", func(t *testing.T) {
+		sv := ipsecRouteBasedStructValue(t, ipsecSessionID, "Test IPSec Session")
+		mockSDK.EXPECT().Get(ipsecSessionGwID, ipsecSessionSvcID, ipsecSessionID).Return(sv, nil)
+
+		exists, err := resourceNsxtPolicyIPSecVpnSessionExists(ipsecSessionServicePath, ipsecSessionID, nil, utl.SessionContext{ClientType: utl.Local})
+		require.NoError(t, err)
+		assert.True(t, exists)
+	})
+
+	t.Run("NotFound means it doesn't exist", func(t *testing.T) {
+		mockSDK.EXPECT().Get(ipsecSessionGwID, ipsecSessionSvcID, ipsecSessionID).Return(nil, vapiErrors.NotFound{})
+
+		exists, err := resourceNsxtPolicyIPSecVpnSessionExists(ipsecSessionServicePath, ipsecSessionID, nil, utl.SessionContext{ClientType: utl.Local})
+		require.NoError(t, err)
+		assert.False(t, exists)
+	})
+
+	t.Run("invalid service path errors", func(t *testing.T) {
+		_, err := resourceNsxtPolicyIPSecVpnSessionExists("not-a-valid-path", ipsecSessionID, nil, utl.SessionContext{ClientType: utl.Local})
+		require.Error(t, err)
+	})
+}

--- a/nsxt/utgomock_resource_nsxt_policy_l2_vpn_session_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_l2_vpn_session_test.go
@@ -189,7 +189,7 @@ func TestMockResourceNsxtPolicyL2VPNSessionDelete(t *testing.T) {
 	})
 }
 
-func TestMockNormalizeL2VpnTransportTunnelPath(t *testing.T) {
+func TestMockNsxtNormalizeL2VpnTransportTunnelPath(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    string
@@ -243,7 +243,7 @@ func TestMockNormalizeL2VpnTransportTunnelPath(t *testing.T) {
 	}
 }
 
-func TestMockSuppressL2VpnTransportTunnelsDiff(t *testing.T) {
+func TestMockNsxtSuppressL2VpnTransportTunnelsDiff(t *testing.T) {
 	flatPath := "/infra/tier-1s/t1/ipsec-vpn-services/svc1/sessions/sess1"
 	localeServicePath := "/infra/tier-1s/t1/locale-services/default/ipsec-vpn-services/svc1/sessions/sess1"
 	localeServicePathCustom := "/infra/tier-1s/t1/locale-services/custom/ipsec-vpn-services/svc1/sessions/sess1"
@@ -413,5 +413,45 @@ func TestMockResourceNsxtPolicyL2VPNSessionReadTransportTunnels(t *testing.T) {
 
 		err := resourceNsxtPolicyL2VPNSessionRead(d, newGoMockProviderClient())
 		require.Error(t, err)
+	})
+}
+
+func TestUnitNsxt_nsxtL2VpnSessionImporter(t *testing.T) {
+	res := resourceNsxtPolicyL2VPNSession()
+
+	t.Run("path too short is rejected", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		d.SetId("/infra/tier-1s/aaa")
+
+		_, err := nsxtL2VpnSessionImporter(d, nil)
+		require.Error(t, err)
+	})
+
+	t.Run("path missing /sessions/ segment is rejected", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		d.SetId("/infra/tier-1s/aaa/locale-services/default/l2vpn-services/bbb/notsessions/ccc")
+
+		_, err := nsxtL2VpnSessionImporter(d, nil)
+		require.Error(t, err)
+	})
+
+	t.Run("project-scoped path is rejected", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		d.SetId("/orgs/o1/projects/p1/infra/tier-1s/aaa/locale-services/default/l2vpn-services/bbb/sessions/ccc")
+
+		_, err := nsxtL2VpnSessionImporter(d, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "project context")
+	})
+
+	t.Run("valid infra-scoped path succeeds", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		d.SetId("/infra/tier-1s/aaa/locale-services/default/l2vpn-services/bbb/sessions/ccc")
+
+		out, err := nsxtL2VpnSessionImporter(d, nil)
+		require.NoError(t, err)
+		require.Len(t, out, 1)
+		assert.Equal(t, "ccc", d.Id())
+		assert.Equal(t, "/infra/tier-1s/aaa/locale-services/default/l2vpn-services/bbb", d.Get("service_path"))
 	})
 }

--- a/nsxt/utgomock_resource_nsxt_policy_lb_pool_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_lb_pool_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	vapiErrors "github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 	"go.uber.org/mock/gomock"
@@ -227,6 +228,261 @@ func TestMockResourceNsxtPolicyLBPoolDelete(t *testing.T) {
 		err := resourceNsxtPolicyLBPoolDelete(d, m)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "API error")
+	})
+}
+
+func TestMockResourceNsxtPolicyLBPoolExists(t *testing.T) {
+	util.NsxVersion = "9.1.0"
+	defer func() { util.NsxVersion = "" }()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockPoolSDK := lbPoolMocks.NewMockLbPoolsClient(ctrl)
+	mockWrapper := &cliinfra.LBPoolClientContext{
+		Client:     mockPoolSDK,
+		ClientType: utl.Local,
+	}
+
+	originalCli := cliLbPoolsClient
+	defer func() { cliLbPoolsClient = originalCli }()
+	cliLbPoolsClient = func(sessionContext utl.SessionContext, connector client.Connector) *cliinfra.LBPoolClientContext {
+		return mockWrapper
+	}
+
+	t.Run("Exists returns true when Get succeeds", func(t *testing.T) {
+		mockPoolSDK.EXPECT().Get(lbPoolID).Return(minimalLBPoolModel(), nil)
+
+		exists, err := resourceNsxtPolicyLBPoolExists(lbPoolID, getPolicyConnector(newGoMockProviderClient()), false)
+		require.NoError(t, err)
+		assert.True(t, exists)
+	})
+
+	t.Run("Exists returns false when not found", func(t *testing.T) {
+		mockPoolSDK.EXPECT().Get(lbPoolID).Return(model.LBPool{}, vapiErrors.NotFound{})
+
+		exists, err := resourceNsxtPolicyLBPoolExists(lbPoolID, getPolicyConnector(newGoMockProviderClient()), false)
+		require.NoError(t, err)
+		assert.False(t, exists)
+	})
+
+	t.Run("Exists propagates other errors", func(t *testing.T) {
+		mockPoolSDK.EXPECT().Get(lbPoolID).Return(model.LBPool{}, vapiErrors.InternalServerError{})
+
+		_, err := resourceNsxtPolicyLBPoolExists(lbPoolID, getPolicyConnector(newGoMockProviderClient()), false)
+		require.Error(t, err)
+	})
+}
+
+func TestUnitNsxt_getPolicyPoolMembersFromSchema(t *testing.T) {
+	res := resourceNsxtPolicyLBPool()
+	data := minimalLBPoolData()
+	data["member"] = []interface{}{
+		map[string]interface{}{
+			"display_name":               "member-1",
+			"admin_state":                "ENABLED",
+			"backup_member":              false,
+			"ip_address":                 "1.1.1.1",
+			"max_concurrent_connections": 5,
+			"port":                       "80",
+			"weight":                     2,
+		},
+	}
+	d := schema.TestResourceDataRaw(t, res.Schema, data)
+
+	members := getPolicyPoolMembersFromSchema(d)
+	require.Len(t, members, 1)
+	assert.Equal(t, "member-1", *members[0].DisplayName)
+	assert.Equal(t, "1.1.1.1", *members[0].IpAddress)
+	assert.Equal(t, "80", *members[0].Port)
+	assert.EqualValues(t, 5, *members[0].MaxConcurrentConnections)
+}
+
+func TestUnitNsxt_setPolicyPoolMembersInSchema(t *testing.T) {
+	res := resourceNsxtPolicyLBPool()
+	d := schema.TestResourceDataRaw(t, res.Schema, minimalLBPoolData())
+
+	name, port := "member-1", "80"
+	weight := int64(3)
+	maxConn := int64(10)
+	adminState := "ENABLED"
+	backup := false
+	ip := "2.2.2.2"
+	err := setPolicyPoolMembersInSchema(d, []model.LBPoolMember{
+		{
+			DisplayName:              &name,
+			AdminState:               &adminState,
+			BackupMember:             &backup,
+			IpAddress:                &ip,
+			Port:                     &port,
+			Weight:                   &weight,
+			MaxConcurrentConnections: &maxConn,
+		},
+	})
+	require.NoError(t, err)
+
+	members := d.Get("member").([]interface{})
+	require.Len(t, members, 1)
+	elem := members[0].(map[string]interface{})
+	assert.Equal(t, "member-1", elem["display_name"])
+	assert.Equal(t, "80", elem["port"])
+}
+
+func TestUnitNsxt_getPolicyPoolMemberGroupFromSchema(t *testing.T) {
+	res := resourceNsxtPolicyLBPool()
+
+	t.Run("nil when member_group is not set", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBPoolData())
+		assert.Nil(t, getPolicyPoolMemberGroupFromSchema(d))
+	})
+
+	t.Run("builds group with ipv4-only filter", func(t *testing.T) {
+		data := minimalLBPoolData()
+		data["member_group"] = []interface{}{
+			map[string]interface{}{
+				"group_path":       "/infra/domains/default/groups/g1",
+				"allow_ipv4":       true,
+				"allow_ipv6":       false,
+				"max_ip_list_size": 10,
+				"port":             "8080",
+			},
+		}
+		d := schema.TestResourceDataRaw(t, res.Schema, data)
+		group := getPolicyPoolMemberGroupFromSchema(d)
+		require.NotNil(t, group)
+		assert.Equal(t, model.LBPoolMemberGroup_IP_REVISION_FILTER_IPV4, *group.IpRevisionFilter)
+		assert.EqualValues(t, 8080, *group.Port)
+		assert.EqualValues(t, 10, *group.MaxIpListSize)
+	})
+
+	t.Run("builds group with dual-stack filter", func(t *testing.T) {
+		data := minimalLBPoolData()
+		data["member_group"] = []interface{}{
+			map[string]interface{}{
+				"group_path": "/infra/domains/default/groups/g1",
+				"allow_ipv4": true,
+				"allow_ipv6": true,
+				"port":       "",
+			},
+		}
+		d := schema.TestResourceDataRaw(t, res.Schema, data)
+		group := getPolicyPoolMemberGroupFromSchema(d)
+		require.NotNil(t, group)
+		assert.Equal(t, model.LBPoolMemberGroup_IP_REVISION_FILTER_IPV4_IPV6, *group.IpRevisionFilter)
+	})
+
+	t.Run("builds group with ipv6-only filter", func(t *testing.T) {
+		data := minimalLBPoolData()
+		data["member_group"] = []interface{}{
+			map[string]interface{}{
+				"group_path": "/infra/domains/default/groups/g1",
+				"allow_ipv4": false,
+				"allow_ipv6": false,
+			},
+		}
+		d := schema.TestResourceDataRaw(t, res.Schema, data)
+		group := getPolicyPoolMemberGroupFromSchema(d)
+		require.NotNil(t, group)
+		assert.Equal(t, model.LBPoolMemberGroup_IP_REVISION_FILTER_IPV6, *group.IpRevisionFilter)
+	})
+}
+
+func TestUnitNsxt_setPolicyPoolMemberGroupInSchema(t *testing.T) {
+	res := resourceNsxtPolicyLBPool()
+
+	t.Run("clears schema when group is nil", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBPoolData())
+		require.NoError(t, setPolicyPoolMemberGroupInSchema(d, nil))
+	})
+
+	t.Run("sets fields from group", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBPoolData())
+		path := "/infra/domains/default/groups/g1"
+		filter := model.LBPoolMemberGroup_IP_REVISION_FILTER_IPV4_IPV6
+		port := int64(80)
+		maxSize := int64(5)
+		err := setPolicyPoolMemberGroupInSchema(d, &model.LBPoolMemberGroup{
+			GroupPath:        &path,
+			IpRevisionFilter: &filter,
+			Port:             &port,
+			MaxIpListSize:    &maxSize,
+		})
+		require.NoError(t, err)
+
+		groups := d.Get("member_group").([]interface{})
+		require.Len(t, groups, 1)
+		elem := groups[0].(map[string]interface{})
+		assert.Equal(t, true, elem["allow_ipv4"])
+		assert.Equal(t, true, elem["allow_ipv6"])
+		assert.Equal(t, "80", elem["port"])
+	})
+}
+
+func TestUnitNsxt_getPolicyPoolSnatFromSchema(t *testing.T) {
+	res := resourceNsxtPolicyLBPool()
+
+	t.Run("DISABLED type", func(t *testing.T) {
+		data := minimalLBPoolData()
+		data["snat"] = []interface{}{map[string]interface{}{"type": "DISABLED"}}
+		d := schema.TestResourceDataRaw(t, res.Schema, data)
+		val, err := getPolicyPoolSnatFromSchema(d)
+		require.NoError(t, err)
+		require.NotNil(t, val)
+	})
+
+	t.Run("AUTOMAP type", func(t *testing.T) {
+		data := minimalLBPoolData()
+		data["snat"] = []interface{}{map[string]interface{}{"type": "AUTOMAP"}}
+		d := schema.TestResourceDataRaw(t, res.Schema, data)
+		val, err := getPolicyPoolSnatFromSchema(d)
+		require.NoError(t, err)
+		require.NotNil(t, val)
+	})
+
+	t.Run("IPPOOL type with CIDR and single IP", func(t *testing.T) {
+		data := minimalLBPoolData()
+		data["snat"] = []interface{}{map[string]interface{}{
+			"type":              "IPPOOL",
+			"ip_pool_addresses": []interface{}{"10.0.0.0/24", "10.0.1.5"},
+		}}
+		d := schema.TestResourceDataRaw(t, res.Schema, data)
+		val, err := getPolicyPoolSnatFromSchema(d)
+		require.NoError(t, err)
+		require.NotNil(t, val)
+	})
+
+	t.Run("no snat configured returns nil", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBPoolData())
+		val, err := getPolicyPoolSnatFromSchema(d)
+		require.NoError(t, err)
+		assert.Nil(t, val)
+	})
+}
+
+func TestUnitNsxt_setPolicyPoolSnatInSchema(t *testing.T) {
+	res := resourceNsxtPolicyLBPool()
+
+	t.Run("nil snat is a no-op", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalLBPoolData())
+		require.NoError(t, setPolicyPoolSnatInSchema(d, nil))
+	})
+
+	t.Run("round-trips DISABLED, AUTOMAP, and IPPOOL", func(t *testing.T) {
+		for _, snatData := range []map[string]interface{}{
+			{"type": "DISABLED"},
+			{"type": "AUTOMAP"},
+			{"type": "IPPOOL", "ip_pool_addresses": []interface{}{"10.0.0.0/24"}},
+		} {
+			data := minimalLBPoolData()
+			data["snat"] = []interface{}{snatData}
+			d := schema.TestResourceDataRaw(t, res.Schema, data)
+			val, err := getPolicyPoolSnatFromSchema(d)
+			require.NoError(t, err)
+			require.NotNil(t, val)
+
+			d2 := schema.TestResourceDataRaw(t, res.Schema, minimalLBPoolData())
+			require.NoError(t, setPolicyPoolSnatInSchema(d2, val))
+		}
 	})
 }
 

--- a/nsxt/utgomock_resource_nsxt_policy_nat_rule_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_nat_rule_test.go
@@ -21,8 +21,10 @@ import (
 	"go.uber.org/mock/gomock"
 
 	t0nat "github.com/vmware/terraform-provider-nsxt/api/infra/tier_0s/nat"
+	t1nat "github.com/vmware/terraform-provider-nsxt/api/infra/tier_1s/nat"
 	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
 	natmocks "github.com/vmware/terraform-provider-nsxt/mocks/infra/tier_0s/nat"
+	t1natmocks "github.com/vmware/terraform-provider-nsxt/mocks/infra/tier_1s/nat"
 	"github.com/vmware/terraform-provider-nsxt/nsxt/util"
 )
 
@@ -225,6 +227,174 @@ func TestMockResourceNsxtPolicyNATRuleDelete(t *testing.T) {
 		err := resourceNsxtPolicyNATRuleDelete(d, m)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "API error")
+	})
+}
+
+func TestUnitNsxt_getNatTypeByAction(t *testing.T) {
+	assert.Equal(t, model.PolicyNat_NAT_TYPE_NAT64, getNatTypeByAction("", model.PolicyNatRule_ACTION_NAT64))
+	assert.Equal(t, model.PolicyNat_NAT_TYPE_USER, getNatTypeByAction("", model.PolicyNatRule_ACTION_SNAT))
+	assert.Equal(t, model.PolicyNat_NAT_TYPE_INTERNAL, getNatTypeByAction(model.PolicyNat_NAT_TYPE_INTERNAL, model.PolicyNatRule_ACTION_SNAT))
+}
+
+func TestUnitNsxt_translatedNetworksNeeded(t *testing.T) {
+	assert.False(t, translatedNetworksNeeded(model.PolicyNatRule_ACTION_NO_SNAT))
+	assert.False(t, translatedNetworksNeeded(model.PolicyNatRule_ACTION_NO_DNAT))
+	assert.True(t, translatedNetworksNeeded(model.PolicyNatRule_ACTION_SNAT))
+}
+
+func TestUnitNsxt_getTranslatedNetworks(t *testing.T) {
+	t.Run("errors when required and missing", func(t *testing.T) {
+		action := model.PolicyNatRule_ACTION_SNAT
+		_, err := getTranslatedNetworks(model.PolicyNatRule{Action: &action})
+		require.Error(t, err)
+	})
+
+	t.Run("nil is fine when not needed", func(t *testing.T) {
+		action := model.PolicyNatRule_ACTION_NO_SNAT
+		val, err := getTranslatedNetworks(model.PolicyNatRule{Action: &action})
+		require.NoError(t, err)
+		assert.Nil(t, val)
+	})
+
+	t.Run("passes through when set", func(t *testing.T) {
+		action := model.PolicyNatRule_ACTION_SNAT
+		nets := "10.0.0.0/24"
+		val, err := getTranslatedNetworks(model.PolicyNatRule{Action: &action, TranslatedNetwork: &nets})
+		require.NoError(t, err)
+		assert.Equal(t, &nets, val)
+	})
+}
+
+func TestUnitNsxt_policyBasedVpnModeNeeded(t *testing.T) {
+	assert.True(t, policyBasedVpnModeNeeded(model.PolicyNatRule_ACTION_DNAT))
+	assert.True(t, policyBasedVpnModeNeeded(model.PolicyNatRule_ACTION_NO_DNAT))
+	assert.False(t, policyBasedVpnModeNeeded(model.PolicyNatRule_ACTION_SNAT))
+}
+
+func TestUnitNsxt_getPolicyBasedVpnMode(t *testing.T) {
+	t.Run("errors when set on unsupported action", func(t *testing.T) {
+		action := model.PolicyNatRule_ACTION_SNAT
+		match := model.PolicyNatRule_POLICY_BASED_VPN_MODE_BYPASS
+		_, err := getPolicyBasedVpnMode(model.PolicyNatRule{Action: &action, PolicyBasedVpnMode: &match})
+		require.Error(t, err)
+	})
+
+	t.Run("fine when unset", func(t *testing.T) {
+		action := model.PolicyNatRule_ACTION_SNAT
+		val, err := getPolicyBasedVpnMode(model.PolicyNatRule{Action: &action})
+		require.NoError(t, err)
+		assert.Nil(t, val)
+	})
+
+	t.Run("fine when set on a supported action", func(t *testing.T) {
+		action := model.PolicyNatRule_ACTION_DNAT
+		match := model.PolicyNatRule_POLICY_BASED_VPN_MODE_MATCH
+		val, err := getPolicyBasedVpnMode(model.PolicyNatRule{Action: &action, PolicyBasedVpnMode: &match})
+		require.NoError(t, err)
+		assert.Equal(t, &match, val)
+	})
+}
+
+func TestUnitNsxt_validateNatTypeAction(t *testing.T) {
+	t.Run("NAT64 action requires NAT64 type", func(t *testing.T) {
+		err := validateNatTypeAction(model.PolicyNatRule_ACTION_NAT64, model.PolicyNat_NAT_TYPE_USER)
+		require.Error(t, err)
+	})
+
+	t.Run("NAT64 type requires NAT64 action", func(t *testing.T) {
+		err := validateNatTypeAction(model.PolicyNatRule_ACTION_SNAT, model.PolicyNat_NAT_TYPE_NAT64)
+		require.Error(t, err)
+	})
+
+	t.Run("matching NAT64 action and type is fine", func(t *testing.T) {
+		require.NoError(t, validateNatTypeAction(model.PolicyNatRule_ACTION_NAT64, model.PolicyNat_NAT_TYPE_NAT64))
+	})
+
+	t.Run("non-NAT64 combination is fine", func(t *testing.T) {
+		require.NoError(t, validateNatTypeAction(model.PolicyNatRule_ACTION_SNAT, model.PolicyNat_NAT_TYPE_USER))
+	})
+}
+
+func TestMockResourceNsxtPolicyNATRuleInvalidGatewayPath(t *testing.T) {
+	res := resourceNsxtPolicyNATRule()
+
+	for _, fn := range []func(*schema.ResourceData, interface{}) error{
+		resourceNsxtPolicyNATRuleCreate,
+		resourceNsxtPolicyNATRuleRead,
+		resourceNsxtPolicyNATRuleUpdate,
+		resourceNsxtPolicyNATRuleDelete,
+	} {
+		data := minimalNATRuleData()
+		data["gateway_path"] = "invalid"
+		d := schema.TestResourceDataRaw(t, res.Schema, data)
+		d.SetId(natRuleID)
+
+		err := fn(d, newGoMockProviderClient())
+		require.Error(t, err)
+	}
+}
+
+func TestMockResourceNsxtPolicyNATRuleTier1Delete(t *testing.T) {
+	util.NsxVersion = "9.1.0"
+	defer func() { util.NsxVersion = "" }()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockT1NatSDK := t1natmocks.NewMockNatRulesClient(ctrl)
+	mockT1Wrapper := &t1nat.PolicyNatRuleClientContext{
+		Client:     mockT1NatSDK,
+		ClientType: utl.Local,
+	}
+	originalT1Cli := cliTier1NatRulesClient
+	defer func() { cliTier1NatRulesClient = originalT1Cli }()
+	cliTier1NatRulesClient = func(sessionContext utl.SessionContext, connector client.Connector) *t1nat.PolicyNatRuleClientContext {
+		return mockT1Wrapper
+	}
+
+	t.Run("Delete on a tier-1 gateway path", func(t *testing.T) {
+		mockT1NatSDK.EXPECT().Delete("gw1", natType, natRuleID).Return(nil)
+
+		res := resourceNsxtPolicyNATRule()
+		data := minimalNATRuleData()
+		data["gateway_path"] = "/infra/tier-1s/gw1"
+		d := schema.TestResourceDataRaw(t, res.Schema, data)
+		d.SetId(natRuleID)
+
+		err := resourceNsxtPolicyNATRuleDelete(d, newGoMockProviderClient())
+		require.NoError(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyNATRuleCreateAlreadyExists(t *testing.T) {
+	util.NsxVersion = "9.1.0"
+	defer func() { util.NsxVersion = "" }()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockNatSDK := natmocks.NewMockNatRulesClient(ctrl)
+	mockWrapper := &t0nat.PolicyNatRuleClientContext{
+		Client:     mockNatSDK,
+		ClientType: utl.Local,
+	}
+	originalCli := cliTier0NatRulesClient
+	defer func() { cliTier0NatRulesClient = originalCli }()
+	cliTier0NatRulesClient = func(sessionContext utl.SessionContext, connector client.Connector) *t0nat.PolicyNatRuleClientContext {
+		return mockWrapper
+	}
+
+	t.Run("Create fails when nsx_id already exists", func(t *testing.T) {
+		mockNatSDK.EXPECT().Get(natGwID, natType, "existing-id").Return(model.PolicyNatRule{Id: &natRuleID}, nil)
+
+		res := resourceNsxtPolicyNATRule()
+		data := minimalNATRuleData()
+		data["nsx_id"] = "existing-id"
+		d := schema.TestResourceDataRaw(t, res.Schema, data)
+
+		err := resourceNsxtPolicyNATRuleCreate(d, newGoMockProviderClient())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "already exists")
 	})
 }
 

--- a/nsxt/utgomock_resource_nsxt_policy_nat_rule_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_nat_rule_test.go
@@ -419,3 +419,27 @@ func minimalNATRuleData() map[string]interface{} {
 		"policy_based_vpn_mode": "",
 	}
 }
+
+func TestUnitNsxt_resourceNsxtPolicyNATRuleImport(t *testing.T) {
+	res := resourceNsxtPolicyNATRule()
+
+	t.Run("full policy path succeeds and sets gateway_path and type", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		d.SetId("/infra/tier-0s/gw-1/nat/USER/nat-rules/rule-1")
+
+		out, err := resourceNsxtPolicyNATRuleImport(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		require.Len(t, out, 1)
+		assert.Equal(t, "/infra/tier-0s/gw-1", d.Get("gateway_path"))
+		assert.Equal(t, "USER", d.Get("type"))
+	})
+
+	t.Run("legacy format with too many segments is rejected", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		d.SetId("gw-1/rule-1/USER/extra")
+
+		_, err := resourceNsxtPolicyNATRuleImport(d, newGoMockProviderClient())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "gateway-id")
+	})
+}

--- a/nsxt/utgomock_resource_nsxt_policy_ospf_area_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_ospf_area_test.go
@@ -184,3 +184,34 @@ func TestMockResourceNsxtPolicyOspfAreaDelete(t *testing.T) {
 		require.Error(t, err)
 	})
 }
+
+func TestUnitNsxt_resourceNsxtPolicyOspfAreaImport(t *testing.T) {
+	res := resourceNsxtPolicyOspfArea()
+
+	t.Run("wrong segment count is rejected", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		d.SetId(ospfAreaGwID + "/" + ospfAreaLsID)
+
+		_, err := resourceNsxtPolicyOspfAreaImport(d, newGoMockProviderClient())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "tier0-id")
+	})
+
+	t.Run("valid path succeeds and sets ospf_path", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSDK, restore := setupOSPFAreaMock(t, ctrl)
+		defer restore()
+		parentPath := ospfAreaOspfPath
+		mockSDK.EXPECT().Get(ospfAreaGwID, ospfAreaLsID, ospfAreaID).Return(nsxModel.OspfAreaConfig{ParentPath: &parentPath}, nil)
+
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		d.SetId(ospfAreaGwID + "/" + ospfAreaLsID + "/" + ospfAreaID)
+
+		out, err := resourceNsxtPolicyOspfAreaImport(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		require.Len(t, out, 1)
+		assert.Equal(t, ospfAreaID, d.Id())
+		assert.Equal(t, ospfAreaOspfPath, d.Get("ospf_path"))
+	})
+}

--- a/nsxt/utgomock_resource_nsxt_policy_predefined_gateway_policy_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_predefined_gateway_policy_test.go
@@ -201,3 +201,159 @@ func TestMockResourceNsxtPolicyPredefinedGatewayPolicyDelete(t *testing.T) {
 		require.Error(t, err)
 	})
 }
+
+func TestMockResourceNsxtPolicyPredefinedGatewayPolicyUpdateSystemPolicy(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, _, restore := setupPredefinedGwPolicyMock(t, ctrl)
+	defer restore()
+
+	t.Run("Update fails when policy is a system policy", func(t *testing.T) {
+		systemCategory := "SystemRules"
+		systemPolicy := predefinedGwPolicyAPIResponse()
+		systemPolicy.Category = &systemCategory
+		mockSDK.EXPECT().Get(predefinedGwPolicyDomain, predefinedGwPolicyID).Return(systemPolicy, nil)
+
+		res := resourceNsxtPolicyPredefinedGatewayPolicy()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalPredefinedGwPolicyData())
+		d.SetId(predefinedGwPolicyID)
+
+		err := resourceNsxtPolicyPredefinedGatewayPolicyUpdate(d, newGoMockProviderClient())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "System policy")
+	})
+
+	t.Run("Update fails when path has no domain segment", func(t *testing.T) {
+		res := resourceNsxtPolicyPredefinedGatewayPolicy()
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{"path": "not-a-valid-path"})
+		d.SetId(predefinedGwPolicyID)
+
+		err := resourceNsxtPolicyPredefinedGatewayPolicyUpdate(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestUnitNsxt_revertGatewayPolicyDefaultRule(t *testing.T) {
+	id := "rule-1"
+	description := "custom description"
+	action := nsxModel.Rule_ACTION_DROP
+	tags := []nsxModel.Tag{{Scope: strPtr("s"), Tag: strPtr("t")}}
+	rule := nsxModel.Rule{Id: &id, Description: &description, Action: &action, Tags: tags}
+
+	reverted := revertGatewayPolicyDefaultRule(rule)
+	assert.Equal(t, "", *reverted.Description)
+	assert.Equal(t, nsxModel.Rule_ACTION_ALLOW, *reverted.Action)
+	assert.Empty(t, reverted.Tags)
+}
+
+func TestUnitNsxt_createPolicyChildRule(t *testing.T) {
+	ruleID := "rule-1"
+	rule := nsxModel.Rule{Id: &ruleID}
+
+	dataValue, err := createPolicyChildRule(ruleID, rule, false)
+	require.NoError(t, err)
+	assert.NotNil(t, dataValue)
+
+	deleteValue, err := createPolicyChildRule(ruleID, rule, true)
+	require.NoError(t, err)
+	assert.NotNil(t, deleteValue)
+}
+
+func TestUnitNsxt_createChildDomainWithGatewayPolicy(t *testing.T) {
+	policyID := "default"
+	policy := nsxModel.GatewayPolicy{Id: &policyID}
+
+	dataValue, err := createChildDomainWithGatewayPolicy("default", policyID, policy)
+	require.NoError(t, err)
+	assert.NotNil(t, dataValue)
+}
+
+func TestUnitNsxt_revertPolicyPredefinedGatewayPolicy(t *testing.T) {
+	defaultRuleID := "default-rule"
+	nonDefaultRuleID := "custom-rule"
+	isDefault := true
+	notDefault := false
+	tags := []nsxModel.Tag{{Scope: strPtr("s"), Tag: strPtr("t")}}
+
+	policy := nsxModel.GatewayPolicy{
+		Rules: []nsxModel.Rule{
+			{Id: &defaultRuleID, IsDefault: &isDefault},
+			{Id: &nonDefaultRuleID, IsDefault: &notDefault},
+		},
+		Tags: tags,
+	}
+
+	reverted, err := revertPolicyPredefinedGatewayPolicy(policy, newGoMockProviderClient())
+	require.NoError(t, err)
+	assert.Equal(t, "", *reverted.Description)
+	assert.Nil(t, reverted.Rules)
+	assert.Len(t, reverted.Children, 2)
+	assert.Empty(t, reverted.Tags)
+}
+
+func TestUnitNsxt_setPolicyDefaultRulesInSchema(t *testing.T) {
+	res := resourceNsxtPolicyPredefinedGatewayPolicy()
+	d := schema.TestResourceDataRaw(t, res.Schema, minimalPredefinedGwPolicyData())
+
+	ruleID := "rule-1"
+	description := "a default rule"
+	scope := []string{"ANY"}
+	rules := []nsxModel.Rule{{Id: &ruleID, Description: &description, Scope: scope}}
+
+	err := setPolicyDefaultRulesInSchema(d, rules)
+	require.NoError(t, err)
+	set := d.Get("default_rule").(*schema.Set)
+	assert.Equal(t, 1, set.Len())
+}
+
+func TestUnitNsxt_updateGatewayPolicyDefaultRuleByScope(t *testing.T) {
+	res := resourceNsxtPolicyPredefinedGatewayPolicy()
+
+	t.Run("matches rule by scope and updates fields", func(t *testing.T) {
+		data := minimalPredefinedGwPolicyData()
+		data["default_rule"] = []interface{}{
+			map[string]interface{}{
+				"nsx_id":      "rule-1",
+				"scope":       "/infra/domains/default/groups/g1",
+				"description": "updated desc",
+				"action":      nsxModel.Rule_ACTION_DROP,
+				"logged":      true,
+				"log_label":   "lbl",
+				"tag":         []interface{}{},
+			},
+		}
+		d := schema.TestResourceDataRaw(t, res.Schema, data)
+
+		ruleID := "rule-1"
+		rule := nsxModel.Rule{Id: &ruleID, Scope: []string{"/infra/domains/default/groups/g1"}}
+
+		updated := updateGatewayPolicyDefaultRuleByScope(rule, d, nil, false)
+		require.NotNil(t, updated)
+		assert.Equal(t, "updated desc", *updated.Description)
+		assert.Equal(t, nsxModel.Rule_ACTION_DROP, *updated.Action)
+	})
+
+	t.Run("no match and not previously deleted returns nil", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalPredefinedGwPolicyData())
+
+		ruleID := "rule-unmatched"
+		rule := nsxModel.Rule{Id: &ruleID, Scope: []string{"/infra/domains/default/groups/other"}}
+
+		updated := updateGatewayPolicyDefaultRuleByScope(rule, d, nil, false)
+		assert.Nil(t, updated)
+	})
+}
+
+func TestUnitNsxt_nsxtPredefinedPolicyImporter(t *testing.T) {
+	res := resourceNsxtPolicyPredefinedGatewayPolicy()
+
+	t.Run("non-policy-path ID sets path and id directly", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		d.SetId("plain-id")
+
+		out, err := nsxtPredefinedPolicyImporter(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		require.Len(t, out, 1)
+		assert.Equal(t, "plain-id", d.Get("path"))
+	})
+}

--- a/nsxt/utgomock_resource_nsxt_policy_predefined_security_policy_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_predefined_security_policy_test.go
@@ -22,6 +22,7 @@ import (
 	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
 	inframocks "github.com/vmware/terraform-provider-nsxt/mocks/infra"
 	domainmocks "github.com/vmware/terraform-provider-nsxt/mocks/infra/domains"
+	orgrootmocks "github.com/vmware/terraform-provider-nsxt/mocks/nsxt"
 )
 
 var (
@@ -199,5 +200,185 @@ func TestMockResourceNsxtPolicyPredefinedSecurityPolicyDelete(t *testing.T) {
 
 		err := resourceNsxtPolicyPredefinedSecurityPolicyDelete(d, newGoMockProviderClient())
 		require.Error(t, err)
+	})
+}
+
+func TestUnitNsxt_updateSecurityPolicyDefaultRule(t *testing.T) {
+	res := resourceNsxtPolicyPredefinedSecurityPolicy()
+
+	t.Run("applies fields from the configured default_rule block", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+			"default_rule": []interface{}{
+				map[string]interface{}{
+					"description": "my default rule",
+					"action":      "DROP",
+					"log_label":   "mylabel",
+					"logged":      true,
+				},
+			},
+		})
+		ruleID := "rule-1"
+		rule := nsxModel.Rule{Id: &ruleID}
+
+		updated := updateSecurityPolicyDefaultRule(rule, d)
+		require.NotNil(t, updated)
+		assert.Equal(t, "my default rule", *updated.Description)
+		assert.Equal(t, "DROP", *updated.Action)
+		assert.Equal(t, "mylabel", *updated.Tag)
+		assert.True(t, *updated.Logged)
+	})
+
+	t.Run("no default_rule block and no change returns nil", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		ruleID := "rule-1"
+		rule := nsxModel.Rule{Id: &ruleID}
+
+		updated := updateSecurityPolicyDefaultRule(rule, d)
+		assert.Nil(t, updated)
+	})
+}
+
+func TestUnitNsxt_revertSecurityPolicyDefaultRule(t *testing.T) {
+	t.Run("resets action, logged, tag and label to defaults", func(t *testing.T) {
+		action := "DROP"
+		logged := true
+		tag := "mylabel"
+		rule := nsxModel.Rule{
+			Action: &action,
+			Logged: &logged,
+			Tag:    &tag,
+			Tags:   []nsxModel.Tag{{Scope: strPtr("s"), Tag: strPtr("t")}},
+		}
+
+		reverted := revertSecurityPolicyDefaultRule(rule)
+		assert.Equal(t, "ALLOW", *reverted.Action)
+		assert.False(t, *reverted.Logged)
+		assert.Equal(t, "", *reverted.Tag)
+		assert.Empty(t, reverted.Tags)
+	})
+}
+
+func TestUnitNsxt_revertPolicyPredefinedSecurityPolicy(t *testing.T) {
+	t.Run("reverts default rules and deletes non-default rules", func(t *testing.T) {
+		isDefault := true
+		notDefault := false
+		defaultRuleID := "default-rule"
+		customRuleID := "custom-rule"
+		action := "DROP"
+		policy := nsxModel.SecurityPolicy{
+			Description: strPtr("original"),
+			Tags:        []nsxModel.Tag{{Scope: strPtr("s"), Tag: strPtr("t")}},
+			Rules: []nsxModel.Rule{
+				{Id: &defaultRuleID, IsDefault: &isDefault, Action: &action},
+				{Id: &customRuleID, IsDefault: &notDefault},
+			},
+		}
+
+		reverted, err := revertPolicyPredefinedSecurityPolicy(policy, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, "", *reverted.Description)
+		assert.Nil(t, reverted.Rules)
+		assert.Empty(t, reverted.Tags)
+		require.Len(t, reverted.Children, 2)
+	})
+
+	t.Run("no rules is a no-op besides clearing description/tags", func(t *testing.T) {
+		policy := nsxModel.SecurityPolicy{Description: strPtr("original")}
+
+		reverted, err := revertPolicyPredefinedSecurityPolicy(policy, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, "", *reverted.Description)
+		assert.Empty(t, reverted.Children)
+	})
+}
+
+func TestMockNsxtSecurityPolicyInfraPatchVPC(t *testing.T) {
+	t.Run("VPC context patches through the org root client", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockOrgRootSDK := orgrootmocks.NewMockOrgRootClient(ctrl)
+		original := cliOrgRootClient
+		cliOrgRootClient = func(_ utl.SessionContext, _ vapiProtocolClient.Connector) *apipkg.OrgRootClientContext {
+			return &apipkg.OrgRootClientContext{Client: mockOrgRootSDK, ClientType: utl.VPC}
+		}
+		defer func() { cliOrgRootClient = original }()
+		mockOrgRootSDK.EXPECT().Patch(gomock.Any(), gomock.Any()).Return(nil)
+
+		policyID := "default"
+		ctx := utl.SessionContext{ClientType: utl.VPC, ProjectID: "project1", VPCID: "vpc1"}
+		policy := nsxModel.SecurityPolicy{Id: &policyID}
+
+		err := securityPolicyInfraPatch(ctx, policy, "default", newGoMockProviderClient())
+		require.NoError(t, err)
+	})
+
+	t.Run("VPC context propagates a Patch error", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockOrgRootSDK := orgrootmocks.NewMockOrgRootClient(ctrl)
+		original := cliOrgRootClient
+		cliOrgRootClient = func(_ utl.SessionContext, _ vapiProtocolClient.Connector) *apipkg.OrgRootClientContext {
+			return &apipkg.OrgRootClientContext{Client: mockOrgRootSDK, ClientType: utl.VPC}
+		}
+		defer func() { cliOrgRootClient = original }()
+		mockOrgRootSDK.EXPECT().Patch(gomock.Any(), gomock.Any()).Return(vapiErrors.InternalServerError{})
+
+		policyID := "default"
+		ctx := utl.SessionContext{ClientType: utl.VPC, ProjectID: "project1", VPCID: "vpc1"}
+		policy := nsxModel.SecurityPolicy{Id: &policyID}
+
+		err := securityPolicyInfraPatch(ctx, policy, "default", newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyPredefinedSecurityPolicyUpdateDefaultRuleChange(t *testing.T) {
+	t.Run("Update patches a changed default_rule block", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSDK, mockInfra, restore := setupPredefinedSecPolicyMock(t, ctrl)
+		defer restore()
+
+		isDefault := true
+		defaultRuleID := "default-rule-1"
+		action := "ALLOW"
+		respWithDefaultRule := predefinedSecPolicyAPIResponse()
+		respWithDefaultRule.Rules = []nsxModel.Rule{
+			{Id: &defaultRuleID, IsDefault: &isDefault, Action: &action},
+		}
+
+		gomock.InOrder(
+			mockSDK.EXPECT().Get(predefinedSecPolicyDomain, predefinedSecPolicyID).Return(respWithDefaultRule, nil),
+			mockInfra.EXPECT().Patch(gomock.Any(), gomock.Any()).Return(nil),
+			mockSDK.EXPECT().Get(predefinedSecPolicyDomain, predefinedSecPolicyID).Return(predefinedSecPolicyAPIResponse(), nil),
+		)
+
+		res := resourceNsxtPolicyPredefinedSecurityPolicy()
+		data := minimalPredefinedSecPolicyData()
+		data["default_rule"] = []interface{}{
+			map[string]interface{}{
+				"description": "updated default rule",
+				"action":      "DROP",
+				"logged":      true,
+			},
+		}
+		d := schema.TestResourceDataRaw(t, res.Schema, data)
+		d.SetId(predefinedSecPolicyID)
+
+		err := resourceNsxtPolicyPredefinedSecurityPolicyUpdate(d, newGoMockProviderClient())
+		require.NoError(t, err)
+	})
+}
+
+func TestUnitNsxt_updatePolicyPredefinedSecurityPolicyEmptyDomain(t *testing.T) {
+	t.Run("fails when domain cannot be extracted from path", func(t *testing.T) {
+		res := resourceNsxtPolicyPredefinedSecurityPolicy()
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+			"path": "/not-a-domain-path",
+		})
+
+		err := updatePolicyPredefinedSecurityPolicy("some-id", d, newGoMockProviderClient())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "domain")
 	})
 }

--- a/nsxt/utgomock_resource_nsxt_policy_project_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_project_test.go
@@ -18,10 +18,13 @@ import (
 	sdkprojects "github.com/vmware/vsphere-automation-sdk-go/services/nsxt/orgs/projects"
 	"go.uber.org/mock/gomock"
 
+	cliinfra "github.com/vmware/terraform-provider-nsxt/api/infra"
 	orgsapi "github.com/vmware/terraform-provider-nsxt/api/orgs"
 	"github.com/vmware/terraform-provider-nsxt/api/orgs/projects"
 	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
+	networkspanmocks "github.com/vmware/terraform-provider-nsxt/mocks/infra"
 	orgsmocks "github.com/vmware/terraform-provider-nsxt/mocks/orgs"
+	projectsmocks "github.com/vmware/terraform-provider-nsxt/mocks/orgs/projects"
 	"github.com/vmware/terraform-provider-nsxt/nsxt/util"
 )
 
@@ -94,6 +97,32 @@ func (vpcSecurityProfilesClientStub) Update(string, string, string, nsxModel.Vpc
 }
 
 var _ sdkprojects.VpcSecurityProfilesClient = vpcSecurityProfilesClientStub{}
+
+func setupNetworkSpansMock(ctrl *gomock.Controller) (*networkspanmocks.MockNetworkSpansClient, func()) {
+	mockSDK := networkspanmocks.NewMockNetworkSpansClient(ctrl)
+	mockWrapper := &cliinfra.NetworkSpanClientContext{
+		Client:     mockSDK,
+		ClientType: utl.Local,
+	}
+	original := cliNetworkSpansClient
+	cliNetworkSpansClient = func(_ utl.SessionContext, _ vapiProtocolClient.Connector) *cliinfra.NetworkSpanClientContext {
+		return mockWrapper
+	}
+	return mockSDK, func() { cliNetworkSpansClient = original }
+}
+
+func setupVpcSecurityProfilesMock(ctrl *gomock.Controller) (*projectsmocks.MockVpcSecurityProfilesClient, func()) {
+	mockSDK := projectsmocks.NewMockVpcSecurityProfilesClient(ctrl)
+	mockWrapper := &projects.VpcSecurityProfileClientContext{
+		Client:     mockSDK,
+		ClientType: utl.Multitenancy,
+	}
+	original := cliVpcSecurityProfilesClient
+	cliVpcSecurityProfilesClient = func(_ utl.SessionContext, _ vapiProtocolClient.Connector) *projects.VpcSecurityProfileClientContext {
+		return mockWrapper
+	}
+	return mockSDK, func() { cliVpcSecurityProfilesClient = original }
+}
 
 func setupVpcSecurityProfilesStub(t *testing.T) func() {
 	t.Helper()
@@ -307,6 +336,228 @@ func TestMockResourceNsxtPolicyProjectDelete(t *testing.T) {
 		d := schema.TestResourceDataRaw(t, res.Schema, minimalProjectData())
 
 		err := resourceNsxtPolicyProjectDelete(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockGetDefaultSpan(t *testing.T) {
+	t.Run("returns the default span path", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSDK, restore := setupNetworkSpansMock(ctrl)
+		defer restore()
+
+		isDefault, notDefault := true, false
+		defaultPath, otherPath := "/infra/network-spans/default", "/infra/network-spans/other"
+		mockSDK.EXPECT().List(nil, nil, nil, nil, nil, nil, nil).Return(nsxModel.NetworkSpanListResult{
+			Results: []nsxModel.NetworkSpan{
+				{Path: &otherPath, IsDefault: &notDefault},
+				{Path: &defaultPath, IsDefault: &isDefault},
+			},
+		}, nil)
+
+		path, err := getDefaultSpan(nil)
+		require.NoError(t, err)
+		assert.Equal(t, defaultPath, path)
+	})
+
+	t.Run("returns empty string on unauthorized error", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSDK, restore := setupNetworkSpansMock(ctrl)
+		defer restore()
+
+		mockSDK.EXPECT().List(nil, nil, nil, nil, nil, nil, nil).Return(nsxModel.NetworkSpanListResult{}, vapiErrors.Unauthorized{})
+
+		path, err := getDefaultSpan(nil)
+		require.NoError(t, err)
+		assert.Empty(t, path)
+	})
+
+	t.Run("fails when no default span exists", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSDK, restore := setupNetworkSpansMock(ctrl)
+		defer restore()
+
+		notDefault := false
+		otherPath := "/infra/network-spans/other"
+		mockSDK.EXPECT().List(nil, nil, nil, nil, nil, nil, nil).Return(nsxModel.NetworkSpanListResult{
+			Results: []nsxModel.NetworkSpan{{Path: &otherPath, IsDefault: &notDefault}},
+		}, nil)
+
+		_, err := getDefaultSpan(nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no default span path found")
+	})
+
+	t.Run("propagates other API errors", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSDK, restore := setupNetworkSpansMock(ctrl)
+		defer restore()
+
+		mockSDK.EXPECT().List(nil, nil, nil, nil, nil, nil, nil).Return(nsxModel.NetworkSpanListResult{}, vapiErrors.InternalServerError{})
+
+		_, err := getDefaultSpan(nil)
+		require.Error(t, err)
+	})
+}
+
+func TestMockPatchVpcSecurityProfile(t *testing.T) {
+	t.Run("patches with enabled true from schema", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSDK, restore := setupVpcSecurityProfilesMock(ctrl)
+		defer restore()
+
+		name := "default"
+		mockSDK.EXPECT().Get(utl.DefaultOrgID, projectID, "default").Return(nsxModel.VpcSecurityProfile{DisplayName: &name}, nil)
+		mockSDK.EXPECT().Patch(utl.DefaultOrgID, projectID, "default", gomock.Any()).DoAndReturn(
+			func(_, _, _ string, obj nsxModel.VpcSecurityProfile) error {
+				assert.True(t, *obj.NorthSouthFirewall.Enabled)
+				return nil
+			},
+		)
+
+		res := resourceNsxtPolicyProject()
+		data := minimalProjectData()
+		data["default_security_profile"] = []interface{}{
+			map[string]interface{}{
+				"north_south_firewall": []interface{}{
+					map[string]interface{}{"enabled": true},
+				},
+			},
+		}
+		d := schema.TestResourceDataRaw(t, res.Schema, data)
+
+		err := patchVpcSecurityProfile(d, nil, projectID)
+		require.NoError(t, err)
+	})
+
+	t.Run("defaults to disabled when default_security_profile is unset", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSDK, restore := setupVpcSecurityProfilesMock(ctrl)
+		defer restore()
+
+		mockSDK.EXPECT().Get(utl.DefaultOrgID, projectID, "default").Return(nsxModel.VpcSecurityProfile{}, nil)
+		mockSDK.EXPECT().Patch(utl.DefaultOrgID, projectID, "default", gomock.Any()).DoAndReturn(
+			func(_, _, _ string, obj nsxModel.VpcSecurityProfile) error {
+				assert.False(t, *obj.NorthSouthFirewall.Enabled)
+				return nil
+			},
+		)
+
+		res := resourceNsxtPolicyProject()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalProjectData())
+
+		err := patchVpcSecurityProfile(d, nil, projectID)
+		require.NoError(t, err)
+	})
+
+	t.Run("fails when the profile is not found", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSDK, restore := setupVpcSecurityProfilesMock(ctrl)
+		defer restore()
+
+		mockSDK.EXPECT().Get(utl.DefaultOrgID, projectID, "default").Return(nsxModel.VpcSecurityProfile{}, vapiErrors.NotFound{})
+
+		res := resourceNsxtPolicyProject()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalProjectData())
+
+		err := patchVpcSecurityProfile(d, nil, projectID)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to fetch")
+	})
+}
+
+func TestMockSetVpcSecurityProfileInSchema(t *testing.T) {
+	t.Run("sets default_security_profile from the API response", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSDK, restore := setupVpcSecurityProfilesMock(ctrl)
+		defer restore()
+
+		enabled := true
+		mockSDK.EXPECT().Get(utl.DefaultOrgID, projectID, "default").Return(nsxModel.VpcSecurityProfile{
+			NorthSouthFirewall: &nsxModel.NorthSouthFirewall{Enabled: &enabled},
+		}, nil)
+
+		res := resourceNsxtPolicyProject()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalProjectData())
+
+		err := setVpcSecurityProfileInSchema(d, nil, projectID)
+		require.NoError(t, err)
+		dsp := d.Get("default_security_profile").([]interface{})
+		require.Len(t, dsp, 1)
+	})
+
+	t.Run("no-ops when the profile is not found", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSDK, restore := setupVpcSecurityProfilesMock(ctrl)
+		defer restore()
+
+		mockSDK.EXPECT().Get(utl.DefaultOrgID, projectID, "default").Return(nsxModel.VpcSecurityProfile{}, vapiErrors.NotFound{})
+
+		res := resourceNsxtPolicyProject()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalProjectData())
+
+		err := setVpcSecurityProfileInSchema(d, nil, projectID)
+		require.NoError(t, err)
+	})
+
+	t.Run("propagates other API errors", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSDK, restore := setupVpcSecurityProfilesMock(ctrl)
+		defer restore()
+
+		mockSDK.EXPECT().Get(utl.DefaultOrgID, projectID, "default").Return(nsxModel.VpcSecurityProfile{}, vapiErrors.InternalServerError{})
+
+		res := resourceNsxtPolicyProject()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalProjectData())
+
+		err := setVpcSecurityProfileInSchema(d, nil, projectID)
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyProjectExistsMocked(t *testing.T) {
+	t.Run("returns true when found", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSDK, restore := setupProjectMock(t, ctrl)
+		defer restore()
+		mockSDK.EXPECT().Get(utl.DefaultOrgID, projectID, gomock.Any()).Return(projectAPIResponse(), nil)
+
+		exists, err := resourceNsxtPolicyProjectExists(projectID, nil, false)
+		require.NoError(t, err)
+		assert.True(t, exists)
+	})
+
+	t.Run("returns false when not found", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSDK, restore := setupProjectMock(t, ctrl)
+		defer restore()
+		mockSDK.EXPECT().Get(utl.DefaultOrgID, projectID, gomock.Any()).Return(nsxModel.Project{}, vapiErrors.NotFound{})
+
+		exists, err := resourceNsxtPolicyProjectExists(projectID, nil, false)
+		require.NoError(t, err)
+		assert.False(t, exists)
+	})
+
+	t.Run("propagates other API errors", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSDK, restore := setupProjectMock(t, ctrl)
+		defer restore()
+		mockSDK.EXPECT().Get(utl.DefaultOrgID, projectID, gomock.Any()).Return(nsxModel.Project{}, vapiErrors.InternalServerError{})
+
+		_, err := resourceNsxtPolicyProjectExists(projectID, nil, false)
 		require.Error(t, err)
 	})
 }

--- a/nsxt/utgomock_resource_nsxt_policy_project_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_project_test.go
@@ -278,6 +278,41 @@ func TestMockResourceNsxtPolicyProjectRead(t *testing.T) {
 		err := resourceNsxtPolicyProjectRead(d, newGoMockProviderClient())
 		require.Error(t, err)
 	})
+
+	t.Run("Read populates span references when NSX 9.1.0+", func(t *testing.T) {
+		util.NsxVersion = "9.1.0"
+		defer func() { util.NsxVersion = "" }()
+
+		restoreSec := setupVpcSecurityProfilesStub(t)
+		defer restoreSec()
+
+		isDefault, isNotDefault := true, false
+		defaultSpan := "/infra/network-spans/default"
+		otherSpan := "/infra/network-spans/other"
+		resp := projectAPIResponse()
+		idSuffix := "suffix1"
+		resp.IdSuffix = &idSuffix
+		resp.VpcDeploymentScope = &nsxModel.VpcDeploymentScope{
+			SpanReferences: []nsxModel.SpanReference{
+				{SpanPath: &defaultSpan, IsDefault: &isDefault},
+				{SpanPath: &otherSpan, IsDefault: &isNotDefault},
+			},
+			ZoneExternalIds: []string{"zone1"},
+		}
+		mockSDK.EXPECT().Get(utl.DefaultOrgID, projectID, gomock.Any()).Return(resp, nil)
+
+		res := resourceNsxtPolicyProject()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalProjectData())
+		d.SetId(projectID)
+
+		err := resourceNsxtPolicyProjectRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, defaultSpan, d.Get("default_span_path"))
+		assert.Equal(t, "suffix1", d.Get("id_suffix"))
+		nonDefault := d.Get("non_default_span_paths").([]interface{})
+		require.Len(t, nonDefault, 1)
+		assert.Equal(t, otherSpan, nonDefault[0])
+	})
 }
 
 func TestMockResourceNsxtPolicyProjectUpdate(t *testing.T) {
@@ -299,6 +334,37 @@ func TestMockResourceNsxtPolicyProjectUpdate(t *testing.T) {
 
 		res := resourceNsxtPolicyProject()
 		d := schema.TestResourceDataRaw(t, res.Schema, minimalProjectData())
+		d.SetId(projectID)
+
+		err := resourceNsxtPolicyProjectUpdate(d, newGoMockProviderClient())
+		require.NoError(t, err)
+	})
+
+	t.Run("Update builds span references and id_suffix when NSX 9.1.0+", func(t *testing.T) {
+		util.NsxVersion = "9.1.0"
+		defer func() { util.NsxVersion = "" }()
+		restoreSec := setupVpcSecurityProfilesStub(t)
+		defer restoreSec()
+
+		gomock.InOrder(
+			mockSDK.EXPECT().Patch(utl.DefaultOrgID, projectID, gomock.Any()).DoAndReturn(
+				func(_ string, _ string, obj nsxModel.Project) error {
+					require.NotNil(t, obj.VpcDeploymentScope)
+					require.Len(t, obj.VpcDeploymentScope.SpanReferences, 1)
+					assert.True(t, *obj.VpcDeploymentScope.SpanReferences[0].IsDefault)
+					require.NotNil(t, obj.IdSuffix)
+					assert.Equal(t, "mysuffix", *obj.IdSuffix)
+					return nil
+				},
+			),
+			mockSDK.EXPECT().Get(utl.DefaultOrgID, projectID, gomock.Any()).Return(projectAPIResponse(), nil),
+		)
+
+		res := resourceNsxtPolicyProject()
+		data := minimalProjectData()
+		data["default_span_path"] = "/infra/network-spans/default"
+		data["id_suffix"] = "mysuffix"
+		d := schema.TestResourceDataRaw(t, res.Schema, data)
 		d.SetId(projectID)
 
 		err := resourceNsxtPolicyProjectUpdate(d, newGoMockProviderClient())
@@ -340,7 +406,7 @@ func TestMockResourceNsxtPolicyProjectDelete(t *testing.T) {
 	})
 }
 
-func TestMockGetDefaultSpan(t *testing.T) {
+func TestMockNsxtGetDefaultSpan(t *testing.T) {
 	t.Run("returns the default span path", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
@@ -404,7 +470,7 @@ func TestMockGetDefaultSpan(t *testing.T) {
 	})
 }
 
-func TestMockPatchVpcSecurityProfile(t *testing.T) {
+func TestMockNsxtPatchVpcSecurityProfile(t *testing.T) {
 	t.Run("patches with enabled true from schema", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
@@ -473,7 +539,7 @@ func TestMockPatchVpcSecurityProfile(t *testing.T) {
 	})
 }
 
-func TestMockSetVpcSecurityProfileInSchema(t *testing.T) {
+func TestMockNsxtSetVpcSecurityProfileInSchema(t *testing.T) {
 	t.Run("sets default_security_profile from the API response", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()

--- a/nsxt/utgomock_resource_nsxt_policy_role_binding_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_role_binding_test.go
@@ -68,6 +68,220 @@ func setupRbMock(t *testing.T, ctrl *gomock.Controller) (*aaamocks.MockRoleBindi
 	return mockSDK, func() { cliRoleBindingsClient = original }
 }
 
+func TestUnitNsxt_rolesPerPath_getAnyRole(t *testing.T) {
+	t.Run("nil map returns nil", func(t *testing.T) {
+		var r rolesPerPath
+		assert.Nil(t, r.getAnyRole())
+	})
+
+	t.Run("no true values returns nil", func(t *testing.T) {
+		r := rolesPerPath{"auditor": false}
+		assert.Nil(t, r.getAnyRole())
+	})
+
+	t.Run("returns the true role", func(t *testing.T) {
+		r := rolesPerPath{"auditor": true}
+		role := r.getAnyRole()
+		require.NotNil(t, role)
+		assert.Equal(t, "auditor", *role)
+	})
+}
+
+func TestUnitNsxt_getRolesForPathFromSchema(t *testing.T) {
+	res := resourceNsxtPolicyUserManagementRoleBinding()
+
+	t.Run("empty when roles_for_path is unset", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalRbData())
+		got := getRolesForPathFromSchema(d)
+		assert.Empty(t, got)
+	})
+
+	t.Run("parses a roles_for_path set", func(t *testing.T) {
+		data := minimalRbData()
+		data["roles_for_path"] = []interface{}{
+			map[string]interface{}{
+				"path":  "/",
+				"roles": []interface{}{"auditor"},
+			},
+		}
+		d := schema.TestResourceDataRaw(t, res.Schema, data)
+		got := getRolesForPathFromSchema(d)
+		require.Contains(t, got, "/")
+		assert.True(t, got["/"]["auditor"])
+	})
+}
+
+func TestUnitNsxt_getRolesForPathList(t *testing.T) {
+	res := resourceNsxtPolicyUserManagementRoleBinding()
+
+	t.Run("converts current roles_for_path with no removals", func(t *testing.T) {
+		data := minimalRbData()
+		data["roles_for_path"] = []interface{}{
+			map[string]interface{}{
+				"path":  "/",
+				"roles": []interface{}{"auditor"},
+			},
+		}
+		d := schema.TestResourceDataRaw(t, res.Schema, data)
+		got := getRolesForPathList(d, rolesForPath{})
+		require.Len(t, got, 1)
+		assert.Equal(t, "/", *got[0].Path)
+	})
+
+	t.Run("appends a DeletePath entry for a path being removed", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalRbData())
+		toRemove := rolesForPath{"/other-path": rolesPerPath{"auditor": true}}
+		got := getRolesForPathList(d, toRemove)
+		require.Len(t, got, 1)
+		assert.Equal(t, "/other-path", *got[0].Path)
+		require.NotNil(t, got[0].DeletePath)
+		assert.True(t, *got[0].DeletePath)
+	})
+
+	t.Run("skips removal for a path also present in the current definition", func(t *testing.T) {
+		data := minimalRbData()
+		data["roles_for_path"] = []interface{}{
+			map[string]interface{}{
+				"path":  "/",
+				"roles": []interface{}{"auditor"},
+			},
+		}
+		d := schema.TestResourceDataRaw(t, res.Schema, data)
+		toRemove := rolesForPath{"/": rolesPerPath{"auditor": true}}
+		got := getRolesForPathList(d, toRemove)
+		require.Len(t, got, 1)
+		assert.Equal(t, "/", *got[0].Path)
+		assert.Nil(t, got[0].DeletePath)
+	})
+}
+
+func TestUnitNsxt_setRolesForPathInSchema(t *testing.T) {
+	res := resourceNsxtPolicyUserManagementRoleBinding()
+
+	t.Run("sets roles_for_path from the API response", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalRbData())
+		path := "/"
+		role := "auditor"
+		setRolesForPathInSchema(d, []nsxModel.RolesForPath{
+			{Path: &path, Roles: []nsxModel.Role{{Role: &role}}},
+		})
+		got := d.Get("roles_for_path").(*schema.Set).List()
+		require.Len(t, got, 1)
+		elem := got[0].(map[string]interface{})
+		assert.Equal(t, "/", elem["path"])
+	})
+
+	t.Run("skips entries with a nil Path", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalRbData())
+		setRolesForPathInSchema(d, []nsxModel.RolesForPath{{Path: nil}})
+		got := d.Get("roles_for_path").(*schema.Set).List()
+		assert.Empty(t, got)
+	})
+}
+
+func TestMockNsxt_getExistingRoleBinding(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupRbMock(t, ctrl)
+	defer restore()
+	rbClient := &aaaapi.RoleBindingClientContext{Client: mockSDK, ClientType: utl.Local}
+
+	t.Run("finds a matching binding", func(t *testing.T) {
+		mockSDK.EXPECT().List(nil, nil, nil, nil, &rbName, nil, nil, nil, nil, nil, nil, nil).Return(
+			nsxModel.RoleBindingListResult{Results: []nsxModel.RoleBinding{rbAPIResponse()}}, nil,
+		)
+		obj, err := getExistingRoleBinding(rbClient, rbName, rbType)
+		require.NoError(t, err)
+		assert.Equal(t, rbID, *obj.Id)
+	})
+
+	t.Run("List error propagates", func(t *testing.T) {
+		mockSDK.EXPECT().List(nil, nil, nil, nil, &rbName, nil, nil, nil, nil, nil, nil, nil).Return(
+			nsxModel.RoleBindingListResult{}, vapiErrors.InternalServerError{},
+		)
+		_, err := getExistingRoleBinding(rbClient, rbName, rbType)
+		require.Error(t, err)
+	})
+
+	t.Run("no matching name/type returns an error", func(t *testing.T) {
+		other := "someone-else"
+		mockSDK.EXPECT().List(nil, nil, nil, nil, &rbName, nil, nil, nil, nil, nil, nil, nil).Return(
+			nsxModel.RoleBindingListResult{Results: []nsxModel.RoleBinding{{Name: &other, Type_: &rbType}}}, nil,
+		)
+		_, err := getExistingRoleBinding(rbClient, rbName, rbType)
+		require.Error(t, err)
+	})
+}
+
+func TestMockNsxt_overwriteRoleBinding(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupRbMock(t, ctrl)
+	defer restore()
+
+	t.Run("success updates then reads", func(t *testing.T) {
+		gomock.InOrder(
+			mockSDK.EXPECT().Update(rbID, gomock.Any()).Return(rbAPIResponse(), nil),
+			mockSDK.EXPECT().Get(rbID, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil).Return(rbAPIResponse(), nil),
+		)
+		res := resourceNsxtPolicyUserManagementRoleBinding()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalRbData())
+		d.SetId(rbID)
+
+		localType := "local_user"
+		existing := rbAPIResponse()
+		path := "/"
+		existing.RolesForPaths = []nsxModel.RolesForPath{{Path: &path, Roles: []nsxModel.Role{{Role: &localType}}}}
+
+		err := overwriteRoleBinding(d, newGoMockProviderClient(), &existing)
+		require.NoError(t, err)
+	})
+
+	t.Run("Update error propagates", func(t *testing.T) {
+		mockSDK.EXPECT().Update(rbID, gomock.Any()).Return(nsxModel.RoleBinding{}, vapiErrors.InternalServerError{})
+		res := resourceNsxtPolicyUserManagementRoleBinding()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalRbData())
+		d.SetId(rbID)
+
+		err := overwriteRoleBinding(d, newGoMockProviderClient(), &nsxModel.RoleBinding{})
+		require.Error(t, err)
+	})
+}
+
+func TestMockNsxt_revertRoleBinding(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSDK, restore := setupRbMock(t, ctrl)
+	defer restore()
+
+	t.Run("success reverts to auditor role", func(t *testing.T) {
+		mockSDK.EXPECT().Update(rbID, gomock.Any()).Return(rbAPIResponse(), nil)
+		res := resourceNsxtPolicyUserManagementRoleBinding()
+		data := minimalRbData()
+		data["roles_for_path"] = []interface{}{
+			map[string]interface{}{
+				"path":  "/some/other/path",
+				"roles": []interface{}{"auditor"},
+			},
+		}
+		d := schema.TestResourceDataRaw(t, res.Schema, data)
+		d.SetId(rbID)
+
+		err := revertRoleBinding(d, newGoMockProviderClient())
+		require.NoError(t, err)
+	})
+
+	t.Run("Update error propagates", func(t *testing.T) {
+		mockSDK.EXPECT().Update(rbID, gomock.Any()).Return(nsxModel.RoleBinding{}, vapiErrors.InternalServerError{})
+		res := resourceNsxtPolicyUserManagementRoleBinding()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalRbData())
+		d.SetId(rbID)
+
+		err := revertRoleBinding(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
 func TestMockResourceNsxtPolicyRoleBindingCreate(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/nsxt/utgomock_resource_nsxt_policy_segment_port_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_segment_port_test.go
@@ -361,7 +361,7 @@ func TestMockResourceNsxtPolicySegmentPortDelete(t *testing.T) {
 	})
 }
 
-func TestMockIsT1Segment(t *testing.T) {
+func TestMockNsxtIsT1Segment(t *testing.T) {
 	tests := []struct {
 		name        string
 		segmentPath string
@@ -400,7 +400,7 @@ func TestMockIsT1Segment(t *testing.T) {
 	}
 }
 
-func TestMockGetT1IdFromSegPath(t *testing.T) {
+func TestMockNsxtGetT1IdFromSegPath(t *testing.T) {
 	tests := []struct {
 		name        string
 		segmentPath string
@@ -434,7 +434,7 @@ func TestMockGetT1IdFromSegPath(t *testing.T) {
 	}
 }
 
-func TestMockSegmentPortImporter(t *testing.T) {
+func TestMockNsxtSegmentPortImporter(t *testing.T) {
 	res := resourceNsxtPolicySegmentPort()
 
 	t.Run("Import with invalid ID (not policy path) returns error without panic", func(t *testing.T) {

--- a/nsxt/utgomock_resource_nsxt_policy_service_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_service_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	vapiErrors "github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 	"go.uber.org/mock/gomock"
@@ -260,4 +261,212 @@ func minimalServiceData() map[string]interface{} {
 		"algorithm_entry":      []interface{}{},
 		"nested_service_entry": []interface{}{},
 	}
+}
+
+func allServiceEntryTypesData() map[string]interface{} {
+	data := minimalServiceData()
+	data["icmp_entry"] = []interface{}{
+		map[string]interface{}{
+			"display_name": "icmp-1",
+			"description":  "icmp desc",
+			"protocol":     "ICMPv4",
+			"icmp_type":    "8",
+			"icmp_code":    "0",
+		},
+	}
+	data["l4_port_set_entry"] = []interface{}{
+		map[string]interface{}{
+			"display_name":      "l4-1",
+			"description":       "l4 desc",
+			"protocol":          "TCP",
+			"destination_ports": []interface{}{"80"},
+			"source_ports":      []interface{}{"1024-2048"},
+		},
+	}
+	data["igmp_entry"] = []interface{}{
+		map[string]interface{}{
+			"display_name": "igmp-1",
+			"description":  "igmp desc",
+		},
+	}
+	data["ether_type_entry"] = []interface{}{
+		map[string]interface{}{
+			"display_name": "ether-1",
+			"description":  "ether desc",
+			"ether_type":   2048,
+		},
+	}
+	data["ip_protocol_entry"] = []interface{}{
+		map[string]interface{}{
+			"display_name": "ipprot-1",
+			"description":  "ipprot desc",
+			"protocol":     6,
+		},
+	}
+	data["algorithm_entry"] = []interface{}{
+		map[string]interface{}{
+			"display_name":     "alg-1",
+			"description":      "alg desc",
+			"destination_port": "21",
+			"source_ports":     []interface{}{"1024-2048"},
+			"algorithm":        "FTP",
+		},
+	}
+	data["nested_service_entry"] = []interface{}{
+		map[string]interface{}{
+			"display_name":        "nested-1",
+			"description":         "nested desc",
+			"nested_service_path": "/infra/services/other-service",
+		},
+	}
+	return data
+}
+
+func TestUnitNsxt_getServiceEntriesFromSchema(t *testing.T) {
+	t.Run("converts one entry of every type", func(t *testing.T) {
+		res := resourceNsxtPolicyService()
+		d := schema.TestResourceDataRaw(t, res.Schema, allServiceEntryTypesData())
+
+		entries, err := getServiceEntriesFromSchema(d)
+		require.NoError(t, err)
+		assert.Len(t, entries, 7)
+	})
+
+	t.Run("fails on invalid icmp_type", func(t *testing.T) {
+		res := resourceNsxtPolicyService()
+		data := minimalServiceData()
+		data["icmp_entry"] = []interface{}{
+			map[string]interface{}{"protocol": "ICMPv4", "icmp_type": "not-a-number", "icmp_code": "", "display_name": "", "description": ""},
+		}
+		d := schema.TestResourceDataRaw(t, res.Schema, data)
+
+		_, err := getServiceEntriesFromSchema(d)
+		require.Error(t, err)
+	})
+
+	t.Run("fails on invalid icmp_code", func(t *testing.T) {
+		res := resourceNsxtPolicyService()
+		data := minimalServiceData()
+		data["icmp_entry"] = []interface{}{
+			map[string]interface{}{"protocol": "ICMPv4", "icmp_type": "", "icmp_code": "not-a-number", "display_name": "", "description": ""},
+		}
+		d := schema.TestResourceDataRaw(t, res.Schema, data)
+
+		_, err := getServiceEntriesFromSchema(d)
+		require.Error(t, err)
+	})
+
+	t.Run("works against a nested map instead of ResourceData", func(t *testing.T) {
+		nestedMap := map[string]interface{}{
+			"icmp_entry": schema.NewSet(schema.HashResource(getIcmpEntrySchema().Elem.(*schema.Resource)), nil),
+		}
+		entries, err := getServiceEntriesFromSchema(nestedMap)
+		require.NoError(t, err)
+		assert.Empty(t, entries)
+	})
+}
+
+func TestUnitNsxt_setServiceEntriesInSchema(t *testing.T) {
+	t.Run("round-trips every entry type back into schema", func(t *testing.T) {
+		res := resourceNsxtPolicyService()
+		d := schema.TestResourceDataRaw(t, res.Schema, allServiceEntryTypesData())
+
+		entries, err := getServiceEntriesFromSchema(d)
+		require.NoError(t, err)
+
+		emptyData := schema.TestResourceDataRaw(t, res.Schema, minimalServiceData())
+		err = setServiceEntriesInSchema(emptyData, entries, true)
+		require.NoError(t, err)
+
+		assert.Len(t, emptyData.Get("icmp_entry").(*schema.Set).List(), 1)
+		assert.Len(t, emptyData.Get("l4_port_set_entry").(*schema.Set).List(), 1)
+		assert.Len(t, emptyData.Get("igmp_entry").(*schema.Set).List(), 1)
+		assert.Len(t, emptyData.Get("ether_type_entry").(*schema.Set).List(), 1)
+		assert.Len(t, emptyData.Get("ip_protocol_entry").(*schema.Set).List(), 1)
+		assert.Len(t, emptyData.Get("algorithm_entry").(*schema.Set).List(), 1)
+		assert.Len(t, emptyData.Get("nested_service_entry").(*schema.Set).List(), 1)
+	})
+
+	t.Run("skips nested_service_entry when nestedSupported is false", func(t *testing.T) {
+		res := resourceNsxtPolicyService()
+		d := schema.TestResourceDataRaw(t, res.Schema, allServiceEntryTypesData())
+
+		entries, err := getServiceEntriesFromSchema(d)
+		require.NoError(t, err)
+
+		emptyData := schema.TestResourceDataRaw(t, res.Schema, minimalServiceData())
+		err = setServiceEntriesInSchema(emptyData, entries, false)
+		require.NoError(t, err)
+		assert.Empty(t, emptyData.Get("nested_service_entry").(*schema.Set).List())
+	})
+}
+
+func TestUnitNsxt_filterServiceEntryDisplayName(t *testing.T) {
+	t.Run("returns empty string when display name is nil", func(t *testing.T) {
+		assert.Equal(t, "", filterServiceEntryDisplayName(nil, nil))
+	})
+
+	t.Run("returns empty string when display name matches the generated id", func(t *testing.T) {
+		name := "auto-id-123"
+		assert.Equal(t, "", filterServiceEntryDisplayName(&name, &name))
+	})
+
+	t.Run("returns the display name when it differs from the id", func(t *testing.T) {
+		name, id := "custom-name", "auto-id-123"
+		assert.Equal(t, "custom-name", filterServiceEntryDisplayName(&name, &id))
+	})
+}
+
+func TestMockResourceNsxtPolicyServiceExists(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockServicesSDK := svcmocks.NewMockServicesClient(ctrl)
+	mockWrapper := &cliinfra.ServiceClientContext{
+		Client:     mockServicesSDK,
+		ClientType: utl.Local,
+	}
+
+	originalCli := cliServicesClient
+	defer func() { cliServicesClient = originalCli }()
+	cliServicesClient = func(sessionContext utl.SessionContext, connector client.Connector) *cliinfra.ServiceClientContext {
+		return mockWrapper
+	}
+
+	t.Run("returns true when the service exists", func(t *testing.T) {
+		mockServicesSDK.EXPECT().Get(svcID).Return(model.Service{Id: &svcID}, nil)
+
+		exists, err := resourceNsxtPolicyServiceExists(utl.SessionContext{}, svcID, nil)
+		require.NoError(t, err)
+		assert.True(t, exists)
+	})
+
+	t.Run("returns false when the service is not found", func(t *testing.T) {
+		mockServicesSDK.EXPECT().Get("missing-id").Return(model.Service{}, vapiErrors.NotFound{})
+
+		exists, err := resourceNsxtPolicyServiceExists(utl.SessionContext{}, "missing-id", nil)
+		require.NoError(t, err)
+		assert.False(t, exists)
+	})
+
+	t.Run("propagates other API errors", func(t *testing.T) {
+		mockServicesSDK.EXPECT().Get("err-id").Return(model.Service{}, errors.New("boom"))
+
+		_, err := resourceNsxtPolicyServiceExists(utl.SessionContext{}, "err-id", nil)
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyServiceCreateEntryConversionError(t *testing.T) {
+	res := resourceNsxtPolicyService()
+	data := minimalServiceData()
+	data["icmp_entry"] = []interface{}{
+		map[string]interface{}{"protocol": "ICMPv4", "icmp_type": "not-a-number", "icmp_code": "", "display_name": "", "description": ""},
+	}
+	d := schema.TestResourceDataRaw(t, res.Schema, data)
+
+	m := newGoMockProviderClient()
+	err := resourceNsxtPolicyServiceCreate(d, m)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Service entries conversion")
 }

--- a/nsxt/utgomock_resource_nsxt_policy_static_route_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_static_route_test.go
@@ -204,3 +204,26 @@ func TestMockResourceNsxtPolicyStaticRouteDelete(t *testing.T) {
 		require.Error(t, err)
 	})
 }
+
+func TestUnitNsxt_resourceNsxtPolicyStaticRouteImport(t *testing.T) {
+	res := resourceNsxtPolicyStaticRoute()
+
+	t.Run("full policy path succeeds and sets gateway_path", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		d.SetId("/infra/tier-0s/gw-1/static-routes/route-1")
+
+		out, err := resourceNsxtPolicyStaticRouteImport(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		require.Len(t, out, 1)
+		assert.Equal(t, "/infra/tier-0s/gw-1", d.Get("gateway_path"))
+	})
+
+	t.Run("legacy format missing a slash is rejected", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		d.SetId("route-1")
+
+		_, err := resourceNsxtPolicyStaticRouteImport(d, newGoMockProviderClient())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "gateway-id")
+	})
+}

--- a/nsxt/utgomock_resource_nsxt_policy_tier0_gateway_interface_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_tier0_gateway_interface_test.go
@@ -17,9 +17,11 @@ import (
 	nsxModel "github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 	"go.uber.org/mock/gomock"
 
+	cliinfra "github.com/vmware/terraform-provider-nsxt/api/infra"
 	tier0sapi "github.com/vmware/terraform-provider-nsxt/api/infra/tier_0s"
 	t0lsapi "github.com/vmware/terraform-provider-nsxt/api/infra/tier_0s/locale_services"
 	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
+	t0sdkmocks "github.com/vmware/terraform-provider-nsxt/mocks/infra"
 	t0lsmocks "github.com/vmware/terraform-provider-nsxt/mocks/infra/tier_0s"
 	t0intmocks "github.com/vmware/terraform-provider-nsxt/mocks/infra/tier_0s/locale_services"
 	"github.com/vmware/terraform-provider-nsxt/nsxt/util"
@@ -279,5 +281,248 @@ func TestMockResourceNsxtPolicyTier0GatewayInterfaceRead_subnetPathVersion(t *te
 		err := resourceNsxtPolicyTier0GatewayInterfaceRead(d, newGoMockProviderClient())
 		require.NoError(t, err)
 		assert.Equal(t, sp, d.Get("subnet_path"))
+	})
+}
+
+func TestMockResourceNsxtPolicyTier0GatewayInterfaceCreateValidation(t *testing.T) {
+	t.Run("fails when neither segment_path nor subnet_path is set for non-loopback type", func(t *testing.T) {
+		res := resourceNsxtPolicyTier0GatewayInterface()
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+			"display_name": t0IntDisplayName,
+			"gateway_path": t0IntGwPath,
+			"type":         nsxModel.Tier0Interface_TYPE_EXTERNAL,
+		})
+
+		err := resourceNsxtPolicyTier0GatewayInterfaceCreate(d, newGoMockProviderClient())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "mandatory")
+	})
+
+	t.Run("fails when enable_pim is set on Global Manager", func(t *testing.T) {
+		res := resourceNsxtPolicyTier0GatewayInterface()
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+			"display_name": t0IntDisplayName,
+			"gateway_path": t0IntGwPath,
+			"type":         nsxModel.Tier0Interface_TYPE_EXTERNAL,
+			"segment_path": t0IntSegmentPath,
+			"enable_pim":   true,
+		})
+
+		err := resourceNsxtPolicyTier0GatewayInterfaceCreate(d, newGoMockGlobalProviderClient())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "enable_pim")
+	})
+
+	t.Run("fails when site_path is missing on Global Manager", func(t *testing.T) {
+		res := resourceNsxtPolicyTier0GatewayInterface()
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+			"display_name": t0IntDisplayName,
+			"gateway_path": t0IntGwPath,
+			"type":         nsxModel.Tier0Interface_TYPE_EXTERNAL,
+			"segment_path": t0IntSegmentPath,
+			"enable_pim":   false,
+		})
+
+		err := resourceNsxtPolicyTier0GatewayInterfaceCreate(d, newGoMockGlobalProviderClient())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "site_path")
+	})
+
+	t.Run("fails when site_path is set on Local Manager", func(t *testing.T) {
+		res := resourceNsxtPolicyTier0GatewayInterface()
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+			"display_name": t0IntDisplayName,
+			"gateway_path": t0IntGwPath,
+			"type":         nsxModel.Tier0Interface_TYPE_EXTERNAL,
+			"segment_path": t0IntSegmentPath,
+			"site_path":    "/infra/sites/default",
+		})
+
+		err := resourceNsxtPolicyTier0GatewayInterfaceCreate(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyTier0GatewayInterfaceCreateExistsCheck(t *testing.T) {
+	t.Run("fails when interface with nsx_id already exists", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockIntfSDK, mockLSSDK, restore := setupT0InterfaceMocks(t, ctrl)
+		defer restore()
+		mockLSSDK.EXPECT().Get(t0IntGwID, defaultPolicyLocaleServiceID).Return(nsxModel.LocaleServices{Id: &t0IntLocaleServiceID}, nil)
+		mockIntfSDK.EXPECT().Get(t0IntGwID, t0IntLocaleServiceID, t0IntID).Return(t0InterfaceAPIResponse(), nil)
+
+		data := minimalT0InterfaceData()
+		data["nsx_id"] = t0IntID
+		res := resourceNsxtPolicyTier0GatewayInterface()
+		d := schema.TestResourceDataRaw(t, res.Schema, data)
+
+		err := resourceNsxtPolicyTier0GatewayInterfaceCreate(d, newGoMockProviderClient())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "already exists")
+	})
+
+	t.Run("propagates a non-not-found error from the exists check", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockIntfSDK, mockLSSDK, restore := setupT0InterfaceMocks(t, ctrl)
+		defer restore()
+		mockLSSDK.EXPECT().Get(t0IntGwID, defaultPolicyLocaleServiceID).Return(nsxModel.LocaleServices{Id: &t0IntLocaleServiceID}, nil)
+		mockIntfSDK.EXPECT().Get(t0IntGwID, t0IntLocaleServiceID, t0IntID).Return(nsxModel.Tier0Interface{}, vapiErrors.InternalServerError{})
+
+		data := minimalT0InterfaceData()
+		data["nsx_id"] = t0IntID
+		res := resourceNsxtPolicyTier0GatewayInterface()
+		d := schema.TestResourceDataRaw(t, res.Schema, data)
+
+		err := resourceNsxtPolicyTier0GatewayInterfaceCreate(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyTier0GatewayInterfaceCreateEdgeClusterMissing(t *testing.T) {
+	t.Run("fails when no locale service with an edge cluster is found", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		_, mockLSSDK, restore := setupT0InterfaceMocks(t, ctrl)
+		defer restore()
+		mockLSSDK.EXPECT().Get(t0IntGwID, defaultPolicyLocaleServiceID).Return(nsxModel.LocaleServices{}, vapiErrors.NotFound{})
+		mockLSSDK.EXPECT().List(t0IntGwID, (*string)(nil), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(
+			nsxModel.LocaleServicesListResult{}, vapiErrors.NotFound{},
+		)
+
+		res := resourceNsxtPolicyTier0GatewayInterface()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalT0InterfaceData())
+
+		err := resourceNsxtPolicyTier0GatewayInterfaceCreate(d, newGoMockProviderClient())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Edge cluster is mandatory")
+	})
+}
+
+func TestMockResourceNsxtPolicyTier0GatewayInterfaceCreateOspf(t *testing.T) {
+	t.Run("fails when ospf is set on a non-EXTERNAL interface", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		_, mockLSSDK, restore := setupT0InterfaceMocks(t, ctrl)
+		defer restore()
+		mockLSSDK.EXPECT().Get(t0IntGwID, defaultPolicyLocaleServiceID).Return(nsxModel.LocaleServices{Id: &t0IntLocaleServiceID}, nil)
+
+		data := map[string]interface{}{
+			"display_name": t0IntDisplayName,
+			"gateway_path": t0IntGwPath,
+			"type":         nsxModel.Tier0Interface_TYPE_LOOPBACK,
+			"urpf_mode":    nsxModel.Tier0Interface_URPF_MODE_STRICT,
+			"ospf": []interface{}{
+				map[string]interface{}{
+					"enabled":          true,
+					"area_path":        "/infra/tier-0s/t0-gw-1/locale-services/default/ospf/areas/0.0.0.0",
+					"enable_bfd":       false,
+					"hello_interval":   10,
+					"dead_interval":    40,
+					"network_type":     nsxModel.PolicyInterfaceOspfConfig_NETWORK_TYPE_BROADCAST,
+					"bfd_profile_path": "",
+				},
+			},
+		}
+		res := resourceNsxtPolicyTier0GatewayInterface()
+		d := schema.TestResourceDataRaw(t, res.Schema, data)
+
+		err := resourceNsxtPolicyTier0GatewayInterfaceCreate(d, newGoMockProviderClient())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Ospf")
+	})
+}
+
+func setupT0GatewayImportMock(t *testing.T, ctrl *gomock.Controller) (*t0sdkmocks.MockTier0sClient, func()) {
+	mockTier0sSDK := t0sdkmocks.NewMockTier0sClient(ctrl)
+	tier0Wrapper := &cliinfra.Tier0ClientContext{
+		Client:     mockTier0sSDK,
+		ClientType: utl.Local,
+	}
+	original := cliTier0sClient
+	cliTier0sClient = func(_ utl.SessionContext, _ vapiProtocolClient.Connector) *cliinfra.Tier0ClientContext {
+		return tier0Wrapper
+	}
+	return mockTier0sSDK, func() { cliTier0sClient = original }
+}
+
+func TestMockResourceNsxtPolicyTier0GatewayInterfaceImport(t *testing.T) {
+	t.Run("succeeds with a valid composite ID", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockTier0sSDK, restore := setupT0GatewayImportMock(t, ctrl)
+		defer restore()
+		gwPath := t0IntGwPath
+		mockTier0sSDK.EXPECT().Get(t0IntGwID).Return(nsxModel.Tier0{Path: &gwPath}, nil)
+
+		res := resourceNsxtPolicyTier0GatewayInterface()
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		d.SetId(t0IntGwID + "/" + t0IntLocaleServiceID + "/" + t0IntID)
+
+		out, err := resourceNsxtPolicyTier0GatewayInterfaceImport(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		require.Len(t, out, 1)
+		assert.Equal(t, t0IntID, out[0].Id())
+		assert.Equal(t, t0IntGwPath, out[0].Get("gateway_path"))
+		assert.Equal(t, t0IntLocaleServiceID, out[0].Get("locale_service_id"))
+	})
+
+	t.Run("fails with a malformed ID", func(t *testing.T) {
+		res := resourceNsxtPolicyTier0GatewayInterface()
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		d.SetId("not-enough-parts")
+
+		_, err := resourceNsxtPolicyTier0GatewayInterfaceImport(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+
+	t.Run("propagates a gateway lookup error", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockTier0sSDK, restore := setupT0GatewayImportMock(t, ctrl)
+		defer restore()
+		mockTier0sSDK.EXPECT().Get(t0IntGwID).Return(nsxModel.Tier0{}, vapiErrors.InternalServerError{})
+
+		res := resourceNsxtPolicyTier0GatewayInterface()
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		d.SetId(t0IntGwID + "/" + t0IntLocaleServiceID + "/" + t0IntID)
+
+		_, err := resourceNsxtPolicyTier0GatewayInterfaceImport(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyTier0GatewayInterfaceReadWithOspf(t *testing.T) {
+	t.Run("Read populates the ospf block from the API object", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockIntfSDK, _, restore := setupT0InterfaceMocks(t, ctrl)
+		defer restore()
+
+		iface := t0InterfaceAPIResponse()
+		enabled, enableBfd := true, false
+		areaPath := "/infra/tier-0s/t0-gw-1/locale-services/default/ospf/areas/0.0.0.0"
+		networkType := nsxModel.PolicyInterfaceOspfConfig_NETWORK_TYPE_BROADCAST
+		hello, dead := int64(10), int64(40)
+		iface.Ospf = &nsxModel.PolicyInterfaceOspfConfig{
+			Enabled:       &enabled,
+			EnableBfd:     &enableBfd,
+			OspfArea:      &areaPath,
+			NetworkType:   &networkType,
+			HelloInterval: &hello,
+			DeadInterval:  &dead,
+		}
+		mockIntfSDK.EXPECT().Get(t0IntGwID, t0IntLocaleServiceID, t0IntID).Return(iface, nil)
+
+		res := resourceNsxtPolicyTier0GatewayInterface()
+		d := schema.TestResourceDataRaw(t, res.Schema, t0InterfaceDataWithLocaleService())
+		d.SetId(t0IntID)
+
+		err := resourceNsxtPolicyTier0GatewayInterfaceRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		ospf := d.Get("ospf").([]interface{})
+		require.Len(t, ospf, 1)
+		assert.Equal(t, areaPath, ospf[0].(map[string]interface{})["area_path"])
 	})
 }

--- a/nsxt/utgomock_resource_nsxt_policy_tier0_gateway_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_tier0_gateway_test.go
@@ -111,6 +111,77 @@ func TestMockResourceNsxtPolicyTier0GatewayRead(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "Error obtaining Tier0 ID")
 	})
+
+	t.Run("Read populates locale_service blocks when configured via locale_service", func(t *testing.T) {
+		mockTier0sSDK.EXPECT().Get(t0GatewayID).Return(model.Tier0{
+			DisplayName:     &t0DisplayName,
+			Description:     &t0Description,
+			Path:            &t0Path,
+			Revision:        &t0Revision,
+			FailoverMode:    &t0FailoverMode,
+			HaMode:          &t0HaMode,
+			DisableFirewall: &t0DisableFirewall,
+		}, nil)
+		lsID := "ls-1"
+		lsPath := "/infra/tier-0s/t0-gw-1/locale-services/ls-1"
+		lsEdgeCluster := "/infra/sites/default/enforcement-points/default/edge-clusters/ec-1"
+		lsResultCount := int64(1)
+		mockLocaleServicesSDK.EXPECT().List(t0GatewayID, gomock.Any(), nil, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(model.LocaleServicesListResult{Results: []model.LocaleServices{
+				{Id: &lsID, Path: &lsPath, EdgeClusterPath: &lsEdgeCluster},
+			}, ResultCount: &lsResultCount}, nil)
+
+		res := resourceNsxtPolicyTier0Gateway()
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+			"locale_service": []interface{}{
+				map[string]interface{}{"nsx_id": "ls-1"},
+			},
+		})
+		d.SetId(t0GatewayID)
+
+		m := newGoMockProviderClient()
+		err := resourceNsxtPolicyTier0GatewayRead(d, m)
+		require.NoError(t, err)
+		services := d.Get("locale_service").(*schema.Set).List()
+		require.Len(t, services, 1)
+		assert.Equal(t, lsPath, services[0].(map[string]interface{})["path"])
+	})
+
+	t.Run("Read populates edge_cluster_path and bgp_config when locale_service is not configured", func(t *testing.T) {
+		mockTier0sSDK.EXPECT().Get(t0GatewayID).Return(model.Tier0{
+			DisplayName:     &t0DisplayName,
+			Description:     &t0Description,
+			Path:            &t0Path,
+			Revision:        &t0Revision,
+			FailoverMode:    &t0FailoverMode,
+			HaMode:          &t0HaMode,
+			DisableFirewall: &t0DisableFirewall,
+		}, nil)
+		lsID := "ls-1"
+		lsEdgeCluster := "/infra/sites/default/enforcement-points/default/edge-clusters/ec-1"
+		lsResultCount := int64(1)
+		mockLocaleServicesSDK.EXPECT().List(t0GatewayID, gomock.Any(), nil, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(model.LocaleServicesListResult{Results: []model.LocaleServices{
+				{Id: &lsID, EdgeClusterPath: &lsEdgeCluster},
+			}, ResultCount: &lsResultCount}, nil)
+
+		mockBgpSDK := bgpmocks.NewMockBgpClient(ctrl)
+		originalBgp := cliBgpClient
+		defer func() { cliBgpClient = originalBgp }()
+		cliBgpClient = func(sessionContext utl.SessionContext, connector client.Connector) *localeservices.BgpRoutingConfigClientContext {
+			return &localeservices.BgpRoutingConfigClientContext{Client: mockBgpSDK, ClientType: utl.Local}
+		}
+		mockBgpSDK.EXPECT().Get(t0GatewayID, lsID).Return(model.BgpRoutingConfig{}, vapiErrors.NotFound{})
+
+		res := resourceNsxtPolicyTier0Gateway()
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		d.SetId(t0GatewayID)
+
+		m := newGoMockProviderClient()
+		err := resourceNsxtPolicyTier0GatewayRead(d, m)
+		require.NoError(t, err)
+		assert.Equal(t, lsEdgeCluster, d.Get("edge_cluster_path"))
+	})
 }
 
 func TestMockResourceNsxtPolicyTier0GatewayCreate(t *testing.T) {
@@ -528,5 +599,138 @@ func TestMockNsxt_initImplicitTier0GatewayLocaleService(t *testing.T) {
 		result, err := initImplicitTier0GatewayLocaleService(utl.SessionContext{ClientType: utl.Local}, d, nil, nil)
 		require.NoError(t, err)
 		assert.NotNil(t, result)
+	})
+}
+
+func TestUnitNsxt_verifyPolicyTier0GatewayConfig(t *testing.T) {
+	res := resourceNsxtPolicyTier0Gateway()
+
+	t.Run("global manager without locale_service or edge_cluster_path fails", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		err := verifyPolicyTier0GatewayConfig(d, true)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "mandatory")
+	})
+
+	t.Run("global manager with edge_cluster_path fails", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+			"edge_cluster_path": "/infra/sites/default/enforcement-points/default/edge-clusters/ec-1",
+		})
+		err := verifyPolicyTier0GatewayConfig(d, true)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not supported")
+	})
+
+	t.Run("global manager with locale_service succeeds", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+			"locale_service": []interface{}{
+				map[string]interface{}{"edge_cluster_path": "/infra/sites/default/enforcement-points/default/edge-clusters/ec-1"},
+			},
+		})
+		require.NoError(t, verifyPolicyTier0GatewayConfig(d, true))
+	})
+
+	t.Run("local manager with edge_cluster_path and no locale_service succeeds", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+			"edge_cluster_path": "/infra/sites/default/enforcement-points/default/edge-clusters/ec-1",
+		})
+		require.NoError(t, verifyPolicyTier0GatewayConfig(d, false))
+	})
+}
+
+func TestUnitNsxt_getTier0AdvancedConfigFromSchema(t *testing.T) {
+	res := resourceNsxtPolicyTier0Gateway()
+
+	t.Run("nil when advanced_config is not set", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		assert.Nil(t, getTier0AdvancedConfigFromSchema(d))
+	})
+
+	t.Run("builds config with connectivity set", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+			"advanced_config": []interface{}{
+				map[string]interface{}{"connectivity": "ALL", "forwarding_up_timer": 5},
+			},
+		})
+		obj := getTier0AdvancedConfigFromSchema(d)
+		require.NotNil(t, obj)
+		require.NotNil(t, obj.Connectivity)
+		assert.Equal(t, "ALL", *obj.Connectivity)
+		assert.Equal(t, int64(5), *obj.ForwardingUpTimer)
+	})
+
+	t.Run("leaves Connectivity nil when empty string", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+			"advanced_config": []interface{}{
+				map[string]interface{}{"connectivity": "", "forwarding_up_timer": 3},
+			},
+		})
+		obj := getTier0AdvancedConfigFromSchema(d)
+		require.NotNil(t, obj)
+		assert.Nil(t, obj.Connectivity)
+		assert.Equal(t, int64(3), *obj.ForwardingUpTimer)
+	})
+}
+
+func TestUnitNsxt_setTier0AdvancedConfigInSchema(t *testing.T) {
+	res := resourceNsxtPolicyTier0Gateway()
+
+	t.Run("clears the block when obj is nil", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		setTier0AdvancedConfigInSchema(d, nil)
+		assert.Empty(t, d.Get("advanced_config").([]interface{}))
+	})
+
+	t.Run("sets the block from an advanced config object", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		connectivity := "OFF"
+		timer := int64(10)
+		setTier0AdvancedConfigInSchema(d, &model.Tier0AdvancedConfig{
+			Connectivity:      &connectivity,
+			ForwardingUpTimer: &timer,
+		})
+		list := d.Get("advanced_config").([]interface{})
+		require.Len(t, list, 1)
+		elem := list[0].(map[string]interface{})
+		assert.Equal(t, "OFF", elem["connectivity"])
+		assert.Equal(t, 10, elem["forwarding_up_timer"])
+	})
+}
+
+func TestMockResourceNsxtPolicyTier0GatewayIsVrf(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockTier0sSDK := t0mocks.NewMockTier0sClient(ctrl)
+	tier0Wrapper := &cliinfra.Tier0ClientContext{Client: mockTier0sSDK, ClientType: utl.Local}
+	original := cliTier0sClient
+	defer func() { cliTier0sClient = original }()
+	cliTier0sClient = func(sessionContext utl.SessionContext, connector client.Connector) *cliinfra.Tier0ClientContext {
+		return tier0Wrapper
+	}
+
+	res := resourceNsxtPolicyTier0Gateway()
+
+	t.Run("returns true when VrfConfig is set", func(t *testing.T) {
+		mockTier0sSDK.EXPECT().Get(t0GatewayID).Return(model.Tier0{VrfConfig: &model.Tier0VrfConfig{}}, nil)
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		isVrf, err := resourceNsxtPolicyTier0GatewayIsVrf(d, newGoMockProviderClient(), t0GatewayID, nil, false)
+		require.NoError(t, err)
+		assert.True(t, isVrf)
+	})
+
+	t.Run("returns false when VrfConfig is nil", func(t *testing.T) {
+		mockTier0sSDK.EXPECT().Get(t0GatewayID).Return(model.Tier0{}, nil)
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		isVrf, err := resourceNsxtPolicyTier0GatewayIsVrf(d, newGoMockProviderClient(), t0GatewayID, nil, false)
+		require.NoError(t, err)
+		assert.False(t, isVrf)
+	})
+
+	t.Run("propagates a Get error", func(t *testing.T) {
+		mockTier0sSDK.EXPECT().Get(t0GatewayID).Return(model.Tier0{}, vapiErrors.InternalServerError{})
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		_, err := resourceNsxtPolicyTier0GatewayIsVrf(d, newGoMockProviderClient(), t0GatewayID, nil, false)
+		require.Error(t, err)
 	})
 }

--- a/nsxt/utgomock_resource_nsxt_policy_tier0_gateway_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_tier0_gateway_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	vapiErrors "github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors"
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
 	"go.uber.org/mock/gomock"
@@ -22,9 +23,11 @@ import (
 	apipkg "github.com/vmware/terraform-provider-nsxt/api"
 	cliinfra "github.com/vmware/terraform-provider-nsxt/api/infra"
 	tier0localeservices "github.com/vmware/terraform-provider-nsxt/api/infra/tier_0s"
+	localeservices "github.com/vmware/terraform-provider-nsxt/api/infra/tier_0s/locale_services"
 	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
 	t0mocks "github.com/vmware/terraform-provider-nsxt/mocks/infra"
 	localeServicesMocks "github.com/vmware/terraform-provider-nsxt/mocks/infra/tier_0s"
+	bgpmocks "github.com/vmware/terraform-provider-nsxt/mocks/infra/tier_0s/locale_services"
 	"github.com/vmware/terraform-provider-nsxt/nsxt/util"
 )
 
@@ -293,5 +296,237 @@ func TestMockResourceNsxtPolicyTier0GatewayDelete(t *testing.T) {
 		err := resourceNsxtPolicyTier0GatewayDelete(d, m)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "Error obtaining Tier0 ID")
+	})
+}
+
+func TestMockResourceNsxtPolicyTier0GatewayExists(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockTier0sSDK := t0mocks.NewMockTier0sClient(ctrl)
+	tier0Wrapper := &cliinfra.Tier0ClientContext{Client: mockTier0sSDK, ClientType: utl.Local}
+	original := cliTier0sClient
+	defer func() { cliTier0sClient = original }()
+	cliTier0sClient = func(sessionContext utl.SessionContext, connector client.Connector) *cliinfra.Tier0ClientContext {
+		return tier0Wrapper
+	}
+	ctx := utl.SessionContext{ClientType: utl.Local}
+
+	t.Run("returns true when Get succeeds", func(t *testing.T) {
+		mockTier0sSDK.EXPECT().Get(t0GatewayID).Return(model.Tier0{}, nil)
+		exists, err := resourceNsxtPolicyTier0GatewayExists(ctx, t0GatewayID, nil)
+		require.NoError(t, err)
+		assert.True(t, exists)
+	})
+
+	t.Run("returns false on NotFound", func(t *testing.T) {
+		mockTier0sSDK.EXPECT().Get(t0GatewayID).Return(model.Tier0{}, vapiErrors.NotFound{})
+		exists, err := resourceNsxtPolicyTier0GatewayExists(ctx, t0GatewayID, nil)
+		require.NoError(t, err)
+		assert.False(t, exists)
+	})
+
+	t.Run("propagates other errors", func(t *testing.T) {
+		mockTier0sSDK.EXPECT().Get(t0GatewayID).Return(model.Tier0{}, vapiErrors.InternalServerError{})
+		exists, err := resourceNsxtPolicyTier0GatewayExists(ctx, t0GatewayID, nil)
+		require.Error(t, err)
+		assert.False(t, exists)
+	})
+}
+
+func TestMockResourceNsxtPolicyTier0GatewayReadBGPConfig(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockBgpSDK := bgpmocks.NewMockBgpClient(ctrl)
+	bgpWrapper := &localeservices.BgpRoutingConfigClientContext{Client: mockBgpSDK, ClientType: utl.Local}
+	original := cliBgpClient
+	defer func() { cliBgpClient = original }()
+	cliBgpClient = func(sessionContext utl.SessionContext, connector client.Connector) *localeservices.BgpRoutingConfigClientContext {
+		return bgpWrapper
+	}
+
+	localeServiceID := "default"
+	localeService := model.LocaleServices{Id: &localeServiceID}
+
+	t.Run("populates bgp_config on success", func(t *testing.T) {
+		enabled := true
+		mockBgpSDK.EXPECT().Get(t0GatewayID, localeServiceID).Return(model.BgpRoutingConfig{Enabled: &enabled}, nil)
+
+		res := resourceNsxtPolicyTier0Gateway()
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		d.SetId(t0GatewayID)
+
+		err := resourceNsxtPolicyTier0GatewayReadBGPConfig(d, newGoMockProviderClient(), nil, localeService)
+		require.NoError(t, err)
+		bgpConfigs := d.Get("bgp_config").([]interface{})
+		require.Len(t, bgpConfigs, 1)
+	})
+
+	t.Run("clears bgp_config when not found", func(t *testing.T) {
+		mockBgpSDK.EXPECT().Get(t0GatewayID, localeServiceID).Return(model.BgpRoutingConfig{}, vapiErrors.NotFound{})
+
+		res := resourceNsxtPolicyTier0Gateway()
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		d.SetId(t0GatewayID)
+
+		err := resourceNsxtPolicyTier0GatewayReadBGPConfig(d, newGoMockProviderClient(), nil, localeService)
+		require.NoError(t, err)
+		assert.Empty(t, d.Get("bgp_config").([]interface{}))
+	})
+
+	t.Run("propagates other errors", func(t *testing.T) {
+		mockBgpSDK.EXPECT().Get(t0GatewayID, localeServiceID).Return(model.BgpRoutingConfig{}, vapiErrors.InternalServerError{})
+
+		res := resourceNsxtPolicyTier0Gateway()
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		d.SetId(t0GatewayID)
+
+		err := resourceNsxtPolicyTier0GatewayReadBGPConfig(d, newGoMockProviderClient(), nil, localeService)
+		require.Error(t, err)
+	})
+}
+
+func TestUnitNsxt_isInterSrIbgpSetInConfig(t *testing.T) {
+	t.Run("returns false when raw config has no bgp_config block", func(t *testing.T) {
+		res := resourceNsxtPolicyTier0Gateway()
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		assert.False(t, isInterSrIbgpSetInConfig(d))
+	})
+}
+
+func TestUnitNsxt_resourceNsxtPolicyTier0GatewayBGPConfigSchemaToStruct(t *testing.T) {
+	tagElem := getTagsSchema().Elem.(*schema.Resource)
+	tagSet := schema.NewSet(schema.HashResource(tagElem), []interface{}{
+		map[string]interface{}{"scope": "s1", "tag": "t1"},
+	})
+	baseCfgMap := func() map[string]interface{} {
+		return map[string]interface{}{
+			"revision":                           1,
+			"ecmp":                               true,
+			"enabled":                            true,
+			"local_as_num":                       "65000",
+			"multipath_relax":                    true,
+			"graceful_restart_mode":              "HELPER_ONLY",
+			"graceful_restart_timer":             180,
+			"graceful_restart_stale_route_timer": 600,
+			"tag":                                tagSet,
+			"inter_sr_ibgp":                      true,
+			"route_aggregation": []interface{}{
+				map[string]interface{}{"prefix": "10.0.0.0/24", "summary_only": true},
+			},
+		}
+	}
+
+	t.Run("non-VRF gateway sets multipath_relax and graceful restart config", func(t *testing.T) {
+		result := resourceNsxtPolicyTier0GatewayBGPConfigSchemaToStruct(baseCfgMap(), false, t0GatewayID)
+		require.NotNil(t, result.MultipathRelax)
+		assert.True(t, *result.MultipathRelax)
+		require.NotNil(t, result.GracefulRestartConfig)
+		require.NotNil(t, result.InterSrIbgp)
+		assert.True(t, *result.InterSrIbgp)
+		require.Len(t, result.RouteAggregations, 1)
+		assert.Equal(t, "10.0.0.0/24", *result.RouteAggregations[0].Prefix)
+		require.NotNil(t, result.LocalAsNum)
+		assert.Equal(t, "65000", *result.LocalAsNum)
+	})
+
+	t.Run("VRF gateway omits multipath_relax and graceful restart config", func(t *testing.T) {
+		result := resourceNsxtPolicyTier0GatewayBGPConfigSchemaToStruct(baseCfgMap(), true, t0GatewayID)
+		assert.Nil(t, result.MultipathRelax)
+		assert.Nil(t, result.GracefulRestartConfig)
+	})
+
+	t.Run("empty local_as_num is omitted", func(t *testing.T) {
+		cfgMap := baseCfgMap()
+		cfgMap["local_as_num"] = ""
+		result := resourceNsxtPolicyTier0GatewayBGPConfigSchemaToStruct(cfgMap, false, t0GatewayID)
+		assert.Nil(t, result.LocalAsNum)
+	})
+}
+
+func TestUnitNsxt_initPolicyTier0ChildBgpConfig(t *testing.T) {
+	t.Run("converts a BgpRoutingConfig into a child struct value", func(t *testing.T) {
+		enabled := true
+		result, err := initPolicyTier0ChildBgpConfig(&model.BgpRoutingConfig{Enabled: &enabled})
+		require.NoError(t, err)
+		assert.NotNil(t, result)
+	})
+}
+
+func TestUnitNsxt_getPolicyVRFConfigFromSchema(t *testing.T) {
+	res := resourceNsxtPolicyTier0Gateway()
+
+	t.Run("returns nil when vrf_config is unset", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		assert.Nil(t, getPolicyVRFConfigFromSchema(d))
+	})
+
+	t.Run("builds a Tier0VrfConfig from schema", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+			"vrf_config": []interface{}{
+				map[string]interface{}{
+					"gateway_path":        "/infra/tier-0s/t0-1",
+					"route_distinguisher": "65000:1",
+					"evpn_transit_vni":    100,
+					"route_target": []interface{}{
+						map[string]interface{}{
+							"address_family": "IPV4",
+							"import_targets": []interface{}{"target:1:1"},
+							"export_targets": []interface{}{"target:1:1"},
+						},
+					},
+				},
+			},
+		})
+
+		config := getPolicyVRFConfigFromSchema(d)
+		require.NotNil(t, config)
+		assert.Equal(t, "/infra/tier-0s/t0-1", *config.Tier0Path)
+		require.NotNil(t, config.RouteDistinguisher)
+		assert.Equal(t, "65000:1", *config.RouteDistinguisher)
+		require.NotNil(t, config.EvpnTransitVni)
+		assert.Equal(t, int64(100), *config.EvpnTransitVni)
+		require.Len(t, config.RouteTargets, 1)
+		assert.Equal(t, "IPV4", *config.RouteTargets[0].AddressFamily)
+	})
+}
+
+func TestUnitNsxt_setPolicyVRFConfigInSchema(t *testing.T) {
+	res := resourceNsxtPolicyTier0Gateway()
+
+	t.Run("no-op when config is nil", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		require.NoError(t, setPolicyVRFConfigInSchema(d, nil))
+	})
+
+	t.Run("sets vrf_config from a Tier0VrfConfig", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		gwPath := "/infra/tier-0s/t0-1"
+		addressFamily := "IPV4"
+		config := &model.Tier0VrfConfig{
+			Tier0Path: &gwPath,
+			RouteTargets: []model.VrfRouteTargets{
+				{AddressFamily: &addressFamily, ImportRouteTargets: []string{"target:1:1"}},
+			},
+		}
+
+		require.NoError(t, setPolicyVRFConfigInSchema(d, config))
+		vrfConfigs := d.Get("vrf_config").([]interface{})
+		require.Len(t, vrfConfigs, 1)
+		elem := vrfConfigs[0].(map[string]interface{})
+		assert.Equal(t, gwPath, elem["gateway_path"])
+	})
+}
+
+func TestMockNsxt_initImplicitTier0GatewayLocaleService(t *testing.T) {
+	res := resourceNsxtPolicyTier0Gateway()
+
+	t.Run("create flow builds a locale service without fetching an existing one", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{
+			"edge_cluster_path": "/infra/sites/default/enforcement-points/default/edge-clusters/ec-1",
+		})
+
+		result, err := initImplicitTier0GatewayLocaleService(utl.SessionContext{ClientType: utl.Local}, d, nil, nil)
+		require.NoError(t, err)
+		assert.NotNil(t, result)
 	})
 }

--- a/nsxt/utgomock_resource_nsxt_policy_tier1_gateway_interface_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_tier1_gateway_interface_test.go
@@ -214,3 +214,27 @@ func TestMockResourceNsxtPolicyTier1GatewayInterfaceDelete(t *testing.T) {
 		require.Error(t, err)
 	})
 }
+
+func TestUnitNsxt_resourceNsxtPolicyTier1GatewayInterfaceImport(t *testing.T) {
+	res := resourceNsxtPolicyTier1GatewayInterface()
+
+	t.Run("full policy path succeeds and sets gateway_path and locale_service_id", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		d.SetId("/infra/tier-1s/gw-1/locale-services/default/interfaces/int-1")
+
+		out, err := resourceNsxtPolicyTier1GatewayInterfaceImport(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		require.Len(t, out, 1)
+		assert.Equal(t, "/infra/tier-1s/gw-1", d.Get("gateway_path"))
+		assert.Equal(t, "default", d.Get("locale_service_id"))
+	})
+
+	t.Run("legacy format with wrong segment count is rejected", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		d.SetId("gw-1/ls-1")
+
+		_, err := resourceNsxtPolicyTier1GatewayInterfaceImport(d, newGoMockProviderClient())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "gateway-id")
+	})
+}

--- a/nsxt/utgomock_resource_nsxt_policy_tier1_gateway_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_tier1_gateway_test.go
@@ -226,3 +226,226 @@ func TestMockResourceNsxtPolicyTier1GatewayDelete(t *testing.T) {
 		require.Error(t, err)
 	})
 }
+
+func TestUnitNsxt_tier1GatewayAdvRulesRoundTrip(t *testing.T) {
+	t.Run("set then get round-trips the rules", func(t *testing.T) {
+		res := resourceNsxtPolicyTier1Gateway()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalT1GatewayData())
+
+		prefix := "GE"
+		rules := []nsxModel.RouteAdvertisementRule{
+			{
+				Name:                    strPtr("rule-1"),
+				Action:                  strPtr("PERMIT"),
+				Subnets:                 []string{"10.0.0.0/24"},
+				RouteAdvertisementTypes: []string{"TIER1_CONNECTED"},
+				PrefixOperator:          &prefix,
+			},
+		}
+
+		err := setAdvRulesInSchema(d, rules)
+		require.NoError(t, err)
+
+		out := getAdvRulesFromSchema(d)
+		require.Len(t, out, 1)
+		assert.Equal(t, "rule-1", *out[0].Name)
+		assert.Equal(t, "PERMIT", *out[0].Action)
+		assert.Equal(t, "GE", *out[0].PrefixOperator)
+		assert.ElementsMatch(t, []string{"10.0.0.0/24"}, out[0].Subnets)
+		assert.ElementsMatch(t, []string{"TIER1_CONNECTED"}, out[0].RouteAdvertisementTypes)
+	})
+
+	t.Run("empty rules round-trip to an empty list", func(t *testing.T) {
+		res := resourceNsxtPolicyTier1Gateway()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalT1GatewayData())
+
+		err := setAdvRulesInSchema(d, nil)
+		require.NoError(t, err)
+		assert.Empty(t, getAdvRulesFromSchema(d))
+	})
+}
+
+func TestMockResourceNsxtPolicyTier1GatewayExistsMocked(t *testing.T) {
+	t.Run("returns true when found", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockT1SDK, _, _, restore := setupT1GatewayMocks(t, ctrl)
+		defer restore()
+		mockT1SDK.EXPECT().Get(t1GwID).Return(t1GatewayAPIResponse(), nil)
+
+		exists, err := resourceNsxtPolicyTier1GatewayExists(utl.SessionContext{ClientType: utl.Local}, t1GwID, nil)
+		require.NoError(t, err)
+		assert.True(t, exists)
+	})
+
+	t.Run("returns false when not found", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockT1SDK, _, _, restore := setupT1GatewayMocks(t, ctrl)
+		defer restore()
+		mockT1SDK.EXPECT().Get(t1GwID).Return(nsxModel.Tier1{}, vapiErrors.NotFound{})
+
+		exists, err := resourceNsxtPolicyTier1GatewayExists(utl.SessionContext{ClientType: utl.Local}, t1GwID, nil)
+		require.NoError(t, err)
+		assert.False(t, exists)
+	})
+
+	t.Run("propagates other API errors", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockT1SDK, _, _, restore := setupT1GatewayMocks(t, ctrl)
+		defer restore()
+		mockT1SDK.EXPECT().Get(t1GwID).Return(nsxModel.Tier1{}, vapiErrors.InternalServerError{})
+
+		_, err := resourceNsxtPolicyTier1GatewayExists(utl.SessionContext{ClientType: utl.Local}, t1GwID, nil)
+		require.Error(t, err)
+	})
+}
+
+func TestMockGetPolicyTier1GatewayLocaleServiceEntry(t *testing.T) {
+	ctx := utl.SessionContext{ClientType: utl.Local}
+
+	t.Run("returns the default-ID locale service when Get succeeds", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		_, _, mockLSSDK, restore := setupT1GatewayMocks(t, ctrl)
+		defer restore()
+		edgeCluster := "/infra/edge-clusters/ec-1"
+		mockLSSDK.EXPECT().Get(t1GwID, defaultPolicyLocaleServiceID).Return(nsxModel.LocaleServices{EdgeClusterPath: &edgeCluster}, nil)
+
+		obj, err := getPolicyTier1GatewayLocaleServiceEntry(ctx, t1GwID, nil)
+		require.NoError(t, err)
+		require.NotNil(t, obj)
+		assert.Equal(t, edgeCluster, *obj.EdgeClusterPath)
+	})
+
+	t.Run("falls back to listing and prefers an entry with an edge cluster path", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		_, _, mockLSSDK, restore := setupT1GatewayMocks(t, ctrl)
+		defer restore()
+		edgeCluster := "/infra/edge-clusters/ec-1"
+		resultCount := int64(2)
+		mockLSSDK.EXPECT().Get(t1GwID, defaultPolicyLocaleServiceID).Return(nsxModel.LocaleServices{}, vapiErrors.NotFound{})
+		mockLSSDK.EXPECT().List(t1GwID, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(
+			nsxModel.LocaleServicesListResult{
+				Results:     []nsxModel.LocaleServices{{}, {EdgeClusterPath: &edgeCluster}},
+				ResultCount: &resultCount,
+			}, nil,
+		)
+
+		obj, err := getPolicyTier1GatewayLocaleServiceEntry(ctx, t1GwID, nil)
+		require.NoError(t, err)
+		require.NotNil(t, obj)
+		assert.Equal(t, edgeCluster, *obj.EdgeClusterPath)
+	})
+
+	t.Run("falls back to any entry when none has an edge cluster path", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		_, _, mockLSSDK, restore := setupT1GatewayMocks(t, ctrl)
+		defer restore()
+		id := "ls-1"
+		resultCount := int64(1)
+		mockLSSDK.EXPECT().Get(t1GwID, defaultPolicyLocaleServiceID).Return(nsxModel.LocaleServices{}, vapiErrors.NotFound{})
+		mockLSSDK.EXPECT().List(t1GwID, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(
+			nsxModel.LocaleServicesListResult{Results: []nsxModel.LocaleServices{{Id: &id}}, ResultCount: &resultCount}, nil,
+		)
+
+		obj, err := getPolicyTier1GatewayLocaleServiceEntry(ctx, t1GwID, nil)
+		require.NoError(t, err)
+		require.NotNil(t, obj)
+		assert.Equal(t, "ls-1", *obj.Id)
+	})
+
+	t.Run("returns nil, nil when no locale services exist", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		_, _, mockLSSDK, restore := setupT1GatewayMocks(t, ctrl)
+		defer restore()
+		resultCount := int64(0)
+		mockLSSDK.EXPECT().Get(t1GwID, defaultPolicyLocaleServiceID).Return(nsxModel.LocaleServices{}, vapiErrors.NotFound{})
+		mockLSSDK.EXPECT().List(t1GwID, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(
+			nsxModel.LocaleServicesListResult{ResultCount: &resultCount}, nil,
+		)
+
+		obj, err := getPolicyTier1GatewayLocaleServiceEntry(ctx, t1GwID, nil)
+		require.NoError(t, err)
+		assert.Nil(t, obj)
+	})
+
+	t.Run("propagates the list error", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		_, _, mockLSSDK, restore := setupT1GatewayMocks(t, ctrl)
+		defer restore()
+		mockLSSDK.EXPECT().Get(t1GwID, defaultPolicyLocaleServiceID).Return(nsxModel.LocaleServices{}, vapiErrors.NotFound{})
+		mockLSSDK.EXPECT().List(t1GwID, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(
+			nsxModel.LocaleServicesListResult{}, vapiErrors.InternalServerError{},
+		)
+
+		_, err := getPolicyTier1GatewayLocaleServiceEntry(ctx, t1GwID, nil)
+		require.Error(t, err)
+	})
+}
+
+func TestMockInitImplicitTier1GatewayLocaleService(t *testing.T) {
+	ctx := utl.SessionContext{ClientType: utl.Local}
+
+	t.Run("create flow with edge_cluster_path builds a fresh locale service, no API call", func(t *testing.T) {
+		res := resourceNsxtPolicyTier1Gateway()
+		data := minimalT1GatewayData()
+		data["edge_cluster_path"] = "/infra/edge-clusters/ec-1"
+		d := schema.TestResourceDataRaw(t, res.Schema, data)
+
+		structValue, err := initImplicitTier1GatewayLocaleService(ctx, d, nil)
+		require.NoError(t, err)
+		assert.NotNil(t, structValue)
+	})
+
+	t.Run("create flow without edge_cluster_path clears it, no API call", func(t *testing.T) {
+		res := resourceNsxtPolicyTier1Gateway()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalT1GatewayData())
+
+		structValue, err := initImplicitTier1GatewayLocaleService(ctx, d, nil)
+		require.NoError(t, err)
+		assert.NotNil(t, structValue)
+	})
+
+	t.Run("update flow reuses the existing locale service entry", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		_, _, mockLSSDK, restore := setupT1GatewayMocks(t, ctrl)
+		defer restore()
+		existingID := "custom-ls"
+		mockLSSDK.EXPECT().Get(t1GwID, defaultPolicyLocaleServiceID).Return(nsxModel.LocaleServices{Id: &existingID}, nil)
+
+		res := resourceNsxtPolicyTier1Gateway()
+		data := minimalT1GatewayData()
+		data["edge_cluster_path"] = "/infra/edge-clusters/ec-1"
+		d := schema.TestResourceDataRaw(t, res.Schema, data)
+		d.SetId(t1GwID)
+
+		structValue, err := initImplicitTier1GatewayLocaleService(ctx, d, nil)
+		require.NoError(t, err)
+		assert.NotNil(t, structValue)
+	})
+
+	t.Run("update flow propagates the lookup error", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		_, _, mockLSSDK, restore := setupT1GatewayMocks(t, ctrl)
+		defer restore()
+		mockLSSDK.EXPECT().Get(t1GwID, defaultPolicyLocaleServiceID).Return(nsxModel.LocaleServices{}, vapiErrors.NotFound{})
+		mockLSSDK.EXPECT().List(t1GwID, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(
+			nsxModel.LocaleServicesListResult{}, vapiErrors.InternalServerError{},
+		)
+
+		res := resourceNsxtPolicyTier1Gateway()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalT1GatewayData())
+		d.SetId(t1GwID)
+
+		_, err := initImplicitTier1GatewayLocaleService(ctx, d, nil)
+		require.Error(t, err)
+	})
+}

--- a/nsxt/utgomock_resource_nsxt_policy_tier1_gateway_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_tier1_gateway_test.go
@@ -302,7 +302,7 @@ func TestMockResourceNsxtPolicyTier1GatewayExistsMocked(t *testing.T) {
 	})
 }
 
-func TestMockGetPolicyTier1GatewayLocaleServiceEntry(t *testing.T) {
+func TestMockNsxtGetPolicyTier1GatewayLocaleServiceEntry(t *testing.T) {
 	ctx := utl.SessionContext{ClientType: utl.Local}
 
 	t.Run("returns the default-ID locale service when Get succeeds", func(t *testing.T) {
@@ -389,7 +389,7 @@ func TestMockGetPolicyTier1GatewayLocaleServiceEntry(t *testing.T) {
 	})
 }
 
-func TestMockInitImplicitTier1GatewayLocaleService(t *testing.T) {
+func TestMockNsxtInitImplicitTier1GatewayLocaleService(t *testing.T) {
 	ctx := utl.SessionContext{ClientType: utl.Local}
 
 	t.Run("create flow with edge_cluster_path builds a fresh locale service, no API call", func(t *testing.T) {

--- a/nsxt/utgomock_resource_nsxt_policy_transit_gateway_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_transit_gateway_test.go
@@ -650,4 +650,225 @@ func TestMockResourceNsxtPolicyTransitGatewayDelete(t *testing.T) {
 		err := resourceNsxtPolicyTransitGatewayDelete(d, newGoMockProviderClient())
 		require.Error(t, err)
 	})
+
+	t.Run("Delete fails when OrgRoot Patch returns error", func(t *testing.T) {
+		m.orgRoot.EXPECT().Patch(gomock.Any(), gomock.Any()).Return(vapiErrors.InternalServerError{})
+
+		res := resourceNsxtPolicyTransitGateway()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalTGWData())
+		d.SetId(tgwID)
+
+		err := resourceNsxtPolicyTransitGatewayDelete(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestUnitNsxt_getCentralizedConfigFromSchema(t *testing.T) {
+	t.Run("returns nil when centralized_config is absent", func(t *testing.T) {
+		res := resourceNsxtPolicyTransitGateway()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalTGWData())
+
+		cfg, err := getCentralizedConfigFromSchema(d, nil)
+		require.NoError(t, err)
+		assert.Nil(t, cfg)
+	})
+
+	t.Run("populates ha_mode and edge_cluster_paths", func(t *testing.T) {
+		data := minimalTGWData()
+		data["centralized_config"] = []interface{}{
+			map[string]interface{}{
+				"ha_mode":            "ACTIVE_STANDBY",
+				"edge_cluster_paths": []interface{}{"/infra/edge-clusters/ec1", "/infra/edge-clusters/ec2"},
+			},
+		}
+		res := resourceNsxtPolicyTransitGateway()
+		d := schema.TestResourceDataRaw(t, res.Schema, data)
+
+		cfg, err := getCentralizedConfigFromSchema(d, nil)
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+		require.NotNil(t, cfg.HaMode)
+		assert.Equal(t, "ACTIVE_STANDBY", *cfg.HaMode)
+		assert.Equal(t, []string{"/infra/edge-clusters/ec1", "/infra/edge-clusters/ec2"}, cfg.EdgeClusterPaths)
+	})
+
+	t.Run("accepts failover_mode at or above NSX 9.2.0", func(t *testing.T) {
+		util.NsxVersion = "9.2.0"
+		defer func() { util.NsxVersion = "" }()
+
+		data := minimalTGWData()
+		data["centralized_config"] = []interface{}{
+			map[string]interface{}{"failover_mode": "PREEMPTIVE"},
+		}
+		res := resourceNsxtPolicyTransitGateway()
+		d := schema.TestResourceDataRaw(t, res.Schema, data)
+
+		cfg, err := getCentralizedConfigFromSchema(d, nil)
+		require.NoError(t, err)
+		require.NotNil(t, cfg.FailoverMode)
+		assert.Equal(t, "PREEMPTIVE", *cfg.FailoverMode)
+	})
+}
+
+func TestUnitNsxt_setCentralizedConfigInSchema(t *testing.T) {
+	t.Run("returns nil for a nil config", func(t *testing.T) {
+		assert.Nil(t, setCentralizedConfigInSchema(nil, nil))
+	})
+
+	t.Run("maps ha_mode and edge_cluster_paths, omitting failover_mode below 9.2.0", func(t *testing.T) {
+		util.NsxVersion = "9.1.0"
+		defer func() { util.NsxVersion = "" }()
+
+		haMode := "ACTIVE_STANDBY"
+		failoverMode := "PREEMPTIVE"
+		cfg := &nsxModel.CentralizedConfig{
+			HaMode:           &haMode,
+			FailoverMode:     &failoverMode,
+			EdgeClusterPaths: []string{"/infra/edge-clusters/ec1"},
+		}
+
+		out := setCentralizedConfigInSchema(cfg, nil)
+		require.Len(t, out, 1)
+		m := out[0].(map[string]interface{})
+		assert.Equal(t, "ACTIVE_STANDBY", m["ha_mode"])
+		assert.Equal(t, []string{"/infra/edge-clusters/ec1"}, m["edge_cluster_paths"])
+		assert.NotContains(t, m, "failover_mode")
+	})
+
+	t.Run("includes failover_mode at or above 9.2.0", func(t *testing.T) {
+		util.NsxVersion = "9.2.0"
+		defer func() { util.NsxVersion = "" }()
+
+		failoverMode := "PREEMPTIVE"
+		cfg := &nsxModel.CentralizedConfig{FailoverMode: &failoverMode}
+
+		out := setCentralizedConfigInSchema(cfg, nil)
+		require.Len(t, out, 1)
+		assert.Equal(t, "PREEMPTIVE", out[0].(map[string]interface{})["failover_mode"])
+	})
+}
+
+func TestUnitNsxt_getSpanFromSchema(t *testing.T) {
+	t.Run("returns nil for nil input", func(t *testing.T) {
+		out, err := getSpanFromSchema(nil)
+		require.NoError(t, err)
+		assert.Nil(t, out)
+	})
+
+	t.Run("returns nil for an empty list", func(t *testing.T) {
+		out, err := getSpanFromSchema([]interface{}{})
+		require.NoError(t, err)
+		assert.Nil(t, out)
+	})
+
+	t.Run("returns nil when the input is not a list", func(t *testing.T) {
+		out, err := getSpanFromSchema("not-a-list")
+		require.NoError(t, err)
+		assert.Nil(t, out)
+	})
+
+	t.Run("builds a ClusterBasedSpan struct", func(t *testing.T) {
+		span := []interface{}{
+			map[string]interface{}{
+				"cluster_based_span": []interface{}{
+					map[string]interface{}{"span_path": "/infra/sites/default/enforcement-points/default"},
+				},
+			},
+		}
+
+		structVal, err := getSpanFromSchema(span)
+		require.NoError(t, err)
+		require.NotNil(t, structVal)
+
+		out, err := setSpanFromSchema(structVal)
+		require.NoError(t, err)
+		spanList := out.([]interface{})
+		require.Len(t, spanList, 1)
+		cbs := spanList[0].(map[string]interface{})["cluster_based_span"].([]interface{})
+		require.Len(t, cbs, 1)
+	})
+}
+
+func TestMockResourceNsxtPolicyTransitGatewayCentralizedConfigRead(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	m := setupTransitGatewayMockFull(t, ctrl)
+
+	t.Run("Read populates centralized_config from a successful API response", func(t *testing.T) {
+		haMode := "ACTIVE_STANDBY"
+		ccResp := nsxModel.CentralizedConfig{HaMode: &haMode}
+		gomock.InOrder(
+			m.tgw.EXPECT().Get(tgwOrgID, tgwProjectID, tgwID).Return(tgwAPIResponse(), nil),
+			m.cc.EXPECT().Get(tgwOrgID, tgwProjectID, tgwID, centralizedConfigID).Return(ccResp, nil),
+			m.bgp.EXPECT().Get(tgwOrgID, tgwProjectID, tgwID).Return(nsxModel.TransitGatewayBgpRoutingConfig{}, vapiErrors.NotFound{}),
+		)
+
+		res := resourceNsxtPolicyTransitGateway()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalTGWData())
+		d.SetId(tgwID)
+
+		err := resourceNsxtPolicyTransitGatewayRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+
+		ccList := d.Get("centralized_config").([]interface{})
+		require.Len(t, ccList, 1)
+		assert.Equal(t, "ACTIVE_STANDBY", ccList[0].(map[string]interface{})["ha_mode"])
+	})
+
+	t.Run("Read fails when CentralizedConfig API returns a non-NotFound error", func(t *testing.T) {
+		gomock.InOrder(
+			m.tgw.EXPECT().Get(tgwOrgID, tgwProjectID, tgwID).Return(tgwAPIResponse(), nil),
+			m.cc.EXPECT().Get(tgwOrgID, tgwProjectID, tgwID, centralizedConfigID).Return(nsxModel.CentralizedConfig{}, vapiErrors.InternalServerError{}),
+		)
+
+		res := resourceNsxtPolicyTransitGateway()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalTGWData())
+		d.SetId(tgwID)
+
+		err := resourceNsxtPolicyTransitGatewayRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+
+	t.Run("Read fails when BgpConfig API returns a non-NotFound error", func(t *testing.T) {
+		gomock.InOrder(
+			m.tgw.EXPECT().Get(tgwOrgID, tgwProjectID, tgwID).Return(tgwAPIResponse(), nil),
+			m.cc.EXPECT().Get(tgwOrgID, tgwProjectID, tgwID, centralizedConfigID).Return(nsxModel.CentralizedConfig{}, vapiErrors.NotFound{}),
+			m.bgp.EXPECT().Get(tgwOrgID, tgwProjectID, tgwID).Return(nsxModel.TransitGatewayBgpRoutingConfig{}, vapiErrors.InternalServerError{}),
+		)
+
+		res := resourceNsxtPolicyTransitGateway()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalTGWData())
+		d.SetId(tgwID)
+
+		err := resourceNsxtPolicyTransitGatewayRead(d, newGoMockProviderClient())
+		require.Error(t, err)
+	})
+}
+
+func TestMockResourceNsxtPolicyTransitGatewayUpdateCentralizedConfig(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	m := setupTransitGatewayMockFull(t, ctrl)
+
+	t.Run("Update attaches a centralized_config child when it changed", func(t *testing.T) {
+		rev := int64(2)
+		gomock.InOrder(
+			m.cc.EXPECT().Get(tgwOrgID, tgwProjectID, tgwID, centralizedConfigID).Return(nsxModel.CentralizedConfig{Revision: &rev}, nil),
+			m.orgRoot.EXPECT().Patch(gomock.Any(), gomock.Any()).Return(nil),
+			m.tgw.EXPECT().Get(tgwOrgID, tgwProjectID, tgwID).Return(tgwAPIResponse(), nil),
+			m.cc.EXPECT().Get(tgwOrgID, tgwProjectID, tgwID, centralizedConfigID).Return(nsxModel.CentralizedConfig{}, vapiErrors.NotFound{}),
+			m.bgp.EXPECT().Get(tgwOrgID, tgwProjectID, tgwID).Return(nsxModel.TransitGatewayBgpRoutingConfig{}, vapiErrors.NotFound{}),
+		)
+
+		data := minimalTGWData()
+		data["centralized_config"] = []interface{}{
+			map[string]interface{}{"ha_mode": "ACTIVE_STANDBY"},
+		}
+		res := resourceNsxtPolicyTransitGateway()
+		d := schema.TestResourceDataRaw(t, res.Schema, data)
+		d.SetId(tgwID)
+
+		err := resourceNsxtPolicyTransitGatewayUpdate(d, newGoMockProviderClient())
+		require.NoError(t, err)
+	})
 }

--- a/nsxt/utgomock_resource_nsxt_policy_transit_gateway_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_transit_gateway_test.go
@@ -787,6 +787,63 @@ func TestUnitNsxt_getSpanFromSchema(t *testing.T) {
 		cbs := spanList[0].(map[string]interface{})["cluster_based_span"].([]interface{})
 		require.Len(t, cbs, 1)
 	})
+
+	t.Run("builds a ZoneBasedSpan struct", func(t *testing.T) {
+		span := []interface{}{
+			map[string]interface{}{
+				"zone_based_span": []interface{}{
+					map[string]interface{}{"zone_external_ids": []interface{}{"zone-1", "zone-2"}},
+				},
+			},
+		}
+
+		structVal, err := getSpanFromSchema(span)
+		require.NoError(t, err)
+		require.NotNil(t, structVal)
+
+		out, err := setSpanFromSchema(structVal)
+		require.NoError(t, err)
+		spanList := out.([]interface{})
+		require.Len(t, spanList, 1)
+		zbs := spanList[0].(map[string]interface{})["zone_based_span"].([]interface{})
+		require.Len(t, zbs, 1)
+		ids := zbs[0].(map[string]interface{})["zone_external_ids"].([]string)
+		assert.Equal(t, []string{"zone-1", "zone-2"}, ids)
+	})
+
+	t.Run("returns nil when neither span type is set", func(t *testing.T) {
+		span := []interface{}{map[string]interface{}{}}
+		out, err := getSpanFromSchema(span)
+		require.NoError(t, err)
+		assert.Nil(t, out)
+	})
+}
+
+func TestMockResourceNsxtPolicyTransitGatewayExists(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	m := setupTransitGatewayMockFull(t, ctrl)
+	sessionContext := utl.SessionContext{ProjectID: tgwProjectID}
+
+	t.Run("returns true when Get succeeds", func(t *testing.T) {
+		m.tgw.EXPECT().Get(tgwOrgID, tgwProjectID, tgwID).Return(tgwAPIResponse(), nil)
+		exists, err := resourceNsxtPolicyTransitGatewayExists(sessionContext, tgwID, nil)
+		require.NoError(t, err)
+		assert.True(t, exists)
+	})
+
+	t.Run("returns false on NotFound", func(t *testing.T) {
+		m.tgw.EXPECT().Get(tgwOrgID, tgwProjectID, tgwID).Return(nsxModel.TransitGateway{}, vapiErrors.NotFound{})
+		exists, err := resourceNsxtPolicyTransitGatewayExists(sessionContext, tgwID, nil)
+		require.NoError(t, err)
+		assert.False(t, exists)
+	})
+
+	t.Run("propagates other errors", func(t *testing.T) {
+		m.tgw.EXPECT().Get(tgwOrgID, tgwProjectID, tgwID).Return(nsxModel.TransitGateway{}, vapiErrors.InternalServerError{})
+		_, err := resourceNsxtPolicyTransitGatewayExists(sessionContext, tgwID, nil)
+		require.Error(t, err)
+	})
 }
 
 func TestMockResourceNsxtPolicyTransitGatewayCentralizedConfigRead(t *testing.T) {
@@ -870,5 +927,26 @@ func TestMockResourceNsxtPolicyTransitGatewayUpdateCentralizedConfig(t *testing.
 
 		err := resourceNsxtPolicyTransitGatewayUpdate(d, newGoMockProviderClient())
 		require.NoError(t, err)
+	})
+}
+
+func TestUnitNsxt_buildTGWBgpConfigChildren(t *testing.T) {
+	t.Run("markDelete true builds a marked-for-delete child regardless of config", func(t *testing.T) {
+		children, err := buildTGWBgpConfigChildren(nil, true)
+		require.NoError(t, err)
+		require.Len(t, children, 1)
+	})
+
+	t.Run("nil config with markDelete false returns no children", func(t *testing.T) {
+		children, err := buildTGWBgpConfigChildren(nil, false)
+		require.NoError(t, err)
+		assert.Nil(t, children)
+	})
+
+	t.Run("non-nil config with markDelete false builds a config child", func(t *testing.T) {
+		ecmp := true
+		children, err := buildTGWBgpConfigChildren(&nsxModel.TransitGatewayBgpRoutingConfig{Ecmp: &ecmp}, false)
+		require.NoError(t, err)
+		require.Len(t, children, 1)
 	})
 }

--- a/nsxt/utgomock_resource_nsxt_policy_virtual_network_appliance_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_virtual_network_appliance_test.go
@@ -59,6 +59,241 @@ func setupVNACRUDClientOverride(mock *epmocks.MockVirtualNetworkAppliancesInClus
 	return func() { cliVNACRUDClient = orig }
 }
 
+func TestUnitNsxt_getVNAClusterPathComponents(t *testing.T) {
+	t.Run("parses a valid cluster path", func(t *testing.T) {
+		site, ep, cluster, err := getVNAClusterPathComponents(vnaClusterPath)
+		require.NoError(t, err)
+		assert.Equal(t, vnaClusterSiteID, site)
+		assert.Equal(t, vnaClusterEPID, ep)
+		assert.Equal(t, vnaClusterID, cluster)
+	})
+
+	t.Run("errors when the site segment is missing", func(t *testing.T) {
+		_, _, _, err := getVNAClusterPathComponents("/enforcement-points/default/virtual-network-appliance-clusters/c1")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "site ID")
+	})
+
+	t.Run("errors when the enforcement-point segment is missing", func(t *testing.T) {
+		_, _, _, err := getVNAClusterPathComponents("/infra/sites/default/virtual-network-appliance-clusters/c1")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "enforcement-point ID")
+	})
+
+	t.Run("errors when the cluster segment is missing", func(t *testing.T) {
+		_, _, _, err := getVNAClusterPathComponents("/infra/sites/default/enforcement-points/default")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cluster ID")
+	})
+}
+
+func TestUnitNsxt_getVNACredentialsFromSchema(t *testing.T) {
+	t.Run("nil input returns nil", func(t *testing.T) {
+		assert.Nil(t, getVNACredentialsFromSchema(nil))
+	})
+
+	t.Run("empty list returns nil", func(t *testing.T) {
+		assert.Nil(t, getVNACredentialsFromSchema([]interface{}{}))
+	})
+
+	t.Run("parses all password fields", func(t *testing.T) {
+		obj := getVNACredentialsFromSchema([]interface{}{
+			map[string]interface{}{
+				"cli_password":   "cli-pass",
+				"root_password":  "root-pass",
+				"audit_password": "audit-pass",
+			},
+		})
+		require.NotNil(t, obj)
+		assert.Equal(t, "cli-pass", *obj.CliPassword)
+		assert.Equal(t, "root-pass", *obj.RootPassword)
+		assert.Equal(t, "audit-pass", *obj.AuditPassword)
+	})
+
+	t.Run("empty password strings are omitted", func(t *testing.T) {
+		obj := getVNACredentialsFromSchema([]interface{}{
+			map[string]interface{}{
+				"cli_password":   "",
+				"root_password":  "",
+				"audit_password": "",
+			},
+		})
+		require.NotNil(t, obj)
+		assert.Nil(t, obj.CliPassword)
+		assert.Nil(t, obj.RootPassword)
+		assert.Nil(t, obj.AuditPassword)
+	})
+}
+
+func TestUnitNsxt_getVNAManagementInterfaceFromSchema(t *testing.T) {
+	t.Run("nil input returns nil", func(t *testing.T) {
+		obj, err := getVNAManagementInterfaceFromSchema(nil)
+		require.NoError(t, err)
+		assert.Nil(t, obj)
+	})
+
+	t.Run("empty list returns nil", func(t *testing.T) {
+		obj, err := getVNAManagementInterfaceFromSchema([]interface{}{})
+		require.NoError(t, err)
+		assert.Nil(t, obj)
+	})
+
+	t.Run("parses network_id and ip_assignment", func(t *testing.T) {
+		obj, err := getVNAManagementInterfaceFromSchema([]interface{}{
+			map[string]interface{}{
+				"network_id": "dvpg-1",
+				"ip_assignment": []interface{}{
+					map[string]interface{}{
+						"dhcp_v4": true,
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, obj)
+		assert.Equal(t, "dvpg-1", *obj.NetworkId)
+		require.Len(t, obj.IpAssignmentSpecs, 1)
+	})
+}
+
+func TestUnitNsxt_setVNAManagementInterfaceInSchema(t *testing.T) {
+	res := resourceNsxtPolicyVirtualNetworkAppliance()
+
+	t.Run("nil object is a no-op", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{"cluster_path": vnaClusterPath})
+		require.NoError(t, setVNAManagementInterfaceInSchema(d, nil))
+		assert.Empty(t, d.Get("management_interface").([]interface{}))
+	})
+
+	t.Run("sets network_id and ip_assignment", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{"cluster_path": vnaClusterPath})
+		networkID := "dvpg-2"
+		sv, err := vAPIConversion(model.Dhcpv4{IpAssignmentType: model.PolicyIpAssignmentSpec_IP_ASSIGNMENT_TYPE_DHCPV4}, model.Dhcpv4BindingType())
+		require.NoError(t, err)
+		err = setVNAManagementInterfaceInSchema(d, &model.VirtualNetworkApplianceManagementInterface{
+			NetworkId:         &networkID,
+			IpAssignmentSpecs: []*vapiData.StructValue{sv},
+		})
+		require.NoError(t, err)
+		list := d.Get("management_interface").([]interface{})
+		require.Len(t, list, 1)
+		assert.Equal(t, networkID, list[0].(map[string]interface{})["network_id"])
+	})
+}
+
+func TestUnitNsxt_getVNADeploymentConfigFromSchema(t *testing.T) {
+	t.Run("nil input returns nil", func(t *testing.T) {
+		assert.Nil(t, getVNADeploymentConfigFromSchema(nil))
+	})
+
+	t.Run("empty list returns nil", func(t *testing.T) {
+		assert.Nil(t, getVNADeploymentConfigFromSchema([]interface{}{}))
+	})
+
+	t.Run("parses fields plus reservation_info", func(t *testing.T) {
+		obj := getVNADeploymentConfigFromSchema([]interface{}{
+			map[string]interface{}{
+				"compute_manager_id":          "cm-1",
+				"cluster_or_resource_pool_id": "crp-1",
+				"datastore_id":                "ds-1",
+				"reservation_info": []interface{}{
+					map[string]interface{}{
+						"cpu_reservation_in_mhz":        1000,
+						"cpu_reservation_in_shares":     model.CPUReservation_RESERVATION_IN_SHARES_HIGH_PRIORITY,
+						"memory_reservation_percentage": 50,
+					},
+				},
+			},
+		})
+		require.NotNil(t, obj)
+		assert.Equal(t, "cm-1", *obj.ComputeManagerId)
+		assert.Equal(t, "crp-1", *obj.ClusterOrResourcePoolId)
+		assert.Equal(t, "ds-1", *obj.DatastoreId)
+		require.NotNil(t, obj.ReservationInfo)
+		assert.Equal(t, int64(1000), *obj.ReservationInfo.CpuReservation.ReservationInMhz)
+		assert.Equal(t, int64(50), *obj.ReservationInfo.MemoryReservation.ReservationPercentage)
+	})
+
+	t.Run("omits fields left empty", func(t *testing.T) {
+		obj := getVNADeploymentConfigFromSchema([]interface{}{map[string]interface{}{
+			"compute_manager_id":          "",
+			"cluster_or_resource_pool_id": "",
+			"datastore_id":                "",
+		}})
+		require.NotNil(t, obj)
+		assert.Nil(t, obj.ComputeManagerId)
+		assert.Nil(t, obj.ClusterOrResourcePoolId)
+		assert.Nil(t, obj.DatastoreId)
+		assert.Nil(t, obj.ReservationInfo)
+	})
+}
+
+func TestUnitNsxt_setVNADeploymentConfigInSchema(t *testing.T) {
+	res := resourceNsxtPolicyVirtualNetworkAppliance()
+
+	t.Run("nil object is a no-op", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{"cluster_path": vnaClusterPath})
+		require.NoError(t, setVNADeploymentConfigInSchema(d, nil))
+		assert.Empty(t, d.Get("vm_deployment_config").([]interface{}))
+	})
+
+	t.Run("sets all fields plus reservation_info", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{"cluster_path": vnaClusterPath})
+		cm := "cm-2"
+		crp := "crp-2"
+		ds := "ds-2"
+		mhz := int64(2000)
+		shares := model.CPUReservation_RESERVATION_IN_SHARES_LOW_PRIORITY
+		pct := int64(75)
+		err := setVNADeploymentConfigInSchema(d, &model.VirtualNetworkApplianceDeploymentConfig{
+			ComputeManagerId:        &cm,
+			ClusterOrResourcePoolId: &crp,
+			DatastoreId:             &ds,
+			ReservationInfo: &model.ReservationInfo{
+				CpuReservation: &model.CPUReservation{
+					ReservationInMhz:    &mhz,
+					ReservationInShares: &shares,
+				},
+				MemoryReservation: &model.MemoryReservation{
+					ReservationPercentage: &pct,
+				},
+			},
+		})
+		require.NoError(t, err)
+		list := d.Get("vm_deployment_config").([]interface{})
+		require.Len(t, list, 1)
+		elem := list[0].(map[string]interface{})
+		assert.Equal(t, cm, elem["compute_manager_id"])
+		ri := elem["reservation_info"].([]interface{})
+		require.Len(t, ri, 1)
+		assert.Equal(t, 2000, ri[0].(map[string]interface{})["cpu_reservation_in_mhz"])
+	})
+}
+
+func TestUnitNsxt_resourceNsxtPolicyVirtualNetworkApplianceImporter(t *testing.T) {
+	res := resourceNsxtPolicyVirtualNetworkAppliance()
+
+	t.Run("valid import ID sets cluster_path and seeds credentials", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		d.SetId(vnaPath)
+
+		out, err := resourceNsxtPolicyVirtualNetworkApplianceImporter(d, nil)
+		require.NoError(t, err)
+		require.Len(t, out, 1)
+		assert.Equal(t, vnaClusterPath, out[0].Get("cluster_path"))
+		creds := out[0].Get("credentials").([]interface{})
+		require.Len(t, creds, 1)
+	})
+
+	t.Run("malformed ID errors", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, map[string]interface{}{})
+		d.SetId("not-a-valid-path")
+
+		_, err := resourceNsxtPolicyVirtualNetworkApplianceImporter(d, nil)
+		require.Error(t, err)
+	})
+}
+
 func TestMockResourceNsxtPolicyVirtualNetworkApplianceCreate(t *testing.T) {
 	util.NsxVersion = "9.1.1"
 	defer func() { util.NsxVersion = "" }()

--- a/nsxt/utgomock_resource_nsxt_policy_vm_tags_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_vm_tags_test.go
@@ -25,9 +25,11 @@ import (
 
 	realizedep "github.com/vmware/terraform-provider-nsxt/api/infra/realized_state/enforcement_points"
 	virtualmachines "github.com/vmware/terraform-provider-nsxt/api/infra/realized_state/virtual_machines"
+	segmentsapi "github.com/vmware/terraform-provider-nsxt/api/infra/segments"
 	utl "github.com/vmware/terraform-provider-nsxt/api/utl"
 	epmocks "github.com/vmware/terraform-provider-nsxt/mocks/infra/realized_state/enforcement_points"
 	vmmocks "github.com/vmware/terraform-provider-nsxt/mocks/infra/realized_state/virtual_machines"
+	portsmocks "github.com/vmware/terraform-provider-nsxt/mocks/infra/segments"
 )
 
 var (
@@ -341,5 +343,166 @@ func TestMockResourceNsxtPolicyVMTagsUpdate(t *testing.T) {
 		err := resourceNsxtPolicyVMTagsUpdate(d, m)
 		require.NoError(t, err)
 		assert.Equal(t, vmExternalID, d.Id())
+	})
+}
+
+func setupPortTagsMocks(t *testing.T) (*epmocks.MockVifsClient, *portsmocks.MockPortsClient) {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	mockVifsSDK := epmocks.NewMockVifsClient(ctrl)
+	mockVifsWrapper := &realizedep.VirtualNetworkInterfaceClientContext{Client: mockVifsSDK, ClientType: utl.Local}
+	origVifs := cliVifsClient
+	t.Cleanup(func() { cliVifsClient = origVifs })
+	cliVifsClient = func(sessionContext utl.SessionContext, connector client.Connector) *realizedep.VirtualNetworkInterfaceClientContext {
+		return mockVifsWrapper
+	}
+
+	mockPortsSDK := portsmocks.NewMockPortsClient(ctrl)
+	mockPortsWrapper := &segmentsapi.SegmentPortClientContext{Client: mockPortsSDK, ClientType: utl.Local}
+	origPorts := cliPortsClient
+	t.Cleanup(func() { cliPortsClient = origPorts })
+	cliPortsClient = func(sessionContext utl.SessionContext, connector client.Connector) *segmentsapi.SegmentPortClientContext {
+		return mockPortsWrapper
+	}
+
+	return mockVifsSDK, mockPortsSDK
+}
+
+func vifWithAttachment(attachmentID string) model.VirtualNetworkInterfaceListResult {
+	total := int64(1)
+	return model.VirtualNetworkInterfaceListResult{
+		Results:     []model.VirtualNetworkInterface{{LportAttachmentId: &attachmentID, OwnerVmId: &vmExternalID}},
+		ResultCount: &total,
+	}
+}
+
+func portListWithAttachment(portID, attachmentID string) model.SegmentPortListResult {
+	total := int64(1)
+	path := "/infra/segments/seg-1/ports/" + portID
+	return model.SegmentPortListResult{
+		Results: []model.SegmentPort{{
+			Id:         &portID,
+			Path:       &path,
+			Attachment: &model.PortAttachment{Id: &attachmentID},
+		}},
+		ResultCount: &total,
+	}
+}
+
+func TestMockUpdateNsxtPolicyVMPortTags(t *testing.T) {
+	ctx := utl.SessionContext{ClientType: utl.Local}
+	portData := []interface{}{map[string]interface{}{
+		"segment_path": "/infra/segments/seg-1",
+		"tag":          schema.NewSet(schema.HashResource(getTagsSchema().Elem.(*schema.Resource)), nil),
+	}}
+
+	t.Run("updates the matching port's tags", func(t *testing.T) {
+		mockVifsSDK, mockPortsSDK := setupPortTagsMocks(t)
+		mockVifsSDK.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(vifWithAttachment("att-1"), nil)
+		mockPortsSDK.EXPECT().List("seg-1", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(portListWithAttachment("port-1", "att-1"), nil)
+		mockPortsSDK.EXPECT().Update("seg-1", "port-1", gomock.Any()).Return(model.SegmentPort{}, nil)
+
+		err := updateNsxtPolicyVMPortTags(ctx, nil, vmExternalID, portData, newGoMockProviderClient(), false)
+		require.NoError(t, err)
+	})
+
+	t.Run("VIF list error propagates", func(t *testing.T) {
+		mockVifsSDK, _ := setupPortTagsMocks(t)
+		mockVifsSDK.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(model.VirtualNetworkInterfaceListResult{}, assert.AnError)
+
+		err := updateNsxtPolicyVMPortTags(ctx, nil, vmExternalID, portData, newGoMockProviderClient(), false)
+		require.Error(t, err)
+	})
+
+	t.Run("segment port list error propagates", func(t *testing.T) {
+		mockVifsSDK, mockPortsSDK := setupPortTagsMocks(t)
+		mockVifsSDK.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(vifWithAttachment("att-1"), nil)
+		mockPortsSDK.EXPECT().List("seg-1", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(model.SegmentPortListResult{}, assert.AnError)
+
+		err := updateNsxtPolicyVMPortTags(ctx, nil, vmExternalID, portData, newGoMockProviderClient(), false)
+		require.Error(t, err)
+	})
+
+	t.Run("no port has a matching attachment is a no-op", func(t *testing.T) {
+		mockVifsSDK, mockPortsSDK := setupPortTagsMocks(t)
+		mockVifsSDK.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(vifWithAttachment("att-other"), nil)
+		mockPortsSDK.EXPECT().List("seg-1", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(portListWithAttachment("port-1", "att-1"), nil)
+
+		err := updateNsxtPolicyVMPortTags(ctx, nil, vmExternalID, portData, newGoMockProviderClient(), false)
+		require.NoError(t, err)
+	})
+}
+
+func TestMockNsxtSetPolicyVMPortTagsInSchema(t *testing.T) {
+	t.Run("populates port block from matching segment port", func(t *testing.T) {
+		mockVifsSDK, mockPortsSDK := setupPortTagsMocks(t)
+		mockVifsSDK.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(vifWithAttachment("att-1"), nil)
+		mockPortsSDK.EXPECT().List("seg-1", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(portListWithAttachment("port-1", "att-1"), nil)
+
+		res := resourceNsxtPolicyVMTags()
+		data := minimalVMTagsData()
+		data["port"] = []interface{}{map[string]interface{}{"segment_path": "/infra/segments/seg-1"}}
+		d := schema.TestResourceDataRaw(t, res.Schema, data)
+
+		err := setPolicyVMPortTagsInSchema(d, newGoMockProviderClient(), vmExternalID)
+		require.NoError(t, err)
+		ports := d.Get("port").([]interface{})
+		require.Len(t, ports, 1)
+		assert.Equal(t, "/infra/segments/seg-1", ports[0].(map[string]interface{})["segment_path"])
+	})
+
+	t.Run("VIF list error propagates", func(t *testing.T) {
+		mockVifsSDK, _ := setupPortTagsMocks(t)
+		mockVifsSDK.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(model.VirtualNetworkInterfaceListResult{}, assert.AnError)
+
+		res := resourceNsxtPolicyVMTags()
+		data := minimalVMTagsData()
+		data["port"] = []interface{}{map[string]interface{}{"segment_path": "/infra/segments/seg-1"}}
+		d := schema.TestResourceDataRaw(t, res.Schema, data)
+
+		err := setPolicyVMPortTagsInSchema(d, newGoMockProviderClient(), vmExternalID)
+		require.Error(t, err)
+	})
+}
+
+func TestUnitNsxt_convertSearchResultToVifList(t *testing.T) {
+	t.Run("converts search results into VirtualNetworkInterface structs", func(t *testing.T) {
+		attachmentID := "att-1"
+		vif := model.VirtualNetworkInterface{LportAttachmentId: &attachmentID, OwnerVmId: &vmExternalID}
+		converter := bindings.NewTypeConverter()
+		sv, errs := converter.ConvertToVapi(vif, model.VirtualNetworkInterfaceBindingType())
+		require.Empty(t, errs)
+
+		results, err := convertSearchResultToVifList([]*data.StructValue{sv.(*data.StructValue)})
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		assert.Equal(t, attachmentID, *results[0].LportAttachmentId)
+	})
+
+	t.Run("empty input returns empty output", func(t *testing.T) {
+		results, err := convertSearchResultToVifList(nil)
+		require.NoError(t, err)
+		assert.Empty(t, results)
+	})
+}
+
+func TestUnitNsxt_listAllPolicySegmentPortsInvalidPath(t *testing.T) {
+	t.Run("tier-0 fixed segment path is rejected", func(t *testing.T) {
+		ctx := utl.SessionContext{ClientType: utl.Local}
+		_, err := listAllPolicySegmentPorts(ctx, nil, "/infra/tier-0s/gw-1/segments/seg-1")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid segment path")
 	})
 }

--- a/nsxt/utgomock_resource_nsxt_vpc_subnet_test.go
+++ b/nsxt/utgomock_resource_nsxt_vpc_subnet_test.go
@@ -355,8 +355,171 @@ func TestMockResourceNsxtVpcSubnetDelete(t *testing.T) {
 	})
 }
 
+func TestMockResourceNsxtVpcSubnetExists(t *testing.T) {
+	ctx := utl.SessionContext{ProjectID: "project1", VPCID: "vpc1"}
+
+	t.Run("Get succeeds means it exists", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSubnetSDK, _, restore := setupSubnetMock(t, ctrl)
+		defer restore()
+		mockSubnetSDK.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), subnetID).Return(subnetAPIResponse(), nil)
+
+		exists, err := resourceNsxtVpcSubnetExists(ctx, subnetID, nil)
+		require.NoError(t, err)
+		assert.True(t, exists)
+	})
+
+	t.Run("NotFound means it does not exist", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSubnetSDK, _, restore := setupSubnetMock(t, ctrl)
+		defer restore()
+		mockSubnetSDK.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), subnetID).Return(nsxModel.VpcSubnet{}, vapiErrors.NotFound{})
+
+		exists, err := resourceNsxtVpcSubnetExists(ctx, subnetID, nil)
+		require.NoError(t, err)
+		assert.False(t, exists)
+	})
+
+	t.Run("other errors propagate", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSubnetSDK, _, restore := setupSubnetMock(t, ctrl)
+		defer restore()
+		mockSubnetSDK.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), subnetID).Return(nsxModel.VpcSubnet{}, vapiErrors.InternalServerError{})
+
+		_, err := resourceNsxtVpcSubnetExists(ctx, subnetID, nil)
+		require.Error(t, err)
+	})
+}
+
+func TestUnitNsxt_isDhcpDeactivated(t *testing.T) {
+	res := resourceNsxtVpcSubnet()
+
+	t.Run("v4: no dhcp_config defaults to deactivated", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalSubnetData())
+		assert.True(t, isDhcpv4Deactivated(d))
+	})
+
+	t.Run("v4: mode SERVER is not deactivated", func(t *testing.T) {
+		data := minimalSubnetData()
+		data["dhcp_config"] = []interface{}{map[string]interface{}{"mode": nsxModel.SubnetDhcpConfig_MODE_SERVER}}
+		d := schema.TestResourceDataRaw(t, res.Schema, data)
+		assert.False(t, isDhcpv4Deactivated(d))
+	})
+
+	t.Run("v4: mode DEACTIVATED is deactivated", func(t *testing.T) {
+		data := minimalSubnetData()
+		data["dhcp_config"] = []interface{}{map[string]interface{}{"mode": nsxModel.SubnetDhcpConfig_MODE_DEACTIVATED}}
+		d := schema.TestResourceDataRaw(t, res.Schema, data)
+		assert.True(t, isDhcpv4Deactivated(d))
+	})
+
+	t.Run("v6: no subnet_dhcpv6_config defaults to deactivated", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalSubnetData())
+		assert.True(t, isDhcpv6Deactivated(d))
+	})
+
+	t.Run("v6: mode SERVER is not deactivated", func(t *testing.T) {
+		data := minimalSubnetData()
+		data["subnet_dhcpv6_config"] = []interface{}{map[string]interface{}{"mode": nsxModel.SubnetDhcpv6Config_MODE_SERVER}}
+		d := schema.TestResourceDataRaw(t, res.Schema, data)
+		assert.False(t, isDhcpv6Deactivated(d))
+	})
+
+	t.Run("v6: mode DEACTIVATED is deactivated", func(t *testing.T) {
+		data := minimalSubnetData()
+		data["subnet_dhcpv6_config"] = []interface{}{map[string]interface{}{"mode": nsxModel.SubnetDhcpv6Config_MODE_DEACTIVATED}}
+		d := schema.TestResourceDataRaw(t, res.Schema, data)
+		assert.True(t, isDhcpv6Deactivated(d))
+	})
+}
+
+func TestUnitNsxt_filterDeactivatedDhcpServerAddresses(t *testing.T) {
+	res := resourceNsxtVpcSubnet()
+
+	t.Run("nil advancedConfig is a no-op", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalSubnetData())
+		filterDeactivatedDhcpServerAddresses(d, nil)
+	})
+
+	t.Run("empty DhcpServerAddresses is a no-op", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalSubnetData())
+		cfg := &nsxModel.SubnetAdvancedConfig{}
+		filterDeactivatedDhcpServerAddresses(d, cfg)
+		assert.Empty(t, cfg.DhcpServerAddresses)
+	})
+
+	t.Run("filters out addresses for deactivated families and empty placeholders", func(t *testing.T) {
+		data := minimalSubnetData()
+		data["dhcp_config"] = []interface{}{map[string]interface{}{"mode": nsxModel.SubnetDhcpConfig_MODE_SERVER}}
+		data["subnet_dhcpv6_config"] = []interface{}{map[string]interface{}{"mode": nsxModel.SubnetDhcpv6Config_MODE_DEACTIVATED}}
+		d := schema.TestResourceDataRaw(t, res.Schema, data)
+
+		cfg := &nsxModel.SubnetAdvancedConfig{
+			DhcpServerAddresses: []string{"10.203.240.2/26", "", "fd00:240:2400::2/64"},
+		}
+		filterDeactivatedDhcpServerAddresses(d, cfg)
+		assert.Equal(t, []string{"10.203.240.2/26"}, cfg.DhcpServerAddresses)
+	})
+}
+
+func TestUnitNsxt_validateDhcpConfig(t *testing.T) {
+	res := resourceNsxtVpcSubnet()
+
+	t.Run("no dhcp_config is allowed", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalSubnetData())
+		require.NoError(t, validateDhcpConfig(d))
+	})
+
+	t.Run("RELAY mode without additional config is allowed", func(t *testing.T) {
+		data := minimalSubnetData()
+		data["dhcp_config"] = []interface{}{map[string]interface{}{"mode": nsxModel.SubnetDhcpConfig_MODE_RELAY}}
+		d := schema.TestResourceDataRaw(t, res.Schema, data)
+		require.NoError(t, validateDhcpConfig(d))
+	})
+
+	t.Run("RELAY mode with additional config is rejected", func(t *testing.T) {
+		data := minimalSubnetData()
+		data["dhcp_config"] = []interface{}{map[string]interface{}{
+			"mode": nsxModel.SubnetDhcpConfig_MODE_RELAY,
+			"dhcp_server_additional_config": []interface{}{map[string]interface{}{
+				"dns_servers": []interface{}{"8.8.8.8"},
+			}},
+		}}
+		d := schema.TestResourceDataRaw(t, res.Schema, data)
+		require.Error(t, validateDhcpConfig(d))
+	})
+
+	t.Run("SERVER mode with additional config is allowed", func(t *testing.T) {
+		data := minimalSubnetData()
+		data["dhcp_config"] = []interface{}{map[string]interface{}{
+			"mode": nsxModel.SubnetDhcpConfig_MODE_SERVER,
+			"dhcp_server_additional_config": []interface{}{map[string]interface{}{
+				"dns_servers": []interface{}{"8.8.8.8"},
+			}},
+		}}
+		d := schema.TestResourceDataRaw(t, res.Schema, data)
+		require.NoError(t, validateDhcpConfig(d))
+	})
+}
+
 func TestValidateSubnetDhcpv6Config(t *testing.T) {
 	res := resourceNsxtVpcSubnet()
+
+	t.Run("no subnet_dhcpv6_config is allowed", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalSubnetData())
+		require.NoError(t, validateSubnetDhcpv6Config(d))
+	})
+
+	t.Run("mode outside RELAY/DEACTIVATED skips the additional-config check", func(t *testing.T) {
+		data := minimalSubnetData()
+		data["subnet_dhcpv6_config"] = []interface{}{map[string]interface{}{"mode": nsxModel.SubnetDhcpv6Config_MODE_SERVER_STATELESS}}
+		d := schema.TestResourceDataRaw(t, res.Schema, data)
+		require.NoError(t, validateSubnetDhcpv6Config(d))
+	})
+
 	t.Run("DHCP_RELAY with dhcpv6_server_additional_config is rejected", func(t *testing.T) {
 		data := minimalSubnetData()
 		data["subnet_dhcpv6_config"] = []interface{}{map[string]interface{}{


### PR DESCRIPTION
The idps data sources (cluster_config, custom_signature, settings,
signature_diff, signature_version, system_signatures) and two idps resources
called SDK client constructors directly instead of through the package's
injectable cliXClient var pattern, which is what makes gomock-based unit
testing possible elsewhere in this codebase. Wire them through injectable
vars (reusing two that already existed) and add mocked test coverage for
the previously-untestable read/list paths.

Also fix 8 test functions (5 pre-existing, 3 introduced in this PR) named
TestMock<Foo> without "Nsxt" in the name, so they never matched
`-run='^(TestMock.*Nsxt.*|TestUnitNsxt_.*)'` and silently never ran in
`make test-unit` or CI despite passing when invoked directly.

Add CRUD, error-path, and pure schema-conversion test coverage across the
package's largest remaining gaps: lb_virtual_server, edge_transport_node
(policy and manager variants), tier0_gateway(_interface), tier1_gateway(_interface),
domain, project, service, transit_gateway, lb_pool, predefined_gateway_policy,
predefined_security_policy, nat_rule, ipsec_vpn_service/session,
ip_pool_static_subnet, role_binding, virtual_network_appliance,
dhcp_v4_static_binding, bgp_neighbor, ospf_area, gateway_policy_rule,
l2_vpn_session, static_route, edge_cluster, and the shared
segment_common/segment_port_common helpers.

Note on the coverage number: this project's `go.mod` pins `go 1.26.6`, which
is what CI's `actions/setup-go` (via `go-version-file: go.mod`) actually
builds and tests with. A newer local Go toolchain (e.g. 1.27.x) counts
statements more granularly and will report a noticeably higher, non-comparable
percentage for the identical code — always measure against go.mod's pinned
version when validating this number locally.
