### PR TITLE
Use policy path for CNA allow_external_blocks

### DIFF
--- a/docs/resources/policy_project_centralized_network_attachment.md
+++ b/docs/resources/policy_project_centralized_network_attachment.md
@@ -26,7 +26,7 @@ resource "nsxt_policy_project_centralized_network_attachment" "example" {
 
   advertise_outbound_networks {
     allow_private         = true
-    allow_external_blocks = ["10.0.0.0/8", "172.16.0.0/12"]
+    allow_external_blocks = [nsxt_policy_ip_block.block.path]
   }
 
   tag {
@@ -69,7 +69,7 @@ The following arguments are supported:
 * `subnet_path` - (Required, Immutable) Policy path of the VPC subnet (overlay or VLAN-backed) to which this CNA is connected. Cannot be changed after creation.
 * `advertise_outbound_networks` - (Optional) Outbound route advertisement configuration.
     * `allow_private` - (Optional) When `true`, disables VPC auto-SNAT and EIP translation on the interface, and enables `TGW_PRIVATE` route redistribution on this connection. Default: `false`.
-    * `allow_external_blocks` - (Optional) List of external IP block CIDRs used as an advertisement filter for prefixes redistributed from the transit gateway.
+    * `allow_external_blocks` - (Optional) List of external IP block paths used as an advertisement filter for prefixes redistributed from the transit gateway.
 * `interface_subnet` - (Optional) Manual IP assignment for per-node edge interfaces. Supports 1–2 entries (one IPv4 and/or one IPv6 subnet). CNAs with manual IP assignment cannot be shared to other centralized transit gateways.
     * `interface_ip_address` - (Required) List of IP addresses assigned to each edge node interface. The count must match the number of edge nodes hosting the centralized transit gateway.
     * `prefix_length` - (Required) Prefix length of the subnet. Valid range: 1–32 for IPv4, 1–128 for IPv6.

--- a/nsxt/resource_nsxt_policy_project_centralized_network_attachment.go
+++ b/nsxt/resource_nsxt_policy_project_centralized_network_attachment.go
@@ -60,11 +60,11 @@ func resourceNsxtPolicyProjectCentralizedNetworkAttachment() *schema.Resource {
 						},
 						"allow_external_blocks": {
 							Type:        schema.TypeList,
-							Description: "External IP blocks (CIDRs) used as advertisement filter for prefixes from the transit gateway.",
+							Description: "External IP blocks (policy paths) used as advertisement filter for prefixes from the transit gateway.",
 							Optional:    true,
 							Elem: &schema.Schema{
 								Type:         schema.TypeString,
-								ValidateFunc: validateIPCidr(),
+								ValidateFunc: validatePolicyPath(),
 							},
 						},
 					},

--- a/nsxt/resource_nsxt_policy_project_centralized_network_attachment_test.go
+++ b/nsxt/resource_nsxt_policy_project_centralized_network_attachment_test.go
@@ -1,0 +1,203 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package nsxt
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func TestAccResourceNsxtPolicyProjectCentralizedNetworkAttachment_basic(t *testing.T) {
+	testResourceName := "nsxt_policy_project_centralized_network_attachment.test"
+	prereqName := getAccTestResourceName()
+	createName := getAccTestResourceName()
+	updateName := getAccTestResourceName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccOnlyLocalManager(t)
+			testAccNSXVersion(t, "9.2.0")
+		},
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyProjectCentralizedNetworkAttachmentCheckDestroy(state, updateName)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyProjectCNATemplate(prereqName, createName, "terraform created", false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicyProjectCentralizedNetworkAttachmentExists(testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", createName),
+					resource.TestCheckResourceAttr(testResourceName, "description", "terraform created"),
+					resource.TestCheckResourceAttrPair(testResourceName, "subnet_path", "nsxt_vpc_subnet.test", "path"),
+					resource.TestCheckResourceAttr(testResourceName, "advertise_outbound_networks.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "advertise_outbound_networks.0.allow_private", "false"),
+					resource.TestCheckResourceAttr(testResourceName, "advertise_outbound_networks.0.allow_external_blocks.#", "1"),
+					resource.TestCheckResourceAttrPair(testResourceName, "advertise_outbound_networks.0.allow_external_blocks.0", "nsxt_policy_ip_block.test", "path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
+				),
+			},
+			{
+				Config: testAccNsxtPolicyProjectCNATemplate(prereqName, updateName, "terraform updated", true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNsxtPolicyProjectCentralizedNetworkAttachmentExists(testResourceName),
+					resource.TestCheckResourceAttr(testResourceName, "display_name", updateName),
+					resource.TestCheckResourceAttr(testResourceName, "description", "terraform updated"),
+					resource.TestCheckResourceAttrPair(testResourceName, "subnet_path", "nsxt_vpc_subnet.test", "path"),
+					resource.TestCheckResourceAttr(testResourceName, "advertise_outbound_networks.#", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "advertise_outbound_networks.0.allow_private", "true"),
+					resource.TestCheckResourceAttr(testResourceName, "advertise_outbound_networks.0.allow_external_blocks.#", "1"),
+					resource.TestCheckResourceAttrPair(testResourceName, "advertise_outbound_networks.0.allow_external_blocks.0", "nsxt_policy_ip_block.test", "path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "nsx_id"),
+					resource.TestCheckResourceAttrSet(testResourceName, "path"),
+					resource.TestCheckResourceAttrSet(testResourceName, "revision"),
+					resource.TestCheckResourceAttr(testResourceName, "tag.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceNsxtPolicyProjectCentralizedNetworkAttachment_importBasic(t *testing.T) {
+	prereqName := getAccTestResourceName()
+	displayName := getAccTestResourceName()
+	testResourceName := "nsxt_policy_project_centralized_network_attachment.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccOnlyLocalManager(t)
+			testAccNSXVersion(t, "9.2.0")
+		},
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccNsxtPolicyProjectCentralizedNetworkAttachmentCheckDestroy(state, displayName)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNsxtPolicyProjectCNATemplate(prereqName, displayName, "terraform created", false),
+			},
+			{
+				ResourceName:      testResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccResourceNsxtPolicyImportIDRetriever(testResourceName),
+			},
+		},
+	})
+}
+
+func testAccNsxtPolicyProjectCentralizedNetworkAttachmentExists(resourceName string) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+		connector := getPolicyConnector(testAccProvider.Meta().(nsxtClients))
+
+		rs, ok := state.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Policy CentralizedNetworkAttachment resource %s not found in resources", resourceName)
+		}
+
+		resourceID := rs.Primary.ID
+		if resourceID == "" {
+			return fmt.Errorf("Policy CentralizedNetworkAttachment resource ID not set in resources")
+		}
+
+		path := rs.Primary.Attributes["path"]
+		sessionContext := testAccGetSessionContextFromParentPath(testAccProvider.Meta(), path)
+		exists, err := resourceNsxtPolicyProjectCNAExists(sessionContext, resourceID, connector)
+		if err != nil {
+			return err
+		}
+		if !exists {
+			return fmt.Errorf("Policy CentralizedNetworkAttachment %s does not exist", resourceID)
+		}
+
+		return nil
+	}
+}
+
+func testAccNsxtPolicyProjectCentralizedNetworkAttachmentCheckDestroy(state *terraform.State, displayName string) error {
+	connector := getPolicyConnector(testAccProvider.Meta().(nsxtClients))
+	for _, rs := range state.RootModule().Resources {
+		if rs.Type != "nsxt_policy_project_centralized_network_attachment" {
+			continue
+		}
+		resourceID := rs.Primary.Attributes["id"]
+		path := rs.Primary.Attributes["path"]
+		sessionContext := testAccGetSessionContextFromParentPath(testAccProvider.Meta(), path)
+		exists, err := resourceNsxtPolicyProjectCNAExists(sessionContext, resourceID, connector)
+		if err != nil {
+			return err
+		}
+		if exists {
+			return fmt.Errorf("Policy CentralizedNetworkAttachment %s still exists", displayName)
+		}
+	}
+	return nil
+}
+
+func testAccNsxtPolicyProjectCNATemplate(prereqName string, displayName string, description string, allowPrivate bool) string {
+	return fmt.Sprintf(`
+data "nsxt_policy_edge_cluster" "test" {
+  display_name = "%s"
+}
+
+resource "nsxt_policy_ip_block" "test" {
+  display_name = "%s"
+  cidr         = "10.120.0.0/22"
+  visibility   = "EXTERNAL"
+}
+
+resource "nsxt_policy_project" "test" {
+  display_name         = "%s"
+  external_ipv4_blocks = [nsxt_policy_ip_block.test.path]
+  site_info {
+    edge_cluster_paths = [data.nsxt_policy_edge_cluster.test.path]
+  }
+}
+
+resource "nsxt_vpc" "test" {
+  context {
+    project_id = nsxt_policy_project.test.id
+  }
+  display_name = "%s"
+  private_ips  = ["192.168.240.0/24"]
+}
+
+resource "nsxt_vpc_subnet" "test" {
+  context {
+    project_id = nsxt_policy_project.test.id
+    vpc_id     = nsxt_vpc.test.id
+  }
+  display_name = "%s"
+  ip_addresses = ["192.168.240.0/26"]
+  access_mode  = "Private"
+}
+
+resource "nsxt_policy_project_centralized_network_attachment" "test" {
+  context {
+    project_id = nsxt_policy_project.test.id
+  }
+  display_name = "%s"
+  description  = "%s"
+  subnet_path  = nsxt_vpc_subnet.test.path
+
+  advertise_outbound_networks {
+    allow_private         = %t
+    allow_external_blocks = [nsxt_policy_ip_block.test.path]
+  }
+
+  tag {
+    scope = "scope1"
+    tag   = "tag1"
+  }
+}`, getEdgeClusterName(), prereqName, prereqName, prereqName, prereqName, displayName, description, allowPrivate)
+}

