### PR TITLE
Fix resolution_scope drift in policy DNS zone

### DIFF
--- a/docs/resources/policy_dns_zone.md
+++ b/docs/resources/policy_dns_zone.md
@@ -48,7 +48,7 @@ The following arguments are supported:
 * `nsx_id` - (Optional) The NSX ID of this resource. If set, this ID will be used to create the resource.
 * `parent_path` - (Required, Force New) Policy path of the parent `nsxt_policy_dns_service`.
 * `dns_domain_name` - (Required, Force New) The domain name for this zone (e.g. `example.com`) or reverse-notation (e.g. `12.168.192.in-addr.arpa`). Immutable after creation.
-* `resolution_scope` - (Optional) List of VPC policy paths within this project. When set and non-empty, only workloads in the specified VPCs can resolve this zone (split-horizon DNS). When unset or empty, all VPCs in the project can resolve the zone. A zone shared with other projects must have `resolution_scope` unset or empty.
+* `resolution_scope` - (Optional) Set of VPC policy paths within this project. When set and non-empty, only workloads in the specified VPCs can resolve this zone (split-horizon DNS). When unset or empty, all VPCs in the project can resolve the zone. A zone shared with other projects must have `resolution_scope` unset or empty.
 * `ttl` - (Optional) Default Time-To-Live in seconds for DNS records in this zone (30-86400). Default: `300`.
 * `soa` - (Optional) SOA (Start of Authority) record parameters. All sub-fields are optional and computed; omitted fields use system defaults.
     * `primary_nameserver` - (Optional, Computed) FQDN of the primary nameserver. Must end with a trailing dot.

--- a/nsxt/resource_nsxt_policy_dns_zone.go
+++ b/nsxt/resource_nsxt_policy_dns_zone.go
@@ -47,13 +47,13 @@ func resourceNsxtPolicyDnsZone() *schema.Resource {
 				Description: "The domain name for this zone (e.g. 'example.com'). Immutable after creation.",
 			},
 			"resolution_scope": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
 					ValidateFunc: validatePolicyPath(),
 				},
-				Description: "Optional list of VPC policy paths for split-horizon DNS. When set, only workloads in the specified VPCs can resolve this zone. When empty, all VPCs in the project can resolve it.",
+				Description: "Optional set of VPC policy paths for split-horizon DNS. When set, only workloads in the specified VPCs can resolve this zone. When empty, all VPCs in the project can resolve it.",
 			},
 			"ttl": {
 				Type:         schema.TypeInt,
@@ -153,7 +153,7 @@ func policyDnsZoneFromSchema(d *schema.ResourceData) model.DnsZone {
 		Ttl:           &ttl,
 	}
 
-	obj.ResolutionScope = getStringListFromSchemaList(d, "resolution_scope")
+	obj.ResolutionScope = getStringListFromSchemaSet(d, "resolution_scope")
 
 	soaList := d.Get("soa").([]interface{})
 	if len(soaList) > 0 {

--- a/nsxt/utgomock_resource_nsxt_policy_dns_zone_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_dns_zone_test.go
@@ -95,6 +95,47 @@ func TestMockResourceNsxtPolicyDnsZoneCreate(t *testing.T) {
 		assert.Equal(t, projectDnsZoneID, d.Id())
 	})
 
+	t.Run("Create success with resolution_scope", func(t *testing.T) {
+		util.NsxVersion = "9.2.0"
+		defer func() { util.NsxVersion = "" }()
+
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSDK, restore := setupDnsZoneMock(t, ctrl)
+		defer restore()
+
+		scopeData := minimalProjectDnsZoneData()
+		scopeData["resolution_scope"] = []interface{}{
+			"/orgs/default/projects/project1/vpcs/vpc-1",
+			"/orgs/default/projects/project1/vpcs/vpc-2",
+		}
+
+		notFoundErr := vapiErrors.NotFound{}
+		var capturedObj nsxModel.DnsZone
+		gomock.InOrder(
+			mockSDK.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), projectDnsZoneID).Return(nsxModel.DnsZone{}, notFoundErr),
+			mockSDK.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any(), projectDnsZoneID, gomock.Any()).DoAndReturn(
+				func(_ string, _ string, _ string, _ string, obj nsxModel.DnsZone) error {
+					capturedObj = obj
+					return nil
+				}),
+			mockSDK.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), projectDnsZoneID).Return(projectDnsZoneAPIResponse(), nil),
+		)
+
+		res := resourceNsxtPolicyDnsZone()
+		assert.Equal(t, schema.TypeSet, res.Schema["resolution_scope"].Type)
+
+		d := schema.TestResourceDataRaw(t, res.Schema, scopeData)
+
+		err := resourceNsxtPolicyDnsZoneCreate(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, projectDnsZoneID, d.Id())
+		assert.ElementsMatch(t, []string{
+			"/orgs/default/projects/project1/vpcs/vpc-1",
+			"/orgs/default/projects/project1/vpcs/vpc-2",
+		}, capturedObj.ResolutionScope)
+	})
+
 	t.Run("Create fails on old NSX version", func(t *testing.T) {
 		util.NsxVersion = "9.1.0"
 		defer func() { util.NsxVersion = "" }()
@@ -124,6 +165,32 @@ func TestMockResourceNsxtPolicyDnsZoneRead(t *testing.T) {
 		err := resourceNsxtPolicyDnsZoneRead(d, newGoMockProviderClient())
 		require.NoError(t, err)
 		assert.Equal(t, projectDnsZoneDisplayName, d.Get("display_name"))
+	})
+
+	t.Run("Read success with resolution_scope", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockSDK, restore := setupDnsZoneMock(t, ctrl)
+		defer restore()
+
+		apiResp := projectDnsZoneAPIResponse()
+		apiResp.ResolutionScope = []string{
+			"/orgs/default/projects/project1/vpcs/vpc-1",
+			"/orgs/default/projects/project1/vpcs/vpc-2",
+		}
+		mockSDK.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), projectDnsZoneID).Return(apiResp, nil)
+
+		res := resourceNsxtPolicyDnsZone()
+		d := schema.TestResourceDataRaw(t, res.Schema, minimalProjectDnsZoneData())
+		d.SetId(projectDnsZoneID)
+
+		err := resourceNsxtPolicyDnsZoneRead(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		assert.Equal(t, projectDnsZoneDisplayName, d.Get("display_name"))
+		resScopeSet := d.Get("resolution_scope").(*schema.Set)
+		assert.Equal(t, 2, resScopeSet.Len())
+		assert.True(t, resScopeSet.Contains("/orgs/default/projects/project1/vpcs/vpc-1"))
+		assert.True(t, resScopeSet.Contains("/orgs/default/projects/project1/vpcs/vpc-2"))
 	})
 
 	t.Run("Read not found clears ID", func(t *testing.T) {


### PR DESCRIPTION
The `resolution_scope` attribute on `nsxt_policy_dns_zone` was defined as `TypeList`, which treats the order of VPC policy paths as significant. However, the NSX backend treats resolution scope as an unordered set, and may return the VPC paths in a different order or cause Terraform to detect perpetual drift whenever the VPC paths are reordered in configuration or returned in canonical ordering.

Change `resolution_scope` from `TypeList` to `TypeSet` so Terraform evaluates the VPC paths as an unordered set, eliminating false diffs on reordering while preserving existing validation and behavior. Update schema helper from `getStringListFromSchemaList` to `getStringListFromSchemaSet`, update documentation, and add unit test coverage for resolution scope creation and reading.