### PR TITLE
Support import for predefined security policy resource (#2186)

### DIFF
--- a/docs/resources/policy_predefined_security_policy.md
+++ b/docs/resources/policy_predefined_security_policy.md
@@ -149,3 +149,16 @@ In addition to arguments listed above, the following attributes are exported:
     * `path` - The NSX path of the policy resource.
     * `sequence_number` - Sequence number of the this rule, is defined by order of rules in the list.
     * `rule_id` - Unique positive number that is assigned by the system and is useful for debugging.
+
+## Importing
+
+An existing Security Policy can be [imported][docs-import] into this resource, via the following command:
+
+[docs-import]: https://developer.hashicorp.com/terraform/cli/import
+
+```shell
+terraform import nsxt_policy_predefined_security_policy.test POLICY_PATH
+```
+
+The above command imports the predefined Security Policy named `test` with policy path `POLICY_PATH`.
+The import command is recommended in case the NSX policy in question already has rules configured, and you wish to reconfigure the policy from scratch.

--- a/nsxt/resource_nsxt_policy_predefined_security_policy.go
+++ b/nsxt/resource_nsxt_policy_predefined_security_policy.go
@@ -26,6 +26,9 @@ func resourceNsxtPolicyPredefinedSecurityPolicy() *schema.Resource {
 		Read:   resourceNsxtPolicyPredefinedSecurityPolicyRead,
 		Update: resourceNsxtPolicyPredefinedSecurityPolicyUpdate,
 		Delete: resourceNsxtPolicyPredefinedSecurityPolicyDelete,
+		Importer: &schema.ResourceImporter{
+			State: nsxtPredefinedPolicyImporter,
+		},
 
 		Schema: getPolicyPredefinedSecurityPolicySchema(),
 	}

--- a/nsxt/resource_nsxt_policy_predefined_security_policy_test.go
+++ b/nsxt/resource_nsxt_policy_predefined_security_policy_test.go
@@ -79,17 +79,6 @@ func TestAccResourceNsxtPolicyPredefinedSecurityPolicy_importBasic_globalManager
 	})
 }
 
-// testAccResourceNsxtPolicyPredefinedSecurityPolicyImportBasic provisions its
-// own Security Policy via nsxt_policy_parent_security_policy rather than
-// relying on a built-in default policy already existing: NSX does not
-// consistently auto-realize default category policies under GM domains
-// across versions (e.g. a fresh NSX 4.2.x Global Manager may have none at
-// all), so a self-created policy is the only environment-independent target.
-//
-// The predefined_security_policy block intentionally leaves description/tag
-// unset: those fields are also owned by nsxt_policy_parent_security_policy on
-// the same underlying object, and patching them here would fight the parent
-// resource for ownership and show up as drift on its own plan.
 func testAccResourceNsxtPolicyPredefinedSecurityPolicyImportBasic(t *testing.T, preCheck func()) {
 	testResourceName := "nsxt_policy_predefined_security_policy.test"
 	name := getAccTestResourceName()
@@ -138,7 +127,7 @@ func TestAccResourceNsxtPolicyPredefinedSecurityPolicy_defaultRule(t *testing.T)
         }`
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t); testAccOnlyLocalManager(t); testAccNSXVersion(t, "3.0.0") },
+		PreCheck:  func() { testAccPreCheck(t); testAccOnlyLocalManager(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -177,7 +166,7 @@ func TestAccResourceNsxtPolicyPredefinedSecurityPolicy_rules(t *testing.T) {
 	testResourceName := "nsxt_policy_predefined_security_policy.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t); testAccOnlyLocalManager(t); testAccNSXVersion(t, "3.0.0") },
+		PreCheck:  func() { testAccPreCheck(t); testAccOnlyLocalManager(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{


### PR DESCRIPTION
Wire up the same generic predefined-policy Importer already used by nsxt_policy_predefined_gateway_policy, and add LM/GM import tests.