--- a/nsxt/utgomock_resource_nsxt_policy_project_centralized_network_attachment_test.go
+++ b/nsxt/utgomock_resource_nsxt_policy_project_centralized_network_attachment_test.go
@@ -141,7 +141,7 @@ func TestMockResourceNsxtPolicyCNACreate(t *testing.T) {
 		data["advertise_outbound_networks"] = []interface{}{
 			map[string]interface{}{
 				"allow_private":         allowPrivate,
-				"allow_external_blocks": []interface{}{"10.0.0.0/8"},
+				"allow_external_blocks": []interface{}{"/infra/ip-blocks/block-1"},
 			},
 		}
 		data["interface_subnet"] = []interface{}{
@@ -159,7 +159,7 @@ func TestMockResourceNsxtPolicyCNACreate(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, captured.AdvertiseOutboundNetworks)
 		assert.True(t, *captured.AdvertiseOutboundNetworks.AllowPrivate)
-		assert.Equal(t, []string{"10.0.0.0/8"}, captured.AdvertiseOutboundNetworks.AllowExternalBlocks)
+		assert.Equal(t, []string{"/infra/ip-blocks/block-1"}, captured.AdvertiseOutboundNetworks.AllowExternalBlocks)
 		require.Len(t, captured.InterfaceSubnets, 1)
 		assert.Equal(t, int64(24), *captured.InterfaceSubnets[0].PrefixLength)
 		assert.Equal(t, "192.168.1.100", *captured.InterfaceSubnets[0].HaVipIpAddress)
@@ -179,7 +179,7 @@ func TestMockResourceNsxtPolicyCNARead(t *testing.T) {
 		apiResp := cnaAPIResponse()
 		apiResp.AdvertiseOutboundNetworks = &nsxModel.AdvertiseOutboundNetworks{
 			AllowPrivate:        &allowPrivate,
-			AllowExternalBlocks: []string{"10.0.0.0/8"},
+			AllowExternalBlocks: []string{"/infra/ip-blocks/block-1"},
 		}
 		apiResp.InterfaceSubnets = []nsxModel.CentralizedNetworkAttachmentInterfaceSubnet{
 			{
@@ -203,7 +203,7 @@ func TestMockResourceNsxtPolicyCNARead(t *testing.T) {
 		require.Len(t, aon, 1)
 		aonMap := aon[0].(map[string]interface{})
 		assert.True(t, aonMap["allow_private"].(bool))
-		assert.Equal(t, []interface{}{"10.0.0.0/8"}, aonMap["allow_external_blocks"])
+		assert.Equal(t, []interface{}{"/infra/ip-blocks/block-1"}, aonMap["allow_external_blocks"])
 
 		subnets := d.Get("interface_subnet").([]interface{})
 		require.Len(t, subnets, 1)
@@ -253,6 +253,46 @@ func TestMockResourceNsxtPolicyCNAUpdate(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("Update with advertise_outbound_networks and interface_subnet", func(t *testing.T) {
+		allowPrivate := true
+		var captured nsxModel.CentralizedNetworkAttachment
+		gomock.InOrder(
+			mockSDK.EXPECT().Update(cnaOrgID, cnaProjectID, cnaID, gomock.Any()).DoAndReturn(
+				func(_, _, _ string, obj nsxModel.CentralizedNetworkAttachment) (nsxModel.CentralizedNetworkAttachment, error) {
+					captured = obj
+					return cnaAPIResponse(), nil
+				}),
+			mockSDK.EXPECT().Get(cnaOrgID, cnaProjectID, cnaID).Return(cnaAPIResponse(), nil),
+		)
+
+		res := resourceNsxtPolicyProjectCentralizedNetworkAttachment()
+		data := minimalCNAData()
+		data["advertise_outbound_networks"] = []interface{}{
+			map[string]interface{}{
+				"allow_private":         allowPrivate,
+				"allow_external_blocks": []interface{}{"/infra/ip-blocks/block-1"},
+			},
+		}
+		data["interface_subnet"] = []interface{}{
+			map[string]interface{}{
+				"interface_ip_address": []interface{}{"192.168.1.10"},
+				"prefix_length":        24,
+				"ha_vip_ip_address":    "192.168.1.100",
+			},
+		}
+		d := schema.TestResourceDataRaw(t, res.Schema, data)
+		d.SetId(cnaID)
+
+		err := resourceNsxtPolicyProjectCNAUpdate(d, newGoMockProviderClient())
+		require.NoError(t, err)
+		require.NotNil(t, captured.AdvertiseOutboundNetworks)
+		assert.True(t, *captured.AdvertiseOutboundNetworks.AllowPrivate)
+		assert.Equal(t, []string{"/infra/ip-blocks/block-1"}, captured.AdvertiseOutboundNetworks.AllowExternalBlocks)
+		require.Len(t, captured.InterfaceSubnets, 1)
+		assert.Equal(t, int64(24), *captured.InterfaceSubnets[0].PrefixLength)
+		assert.Equal(t, "192.168.1.100", *captured.InterfaceSubnets[0].HaVipIpAddress)
+	})
+
 	t.Run("Update fails when ID is empty", func(t *testing.T) {
 		res := resourceNsxtPolicyProjectCentralizedNetworkAttachment()
 		d := schema.TestResourceDataRaw(t, res.Schema, minimalCNAData())
@@ -286,4 +326,25 @@ func TestMockResourceNsxtPolicyCNADelete(t *testing.T) {
 		err := resourceNsxtPolicyProjectCNADelete(d, newGoMockProviderClient())
 		require.Error(t, err)
 	})
+}
+
+func TestUnitNsxt_PolicyProjectCNASchemaValidation(t *testing.T) {
+	res := resourceNsxtPolicyProjectCentralizedNetworkAttachment()
+	aonSchema := res.Schema["advertise_outbound_networks"].Elem.(*schema.Resource).Schema
+	extBlocksSchema := aonSchema["allow_external_blocks"].Elem.(*schema.Schema)
+	validate := extBlocksSchema.ValidateFunc
+
+	// Negative cases: CIDRs and invalid paths must fail validation
+	_, errs := validate("10.0.0.0/8", "allow_external_blocks")
+	assert.NotEmpty(t, errs, "CIDR string should be rejected by validatePolicyPath()")
+
+	_, errs = validate("invalid-path", "allow_external_blocks")
+	assert.NotEmpty(t, errs, "Non-path string should be rejected")
+
+	// Positive cases: Valid infra and project paths must pass validation
+	_, errs = validate("/infra/ip-blocks/block-1", "allow_external_blocks")
+	assert.Empty(t, errs, "Infra IP block path should be accepted")
+
+	_, errs = validate("/orgs/default/projects/project1/infra/ip-blocks/block-1", "allow_external_blocks")
+	assert.Empty(t, errs, "Project-scoped IP block path should be accepted")
 }


### PR DESCRIPTION
The NSX Policy API expects policy paths to IpAddressBlock resources rather than raw CIDRs for allow_external_blocks under CentralizedNetworkAttachment. Passing raw CIDR strings causes NSX API error PM500012 ('The path=[...] is invalid').

Update allow_external_blocks in
resourceNsxtPolicyProjectCentralizedNetworkAttachment to use validatePolicyPath() instead of validateIPCidr(). Update the documentation example and description, add mock unit tests and schema validation tests, and add acceptance tests with 9.2 version gates covering policy path references.